### PR TITLE
test: cover view_prefs load_last/save positive paths

### DIFF
--- a/frontend/src/client_store.rs
+++ b/frontend/src/client_store.rs
@@ -77,6 +77,8 @@ mod mobile_store {
     /// target) so a crash mid-write can't leave a half-written `prefs.json`
     /// that fails to parse on next launch and drops every stored pref.
     pub fn set(key: &str, value: &str) {
+        #[cfg(test)]
+        SET_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let snapshot = {
             let Ok(mut m) = map().write() else {
                 return;
@@ -91,6 +93,24 @@ mod mobile_store {
                 tracing::warn!(error = %e, path = %path.display(), "could not persist client prefs");
             }
         }
+    }
+
+    /// Test-only count of [`set`] calls, so a caller-level test can observe a
+    /// dedup-write skip (a call that never reaches this module) without
+    /// reaching into the private map itself.
+    #[cfg(test)]
+    pub(super) static SET_CALLS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    /// Test-only reset: empties the map and zeroes the call counter, so each
+    /// test starts from a clean slate despite sharing this process-global
+    /// store.
+    #[cfg(test)]
+    pub(super) fn reset_for_test() {
+        if let Ok(mut m) = map().write() {
+            m.clear();
+        }
+        SET_CALLS.store(0, std::sync::atomic::Ordering::SeqCst);
     }
 
     #[cfg(test)]
@@ -111,6 +131,22 @@ mod mobile_store {
             assert!(parse_map("[1,2,3]").is_empty());
         }
     }
+}
+
+/// Test-only: reset the mobile backend's in-memory map and [`set`] call
+/// counter. Exposed at module scope so cross-file test modules (e.g.
+/// [`crate::view_prefs`]'s) can reach it without `mobile_store` itself being
+/// `pub`.
+#[cfg(all(test, feature = "mobile"))]
+pub fn reset_for_test() {
+    mobile_store::reset_for_test();
+}
+
+/// Test-only: total number of [`set`] calls the mobile backend has serviced
+/// since the last [`reset_for_test`].
+#[cfg(all(test, feature = "mobile"))]
+pub fn set_call_count_for_test() -> usize {
+    mobile_store::SET_CALLS.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 #[cfg(feature = "mobile")]

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -71,6 +71,96 @@ pub fn load_last() -> Option<ViewPrefs> {
     last_library().map(|path| load(&path))
 }
 
+// Mobile tests — the only non-wasm target where `client_store` actually
+// persists, so it's the only place `load_last`'s positive path and `save`'s
+// dedup-write skip can be exercised without a browser. The mobile backend is
+// one process-global map flushed to a file under `$HOME` (`client_store.rs`),
+// so tests serialize on `TEST_GUARD` and reset it between cases rather than
+// touching a developer's real `$HOME/.omnibus`.
+#[cfg(all(test, feature = "mobile"))]
+mod mobile_tests {
+    use super::*;
+    use omnibus_shared::{SortDir, SortKey, ViewFilters, ViewMode};
+    use std::sync::Mutex;
+
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Run `f` with `$HOME` redirected to a scratch dir and the mobile store
+    /// reset, so the mobile backend's disk flush (`client_store.rs`) lands in
+    /// a throwaway location instead of a developer's real `~/.omnibus`.
+    /// Nothing else in this crate reads or writes `$HOME` under `test`, so
+    /// this is safe alongside `TEST_GUARD` serializing the map/call-counter
+    /// state that lives independently of the env var.
+    fn with_isolated_store(f: impl FnOnce()) {
+        let scratch = tempfile::tempdir().expect("tempdir for isolated client_store");
+        let prior_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", scratch.path());
+        crate::client_store::reset_for_test();
+
+        f();
+
+        crate::client_store::reset_for_test();
+        match prior_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    fn sample_prefs() -> ViewPrefs {
+        ViewPrefs {
+            view_mode: ViewMode::Table,
+            sort_key: SortKey::Author,
+            sort_dir: SortDir::Desc,
+            filters: ViewFilters {
+                formats: vec!["epub".into()],
+                ..Default::default()
+            },
+            filters_open: true,
+        }
+    }
+
+    #[test]
+    fn load_last_returns_the_saved_prefs_after_save_records_the_pointer() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        with_isolated_store(|| {
+            assert_eq!(last_library(), None);
+            assert_eq!(load_last(), None);
+
+            let prefs = sample_prefs();
+            save("/library/a", &prefs);
+
+            assert_eq!(last_library(), Some("/library/a".to_string()));
+            assert_eq!(load_last(), Some(prefs));
+        });
+    }
+
+    #[test]
+    fn save_skips_the_pointer_write_when_the_library_already_matches() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        with_isolated_store(|| {
+            // First save for this library: the pointer is unset, so it names
+            // "/library/a" and also writes the pointer — two underlying
+            // `client_store::set` calls (the per-library record, then the
+            // pointer).
+            save("/library/a", &ViewPrefs::default());
+            let calls_after_first = crate::client_store::set_call_count_for_test();
+            assert_eq!(calls_after_first, 2);
+
+            // Re-saving the same library — even with different prefs — must
+            // skip the pointer write, since it already names "/library/a".
+            // Only the per-library record write should land, so the call
+            // count grows by one, not two.
+            let updated = sample_prefs();
+            save("/library/a", &updated);
+            let calls_after_second = crate::client_store::set_call_count_for_test();
+            assert_eq!(calls_after_second - calls_after_first, 1);
+
+            assert_eq!(load("/library/a"), updated);
+            assert_eq!(last_library(), Some("/library/a".to_string()));
+        });
+    }
+}
+
 // SSR / server-only tests — exercise the no-persistence path that compiles
 // under the default `cargo test -p omnibus-frontend --features server`. The
 // `web`/`mobile` persistence lives in `client_store` behind its own cfgs and is

