### PR TITLE
refactor: extract helpers to bring 17 page functions under the 80-line cap (#1721)

### DIFF
--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -235,7 +235,7 @@ pub(super) fn BdJournalEntryCard(
         error: use_signal(|| None::<String>),
         reload,
     };
-    let mut expanded = use_signal(|| false);
+    let expanded = use_signal(|| false);
     let editing = edit.editing;
     let error = edit.error;
 
@@ -282,24 +282,43 @@ pub(super) fn BdJournalEntryCard(
                     edit,
                 }
             } else {
-                div {
-                    class: "{body_class}",
-                    dangerous_inner_html: "{entry.body_html}",
-                }
-                if can_expand && !expanded() {
-                    button {
-                        r#type: "button",
-                        class: "btn ghost sm bd-journal-show-more",
-                        "data-testid": "journal-show-more",
-                        "aria-expanded": "{expanded()}",
-                        onclick: move |_| expanded.set(true),
-                        "Show more \u{2193}"
-                    }
-                }
-                if let Some(msg) = error() {
-                    span { class: "mono bd-journal-error", role: "alert", "{msg}" }
+                BdJournalEntryBody {
+                    body_html: entry.body_html.clone(),
+                    body_class: body_class.to_string(),
+                    can_expand,
+                    expanded,
+                    error: error(),
                 }
             }
+        }
+    }
+}
+
+/// Rendered markdown body + "Show more" toggle + inline error, extracted
+/// from [`BdJournalEntryCard`] to keep it under the line cap. Rendered only
+/// when the entry isn't in edit mode.
+#[component]
+fn BdJournalEntryBody(
+    body_html: String,
+    body_class: String,
+    can_expand: bool,
+    mut expanded: Signal<bool>,
+    error: Option<String>,
+) -> Element {
+    rsx! {
+        div { class: "{body_class}", dangerous_inner_html: "{body_html}" }
+        if can_expand && !expanded() {
+            button {
+                r#type: "button",
+                class: "btn ghost sm bd-journal-show-more",
+                "data-testid": "journal-show-more",
+                "aria-expanded": "{expanded()}",
+                onclick: move |_| expanded.set(true),
+                "Show more \u{2193}"
+            }
+        }
+        if let Some(msg) = error {
+            span { class: "mono bd-journal-error", role: "alert", "{msg}" }
         }
     }
 }

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -284,7 +284,7 @@ pub(super) fn BdJournalEntryCard(
             } else {
                 BdJournalEntryBody {
                     body_html: entry.body_html.clone(),
-                    body_class: body_class.to_string(),
+                    body_class,
                     can_expand,
                     expanded,
                     error: error(),
@@ -300,7 +300,7 @@ pub(super) fn BdJournalEntryCard(
 #[component]
 fn BdJournalEntryBody(
     body_html: String,
-    body_class: String,
+    body_class: &'static str,
     can_expand: bool,
     mut expanded: Signal<bool>,
     error: Option<String>,

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -71,33 +71,12 @@ pub(super) fn LandingHeader(
                 }
             }
             div { class: "lib-header-row",
-                div { class: "lib-header-title-wrap",
-                    p { class: "lib-header-title", "data-testid": "lib-section-title",
-                        em { "{section_title}" }
-                        span { class: "lib-header-count",
-                            " · {book_count} "
-                            if book_count == 1 { "book" } else { "books" }
-                        }
-                        // The receipt: hidden books must never look like
-                        // data loss, so the exclusion always shows its count.
-                        if let Some(n) = hidden_count.filter(|n| *n > 0) {
-                            span {
-                                class: "lib-header-hidden",
-                                "data-testid": "lib-hidden-count",
-                                " · {n} hidden"
-                            }
-                        }
-                    }
-                    if can_edit {
-                        button {
-                            r#type: "button",
-                            class: "shelf-edit-btn",
-                            "data-testid": "shelf-edit",
-                            "aria-label": "Edit shelf",
-                            onclick: move |_| on_edit_shelf.call(()),
-                            {pencil_glyph()}
-                        }
-                    }
+                LandingHeaderTitleRow {
+                    section_title,
+                    book_count,
+                    hidden_count,
+                    can_edit,
+                    on_edit_shelf,
                 }
                 Toolbar {
                     prefs: prefs,
@@ -107,20 +86,75 @@ pub(super) fn LandingHeader(
             if let Some(shelf) = selected_shelf.as_ref() {
                 ShelfFacets { shelf: shelf.clone() }
             }
-            if path_missing {
-                p { class: "lib-header-hint",
-                    "Configure your ebook library path in Settings."
+            LandingHeaderMessages { path_missing, page_error, lib_err }
+        }
+    }
+}
+
+/// Section title + book count + hidden-formats receipt + the shelf edit
+/// pencil, extracted from [`LandingHeader`] to keep it under the line cap.
+#[component]
+fn LandingHeaderTitleRow(
+    section_title: String,
+    book_count: usize,
+    hidden_count: Option<i64>,
+    can_edit: bool,
+    on_edit_shelf: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div { class: "lib-header-title-wrap",
+            p { class: "lib-header-title", "data-testid": "lib-section-title",
+                em { "{section_title}" }
+                span { class: "lib-header-count",
+                    " · {book_count} "
+                    if book_count == 1 { "book" } else { "books" }
+                }
+                // The receipt: hidden books must never look like data loss,
+                // so the exclusion always shows its count.
+                if let Some(n) = hidden_count.filter(|n| *n > 0) {
+                    span {
+                        class: "lib-header-hidden",
+                        "data-testid": "lib-hidden-count",
+                        " · {n} hidden"
+                    }
                 }
             }
-            if let Some(msg) = page_error.as_ref() {
-                // Tagged because a failed shelf-member fetch and a genuinely
-                // empty shelf both render an empty grid — this banner is the
-                // only thing that tells them apart.
-                p { class: "error", "data-testid": "lib-page-error", "⚠ {msg}" }
+            if can_edit {
+                button {
+                    r#type: "button",
+                    class: "shelf-edit-btn",
+                    "data-testid": "shelf-edit",
+                    "aria-label": "Edit shelf",
+                    onclick: move |_| on_edit_shelf.call(()),
+                    {pencil_glyph()}
+                }
             }
-            if let Some(msg) = lib_err.as_ref() {
-                p { class: "error", "⚠ {msg}" }
+        }
+    }
+}
+
+/// Path-missing hint + page-level + library-path error banners, extracted
+/// from [`LandingHeader`] to keep it under the line cap.
+#[component]
+fn LandingHeaderMessages(
+    path_missing: bool,
+    page_error: Option<String>,
+    lib_err: Option<String>,
+) -> Element {
+    rsx! {
+        if path_missing {
+            p { class: "lib-header-hint",
+                "Configure your ebook library path in Settings."
             }
+        }
+        if let Some(msg) = page_error.as_ref() {
+            // Tagged because a failed shelf-member fetch and a genuinely
+            // empty shelf both render an empty grid — this banner is the
+            // only thing that tells them apart.
+            p { class: "error", "data-testid": "lib-page-error", "⚠ {msg}" }
+        }
+        if let Some(msg) = lib_err.as_ref() {
+            p { class: "error", "⚠ {msg}" }
         }
     }
 }

--- a/frontend/src/pages/landing/signals.rs
+++ b/frontend/src/pages/landing/signals.rs
@@ -219,21 +219,44 @@ struct ShelfWiring {
 /// suggestion-pool refetch, page-1 fetch on sort/filter/query change, the
 /// load-more append + web scroll observer, and the two-stage prefs hydration
 /// (last-browsed library on mount, then the authoritative path once a fetch
-/// resolves it).
+/// resolves it). Each stage is a named helper below so this stays a plain
+/// sequence of calls.
 #[allow(clippy::too_many_arguments)] // one bundle per pipeline; splitting further hides the wiring
 fn wire_landing_effects(
     server_url: &str,
     query: Signal<String>,
-    mut prefs: Signal<ViewPrefs>,
+    prefs: Signal<ViewPrefs>,
     want_more: Signal<u32>,
     is_admin: ReadSignal<bool>,
     pools: SuggestionPools,
     fetch_sigs: FetchSignals,
     shelf_wiring: ShelfWiring,
-    mut bulk_selected: Signal<BTreeSet<String>>,
+    bulk_selected: Signal<BTreeSet<String>>,
 ) {
     spawn_suggestion_pools_effect(server_url.to_string(), is_admin, pools);
 
+    let fetch_key = wire_page_fetch_effects(server_url, query, prefs, want_more, fetch_sigs);
+    wire_bulk_selection_clear(fetch_key, shelf_wiring.selection, bulk_selected);
+    wire_prefs_hydration(prefs, fetch_sigs);
+    wire_shelf_effects(server_url, prefs, shelf_wiring);
+}
+
+/// Refetches page 1 on query/sort/filter/hidden-formats change and arms the
+/// load-more append (plus the web scroll observer). Returns the `fetch_key`
+/// memo so the caller can also key the bulk-selection-clear effect on it.
+fn wire_page_fetch_effects(
+    server_url: &str,
+    query: Signal<String>,
+    prefs: Signal<ViewPrefs>,
+    want_more: Signal<u32>,
+    fetch_sigs: FetchSignals,
+) -> Memo<(
+    String,
+    omnibus_shared::SortKey,
+    omnibus_shared::SortDir,
+    omnibus_shared::ViewFilters,
+    Vec<String>,
+)> {
     // The viewer's hidden-formats pref, canonical order. Starts empty until
     // `/me` resolves (or on SSR), so the very first fetch may run without the
     // exclusion — the memo change then triggers exactly one refetch.
@@ -273,21 +296,37 @@ fn wire_landing_effects(
     #[cfg(feature = "web")]
     spawn_load_more_observer(fetch_sigs.next_cursor);
 
-    // Drop the bulk-edit selection whenever the visible list changes
-    // wholesale — a refetch (query/sort/filter change) or a gallery pick.
-    // Checked rows that are no longer rendered would otherwise be edited
-    // invisibly from a stale selection.
-    let selection_for_bulk = shelf_wiring.selection;
+    fetch_key
+}
+
+/// Drops the bulk-edit selection whenever the visible list changes wholesale
+/// — a refetch (query/sort/filter change) or a gallery pick. Checked rows
+/// that are no longer rendered would otherwise be edited invisibly from a
+/// stale selection.
+fn wire_bulk_selection_clear(
+    fetch_key: Memo<(
+        String,
+        omnibus_shared::SortKey,
+        omnibus_shared::SortDir,
+        omnibus_shared::ViewFilters,
+        Vec<String>,
+    )>,
+    selection: Signal<ShelfSelection>,
+    mut bulk_selected: Signal<BTreeSet<String>>,
+) {
     use_effect(move || {
         let _ = fetch_key();
-        let _ = selection_for_bulk();
+        let _ = selection();
         if !bulk_selected.peek().is_empty() {
             bulk_selected.write().clear();
         }
     });
+}
 
-    // Hydrate prefs from the last-browsed library *before* page 1 goes out, so
-    // the grid's first paint is already in the viewer's sort order (#1818).
+/// Two-stage view-prefs hydration: the last-browsed library on mount (so the
+/// grid's first paint is already sorted, #1818), then the authoritative path
+/// once a fetch reveals it (covering the pointer having guessed wrong).
+fn wire_prefs_hydration(mut prefs: Signal<ViewPrefs>, fetch_sigs: FetchSignals) {
     // Reads nothing reactively, so it runs exactly once after mount — and
     // `prefs_ready` flips either way, since a first-ever visit has no pointer
     // and must still proceed on the defaults rather than never fetching.
@@ -315,7 +354,12 @@ fn wire_landing_effects(
             }
         }
     });
+}
 
+/// Arms the shelf-gallery + hero effects: the shelves list, the hero feed,
+/// the selected shelf's full detail, its member list, and the one-time
+/// reconcile of a persisted gallery pick.
+fn wire_shelf_effects(server_url: &str, prefs: Signal<ViewPrefs>, shelf_wiring: ShelfWiring) {
     let ShelfWiring {
         mut selection,
         shelves,

--- a/frontend/src/pages/settings/users/modals.rs
+++ b/frontend/src/pages/settings/users/modals.rs
@@ -126,25 +126,18 @@ fn build_new_user_submit_handler(
     }
 }
 
-/// Edit-user modal: permission toggles + an optional password reset.
-#[component]
-pub(super) fn EditUserModal(
-    user: AdminUserRow,
-    on_close: EventHandler<()>,
+/// Builds the edit-user submit handler: saves permissions, then (if a new
+/// password was entered) resets it, mirroring
+/// [`build_new_user_submit_handler`]'s shape.
+fn build_edit_user_submit_handler(
+    uid: i64,
+    perms: Signal<UserPermissions>,
+    new_password: Signal<String>,
+    mut error: Signal<Option<String>>,
+    mut saving: Signal<bool>,
     on_saved: EventHandler<()>,
-) -> Element {
-    let uid = user.id;
-    let perms = use_signal(|| UserPermissions {
-        is_admin: user.is_admin,
-        can_upload: user.can_upload,
-        can_edit: user.can_edit,
-        can_download: user.can_download,
-    });
-    let mut new_password = use_signal(String::new);
-    let mut error = use_signal(|| None::<String>);
-    let mut saving = use_signal(|| false);
-
-    let submit = move |evt: Event<FormData>| {
+) -> impl FnMut(Event<FormData>) + 'static {
+    move |evt: Event<FormData>| {
         evt.prevent_default();
         if saving() {
             return;
@@ -169,7 +162,27 @@ pub(super) fn EditUserModal(
             on_saved.call(());
             saving.set(false);
         });
-    };
+    }
+}
+
+/// Edit-user modal: permission toggles + an optional password reset.
+#[component]
+pub(super) fn EditUserModal(
+    user: AdminUserRow,
+    on_close: EventHandler<()>,
+    on_saved: EventHandler<()>,
+) -> Element {
+    let uid = user.id;
+    let perms = use_signal(|| UserPermissions {
+        is_admin: user.is_admin,
+        can_upload: user.can_upload,
+        can_edit: user.can_edit,
+        can_download: user.can_download,
+    });
+    let mut new_password = use_signal(String::new);
+    let mut error = use_signal(|| None::<String>);
+    let saving = use_signal(|| false);
+    let submit = build_edit_user_submit_handler(uid, perms, new_password, error, saving, on_saved);
 
     let pw = new_password();
     let show_meter = !pw.is_empty();


### PR DESCRIPTION
## Summary
- Closes #1721.
- The issue's original 17 functions were all **already fixed** — PR #1735 (merged 2026-08-07) resolved them, before this session ever started work. Verified by brace-matched function-boundary scan against current `main`; all 17 are at or well under 80 lines.
- The issue was subsequently **reopened** with fresh evidence: a follow-up spot-check found 4 functions in the same touched files that PR #1735's sweep missed (same root cause — files rewritten by that PR but these particular functions weren't split). This PR fixes those 4, per the issue's updated acceptance criteria:
  - `frontend/src/pages/landing/signals.rs::wire_landing_effects` (150 lines → split into `wire_page_fetch_effects`, `wire_bulk_selection_clear`, `wire_prefs_hydration`, `wire_shelf_effects`, each a named staged helper, consistent with AC3's "not rsx, split into constructor/wiring helpers" precedent already used elsewhere in the file).
  - `frontend/src/pages/landing/sections.rs::LandingHeader` (88 lines → extracted sibling `#[component]`s `LandingHeaderTitleRow` and `LandingHeaderMessages` for self-contained visual sections, mirroring the file's existing `BdCtaRow`-style pattern).
  - `frontend/src/pages/settings/users/modals.rs::EditUserModal` (82 lines → extracted `build_edit_user_submit_handler`, mirroring the file's own existing `build_new_user_submit_handler` for `NewUserModal`).
  - `frontend/src/pages/book_detail/journal/entry_card.rs::BdJournalEntryCard` (81 lines → extracted sibling `#[component]` `BdJournalEntryBody` for the non-editing rendered-body + show-more + inline-error section).
- Pure refactor — no behavior, render output, or markup-contract (roles/labels/testids) changes. No `#[cfg(feature = "web"/"mobile"/"server")]` gate was introduced around any rsx body (rule 07 hydration parity preserved).

## Per-function status

| Function | File | Status |
|---|---|---|
| `BdRatingWidget` | `book_detail/rating.rs` | already-fixed (57 lines on `main`) |
| `SelectionPopover` | `reader/selection.rs` | already-fixed (40 lines) |
| `UsersSection` | `settings/users/mod.rs` | already-fixed (42 lines) |
| `setup_landing_signals` | `landing/signals.rs` | already-fixed (46 lines) |
| `ShelvesIndexPage` | `shelves_index.rs` | already-fixed (57 lines) |
| `BdJournalSection` | `book_detail/journal.rs` | already-fixed (27 lines) |
| `Toolbar` | `landing/toolbar.rs` | already-fixed (12 lines) |
| `AuthorsIndexPage` | `authors_index.rs` | already-fixed (74 lines) |
| `BdJournalEntryHeader` | `book_detail/journal/entry_card.rs` | already-fixed (37 lines) |
| `RegisterPage` | `auth/register.rs` | already-fixed (53 lines) |
| `DockTransport` | `listen/mini_dock/transport.rs` | already-fixed (40 lines) |
| `ShelfDetailPage` | `shelf_detail/mod.rs` | already-fixed (65 lines) |
| `NewUserModal` | `settings/users/modals.rs` | already-fixed (34 lines) |
| `LandingContent` | `landing/sections.rs` | already-fixed (30 lines) |
| `MiniDock` | `listen/mini_dock/mod.rs` | already-fixed (31 lines) |
| `TitleSearch` | `check_in/search.rs` | already-fixed (23 lines) |
| `BookListenPage` | `listen.rs` | already-fixed (23 lines) |
| `wire_landing_effects` (reopened AC) | `landing/signals.rs` | **fixed-here** (150 → 46 lines; 4 new helpers) |
| `LandingHeader` (reopened AC) | `landing/sections.rs` | **fixed-here** (88 → ~40 lines; 2 sibling components) |
| `EditUserModal` (reopened AC) | `settings/users/modals.rs` | **fixed-here** (82 → ~40 lines; 1 named helper) |
| `BdJournalEntryCard` (reopened AC) | `book_detail/journal/entry_card.rs` | **fixed-here** (81 → ~55 lines; 1 sibling component) |

A repo-wide brace-depth scan of `frontend/src/pages/**` after this change turns up several *other* functions still over 80 lines (e.g. `ComicReadPage`, `SpeedPanelBody`, `ReaderLayout`, etc.) — these are outside the scope of both the original and reopened text of #1721 and are left untouched.

## Test plan
- [x] `cargo fmt --check` — PASS (clean)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (729 passed, 0 failed)

No new tests added per the mechanical-refactor guidance in rule 03/05 — existing render/interaction tests cover behavior and all pass unchanged.

## Version
- [x] **No release** — tech-debt refactor, no behavior change.

## Notes
- Disk space was healthy throughout (`df -h /` showed ~20G free at session start); no build interruptions from shared-disk pressure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1iq7F7VRQV3mx28EWDuAC)_