### PR TITLE
test: cover OPDS browse handlers' DB-failure paths

### DIFF
--- a/server/src/backend/opds/tests.rs
+++ b/server/src/backend/opds/tests.rs
@@ -986,6 +986,19 @@ async fn basic_auth_surfaces_an_account_lockout_as_403() {
 }
 
 #[tokio::test]
+async fn basic_auth_returns_500_when_the_pool_closes_during_credential_verification() {
+    // A closed pool must surface as a 5xx during `verify_login`, not
+    // silently fall through to an anonymous 401 challenge.
+    let (app, pool, _token) = fixture().await;
+    pool.close().await;
+    let res = app
+        .oneshot(get_with_basic("/opds", "basic-reader", "opds-basic-pass-1"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
 async fn bearer_sessions_still_authenticate_after_the_basic_fallback_landed() {
     // AC3 (#1805): the session path is tried first and unchanged — a valid
     // bearer token must not be affected by the Basic fallback.
@@ -1287,6 +1300,34 @@ async fn all_books_rejects_a_malformed_cursor() {
 }
 
 #[tokio::test]
+async fn all_books_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = all::all_books(
+        fake_opds_user(),
+        State(state),
+        Query(all::AllQuery { cursor: None }),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn v2_all_books_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = json_all::all_books(
+        fake_opds_user(),
+        State(state),
+        Query(all::AllQuery { cursor: None }),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
 async fn atom_series_browse_matches_the_json_catalog() {
     // AC3 (#1812): the Atom series browse serves the same series and
     // members as the /opds/v2 equivalent it reaches parity with.
@@ -1341,6 +1382,24 @@ async fn atom_series_browse_matches_the_json_catalog() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn series_index_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = series::index(fake_opds_user(), State(state)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn series_acquisition_feed_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = series::acquisition_feed(fake_opds_user(), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 // ---------------------------------------------------------------- Shelves
@@ -1500,4 +1559,40 @@ async fn shelf_feeds_exclude_non_ebook_library_members() {
         );
     }
     let _ = token;
+}
+
+#[tokio::test]
+async fn shelves_index_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = shelves::index(fake_opds_user(), State(state)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn shelves_acquisition_feed_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = shelves::acquisition_feed(fake_opds_user(), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn v2_shelves_index_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = json_shelves::index(fake_opds_user(), State(state)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn v2_shelves_acquisition_feed_returns_500_when_the_pool_is_closed() {
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+    let res = json_shelves::acquisition_feed(fake_opds_user(), State(state), Path(1)).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary
- Closes #1828
- Adds closed-pool 500 tests for the `Err(e) => internal(...)` branch of the OPDS All Books, Series, and Shelves browse handlers (Atom + JSON `/opds/v2/*` siblings), none of which had DB-failure-path coverage:
  - `all::all_books` / `json_all::all_books`
  - `series::index` / `series::acquisition_feed`
  - `shelves::index` / `shelves::acquisition_feed`
  - `json_shelves::index` / `json_shelves::acquisition_feed`
- Adds a router-level test for `auth::basic::OpdsAuthUser`'s DB-error branch during Basic Auth credential verification, confirming a closed pool surfaces as `500` (via `verify_login`) rather than falling through to an anonymous 401.
- Test-only change; no production code touched.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — 806 passed, 2 pre-existing unrelated failures (`backend::uploads::tests::{commit_rejects_read_only_library_with_400,audiobook_commit_rejects_read_only_library_with_400}` — these simulate a read-only library via `chmod 0o555`, which the root user in this sandbox ignores; confirmed unrelated by re-running the full suite with just those two skipped: 806 passed, 0 failed)

## Version
- [x] **Patch** — the default; leaving unlabeled (test-only change)

## Notes
- None of the nine new tests touch production code — `server/src/backend/opds/tests.rs` is the only file changed, and it stays well under the file's pre-existing size (no restructuring, per the issue's explicit note).
- `json_series.rs`'s `Err` branch is not covered here — it shipped in an earlier PR (predating #1809/#1814-#1816) and isn't in #1828's evidence list; it may be a candidate for #1774 instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1iq7F7VRQV3mx28EWDuAC)_