### PR TITLE
refactor: stabilize author-detail avatar swap and dedupe modal shells

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1599,6 +1599,7 @@ button.spoiler {
   border: 1px solid var(--line-2);
   display: grid;
   place-items: center;
+  overflow: hidden;
   font-family: var(--serif);
   font-size: 56px;
   font-style: italic;
@@ -1608,12 +1609,16 @@ button.spoiler {
   .disc-avatar { width: 80px; height: 80px; font-size: 36px; }
 }
 
-/* F1.11 — When the avatar is the resolved profile photo, drop the
-   typographic styling and clip the image to the circle. The `img` element
-   shares the `.disc-avatar` class so the size/border tokens stay in sync
-   with the letter variant. */
+/* F1.11 — When the avatar is the resolved profile photo, the `img` nests
+   inside the stable `.disc-avatar` circle (rule 07 — a `has_photo` flip
+   diffs the child, not the node) rather than swapping element type. Fill
+   the parent's clipped circle instead of carrying its own size/border,
+   mirroring `.idx-card-avatar--photo` / `UserAvatar`'s `-photo` classes. */
 .disc-avatar--photo {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+  display: block;
   background: var(--bg-2);
 }
 

--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -35,19 +35,30 @@ fn dismiss_unless_busy(busy: bool, on_dismiss: EventHandler<()>) {
 /// Modal backdrop + panel shell shared by every dialog in the app: a
 /// backdrop click dismisses (unless `busy`), a click inside the panel
 /// itself does not bubble to the backdrop. Callers supply their own body
-/// markup as `children`.
+/// markup as `children`, and optionally a `head` slot (title + close
+/// button) rendered above it — `backdrop_class` defaults to the original
+/// fixed class so every pre-existing caller is unaffected; a caller
+/// with its own backdrop chrome (centered vs. bottom-sheet, blur, z-index)
+/// overrides it. The `head` slot stays a raw `Element` rather than a
+/// `title: String` because callers disagree on heading tag and class
+/// (`ModalShell`'s `h3`/`users-modal-*` vs. `DrillIn`'s `h4`/`st-drill-*`
+/// plus a leading grabber bar) — forcing one shape would change either
+/// caller's rendered markup, which is the one thing this refactor must not
+/// do.
 #[component]
 pub fn ConfirmModal(
     testid: String,
     aria_label: String,
+    #[props(default = "author-photo-modal-backdrop".to_string())] backdrop_class: String,
     dialog_class: String,
     busy: bool,
     on_dismiss: EventHandler<()>,
+    #[props(default)] head: Option<Element>,
     children: Element,
 ) -> Element {
     rsx! {
         div {
-            class: "author-photo-modal-backdrop",
+            class: "{backdrop_class}",
             role: "dialog",
             aria_modal: "true",
             aria_label: "{aria_label}",
@@ -56,7 +67,10 @@ pub fn ConfirmModal(
                 evt.stop_propagation();
                 dismiss_unless_busy(busy, on_dismiss);
             },
-            div { class: "{dialog_class}", onclick: move |evt| evt.stop_propagation(), {children} }
+            div { class: "{dialog_class}", onclick: move |evt| evt.stop_propagation(),
+                if let Some(h) = head { {h} }
+                {children}
+            }
         }
     }
 }

--- a/frontend/src/pages/author.rs
+++ b/frontend/src/pages/author.rs
@@ -266,23 +266,25 @@ fn author_avatar(
                     });
                 }
             },
-            if let Some(url) =
-                photo_url.filter(|u| broken_photo_src.read().as_deref() != Some(u.as_str()))
-            {
-                img {
-                    class: "disc-avatar disc-avatar--photo",
-                    // `media_url` server-prefixes and (mobile) appends the
-                    // session token so the WebView's `<img>` fetch
-                    // authenticates; no-op on web.
-                    src: "{url}",
-                    alt: "{a.name}",
-                    onerror: {
-                        let url = url.clone();
-                        move |_| broken_photo_src.set(Some(url.clone()))
-                    },
+            div { class: "disc-avatar",
+                if let Some(url) =
+                    photo_url.filter(|u| broken_photo_src.read().as_deref() != Some(u.as_str()))
+                {
+                    img {
+                        class: "disc-avatar--photo",
+                        // `media_url` server-prefixes and (mobile) appends the
+                        // session token so the WebView's `<img>` fetch
+                        // authenticates; no-op on web.
+                        src: "{url}",
+                        alt: "{a.name}",
+                        onerror: {
+                            let url = url.clone();
+                            move |_| broken_photo_src.set(Some(url.clone()))
+                        },
+                    }
+                } else {
+                    "{initial}"
                 }
-            } else {
-                div { class: "disc-avatar", "{initial}" }
             }
         }
     }

