### PR TITLE
refactor: batch Kobo annotation ingest upserts and deletes (#1837)

### DIFF
--- a/db/src/annotations/mod.rs
+++ b/db/src/annotations/mod.rs
@@ -5,7 +5,7 @@
 //! `*_kobo_annotations` functions.
 
 use omnibus_shared::{CreateHighlight, Highlight, HighlightColor};
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
 use crate::resolve_canonical_book_uuid;
 
@@ -361,6 +361,17 @@ pub async fn served_kobo_annotations_batch(
     Ok(out)
 }
 
+/// Bound-parameter-safe chunk size for the upsert VALUES batch: 8 binds per
+/// row keeps each chunked statement's total well under SQLite's ~999
+/// bound-parameter cap (120 * 8 = 960), mirroring the chunking pattern in
+/// `metadata_overrides::upsert::load_overrides_bulk`.
+const UPSERT_CHUNK_SIZE: usize = 120;
+
+/// Bound-parameter-safe chunk size for the delete `IN (...)` batch: one bind
+/// for `user_id` plus one per client_id keeps each chunked statement well
+/// under SQLite's ~999 bound-parameter cap.
+const DELETE_CHUNK_SIZE: usize = 500;
+
 /// Apply one device PATCH: upsert `updates` (keyed on the device-minted id in
 /// `client_id` — a re-upload updates color/note/text/anchor in place, so
 /// replays are idempotent) and delete `deleted_client_ids`, in one
@@ -378,15 +389,34 @@ pub async fn ingest_kobo_annotations(
         .ok_or(HighlightError::BookNotFound)?;
 
     let mut tx = pool.begin().await.map_err(HighlightError::Sqlx)?;
-    for a in updates {
+    upsert_kobo_annotations(&mut tx, user_id, &canonical, updates).await?;
+    delete_kobo_annotations(&mut tx, user_id, deleted_client_ids).await?;
+    tx.commit().await.map_err(HighlightError::Sqlx)?;
+    Ok(())
+}
+
+/// Chunked multi-row upsert for a device PATCH's `updates` batch, in place of
+/// one `INSERT ... ON CONFLICT` per row.
+async fn upsert_kobo_annotations(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    canonical_book_uuid: &str,
+    updates: &[IngestKoboAnnotation],
+) -> Result<(), HighlightError> {
+    for chunk in updates.chunks(UPSERT_CHUNK_SIZE) {
+        let rows = std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
         // The CFI conflict rule keeps the stored web anchor truthful: a
         // moved kobo_location takes the fresh derivation even when it's
         // NULL (a stale CFI is a wrong location), while an unmoved anchor
-        // keeps an existing CFI over a derivation that merely failed.
-        sqlx::query(
+        // keeps an existing CFI over a derivation that merely failed. Each
+        // conflicting row in the batch resolves this independently against
+        // its own `excluded.*` values.
+        let sql = format!(
             "INSERT INTO annotations
                  (user_id, book_uuid, epub_cfi_range, kobo_location, color, note, text, client_id)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             VALUES {rows}
              ON CONFLICT(user_id, client_id) WHERE client_id IS NOT NULL DO UPDATE SET
                  epub_cfi_range = CASE
                      WHEN annotations.kobo_location IS NOT excluded.kobo_location
@@ -397,27 +427,44 @@ pub async fn ingest_kobo_annotations(
                  color = excluded.color,
                  note = excluded.note,
                  text = excluded.text,
-                 updated_at = strftime('%s','now')",
-        )
-        .bind(user_id)
-        .bind(&canonical)
-        .bind(a.epub_cfi_range.as_deref())
-        .bind(&a.kobo_location)
-        .bind(a.color.as_str())
-        .bind(a.note.as_deref())
-        .bind(a.text.as_deref())
-        .bind(&a.client_id)
-        .execute(&mut *tx)
-        .await?;
+                 updated_at = strftime('%s','now')"
+        );
+        let mut q = sqlx::query(&sql);
+        for a in chunk {
+            q = q
+                .bind(user_id)
+                .bind(canonical_book_uuid)
+                .bind(a.epub_cfi_range.as_deref())
+                .bind(&a.kobo_location)
+                .bind(a.color.as_str())
+                .bind(a.note.as_deref())
+                .bind(a.text.as_deref())
+                .bind(&a.client_id);
+        }
+        q.execute(&mut **tx).await?;
     }
-    for client_id in deleted_client_ids {
-        sqlx::query("DELETE FROM annotations WHERE user_id = ? AND client_id = ?")
-            .bind(user_id)
-            .bind(client_id)
-            .execute(&mut *tx)
-            .await?;
+    Ok(())
+}
+
+/// Chunked `DELETE ... WHERE client_id IN (...)` for a device PATCH's
+/// `deleted_client_ids` batch, in place of one `DELETE` per row.
+async fn delete_kobo_annotations(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    deleted_client_ids: &[String],
+) -> Result<(), HighlightError> {
+    for chunk in deleted_client_ids.chunks(DELETE_CHUNK_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql =
+            format!("DELETE FROM annotations WHERE user_id = ? AND client_id IN ({placeholders})");
+        let mut q = sqlx::query(&sql).bind(user_id);
+        for client_id in chunk {
+            q = q.bind(client_id);
+        }
+        q.execute(&mut **tx).await?;
     }
-    tx.commit().await.map_err(HighlightError::Sqlx)?;
     Ok(())
 }
 

--- a/db/src/annotations/tests.rs
+++ b/db/src/annotations/tests.rs
@@ -685,6 +685,60 @@ async fn ingest_kobo_annotations_deletes_rows_by_device_minted_id() {
 }
 
 #[tokio::test]
+async fn ingest_kobo_annotations_applies_a_multi_row_batch_conflict_insert_and_delete_together() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+
+    // Pre-existing rows: kobo-1 will be updated in place, kobo-3 will be
+    // deleted, both inside the same batched call under test.
+    ingest_kobo_annotations(
+        &pool,
+        user,
+        &uuid,
+        &[
+            kobo_upload("kobo-1", HighlightColor::Amber, None),
+            kobo_upload("kobo-3", HighlightColor::Blue, None),
+        ],
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // One call carries a conflicting update (kobo-1), a fresh insert
+    // (kobo-2), and a delete (kobo-3) — exercising the chunked multi-row
+    // VALUES upsert and the IN (...) delete together.
+    let mut edited_kobo_1 = kobo_upload("kobo-1", HighlightColor::Violet, Some("edited"));
+    edited_kobo_1.text = Some("re-selected prose".into());
+    ingest_kobo_annotations(
+        &pool,
+        user,
+        &uuid,
+        &[
+            edited_kobo_1,
+            kobo_upload("kobo-2", HighlightColor::Green, None),
+        ],
+        &["kobo-3".to_string()],
+    )
+    .await
+    .unwrap();
+
+    let mut listed = list_highlights(&pool, user, &uuid).await.unwrap();
+    listed.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+    assert_eq!(listed.len(), 2, "kobo-3 deleted, kobo-1 and kobo-2 remain");
+    assert_eq!(listed[0].client_id.as_deref(), Some("kobo-1"));
+    assert_eq!(listed[0].color, HighlightColor::Violet);
+    assert_eq!(listed[0].note.as_deref(), Some("edited"));
+    assert_eq!(listed[0].text.as_deref(), Some("re-selected prose"));
+    assert_eq!(listed[1].client_id.as_deref(), Some("kobo-2"));
+    assert_eq!(listed[1].color, HighlightColor::Green);
+
+    let served = served_kobo_annotations(&pool, user, &uuid).await.unwrap();
+    assert_eq!(served.len(), 2);
+    assert!(served.iter().all(|s| s.client_id != "kobo-3"));
+}
+
+#[tokio::test]
 async fn ingest_kobo_annotations_returns_book_not_found_for_an_unknown_uuid() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "alice").await;


### PR DESCRIPTION
## Summary
- `ingest_kobo_annotations` upserted a device's annotation batch with one `INSERT ... ON CONFLICT` per row and one `DELETE` per row, sequentially inside a single `sqlx::Transaction`, instead of the chunked multi-row `INSERT ... VALUES (..),(..) ON CONFLICT` pattern already used by every sibling batch-write helper (`load_overrides_bulk`, `shelves/write.rs::insert_books`, `suggestions/data.rs::insert_suggestion_rows`, `normalize.rs::backfill_norm_columns`).
- Bounded at 500 rows/PATCH (`MAX_ENTRIES`) so not unbounded, but a first-sync PATCH from a device with a backlog could issue up to ~1,000 sequential awaited round-trips while holding SQLite's single writer lock, blocking every other write in the app for that duration.
- Replaced both loops with chunked multi-row statements: 120 rows/chunk for the 8-column upsert, 500 rows/chunk for the delete's `IN (...)` — both staying under SQLite's ~999 bound-parameter cap.
- Closes #1837

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` (annotations + kobo modules) — PASS (66 passed, 0 failed), including a new test `ingest_kobo_annotations_applies_a_multi_row_batch_conflict_insert_and_delete_together` asserting a multi-row batch applies conflict-update, fresh-insert, and delete correctly in one call. Existing `db/src/annotations/tests.rs` coverage passes unmodified (behavior-preserving).

## Version
- [x] **Patch** — left unlabeled (default)

## Notes
- Surgical change: only `db/src/annotations/mod.rs` and `db/src/annotations/tests.rs` touched. The conflict `CASE` expression's `excluded.*` references work unchanged in a multi-row `VALUES` statement — each conflicting row resolves independently against its own `excluded.*` values.

---
_Generated by [Claude Code](https://claude.ai/code/session_015k7w9BnhXw3vif6EfrzZQi)_