### PR TITLE
fix: report thumbnail backfill progress only for stale covers (#1817)

### DIFF
--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -350,10 +350,12 @@ async fn fetch_page_count_candidates(
 /// lazy generation path in `server::backend::covers::thumb_cache_miss_response`.
 ///
 /// Posted as a separate worker task after each ebook library scan (mirroring
-/// [`backfill_word_counts`]). Cheap when caught up: a book whose three sizes
-/// are already fresh per [`thumbs::is_stale_async`] is skipped without touching its
-/// cover bytes, so a re-scan of an unchanged library does no re-encoding —
-/// exactly what [`thumbs::ensure_thumbnails_sync`] does for a single book.
+/// [`backfill_word_counts`]). Cheap when caught up: candidates are first
+/// partitioned by [`thumbs::is_stale_async`] into the subset actually needing
+/// a re-encode (#1817) — a book with all three sizes already fresh never
+/// touches its cover bytes, is never logged, and never advances the reported
+/// `total`, so a re-scan of an unchanged library posts no visible progress
+/// task at all.
 ///
 /// Processes one book at a time (decode + encode is CPU-bound and runs on
 /// the blocking pool via `spawn_blocking`) rather than fanning out, so a
@@ -361,7 +363,8 @@ async fn fetch_page_count_candidates(
 /// for CPU. A per-book failure (missing cover, decode error, I/O) is logged
 /// and skipped rather than aborting the batch — the next scan or an
 /// interactive view retries it via the lazy path. `on_progress(processed,
-/// total)` is called per book for the UI, mirroring the sibling backfills.
+/// total)` is called once per stale book for the UI, mirroring the sibling
+/// backfills.
 pub(crate) async fn backfill_thumbs(
     pool: &SqlitePool,
     library_path: &str,
@@ -372,17 +375,27 @@ pub(crate) async fn backfill_thumbs(
         return Ok(());
     }
 
-    let total = u32::try_from(candidates.len()).unwrap_or(u32::MAX);
+    let mut stale = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        if is_any_thumb_stale(candidate.0, candidate.1).await {
+            stale.push(candidate);
+        }
+    }
+    if stale.is_empty() {
+        return Ok(());
+    }
+
+    let total = u32::try_from(stale.len()).unwrap_or(u32::MAX);
     tracing::info!(
         count = total,
         "pre-generating thumbnails for existing covers"
     );
 
     let mut processed = 0u32;
-    for (book_id, last_modified_epoch, title) in candidates {
+    for (book_id, last_modified_epoch, title) in stale {
         processed = processed.saturating_add(1);
         on_progress(processed, total, &title);
-        regenerate_thumbs_if_stale(pool, book_id, last_modified_epoch).await;
+        regenerate_thumbs(pool, book_id, last_modified_epoch).await;
     }
 
     let cap = thumbs::cap_bytes();
@@ -399,21 +412,22 @@ pub(crate) async fn backfill_thumbs(
     Ok(())
 }
 
-/// Regenerate one book's three thumbnail sizes if any is stale per
-/// [`thumbs::is_stale_async`], skipping (and logging) a missing cover,
-/// fetch failure, or generation failure rather than aborting the batch.
-async fn regenerate_thumbs_if_stale(pool: &SqlitePool, book_id: i64, last_modified_epoch: i64) {
-    let mut all_fresh = true;
+/// Whether any of a book's three thumbnail sizes is stale per
+/// [`thumbs::is_stale_async`] — the [`backfill_thumbs`] partition predicate.
+async fn is_any_thumb_stale(book_id: i64, last_modified_epoch: i64) -> bool {
     for size in thumbs::ThumbSize::all() {
         if thumbs::is_stale_async(book_id, size, last_modified_epoch).await {
-            all_fresh = false;
-            break;
+            return true;
         }
     }
-    if all_fresh {
-        return;
-    }
+    false
+}
 
+/// Regenerate one book's three thumbnail sizes, skipping (and logging) a
+/// missing cover, fetch failure, or generation failure rather than aborting
+/// the batch. Callers are expected to have already established via
+/// [`is_any_thumb_stale`] that this book needs re-encoding.
+async fn regenerate_thumbs(pool: &SqlitePool, book_id: i64, last_modified_epoch: i64) {
     let cover = match covers::get_cover(pool, book_id).await {
         Ok(Some((_mime, bytes))) => bytes,
         Ok(None) => return,

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -12,7 +12,7 @@ use crate::pool::init_db;
 use crate::sync::{replace_books, sync_audiobooks, sync_books, AudiobookSyncPlan, SyncPlan};
 use crate::test_support::{
     build_stored_zip, count_rows, indexed, indexed_audiobook, indexed_with_stat, make_test_dir,
-    uuid_by_scan_key, CoversTempDir,
+    uuid_by_scan_key, CoversTempDir, EnvVarGuard,
 };
 
 /// Seed a `scan_roots` row for `path` with an explicit `last_indexed`
@@ -1292,6 +1292,180 @@ async fn backfill_page_counts_is_a_noop_when_no_candidates_exist() {
     assert_eq!(calls, 0);
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------- thumbnail backfill (#1752 / #1817 phantom-progress fix) ----------
+
+/// Seed a `has_cover = 1` book with a real cover file on disk, so
+/// `backfill_thumbs` has bytes to (maybe) re-encode. `last_modified` is
+/// pinned far in the past so any thumbnail written just now is unambiguously
+/// fresher than it, regardless of clock resolution.
+async fn seed_covered_book(pool: &SqlitePool, lib_id: i64, uuid: &str, title: &str) -> i64 {
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort, has_cover, last_modified) \
+         VALUES (?, ?, ?, '', ?, ?, 1, 1) RETURNING id",
+    )
+    .bind(uuid)
+    .bind(uuid)
+    .bind(lib_id)
+    .bind(title)
+    .bind(title)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    std::fs::write(
+        crate::covers_dir().join(format!("{uuid}.png")),
+        crate::ebook::test_support::solid_color_png(200, 40, 40, 8, 8),
+    )
+    .unwrap();
+    book_id
+}
+
+/// Write sentinel bytes (never produced by a real encode) at all three
+/// thumbnail sizes for `book_id`, so it reads as fresh relative to its
+/// far-past `last_modified` and a would-be re-encode is detectable.
+fn write_fresh_sentinel_thumbs(book_id: i64) {
+    let sentinel = b"not-a-real-webp-sentinel".to_vec();
+    for size in crate::thumbs::ThumbSize::all() {
+        std::fs::write(crate::thumbs::thumb_path_for(book_id, size), &sentinel).unwrap();
+    }
+}
+
+/// AC1: a library whose covers are all already fresh posts no visible
+/// progress — `on_progress` never fires and `backfill_thumbs` returns
+/// without ever calling into the encode path.
+#[tokio::test]
+async fn backfill_thumbs_reports_no_progress_when_every_cover_is_already_fresh() {
+    let covers_dir = make_test_dir("thumb-backfill-all-fresh-covers");
+    let thumbs_dir = make_test_dir("thumb-backfill-all-fresh-thumbs");
+    let _env = EnvVarGuard::set_os("OMNIBUS_COVERS_DIR", Some(covers_dir.as_os_str()))
+        .also_set_os("OMNIBUS_THUMBS_DIR", Some(thumbs_dir.as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("thumb-backfill-all-fresh-lib");
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) RETURNING id",
+    )
+    .bind(dir.to_str().unwrap())
+    .bind(dir.to_str().unwrap())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let a = seed_covered_book(&pool, lib_id, "uuid-fresh-a", "Fresh A").await;
+    let b = seed_covered_book(&pool, lib_id, "uuid-fresh-b", "Fresh B").await;
+    write_fresh_sentinel_thumbs(a);
+    write_fresh_sentinel_thumbs(b);
+
+    let mut calls = 0u32;
+    backfill_thumbs(&pool, dir.to_str().unwrap(), |_, _, _| calls += 1)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        calls, 0,
+        "on_progress must not fire when every candidate is already fresh"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&covers_dir);
+    let _ = std::fs::remove_dir_all(&thumbs_dir);
+}
+
+/// AC2: a library where every cover is stale reports `count = N` and calls
+/// `on_progress` exactly N times with `total = N`.
+#[tokio::test]
+async fn backfill_thumbs_reports_count_matching_the_stale_set_when_all_covers_are_stale() {
+    let covers_dir = make_test_dir("thumb-backfill-all-stale-covers");
+    let thumbs_dir = make_test_dir("thumb-backfill-all-stale-thumbs");
+    let _env = EnvVarGuard::set_os("OMNIBUS_COVERS_DIR", Some(covers_dir.as_os_str()))
+        .also_set_os("OMNIBUS_THUMBS_DIR", Some(thumbs_dir.as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("thumb-backfill-all-stale-lib");
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) RETURNING id",
+    )
+    .bind(dir.to_str().unwrap())
+    .bind(dir.to_str().unwrap())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    // No thumbnails written on disk at all, so every size for every book is
+    // stale (a missing thumbnail counts as stale).
+    seed_covered_book(&pool, lib_id, "uuid-stale-a", "Stale A").await;
+    seed_covered_book(&pool, lib_id, "uuid-stale-b", "Stale B").await;
+
+    let mut progress: Vec<(u32, u32)> = Vec::new();
+    backfill_thumbs(&pool, dir.to_str().unwrap(), |p, t, _| {
+        progress.push((p, t))
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(progress, vec![(1, 2), (2, 2)]);
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&covers_dir);
+    let _ = std::fs::remove_dir_all(&thumbs_dir);
+}
+
+/// AC4: a library with both fresh and stale covers reports progress only
+/// for the stale ones — the mixed case the phantom-progress bug collapsed
+/// into "report every book with a cover".
+#[tokio::test]
+async fn backfill_thumbs_reports_progress_only_for_stale_covers_in_a_mixed_library() {
+    let covers_dir = make_test_dir("thumb-backfill-mixed-covers");
+    let thumbs_dir = make_test_dir("thumb-backfill-mixed-thumbs");
+    let _env = EnvVarGuard::set_os("OMNIBUS_COVERS_DIR", Some(covers_dir.as_os_str()))
+        .also_set_os("OMNIBUS_THUMBS_DIR", Some(thumbs_dir.as_os_str()));
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let dir = make_test_dir("thumb-backfill-mixed-lib");
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES (?, ?) RETURNING id",
+    )
+    .bind(dir.to_str().unwrap())
+    .bind(dir.to_str().unwrap())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let fresh = seed_covered_book(&pool, lib_id, "uuid-mixed-fresh", "Mixed Fresh").await;
+    write_fresh_sentinel_thumbs(fresh);
+    // No thumbnails written for this one, so it's the sole stale candidate.
+    seed_covered_book(&pool, lib_id, "uuid-mixed-stale", "Mixed Stale").await;
+
+    let mut titles: Vec<String> = Vec::new();
+    let mut progress: Vec<(u32, u32)> = Vec::new();
+    backfill_thumbs(&pool, dir.to_str().unwrap(), |p, t, title| {
+        progress.push((p, t));
+        titles.push(title.to_string());
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        progress,
+        vec![(1, 1)],
+        "total and processed must both reflect the single stale book, not the two candidates"
+    );
+    assert_eq!(
+        titles,
+        vec!["Mixed Stale".to_string()],
+        "on_progress must not fire for the already-fresh book"
+    );
+
+    let sentinel = b"not-a-real-webp-sentinel".to_vec();
+    for size in crate::thumbs::ThumbSize::all() {
+        let on_disk = std::fs::read(crate::thumbs::thumb_path_for(fresh, size)).unwrap();
+        assert_eq!(
+            on_disk, sentinel,
+            "the already-fresh book's thumbnail for size {size} must not be re-encoded"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&covers_dir);
+    let _ = std::fs::remove_dir_all(&thumbs_dir);
 }
 
 // ---------- #1057: ReindexStats plumbed off a real scan ----------


### PR DESCRIPTION
## Summary
- Closes #1817
- `backfill_thumbs` logged `count = total candidates` and called `on_progress` for every book with a cover, even though `regenerate_thumbs_if_stale` went on to skip every already-fresh one — a no-op re-scan reported a full-size phantom progress task.
- Candidates are now partitioned by `thumbs::is_stale_async` up front (`is_any_thumb_stale`); the log line, the reported `total`, and `on_progress` all track only the stale subset. A fully caught-up library now posts no visible task and logs nothing.

## Test plan
- [x] `cd /home/user/omnibus-wt-1817 && CARGO_TARGET_DIR=/tmp/omnibus-target-1817 cargo fmt -p omnibus-db` — PASS (no diff)
- [x] `cd /home/user/omnibus-wt-1817 && CARGO_TARGET_DIR=/tmp/omnibus-target-1817 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cd /home/user/omnibus-wt-1817 && CARGO_TARGET_DIR=/tmp/omnibus-target-1817 cargo test -p omnibus-db` — 1956 passed, 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing environment limitation: `test_data/audiobooks/public_domain/` fixtures aren't downloaded in this sandbox (`just fixtures` needs `just`/nix, unavailable here) — unrelated to this change. All tests touching this change pass, including the three new ones and the existing `task_backfill_thumbs_skips_a_book_whose_thumbnails_are_already_fresh` / `task_scan_posts_backfill_thumbs_that_pregenerates_all_sizes_for_a_covered_book`.

New tests added in `db/src/indexer/tests.rs`:
- `backfill_thumbs_reports_no_progress_when_every_cover_is_already_fresh` (AC1)
- `backfill_thumbs_reports_count_matching_the_stale_set_when_all_covers_are_stale` (AC2)
- `backfill_thumbs_reports_progress_only_for_stale_covers_in_a_mixed_library` (AC4)

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- `db` crate only, no schema or API changes.
- Label `bug` should be applied (omitted here since this tool call doesn't support labels on create).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQAjLMLTEJqehG7NmQA7Z9)_