### PR TITLE
fix: cap list_users at LIST_USERS_LIMIT to match device/session siblings

### DIFF
--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -411,6 +411,12 @@ pub async fn registration_enabled(pool: &SqlitePool) -> AuthResult<bool> {
 
 // ── Admin user management (F5.4) ─────────────────────────────────────
 
+/// Hard cap on how many users `list_users` returns for the admin Users
+/// table. Matches `LIST_DEVICES_LIMIT`/`LIST_SESSIONS_LIMIT` — a defensive
+/// ceiling so a pathological user count can't produce an unbounded REST
+/// response; a real deployment is nowhere near this.
+pub const LIST_USERS_LIMIT: i64 = 1000;
+
 /// Map a `users` row to the admin-table [`AdminUserRow`] projection,
 /// resolving `locked` against `now` (a `locked_until` in the past is not a
 /// live lockout).
@@ -430,15 +436,16 @@ fn row_to_admin_user(row: &sqlx::sqlite::SqliteRow, now: i64) -> AdminUserRow {
     }
 }
 
-/// List every user for the admin Users table, oldest first. Returns the
-/// safe [`AdminUserRow`] projection (no password material) with per-row
-/// created time and live locked state.
+/// List every user for the admin Users table, oldest first, up to
+/// [`LIST_USERS_LIMIT`]. Returns the safe [`AdminUserRow`] projection (no
+/// password material) with per-row created time and live locked state.
 pub async fn list_users(pool: &SqlitePool) -> AuthResult<Vec<AdminUserRow>> {
     let rows = sqlx::query(
         "SELECT id, username, is_admin, can_upload, can_edit, can_download,
                 kindle_email, display_name, created_at, locked_until
-         FROM users ORDER BY created_at ASC, id ASC",
+         FROM users ORDER BY created_at ASC, id ASC LIMIT ?",
     )
+    .bind(LIST_USERS_LIMIT)
     .fetch_all(pool)
     .await?;
     let now = now_unix();

--- a/db/src/auth/users.rs
+++ b/db/src/auth/users.rs
@@ -436,7 +436,7 @@ fn row_to_admin_user(row: &sqlx::sqlite::SqliteRow, now: i64) -> AdminUserRow {
     }
 }
 
-/// List every user for the admin Users table, oldest first, up to
+/// List users for the admin Users table, oldest first, capped at
 /// [`LIST_USERS_LIMIT`]. Returns the safe [`AdminUserRow`] projection (no
 /// password material) with per-row created time and live locked state.
 pub async fn list_users(pool: &SqlitePool) -> AuthResult<Vec<AdminUserRow>> {

--- a/db/src/auth/users/tests.rs
+++ b/db/src/auth/users/tests.rs
@@ -1,9 +1,30 @@
 //! Tests for user account management: first-user admin promotion and
 //! registration lockout, username collision/validation, password changes
-//! (including session revocation on change), and the admin user projection.
+//! (including session revocation on change), and the admin user projection
+//! (including its `LIST_USERS_LIMIT` response ceiling).
 
 use super::*;
 use crate::auth::test_support::pool;
+
+/// Bulk-insert `count` user rows without going through `create_user` /
+/// `admin_create_user` — used only to exercise `list_users`'s
+/// `LIST_USERS_LIMIT` in isolation, well above what a real registration
+/// flow would ever populate in a test.
+async fn seed_users_raw(pool: &SqlitePool, count: i64) {
+    sqlx::query(
+        r"
+        WITH RECURSIVE n(i) AS (
+            SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?
+        )
+        INSERT INTO users (username, password_hash, created_at)
+        SELECT 'bulk-user-' || i, 'not-a-real-hash', i FROM n
+        ",
+    )
+    .bind(count)
+    .execute(pool)
+    .await
+    .unwrap();
+}
 
 #[tokio::test]
 async fn first_user_is_admin_and_disables_registration() {
@@ -409,6 +430,22 @@ async fn list_users_returns_projection_ordered_oldest_first() {
     assert_eq!(rows[1].id, reader.id);
     assert!(!rows[1].is_admin);
     assert!(rows[1].can_download && !rows[1].can_upload);
+}
+
+/// `list_users` must not return more than `LIST_USERS_LIMIT` rows even when
+/// the underlying table holds more.
+#[tokio::test]
+async fn list_users_caps_response_at_list_users_limit() {
+    let p = pool().await;
+    let over_cap = LIST_USERS_LIMIT + 50;
+    seed_users_raw(&p, over_cap).await;
+
+    let rows = list_users(&p).await.unwrap();
+    assert_eq!(
+        rows.len() as i64,
+        LIST_USERS_LIMIT,
+        "list_users must not return more than LIST_USERS_LIMIT rows",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `db::auth::list_users` (backing `GET /api/users`) selected every row from `users` with no `LIMIT`, unlike its siblings `list_devices_for_user` / `list_sessions_for_user`, which are both capped and tested for it.
- Added `LIST_USERS_LIMIT` (1000, generous — a real deployment is nowhere near this) following the `LIST_DEVICES_LIMIT`/`LIST_SESSIONS_LIMIT` naming convention, and bound the `list_users` query to it.
- Closes #1838

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (handler in `server/src/backend/users.rs` needed no changes; its call to `list_users` is unaffected)
- [x] `cargo test -p omnibus-db` — PASS (1958 passed, 1 unrelated pre-existing failure from missing local audiobook test fixtures — `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, requires `just fixtures`, unaffected by this change)
- [x] New test `list_users_caps_response_at_list_users_limit` in `db/src/auth/users/tests.rs`, mirroring `list_devices_for_user_caps_response_at_list_devices_limit` / `list_sessions_for_user_caps_response_at_list_sessions_limit` — PASS

## Version
- [x] **Patch** — left unlabeled (default)

## Notes
- Surgical change: only `db/src/auth/users.rs` and its sibling `db/src/auth/users/tests.rs` touched. The REST handler in `server/src/backend/users.rs` needed no changes since `list_users`'s signature is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_015k7w9BnhXw3vif6EfrzZQi)_