### PR TITLE
refactor: extract helpers to bring 11 functions under the 80-line cap

### DIFF
--- a/frontend/src/components/chip_editor.rs
+++ b/frontend/src/components/chip_editor.rs
@@ -161,10 +161,10 @@ fn use_chip_editor_state(autofocus: bool) -> ChipEditorState {
 #[component]
 pub fn ChipEditor(props: ChipEditorProps) -> Element {
     let ChipEditorState {
-        mut input,
-        mut highlight,
+        input,
+        highlight,
         focused,
-        mut suppress_open,
+        suppress_open,
         mut root_el,
     } = use_chip_editor_state(props.options.autofocus);
 
@@ -175,35 +175,16 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
     let on_change_remove = on_change;
     let on_close = props.on_close;
 
-    let mut commit = move |name: String| {
-        commit_chip(
-            name,
-            &mut values_sig,
-            &mut input,
-            &mut highlight,
-            &mut suppress_open,
-            &on_change,
-        );
-    };
-    let on_keydown = move |e: Event<KeyboardData>| {
-        dispatch_keydown(
-            e,
-            &selection_kd,
-            &mut input,
-            &mut highlight,
-            &mut commit,
-            &on_close,
-        );
-    };
-    let callbacks = build_input_area_callbacks(
+    let callbacks = build_callbacks(
+        values_sig,
         input,
         highlight,
         focused,
         suppress_open,
         root_el,
+        on_change,
         on_close,
-        on_keydown,
-        commit,
+        selection_kd,
     );
 
     rsx! {
@@ -241,6 +222,53 @@ pub fn ChipEditor(props: ChipEditorProps) -> Element {
             }
         }
     }
+}
+
+/// Build the `commit`/`on_keydown` closures from the editor's local signals
+/// and `selection`, then hand them to [`build_input_area_callbacks`] along
+/// with the remaining input-area signals.
+#[allow(clippy::too_many_arguments)]
+fn build_callbacks(
+    mut values_sig: Signal<Vec<String>>,
+    mut input: Signal<String>,
+    mut highlight: Signal<Option<usize>>,
+    focused: Signal<bool>,
+    mut suppress_open: Signal<bool>,
+    root_el: Signal<Option<ChipEditorRoot>>,
+    on_change: EventHandler<Vec<String>>,
+    on_close: EventHandler<()>,
+    selection: SelectionView,
+) -> ChipInputAreaCallbacks {
+    let mut commit = move |name: String| {
+        commit_chip(
+            name,
+            &mut values_sig,
+            &mut input,
+            &mut highlight,
+            &mut suppress_open,
+            &on_change,
+        );
+    };
+    let on_keydown = move |e: Event<KeyboardData>| {
+        dispatch_keydown(
+            e,
+            &selection,
+            &mut input,
+            &mut highlight,
+            &mut commit,
+            &on_close,
+        );
+    };
+    build_input_area_callbacks(
+        input,
+        highlight,
+        focused,
+        suppress_open,
+        root_el,
+        on_close,
+        on_keydown,
+        commit,
+    )
 }
 
 /// Assemble the input area's focus/blur/input/keydown/pick callbacks from


### PR DESCRIPTION
## Summary
- Closes #1765
- Re-verified all 11 functions listed in the issue against current line counts (they had shifted since filing). Per-function status:
  - `run_inner` (`frontend/src/offline/downloads/engine.rs`) — **already fixed**, now 66 lines (already split into `load_book`/`plan_for_format`/`prepare_files`/`run_downloads`).
  - `download_file` (`frontend/src/offline/downloads/engine.rs`) — **already fixed**, now 54 lines (already split into `send_ranged_request`/`write_body_to_part`).
  - `backfill_thumbs` (`db/src/indexer/backfill.rs`) — **already fixed**, now 46 lines (already split into `fetch_thumb_candidates`/`is_any_thumb_stale`/`regenerate_thumbs`).
  - `put_state` (`server/src/backend/kobo/state.rs`) — **already fixed**, now 28 lines (already split into `apply_reading_state_entry`).
  - `ChipEditor` (`frontend/src/components/chip_editor.rs`) — **fixed in this PR**, was 83 lines, now 64. Extracted a `build_callbacks` helper (mirrors the existing `build_input_area_callbacks` split) that assembles the `commit`/`on_keydown` closures.
  - `SpOverlay` (`frontend/src/components/search_palette/overlay.rs`) — **already fixed**, now 69 lines (already split into `build_overlay_wiring`).
  - `QuoteCardPanel` (`frontend/src/components/quote_card.rs`) — **already fixed**, now 37 lines.
  - `execute` (`db/src/worker/handlers.rs`) — **left as the defensible exception** the issue calls out. It's 121 lines but is already a clean one-arm-per-`Task`-variant flat match, with every arm delegating to a per-kind helper/handler method (`anyhow_outcome`, `kindle_outcome`, `kepub_outcome`, `self.handle_*`). Splitting the match itself (e.g. into two matches by category) would reduce cohesion — a reader loses the ability to see "every task kind, in one place" — without making any individual arm clearer. Judged not worth the split.
  - `move_progress_and_history` (`db/src/merge/transaction.rs`) — **already fixed**, now 49 lines.
  - `extract_metadata` (`db/src/ebook/parse.rs`) — **already fixed**, now 45 lines.
  - `Cover` (`frontend/src/components/atrium.rs`) — **already fixed**, now 62 lines.
- Pure mechanical refactor — no behavior change. The only file touched is `frontend/src/components/chip_editor.rs`.

## Test plan
- [x] `cargo fmt --check` — PASS (no diff)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (clean)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (729 passed; 0 failed)
- [x] Manually re-read the current line count of all 11 functions listed in the issue before making any change, per the issue's "re-verify current line numbers before starting" instruction.
- No new tests added (pure mechanical extraction of an existing closure-building block into a named helper); existing `ChipEditor`/`chip_editor` module tests continue to pass under the new `build_callbacks` helper.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- `db/` and `server/` were not touched (all functions in those crates were already under the cap), so only `omnibus-frontend` needed lint/test verification.
- Dev environment note: the shared build node was under severe, transient disk pressure from concurrent sibling worktree builds during this session (repeatedly hit `No space left on device` on `cargo build`/`clippy`/`test`); all commands above were eventually run to completion and PASS once disk headroom recovered. Not a code issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1iq7F7VRQV3mx28EWDuAC)_