--- a/frontend/src/pages/settings/users/modals.rs
+++ b/frontend/src/pages/settings/users/modals.rs
@@ -213,9 +213,10 @@ pub(super) fn EditUserModal(
 
 /// Delete-confirmation modal. Warns when the admin is deleting their own
 /// account; the last-admin guard is enforced server-side and surfaced inline.
-/// Built on the shared `ConfirmModal` shell (see `components::confirm_modal`)
-/// rather than `ModalShell`, so the backdrop can't be dismissed mid-delete —
-/// `ModalShell`'s own backdrop has no busy gate at all.
+/// Passes `busy` through to the shared `ConfirmModal` shell (see
+/// `components::confirm_modal`) so the backdrop can't be dismissed
+/// mid-delete — unlike `ModalShell` above, which always passes `busy: false`
+/// since none of its callers need that gate.
 #[component]
 pub(super) fn DeleteUserModal(
     user: AdminUserRow,
@@ -437,8 +438,14 @@ fn render_device_list(
     }
 }
 
-/// Shared modal overlay + card chrome. Clicking the scrim or the close button
-/// dismisses; clicks inside the card don't propagate.
+/// Shared modal overlay + card chrome, built on the `ConfirmModal` shell
+/// (see `components::confirm_modal`) with its `head` slot carrying the
+/// title bar and close button. Clicking the scrim or the close button
+/// dismisses; clicks inside the card don't propagate. Unlike
+/// `DeleteUserModal`'s use of `ConfirmModal`, this always passes `busy:
+/// false` — none of `ModalShell`'s callers (new/edit/sessions) gate the
+/// backdrop on an in-flight save, matching this shell's pre-refactor
+/// behavior.
 #[component]
 fn ModalShell(
     title: String,
@@ -447,15 +454,14 @@ fn ModalShell(
     children: Element,
 ) -> Element {
     rsx! {
-        div {
-            class: "users-modal-overlay",
-            "data-testid": "{testid}",
-            onclick: move |_| on_close.call(()),
-            div {
-                class: "users-modal-card",
-                role: "dialog",
-                "aria-modal": "true",
-                onclick: move |e| e.stop_propagation(),
+        ConfirmModal {
+            testid: testid.clone(),
+            aria_label: title.clone(),
+            backdrop_class: "users-modal-overlay".to_string(),
+            dialog_class: "users-modal-card".to_string(),
+            busy: false,
+            on_dismiss: move |_| on_close.call(()),
+            head: rsx! {
                 div { class: "users-modal-head",
                     h3 { "{title}" }
                     button {
@@ -466,8 +472,8 @@ fn ModalShell(
                         "\u{00d7}"
                     }
                 }
-                div { class: "users-modal-body", {children} }
-            }
+            },
+            div { class: "users-modal-body", {children} }
         }
     }
 }

--- a/frontend/src/pages/stats/drill_in.rs
+++ b/frontend/src/pages/stats/drill_in.rs
@@ -7,7 +7,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::{Contributor, EbookMetadata, FinishedBook, StatsRange, StatsSummary};
 
-use crate::components::{CoverTile, CoverTileKind};
+use crate::components::{ConfirmModal, CoverTile, CoverTileKind};
 use crate::use_server_url;
 
 /// Which headline tile a drill-in sheet/modal is showing detail for.
@@ -244,7 +244,12 @@ fn finished_book_as_ebook(book: &FinishedBook) -> EbookMetadata {
 
 /// The drill-in sheet/modal: header + close, delta chip, trend chart, and
 /// (Finished only) the finished-books list. `expanded` closes on backdrop
-/// click or the close button.
+/// click or the close button. Built on the shared `ConfirmModal` shell (see
+/// `components::confirm_modal`) — `busy: false` since no mutation is ever
+/// in flight here, the grabber + title/close head go in the `head` slot,
+/// and `backdrop_class`/`dialog_class` keep this sheet's own bottom-sheet
+/// (mobile) / centered-modal (desktop) chrome rather than the default
+/// author-photo backdrop.
 #[component]
 pub(super) fn DrillIn(
     metric: Metric,
@@ -258,14 +263,14 @@ pub(super) fn DrillIn(
     let bars = build_trend_bars(&trend_points(metric, &summary));
 
     rsx! {
-        div {
-            class: "st-drill-scrim",
-            "data-testid": "stats-drill-in",
-            role: "dialog",
-            aria_modal: "true",
+        ConfirmModal {
+            testid: "stats-drill-in".to_string(),
             aria_label: "{metric.title()} detail",
-            onclick: move |_| expanded.set(None),
-            div { class: "st-drill-sheet", onclick: move |e| e.stop_propagation(),
+            backdrop_class: "st-drill-scrim".to_string(),
+            dialog_class: "st-drill-sheet".to_string(),
+            busy: false,
+            on_dismiss: move |_| expanded.set(None),
+            head: rsx! {
                 div { class: "st-drill-grabber" }
                 div { class: "st-drill-head",
                     h4 { "{metric.title()}" }
@@ -278,12 +283,12 @@ pub(super) fn DrillIn(
                         "\u{2715}"
                     }
                 }
-                div { class: "st-drill-body",
-                    {render_delta(delta, vs)}
-                    {render_trend(metric, &bars)}
-                    if metric == Metric::Finished {
-                        {render_finished_list(&summary.finished_books, summary.books_finished, &server_url)}
-                    }
+            },
+            div { class: "st-drill-body",
+                {render_delta(delta, vs)}
+                {render_trend(metric, &bars)}
+                if metric == Metric::Finished {
+                    {render_finished_list(&summary.finished_books, summary.books_finished, &server_url)}
                 }
             }
         }

--- a/ui_tests/playwright/tests/flows/author_photo.spec.ts
+++ b/ui_tests/playwright/tests/flows/author_photo.spec.ts
@@ -98,8 +98,11 @@ test("admin upload swaps the letter avatar for the photo", async ({
   }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
 
   await expect(img).toHaveAttribute("src", `/api/authors/${id}/photo`);
-  // Letter variant should no longer render in the hero.
-  await expect(page.locator("div.disc-avatar")).toHaveCount(0);
+  // #1839 — `.disc-avatar` is the stable outer circle (rule 07: a
+  // `has_photo` flip must patch the child, not swap the element), so it
+  // stays present with the photo inside; only the letter fallback text
+  // should be gone.
+  await expect(page.locator("div.disc-avatar")).not.toContainText("A");
 
   // Sanity-check the image bytes load — fetch directly from the page
   // context so cookies ride along. We can't rely on `waitForResponse` here


### PR DESCRIPTION
## Summary
- Closes #1839
- `author.rs`'s `author_avatar` (author *detail* page) swapped element type
  (`img` vs `div`) between the photo and letter states — the same hydration
  hazard #1723 fixed on the author *listing* page and the pattern documented
  in `components/user_avatar.rs` (rule 07). A stable outer `div.disc-avatar`
  now hosts either the `img` or the initial text as its child, so a
  `has_photo`/broken-image flip patches the child instead of replacing the
  node. Updated `.disc-avatar`/`.disc-avatar--photo` in `atrium.css` to match
  the same "stable circle, `-photo` fills it" shape already used by
  `.idx-card-avatar`/`.idx-card-avatar--photo` and `UserAvatar`'s `-photo`
  classes.
- `ModalShell` (`settings/users/modals.rs`) and `DrillIn`
  (`stats/drill_in.rs`) each hand-rolled their own scrim/dialog/close-button
  chrome, duplicating `ConfirmModal`'s shell (`components/confirm_modal.rs`).
  `ConfirmModal` gains two optional props — `backdrop_class` (defaults to its
  original fixed class, so every pre-existing caller is unaffected) and a
  `head` slot for title+close-button markup (kept as a raw `Element` rather
  than a plain `title: String` because the two callers disagree on heading
  tag/class and `DrillIn` also needs a leading grabber bar — forcing one
  shape would have changed either caller's rendered markup). Both modals now
  build on `ConfirmModal` instead of duplicating it.
- One test-contract update: `author_photo.spec.ts` asserted
  `div.disc-avatar` had count 0 while the photo was showing — that was only
  ever true because of the hydration bug this PR fixes (the div used to only
  exist in the letter branch). Updated the assertion to check the letter
  fallback text is gone (`not.toContainText("A")`) instead, since the div is
  now the stable wrapper in both states.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (729 passed, 0 failed)
- [x] `pnpm run lint` (Biome) on `ui_tests/playwright` — PASS
- [x] `pnpm run typecheck` (tsc) on `ui_tests/playwright` — PASS
- [ ] Playwright E2E (`author_photo.spec.ts`, `users.spec.ts`, `stats.spec.ts`) — **not run**: this cloud environment has no nix/browser E2E harness. Markup/CSS classes were checked by hand against the contract selectors in `ui_tests/playwright/tests/flows/` (`author_photo.spec.ts`, `users.spec.ts`, `stats.spec.ts`) and preserved, with the one necessary assertion update noted above.
- [ ] wasm32 web build — **not run**: no `.#web` nix shell available here. Hydration parity was instead verified by reading against `.claude/rules/07-hydration.md` — every changed component body is target-agnostic (no `#[cfg(feature = "web"/"mobile"/"server")]` around rsx), and the new `ConfirmModal` props are plain `Option<...>`/`String` values computed identically on every target.

## Version
Unlabeled — default patch release.

## Notes
- Both findings from #1839 were still present on `main` prior to this PR;
  neither was already fixed.


---
_Generated by [Claude Code](https://claude.ai/code/session_015k7w9BnhXw3vif6EfrzZQi)_