### PR TITLE
test: cover the DB-failure (500) path for GET /api/admin/health

### DIFF
--- a/server/src/backend/admin_health/tests.rs
+++ b/server/src/backend/admin_health/tests.rs
@@ -1,14 +1,38 @@
 //! Integration tests for `GET /api/admin/health`: `AdminUser` gating (401
-//! anonymous / 403 non-admin) and a 200 admin response carrying every
-//! section of the report.
+//! anonymous / 403 non-admin), a 200 admin response carrying every section
+//! of the report, and the handler's own DB-failure (500) branch.
 
-use axum::{body::to_bytes, http::StatusCode};
-use omnibus_db::test_support::seed_minimal_books;
+use axum::{body::to_bytes, extract::State, http::StatusCode};
+use omnibus_db::{auth::SessionKind, test_support::seed_minimal_books};
 use omnibus_shared::admin_health::AdminHealthReport;
 use tower::ServiceExt;
 
+use super::get_admin_health;
 use crate::auth::test_support as auth_test_support;
+use crate::auth::{AdminUser, AuthUser};
 use crate::backend::test_support::*;
+
+/// A minimal admin `AuthUser` for driving the handler directly (bypassing
+/// the `AdminUser` extractor). Needed because `build_report`'s own
+/// DB-failure branch shares the pool with the extractor's own session
+/// lookup, so closing the pool before a routed request would fail
+/// extraction rather than the handler body under test.
+fn fake_admin(id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "admin".to_string(),
+        is_admin: true,
+        can_upload: true,
+        can_edit: true,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id: 1,
+        session_kind: SessionKind::Bearer,
+    }
+}
 
 #[tokio::test]
 async fn get_admin_health_returns_401_when_anonymous() {
@@ -57,4 +81,18 @@ async fn get_admin_health_returns_200_with_every_section_for_an_admin() {
     // process-wide buffer shared with `logging::error_ring_layer`'s own
     // tests, which legitimately record real entries into it concurrently.
     assert!(report.worker_queue.is_empty());
+}
+
+// ── DB-failure path (500) ────────────────────────────────────────────
+//
+// Invoked directly (rather than through `oneshot`) with a hand-built
+// `AdminUser` and a pool closed only after the point at which the
+// `AdminUser` extractor would have already run — see `fake_admin` above.
+
+#[tokio::test]
+async fn get_admin_health_returns_500_when_db_is_unavailable() {
+    let (_app, state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_admin_health(AdminUser(fake_admin(1)), State(state)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary
- `server/src/backend/admin_health/tests.rs` covered 401 anonymous, 403 non-admin, and 200 admin — but not the handler's `Err(error) => internal("admin health report", error)` branch, so the 5xx path was untested (the same gap #1775/PR #1782 fixed for the sibling `admin_sessions` handler).
- Adds `get_admin_health_returns_500_when_db_is_unavailable` plus a `fake_admin` helper, invoking the handler directly with a hand-built `AdminUser` and a closed-pool `AppState` — routing through `oneshot` would trip the `AdminUser` extractor's own DB query first rather than exercising the handler's own error arm, per the pattern PR #1782 established for `admin_sessions`.

## Test plan
- [x] `cargo test -p omnibus admin_health` — 4 passed, 0 failed (401, 403, 200, and the new 500 test).

Closes #1784


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQAjLMLTEJqehG7NmQA7Z9)_