--- a/frontend/src/view_prefs.rs
+++ b/frontend/src/view_prefs.rs
@@ -85,25 +85,44 @@ mod mobile_tests {
 
     static TEST_GUARD: Mutex<()> = Mutex::new(());
 
+    /// RAII guard that restores `$HOME` and resets the mobile store on drop —
+    /// including on an unwind from a failed assertion inside `f`. Without
+    /// this, a panicking test would skip the restore and leave `$HOME`
+    /// pointed at a deleted tempdir plus a dirty process-global mobile store
+    /// for every later test in the same process.
+    struct IsolatedStoreGuard {
+        prior_home: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for IsolatedStoreGuard {
+        fn drop(&mut self) {
+            crate::client_store::reset_for_test();
+            match self.prior_home.take() {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
     /// Run `f` with `$HOME` redirected to a scratch dir and the mobile store
     /// reset, so the mobile backend's disk flush (`client_store.rs`) lands in
     /// a throwaway location instead of a developer's real `~/.omnibus`.
-    /// Nothing else in this crate reads or writes `$HOME` under `test`, so
-    /// this is safe alongside `TEST_GUARD` serializing the map/call-counter
-    /// state that lives independently of the env var.
+    /// `$HOME` is process-global and also read by `crate::data::app_dirs::data_dir`,
+    /// and tests can run in parallel within one process — callers must hold
+    /// `TEST_GUARD` for the duration. Cleanup runs via `IsolatedStoreGuard`'s
+    /// `Drop`, so it fires even if `f` panics — the panic still propagates
+    /// once unwinding drops the guard.
     fn with_isolated_store(f: impl FnOnce()) {
         let scratch = tempfile::tempdir().expect("tempdir for isolated client_store");
-        let prior_home = std::env::var_os("HOME");
+        let guard = IsolatedStoreGuard {
+            prior_home: std::env::var_os("HOME"),
+        };
         std::env::set_var("HOME", scratch.path());
         crate::client_store::reset_for_test();
 
         f();
 
-        crate::client_store::reset_for_test();
-        match prior_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
+        drop(guard);
     }
 
     fn sample_prefs() -> ViewPrefs {


### PR DESCRIPTION
## Summary
- Closes #1830
- `load_last()` and `save()`'s dedup-write skip (introduced in #1819) had no Rust unit coverage — only the SSR/`None` branch was tested, leaving the positive path exercised solely by the Playwright E2E spec.
- Add a `#[cfg(all(test, feature = "mobile"))]` test module in `frontend/src/view_prefs.rs` — the only non-wasm target where `client_store` actually persists — covering:
  - `load_last()` returning `Some(prefs)` with a matching pointer after a prior `save()`.
  - `save()`'s dedup-write skip: re-saving an already-current library issues exactly one fewer underlying `client_store::set` call than the first save (which must also write the pointer).
- `frontend/src/client_store.rs` gains a small `#[cfg(test)]`-only seam (`reset_for_test`, `set_call_count_for_test`, and a `SET_CALLS` counter inside `mobile_store`) so the dedup skip is externally observable and so tests reset the process-global mobile map instead of leaking state between cases. The new tests also redirect `$HOME` to a scratch tempdir for the duration of each test so they never touch a developer's real `~/.omnibus/prefs.json`. No production behavior changes — every addition is `#[cfg(test)]`-gated.
- Existing Playwright coverage in `persistence.spec.ts` is left as-is per the issue.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (729 passed; 0 failed)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features mobile -- -D warnings` — PASS (0 warnings; extra check since the new tests live behind this feature)
- [x] `cargo test -p omnibus-frontend --features mobile view_prefs` — PASS (2 passed: `load_last_returns_the_saved_prefs_after_save_records_the_pointer`, `save_skips_the_pointer_write_when_the_library_already_matches`)

## Version
- [ ] **Minor** — add the `minor version` label.
- [ ] **Patch** — the default; leaving unlabeled.
- [ ] **No release** — leaving version labeling to the maintainer/orchestrator to apply, per this PR's task constraints.

## Notes
- Test-only change; no production code paths altered.
