### PR TITLE
fix: enforce can_download on /api ebook and audiobook download routes (#1810)

### DIFF
--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 
 use axum::{
+    http::StatusCode,
     response::{IntoResponse, Response},
     Extension, Router,
 };
@@ -17,6 +18,7 @@ use omnibus_db::{
 };
 use sqlx::SqlitePool;
 
+use crate::auth::AuthUser;
 use crate::http_errors::internal;
 use crate::rate_limit::RateLimiter;
 
@@ -88,6 +90,17 @@ pub const SEARCH_RATE_LIMIT_MAX: u32 = 30;
 pub const UPLOAD_RATE_LIMIT_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
 /// Max upload requests per [`UPLOAD_RATE_LIMIT_WINDOW`] per IP.
 pub const UPLOAD_RATE_LIMIT_MAX: u32 = 10;
+
+/// 403 unless `user` may download. The single enforcement point for every
+/// download-shaped route — one whose purpose is handing the caller a file to
+/// keep (`Content-Disposition: attachment`), as opposed to the in-app
+/// reading/streaming routes (`/file`, `/parts/{ordinal}`, page images, HLS),
+/// which stay open to any authenticated user. Shared by the `/api/*`
+/// handlers here and by `opds::delegate`'s Basic-auth'd acquisition routes,
+/// so the two surfaces cannot drift on what counts as a download.
+fn deny_without_download(user: &AuthUser) -> Option<Response> {
+    (!user.can_download).then(|| (StatusCode::FORBIDDEN, "download not permitted").into_response())
+}
 
 /// Serve a file from disk as a browser download: streamed (so large
 /// audiobook files aren't buffered into memory), Range-capable, conditional,

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -252,12 +252,15 @@ pub(super) struct DownloadQuery {
 /// yield the first part today — there is no on-the-fly archiving yet, so
 /// per-part downloads go through the format switcher's file picker.
 pub(super) async fn get_audiobook_download(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(uuid): Path<String>,
     Query(query): Query<DownloadQuery>,
     req: Request,
 ) -> Response {
+    if let Some(denied) = super::deny_without_download(&user) {
+        return denied;
+    }
     let resolved = match hls::resolve_audiobook_file(&state.pool, &uuid, query.file_id).await {
         Ok(Some(r)) => r,
         Ok(None) => return axum::http::StatusCode::NOT_FOUND.into_response(),

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -712,6 +712,25 @@ async fn api_get_audiobook_download_returns_404_for_unknown_uuid() {
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 }
 
+/// AC1 (#1810): `can_download = 0` must 403 the attachment download route,
+/// the same guard the OPDS acquisition delegate already enforces for
+/// `/opds/audiobooks/{uuid}/download`.
+#[tokio::test]
+async fn api_get_audiobook_download_returns_403_when_user_cannot_download() {
+    let (app, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    revoke_can_download(&pool, user.id).await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer(
+            "/api/audiobooks/some-uuid/download",
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
 #[tokio::test]
 async fn api_get_audiobook_download_serves_first_part_as_attachment() {
     // Serves the lowest-ordinal part's real file, streamed via ServeFile,
@@ -774,6 +793,45 @@ async fn api_get_audiobook_download_serves_first_part_as_attachment() {
         .await
         .unwrap();
     assert_eq!(body.as_ref(), &payload[..]);
+}
+
+/// AC1 (#1810): `/parts/{ordinal}` is the in-app playback stream, not a
+/// download — it must stay reachable even for a `can_download = 0` user.
+/// Only the `Content-Disposition: attachment` `/download` route enforces
+/// the flag.
+#[tokio::test]
+async fn api_get_audiobook_part_returns_200_when_user_cannot_download() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let library_path = dir.path().to_string_lossy().to_string();
+    std::fs::create_dir_all(dir.path().join("Author/Book")).unwrap();
+    let file_path = dir.path().join("Author/Book/01.mp3");
+    std::fs::File::create(&file_path)
+        .unwrap()
+        .write_all(&[0u8; 10])
+        .unwrap();
+
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    revoke_can_download(&pool, user.id).await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let uuid = seed_audiobook_with_parts(
+        &pool,
+        &library_path,
+        "MP3",
+        &[(0, "Author/Book/01.mp3", 60.0)],
+    )
+    .await;
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/audiobooks/{uuid}/parts/0"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/server/src/backend/ebooks.rs
+++ b/server/src/backend/ebooks.rs
@@ -480,10 +480,13 @@ const KEPUB_CONVERT_BUDGET: std::time::Duration = std::time::Duration::from_secs
 /// the canonical `book_uuid` so a future USB annotation import can map the
 /// device's `ContentID` back to the book.
 pub(super) async fn get_ebook_kepub(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(uuid): Path<String>,
 ) -> Response {
+    if let Some(denied) = super::deny_without_download(&user) {
+        return denied;
+    }
     let id = match db::resolve_book_id_by_uuid(&state.pool, &uuid).await {
         Ok(Some(id)) => id,
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
@@ -575,12 +578,15 @@ fn download_response(bytes: Vec<u8>, filename: &str) -> Response {
 /// disposition differs, so the in-app reader keeps streaming inline via
 /// `/file` while the export menu drives a real save-to-disk via `/download`.
 pub(super) async fn get_ebook_download(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(uuid): Path<String>,
     Query(query): Query<EbookFileQuery>,
     req: Request,
 ) -> Response {
+    if let Some(denied) = super::deny_without_download(&user) {
+        return denied;
+    }
     let (source, id) = match resolve_epub_path(&state, &uuid, query.file_id).await {
         Ok(resolved) => resolved,
         Err((resp, _)) => return resp,

--- a/server/src/backend/ebooks/tests.rs
+++ b/server/src/backend/ebooks/tests.rs
@@ -436,6 +436,28 @@ async fn api_get_ebook_file_returns_200_with_epub_bytes() {
     std::fs::remove_dir_all(&tmp).ok();
 }
 
+/// AC1 (#1810): `/file` is the in-app reader stream, not a download — it
+/// must stay reachable even for a `can_download = 0` user. Only the
+/// `Content-Disposition: attachment` routes (`/download`, `/kepub`) enforce
+/// the flag.
+#[tokio::test]
+async fn api_get_ebook_file_returns_200_when_user_cannot_download() {
+    let (_, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    revoke_can_download(&pool, user.id).await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (uuid, _book_id, tmp) = seed_epub_on_disk(&pool).await;
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .oneshot(get_with_bearer(&format!("/api/ebooks/{uuid}/file"), &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
 /// The `/file` stream is gated by `MediaAuthUser`, so a `?token=` query param
 /// authenticates it with neither a cookie nor a bearer header — the path
 /// epub.js takes from inside the mobile WebView. Mirrors the bearer 200 test
@@ -752,6 +774,21 @@ async fn api_get_ebook_kepub_returns_401_when_anonymous() {
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
 }
 
+/// AC1 (#1810): `can_download = 0` must 403 the KEPUB download route, the
+/// same guard the OPDS acquisition delegates already enforce.
+#[tokio::test]
+async fn api_get_ebook_kepub_returns_403_when_user_cannot_download() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    revoke_can_download(&pool, user.id).await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/ebooks/some-uuid/kepub", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+}
+
 #[tokio::test]
 async fn api_get_ebook_kepub_returns_404_for_unknown_uuid() {
     let (app, _state, pool) = fixture().await;
@@ -841,6 +878,22 @@ async fn api_get_ebook_download_returns_401_when_anonymous() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// AC1 (#1810): `can_download = 0` must 403 the raw-EPUB download route
+/// before it ever resolves the uuid, mirroring `deny_without_download` on
+/// the OPDS acquisition delegate for the same URL shape.
+#[tokio::test]
+async fn api_get_ebook_download_returns_403_when_user_cannot_download() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    revoke_can_download(&pool, user.id).await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let res = app
+        .oneshot(get_with_bearer("/api/ebooks/some-uuid/download", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]

--- a/server/src/backend/opds/delegate.rs
+++ b/server/src/backend/opds/delegate.rs
@@ -9,23 +9,14 @@
 
 use axum::{
     extract::{Path, Query, Request, State},
-    http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
+    http::HeaderMap,
+    response::Response,
 };
 
-use crate::auth::{AuthUser, MediaAuthUser, OpdsAuthUser};
+use crate::auth::{MediaAuthUser, OpdsAuthUser};
 
-use super::super::{audiobooks, covers, ebooks};
+use super::super::{audiobooks, covers, deny_without_download, ebooks};
 use super::AppState;
-
-/// 403 unless the user may download. Applied to the acquisition routes
-/// only — covers/thumbs stay open to any authenticated user because the
-/// catalog is unrenderable without them, matching the browse UI. (The
-/// `/api/*` download originals predate `can_download` and don't enforce
-/// it yet — tracked separately.)
-fn deny_without_download(user: &AuthUser) -> Option<Response> {
-    (!user.can_download).then(|| (StatusCode::FORBIDDEN, "download not permitted").into_response())
-}
 
 /// `GET /opds/covers/{uuid}` → [`covers::get_cover`].
 pub(super) async fn cover(

--- a/server/src/backend/test_support.rs
+++ b/server/src/backend/test_support.rs
@@ -334,6 +334,18 @@ impl Drop for DataDirGuard {
     }
 }
 
+/// Flip `can_download` off for an already-created user. `auth::test_support`
+/// user factories always insert `can_download = 1`, so download-permission
+/// tests start from a real user and revoke the flag here rather than adding
+/// a third factory variant just for this one column.
+pub(crate) async fn revoke_can_download(pool: &sqlx::SqlitePool, user_id: i64) {
+    sqlx::query("UPDATE users SET can_download = 0 WHERE id = ?")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("revoke can_download");
+}
+
 pub(crate) async fn seed_author(pool: &sqlx::SqlitePool, name: &str) -> i64 {
     sqlx::query_scalar::<_, i64>("INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id")
         .bind(name)


### PR DESCRIPTION
## Summary
- Closes #1810
- `ebooks::get_ebook_download`, `ebooks::get_ebook_kepub`, and `audiobooks::get_audiobook_download` now 403 for a user with `can_download = 0`, matching the enforcement PR #1809 added on the OPDS acquisition delegates.
- Hoisted `opds::delegate`'s `deny_without_download` guard up into `server/src/backend.rs` (a private fn visible to its descendant modules, same visibility pattern as the existing `serve_file`/`serve_download` helpers) so the OPDS delegates and the `/api` handlers share one enforcement path instead of two copies that could drift (AC2). `opds/delegate.rs` now imports the hoisted helper; its own tests and behavior are unchanged.
- The in-app reading/streaming routes — `/file` (ebook reader stream), `/parts/{ordinal}` (audiobook playback), CBZ page images, HLS manifest/segments — are deliberately **not** gated: they're reads, not downloads, per the issue's guidance.
- Frontend/mobile UI affordances were left untouched (optional/best-effort per the issue; kept this change surgical to the backend).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus` — 788 passed, 2 failed (both pre-existing and unrelated: `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` fail in this sandbox because the tests run as root, which bypasses the `chmod 0o555` read-only permission bits the tests rely on — the affected file, `server/src/backend/uploads.rs`, isn't touched by this change)
- [x] New coverage (AC3): `api_get_ebook_download_returns_403_when_user_cannot_download`, `api_get_ebook_kepub_returns_403_when_user_cannot_download`, `api_get_audiobook_download_returns_403_when_user_cannot_download` (403 path), plus `api_get_ebook_file_returns_200_when_user_cannot_download` and `api_get_audiobook_part_returns_200_when_user_cannot_download` as a regression guard that the reading/streaming routes stay open. Existing `..._returns_200_...` tests for the download/kepub routes (which use the default `can_download = true` test user) cover the happy path (AC1).
- [x] `backend::opds::tests::*` (47 tests) re-run to confirm the hoist didn't change OPDS behavior — all pass unchanged.

## Version
- [x] **Patch** — the default; leave unlabeled.

## Notes
- Label `tech-debt` and assignee `@me` should be applied — noting here in case the creating tool didn't set them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQAjLMLTEJqehG7NmQA7Z9)_