### PR TITLE
feat: add library cleanup detection module (#962)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,6 +4511,7 @@ dependencies = [
  "pulldown-cmark",
  "quick-xml",
  "rand_core 0.6.4",
+ "regex",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -157,6 +157,12 @@ uuid = { version = "1", features = ["v4", "v5"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 urlencoding = "2"
 
+# F5.9 library cleanup (#962): regex-based detectors — junk-author tooling
+# artifacts, book-title cruft prefixes/suffixes. Already present in
+# Cargo.lock transitively (via other crates' deps), so this adds no new
+# download, just a direct edge for this crate's own use.
+regex = "1"
+
 # F4.3 Send-to-Kindle: SMTP delivery of the EPUB as an email attachment.
 # rustls-based TLS matches the async-TLS choice used by sqlx/reqwest so we
 # never pull in OpenSSL; `builder` provides the multipart `Message` API.

--- a/db/src/cleanup.rs
+++ b/db/src/cleanup.rs
@@ -1,8 +1,8 @@
-//! Library-cleanup detection (F5.9, #962): five domain-specific algorithms
-//! that surface near-duplicate authors/series/tags, semicolon-soup tags,
-//! filename cruft in book titles, and junk-author rows left behind by a
-//! third-party import. Detection only — the persisted `dedup_suggestions`
-//! queue and the apply/undo primitives are separate follow-up modules.
+//! Library-cleanup detection: five domain-specific algorithms that surface
+//! near-duplicate authors/series/tags, semicolon-soup tags, filename cruft
+//! in book titles, and junk-author rows left behind by a third-party
+//! import. Detection only — the persisted `dedup_suggestions` queue and
+//! the apply/undo primitives are separate follow-up modules.
 
 use std::collections::{HashMap, HashSet};
 
@@ -82,7 +82,9 @@ pub struct DetectedSuggestion {
     /// The other name in a two-way merge, or the proposed title for a
     /// rename. `None` when the suggestion has no single "other" name.
     pub secondary_name: Option<String>,
-    /// How many library books are affected if the suggestion is applied.
+    /// How many *distinct* library books are affected if the suggestion is
+    /// applied — a merge group's book is counted once even if it's linked
+    /// to more than one of the group's members.
     pub book_count: i64,
     pub payload: CleanupPayload,
 }
@@ -132,9 +134,25 @@ pub async fn detect_book_titles(
     let prefixes = compile_all(TITLE_PREFIX_PATTERNS)?;
     let suffix = Regex::new(TITLE_SUFFIX_PATTERN)?;
 
-    let rows: Vec<(i64, String, String)> = sqlx::query_as("SELECT id, uuid, title FROM books")
-        .fetch_all(pool)
-        .await?;
+    // Sound prefilter: every pattern in TITLE_PREFIX_PATTERNS /
+    // TITLE_SUFFIX_PATTERN requires at least one of these five literal
+    // characters to match at all (','+'-' for the author-dash prefix,
+    // '['/']' for the series-bracket prefix, '#' for the series-hash
+    // prefix, '-' for the acronym-index prefix, '('/')' for the trailing
+    // parenthetical) — a title with none of them cannot match any pattern,
+    // so skipping it here can never miss a real suggestion. Cuts the
+    // regex work (and the row transfer) down from every book to only the
+    // ones that could plausibly match.
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        "SELECT id, uuid, title FROM books
+          WHERE instr(title, ',') > 0
+             OR instr(title, '-') > 0
+             OR instr(title, '[') > 0
+             OR instr(title, '#') > 0
+             OR instr(title, '(') > 0",
+    )
+    .fetch_all(pool)
+    .await?;
 
     Ok(rows
         .into_iter()
@@ -179,45 +197,71 @@ impl MergeEntity {
         }
     }
 
-    /// `(id, name, sort, book_count)` for every row, `sort` NULL where the
-    /// table has no such column (tags).
+    /// `(id, name, sort, book_id)` — one row per linked book, `NULL` book_id
+    /// for an entity with none, `sort` NULL where the table has no such
+    /// column (tags). Left un-aggregated (no `COUNT`/`GROUP BY`) so a merge
+    /// group can later count *distinct* affected books instead of summing
+    /// each entity's count, which would double-count a book linked to more
+    /// than one of the group's members.
     fn sql(self) -> &'static str {
         match self {
             Self::Author => {
-                "SELECT a.id, a.name, a.sort, COUNT(bal.book) AS book_count
+                "SELECT a.id, a.name, a.sort, bal.book AS book_id
                    FROM authors a
-                   LEFT JOIN books_authors_link bal ON bal.author = a.id
-                  GROUP BY a.id, a.name, a.sort"
+                   LEFT JOIN books_authors_link bal ON bal.author = a.id"
             }
             Self::Series => {
-                "SELECT s.id, s.name, s.sort, COUNT(bsl.book) AS book_count
+                "SELECT s.id, s.name, s.sort, bsl.book AS book_id
                    FROM series s
-                   LEFT JOIN books_series_link bsl ON bsl.series = s.id
-                  GROUP BY s.id, s.name, s.sort"
+                   LEFT JOIN books_series_link bsl ON bsl.series = s.id"
             }
             Self::Tag => {
-                "SELECT t.id, t.name, NULL AS sort, COUNT(btl.book) AS book_count
+                "SELECT t.id, t.name, NULL AS sort, btl.book AS book_id
                    FROM tags t
-                   LEFT JOIN books_tags_link btl ON btl.tag = t.id
-                  GROUP BY t.id, t.name"
+                   LEFT JOIN books_tags_link btl ON btl.tag = t.id"
             }
         }
     }
 }
 
-#[derive(Debug, Clone, sqlx::FromRow)]
+#[derive(Debug)]
 struct EntityRow {
     id: i64,
     name: String,
     sort: Option<String>,
-    book_count: i64,
+    /// Ids of every book linked to this entity — a set (not a count) so a
+    /// merge group can union several entities' books and count *distinct*
+    /// rows rather than double-counting a book linked to more than one.
+    book_ids: HashSet<i64>,
 }
 
+impl EntityRow {
+    fn book_count(&self) -> i64 {
+        self.book_ids.len() as i64
+    }
+}
+
+/// Fetch every row of `entity`'s table, folding the one-row-per-linked-book
+/// result of [`MergeEntity::sql`] into one [`EntityRow`] per distinct id.
 async fn fetch_entity_rows(
     pool: &SqlitePool,
     entity: MergeEntity,
 ) -> Result<Vec<EntityRow>, CleanupError> {
-    Ok(sqlx::query_as(entity.sql()).fetch_all(pool).await?)
+    let raw: Vec<(i64, String, Option<String>, Option<i64>)> =
+        sqlx::query_as(entity.sql()).fetch_all(pool).await?;
+    let mut rows: HashMap<i64, EntityRow> = HashMap::new();
+    for (id, name, sort, book_id) in raw {
+        let row = rows.entry(id).or_insert_with(|| EntityRow {
+            id,
+            name,
+            sort,
+            book_ids: HashSet::new(),
+        });
+        if let Some(book_id) = book_id {
+            row.book_ids.insert(book_id);
+        }
+    }
+    Ok(rows.into_values().collect())
 }
 
 /// Shared merge-detection body: Tier-0 GROUP-BY on the normalized key, then
@@ -269,23 +313,28 @@ fn fuzzy_merge_suggestions(
     kind: CleanupKind,
     singles: &[(&str, &EntityRow)],
 ) -> Vec<DetectedSuggestion> {
-    let mut first_token_buckets: HashMap<&str, Vec<(&str, &EntityRow)>> = HashMap::new();
+    // Each candidate's token set is built once here, up front, and reused
+    // for every pairwise comparison its bucket runs below — rebuilding it
+    // per comparison would redo the same split/collect work O(bucket_len)
+    // times over.
+    let mut first_token_buckets: HashMap<&str, Vec<(HashSet<&str>, &EntityRow)>> = HashMap::new();
     for &(key, row) in singles {
-        if let Some(first) = key.split_whitespace().next() {
-            first_token_buckets
-                .entry(first)
-                .or_default()
-                .push((key, row));
-        }
+        let Some(first) = key.split_whitespace().next() else {
+            continue;
+        };
+        first_token_buckets
+            .entry(first)
+            .or_default()
+            .push((token_set(key), row));
     }
 
     let mut suggestions = Vec::new();
     for bucket in first_token_buckets.values() {
-        for (i, &(key_a, row_a)) in bucket.iter().enumerate() {
-            for &(key_b, row_b) in &bucket[i + 1..] {
-                let score = jaccard(&token_set(key_a), &token_set(key_b));
+        for (i, (tokens_a, row_a)) in bucket.iter().enumerate() {
+            for (tokens_b, row_b) in &bucket[i + 1..] {
+                let score = jaccard(tokens_a, tokens_b);
                 if score >= FUZZY_JACCARD_THRESHOLD {
-                    let pair = [row_a, row_b];
+                    let pair = [*row_a, *row_b];
                     if let Some(canonical) = pick_canonical(&pair) {
                         suggestions.push(merge_suggestion(
                             kind,
@@ -323,8 +372,8 @@ fn jaccard(a: &HashSet<&str>, b: &HashSet<&str>) -> f64 {
 /// empty, which callers never pass.
 fn pick_canonical<'a>(group: &[&'a EntityRow]) -> Option<&'a EntityRow> {
     group.iter().copied().reduce(|best, row| {
-        if row.book_count > best.book_count
-            || (row.book_count == best.book_count && row.id < best.id)
+        if row.book_count() > best.book_count()
+            || (row.book_count() == best.book_count() && row.id < best.id)
         {
             row
         } else {
@@ -350,7 +399,14 @@ fn merge_suggestion(
         .filter(|r| r.id != canonical.id)
         .map(|r| r.name.clone())
         .collect();
-    let book_count = group.iter().map(|r| r.book_count).sum();
+    // Distinct union, not a sum: a book linked to more than one of the
+    // group's members (common for tags, possible for messy author imports)
+    // must be counted once, not once per member that links to it.
+    let book_count = group
+        .iter()
+        .flat_map(|r| r.book_ids.iter())
+        .collect::<HashSet<_>>()
+        .len() as i64;
     DetectedSuggestion {
         kind,
         action: CleanupAction::Merge,
@@ -389,7 +445,7 @@ async fn detect_junk_authors(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion
             score: 1.0,
             primary_name: row.name.clone(),
             secondary_name: None,
-            book_count: row.book_count,
+            book_count: row.book_count(),
             payload: CleanupPayload::Delete {
                 entity_id: row.id,
                 name: row.name,
@@ -447,7 +503,7 @@ fn tag_split_suggestion(
         score,
         primary_name: row.name.clone(),
         secondary_name: None,
-        book_count: row.book_count,
+        book_count: row.book_count(),
         payload: CleanupPayload::Split {
             source_id: row.id,
             source_name: row.name,

--- a/db/src/cleanup.rs
+++ b/db/src/cleanup.rs
@@ -1,0 +1,534 @@
+//! Library-cleanup detection (F5.9, #962): five domain-specific algorithms
+//! that surface near-duplicate authors/series/tags, semicolon-soup tags,
+//! filename cruft in book titles, and junk-author rows left behind by a
+//! third-party import. Detection only — the persisted `dedup_suggestions`
+//! queue and the apply/undo primitives are separate follow-up modules.
+
+use std::collections::{HashMap, HashSet};
+
+use omnibus_shared::{CleanupAction, CleanupKind};
+use regex::Regex;
+use serde::Serialize;
+use sqlx::SqlitePool;
+
+use crate::normalize::normalize_author;
+
+#[cfg(test)]
+mod tests;
+
+/// Errors returned by the cleanup detectors.
+#[derive(Debug, thiserror::Error)]
+pub enum CleanupError {
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+    #[error("invalid detector pattern: {0}")]
+    Pattern(#[from] regex::Error),
+}
+
+/// Confidence tier of a detected suggestion, per F5.9's technical design:
+/// Tier 0 is a high-confidence normalized-key or regex match; Tier 1 is a
+/// fuzzy match, always surfaced (never gated behind an opt-in toggle).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Tier {
+    Zero,
+    One,
+}
+
+/// Enough information to act on a detected suggestion later: what the apply
+/// primitive would do, keyed by [`CleanupAction`].
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CleanupPayload {
+    /// Combine `source_ids` into `canonical_id` (author/series/tag merges).
+    Merge {
+        source_ids: Vec<i64>,
+        source_names: Vec<String>,
+        canonical_id: i64,
+        canonical_name: String,
+    },
+    /// Replace tag `source_id` with the listed `atoms`, split on `delimiter`.
+    Split {
+        source_id: i64,
+        source_name: String,
+        atoms: Vec<String>,
+        delimiter: String,
+    },
+    /// Adopt `proposed_title` for `book_id` in place of `current_title`.
+    Rename {
+        book_id: i64,
+        book_uuid: String,
+        current_title: String,
+        proposed_title: String,
+    },
+    /// Remove `entity_id` outright (junk-author rows).
+    Delete { entity_id: i64, name: String },
+}
+
+/// One detected cleanup opportunity, ready to persist as a
+/// `dedup_suggestions` row (`kind`/`action`/[`CleanupPayload`]) once the
+/// apply layer lands.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DetectedSuggestion {
+    pub kind: CleanupKind,
+    pub action: CleanupAction,
+    pub tier: Tier,
+    /// 1.0 for an exact Tier-0 match; the similarity score for a fuzzy
+    /// Tier-1 match (`>= FUZZY_JACCARD_THRESHOLD`).
+    pub score: f64,
+    /// The entity that survives a merge, or the single entity a
+    /// split/rename/delete acts on.
+    pub primary_name: String,
+    /// The other name in a two-way merge, or the proposed title for a
+    /// rename. `None` when the suggestion has no single "other" name.
+    pub secondary_name: Option<String>,
+    /// How many library books are affected if the suggestion is applied.
+    pub book_count: i64,
+    pub payload: CleanupPayload,
+}
+
+// ---------------------------------------------------------------------------
+// Public detectors
+// ---------------------------------------------------------------------------
+
+/// Detect duplicate authors (normalized-key + fuzzy merges) plus junk-author
+/// rows left behind by third-party tooling (Calibre/Smashwords artifacts).
+pub async fn detect_authors(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let mut suggestions = detect_merges(pool, MergeEntity::Author).await?;
+    suggestions.extend(detect_junk_authors(pool).await?);
+    Ok(suggestions)
+}
+
+/// Detect duplicate series via the same normalized-key + fuzzy shape as
+/// [`detect_authors`].
+pub async fn detect_series(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    detect_merges(pool, MergeEntity::Series).await
+}
+
+/// Detect duplicate tags via the same normalized-key + fuzzy shape as
+/// [`detect_authors`].
+pub async fn detect_tags_merge(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    detect_merges(pool, MergeEntity::Tag).await
+}
+
+/// Detect tags that should be split into atoms: a `;`-delimited soup
+/// (Tier 0) or a long name with embedded commas (Tier 1).
+pub async fn detect_tags_split(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let rows = fetch_entity_rows(pool, MergeEntity::Tag).await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let (tier, delimiter, atoms) = split_candidate(&row.name)?;
+            Some(tag_split_suggestion(row, tier, delimiter, atoms))
+        })
+        .collect())
+}
+
+/// Detect book titles carrying filename cruft: an author/series/index
+/// prefix (Tier 0) or a trailing parenthetical edition note (Tier 1).
+pub async fn detect_book_titles(
+    pool: &SqlitePool,
+) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let prefixes = compile_all(TITLE_PREFIX_PATTERNS)?;
+    let suffix = Regex::new(TITLE_SUFFIX_PATTERN)?;
+
+    let rows: Vec<(i64, String, String)> = sqlx::query_as("SELECT id, uuid, title FROM books")
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|(id, uuid, title)| {
+            let (tier, proposed) = strip_title_cruft(&title, &prefixes, &suffix)?;
+            Some(book_title_suggestion(id, uuid, title, proposed, tier))
+        })
+        .collect())
+}
+
+/// Run every detector and return their suggestions concatenated. Each
+/// detector targets its own table independently, so a caller wanting only
+/// one kind should call it directly instead of filtering this result.
+pub async fn detect_all(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let mut suggestions = detect_authors(pool).await?;
+    suggestions.extend(detect_series(pool).await?);
+    suggestions.extend(detect_tags_merge(pool).await?);
+    suggestions.extend(detect_tags_split(pool).await?);
+    suggestions.extend(detect_book_titles(pool).await?);
+    Ok(suggestions)
+}
+
+// ---------------------------------------------------------------------------
+// Merge detection: authors / series / tags share one normalized-key +
+// fuzzy-Jaccard shape, parameterized on which taxonomy table to read.
+// ---------------------------------------------------------------------------
+
+/// Which normalized taxonomy table a merge-detection pass targets.
+#[derive(Debug, Clone, Copy)]
+enum MergeEntity {
+    Author,
+    Series,
+    Tag,
+}
+
+impl MergeEntity {
+    fn kind(self) -> CleanupKind {
+        match self {
+            Self::Author => CleanupKind::Author,
+            Self::Series => CleanupKind::Series,
+            Self::Tag => CleanupKind::Tag,
+        }
+    }
+
+    /// `(id, name, sort, book_count)` for every row, `sort` NULL where the
+    /// table has no such column (tags).
+    fn sql(self) -> &'static str {
+        match self {
+            Self::Author => {
+                "SELECT a.id, a.name, a.sort, COUNT(bal.book) AS book_count
+                   FROM authors a
+                   LEFT JOIN books_authors_link bal ON bal.author = a.id
+                  GROUP BY a.id, a.name, a.sort"
+            }
+            Self::Series => {
+                "SELECT s.id, s.name, s.sort, COUNT(bsl.book) AS book_count
+                   FROM series s
+                   LEFT JOIN books_series_link bsl ON bsl.series = s.id
+                  GROUP BY s.id, s.name, s.sort"
+            }
+            Self::Tag => {
+                "SELECT t.id, t.name, NULL AS sort, COUNT(btl.book) AS book_count
+                   FROM tags t
+                   LEFT JOIN books_tags_link btl ON btl.tag = t.id
+                  GROUP BY t.id, t.name"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct EntityRow {
+    id: i64,
+    name: String,
+    sort: Option<String>,
+    book_count: i64,
+}
+
+async fn fetch_entity_rows(
+    pool: &SqlitePool,
+    entity: MergeEntity,
+) -> Result<Vec<EntityRow>, CleanupError> {
+    Ok(sqlx::query_as(entity.sql()).fetch_all(pool).await?)
+}
+
+/// Shared merge-detection body: Tier-0 GROUP-BY on the normalized key, then
+/// a Tier-1 fuzzy pass over whatever the Tier-0 grouping left as singletons.
+async fn detect_merges(
+    pool: &SqlitePool,
+    entity: MergeEntity,
+) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let rows = fetch_entity_rows(pool, entity).await?;
+    let kind = entity.kind();
+
+    let mut buckets: HashMap<String, Vec<&EntityRow>> = HashMap::new();
+    for row in &rows {
+        if let Some(key) = tier0_key(&row.name, row.sort.as_deref()) {
+            buckets.entry(key).or_default().push(row);
+        }
+    }
+
+    let mut suggestions = Vec::new();
+    let mut singles: Vec<(&str, &EntityRow)> = Vec::new();
+    for (key, group) in &buckets {
+        if group.len() >= 2 {
+            if let Some(canonical) = pick_canonical(group) {
+                suggestions.push(merge_suggestion(kind, Tier::Zero, 1.0, group, canonical));
+            }
+        } else if let [row] = group.as_slice() {
+            singles.push((key.as_str(), row));
+        }
+    }
+
+    suggestions.extend(fuzzy_merge_suggestions(kind, &singles));
+    Ok(suggestions)
+}
+
+/// The Tier-0 GROUP-BY key for an author/series/tag row: `COALESCE(sort,
+/// name)` folded through [`normalize_author`] — the same lowercase /
+/// strip-punctuation / collapse-whitespace fold, plus the `"Last, First"`
+/// comma swap, that already keys the cross-format auto-attach match.
+/// `None` when nothing survives (e.g. a name of only punctuation).
+fn tier0_key(name: &str, sort: Option<&str>) -> Option<String> {
+    normalize_author(sort.unwrap_or(name))
+}
+
+/// Tier-1 pass: bucket the rows a Tier-0 key left as singletons by shared
+/// first token (keeps the comparison sub-quadratic on large sets), then
+/// emit a merge suggestion for every pair inside a bucket scoring at least
+/// [`FUZZY_JACCARD_THRESHOLD`] on whole-token-set Jaccard.
+fn fuzzy_merge_suggestions(
+    kind: CleanupKind,
+    singles: &[(&str, &EntityRow)],
+) -> Vec<DetectedSuggestion> {
+    let mut first_token_buckets: HashMap<&str, Vec<(&str, &EntityRow)>> = HashMap::new();
+    for &(key, row) in singles {
+        if let Some(first) = key.split_whitespace().next() {
+            first_token_buckets
+                .entry(first)
+                .or_default()
+                .push((key, row));
+        }
+    }
+
+    let mut suggestions = Vec::new();
+    for bucket in first_token_buckets.values() {
+        for (i, &(key_a, row_a)) in bucket.iter().enumerate() {
+            for &(key_b, row_b) in &bucket[i + 1..] {
+                let score = jaccard(&token_set(key_a), &token_set(key_b));
+                if score >= FUZZY_JACCARD_THRESHOLD {
+                    let pair = [row_a, row_b];
+                    if let Some(canonical) = pick_canonical(&pair) {
+                        suggestions.push(merge_suggestion(
+                            kind,
+                            Tier::One,
+                            score,
+                            &pair,
+                            canonical,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    suggestions
+}
+
+/// Fuzzy-match threshold: token-set Jaccard >= 0.85 (F5.9 technical design).
+const FUZZY_JACCARD_THRESHOLD: f64 = 0.85;
+
+fn token_set(key: &str) -> HashSet<&str> {
+    key.split_whitespace().collect()
+}
+
+/// Whole-token-set Jaccard similarity: `|A ∩ B| / |A ∪ B|`.
+fn jaccard(a: &HashSet<&str>, b: &HashSet<&str>) -> f64 {
+    let union = a.union(b).count();
+    if union == 0 {
+        return 0.0;
+    }
+    a.intersection(b).count() as f64 / union as f64
+}
+
+/// Choose which row in a merge group survives: most linked books, ties
+/// broken toward the lower id (first inserted). `None` only if `group` is
+/// empty, which callers never pass.
+fn pick_canonical<'a>(group: &[&'a EntityRow]) -> Option<&'a EntityRow> {
+    group.iter().copied().reduce(|best, row| {
+        if row.book_count > best.book_count
+            || (row.book_count == best.book_count && row.id < best.id)
+        {
+            row
+        } else {
+            best
+        }
+    })
+}
+
+fn merge_suggestion(
+    kind: CleanupKind,
+    tier: Tier,
+    score: f64,
+    group: &[&EntityRow],
+    canonical: &EntityRow,
+) -> DetectedSuggestion {
+    let source_ids: Vec<i64> = group
+        .iter()
+        .filter(|r| r.id != canonical.id)
+        .map(|r| r.id)
+        .collect();
+    let source_names: Vec<String> = group
+        .iter()
+        .filter(|r| r.id != canonical.id)
+        .map(|r| r.name.clone())
+        .collect();
+    let book_count = group.iter().map(|r| r.book_count).sum();
+    DetectedSuggestion {
+        kind,
+        action: CleanupAction::Merge,
+        tier,
+        score,
+        primary_name: canonical.name.clone(),
+        secondary_name: source_names.first().cloned(),
+        book_count,
+        payload: CleanupPayload::Merge {
+            source_ids,
+            source_names,
+            canonical_id: canonical.id,
+            canonical_name: canonical.name.clone(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Junk-author delete detection
+// ---------------------------------------------------------------------------
+
+/// Tooling-artifact author names left behind by a Calibre/Smashwords import
+/// — e.g. `calibre (0.7.23) [http://calibre-ebook.com]`.
+const JUNK_AUTHOR_PATTERNS: &[&str] = &[r"^calibre \(", r"\[http", r"Smashwords, Inc\."];
+
+async fn detect_junk_authors(pool: &SqlitePool) -> Result<Vec<DetectedSuggestion>, CleanupError> {
+    let patterns = compile_all(JUNK_AUTHOR_PATTERNS)?;
+    let rows = fetch_entity_rows(pool, MergeEntity::Author).await?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| patterns.iter().any(|re| re.is_match(&row.name)))
+        .map(|row| DetectedSuggestion {
+            kind: CleanupKind::Author,
+            action: CleanupAction::Delete,
+            tier: Tier::Zero,
+            score: 1.0,
+            primary_name: row.name.clone(),
+            secondary_name: None,
+            book_count: row.book_count,
+            payload: CleanupPayload::Delete {
+                entity_id: row.id,
+                name: row.name,
+            },
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Tag split detection
+// ---------------------------------------------------------------------------
+
+/// A tag name at or above this length is a candidate for the Tier-1
+/// embedded-comma split heuristic.
+const TAG_SPLIT_LONG_LEN: usize = 30;
+
+/// Detect a tag name that should be split into atoms: a `;`-delimited soup
+/// (Tier 0) or a long name with embedded commas (Tier 1). Returns
+/// `(tier, delimiter, atoms)`; `None` when `name` doesn't look splittable.
+fn split_candidate(name: &str) -> Option<(Tier, &'static str, Vec<String>)> {
+    if name.contains(';') {
+        let atoms = split_trim(name, ';');
+        if atoms.len() >= 2 {
+            return Some((Tier::Zero, ";", atoms));
+        }
+    }
+    if name.len() >= TAG_SPLIT_LONG_LEN && name.contains(',') {
+        let atoms = split_trim(name, ',');
+        if atoms.len() >= 2 {
+            return Some((Tier::One, ",", atoms));
+        }
+    }
+    None
+}
+
+fn split_trim(name: &str, delimiter: char) -> Vec<String> {
+    name.split(delimiter)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn tag_split_suggestion(
+    row: EntityRow,
+    tier: Tier,
+    delimiter: &'static str,
+    atoms: Vec<String>,
+) -> DetectedSuggestion {
+    let score = if tier == Tier::Zero { 1.0 } else { 0.75 };
+    DetectedSuggestion {
+        kind: CleanupKind::Tag,
+        action: CleanupAction::Split,
+        tier,
+        score,
+        primary_name: row.name.clone(),
+        secondary_name: None,
+        book_count: row.book_count,
+        payload: CleanupPayload::Split {
+            source_id: row.id,
+            source_name: row.name,
+            atoms,
+            delimiter: delimiter.to_string(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Book-title cruft detection
+// ---------------------------------------------------------------------------
+
+/// Leading-prefix patterns stripped from a book title, tried in order (the
+/// first match wins). All Tier 0 — unambiguous filename artifacts.
+const TITLE_PREFIX_PATTERNS: &[&str] = &[
+    r"^[^,]+,\s*[^-]+-\s*",       // "Maas, Sarah J - "
+    r"^\[[^\]]+\s+\d+\]\s*",      // "[Mistborn 01] "
+    r"^[\w .]+#\d+\s*",           // "Mistborn #1 "
+    r"^[A-Za-z]{2,8}\d{1,3}-\s*", // "ToG04-"
+];
+
+/// Trailing parenthetical (edition/series note) stripped from a book
+/// title. Tier 1 — lower confidence than the leading-cruft patterns
+/// because a legitimate title can end in a parenthetical.
+const TITLE_SUFFIX_PATTERN: &str = r"\s*\([^()]*\)\s*$";
+
+/// Apply the leading-prefix (Tier 0) and trailing-parenthetical (Tier 1)
+/// patterns to `title`. Returns the winning tier and the stripped title, or
+/// `None` if neither pattern matched or the result is empty/unchanged.
+fn strip_title_cruft(title: &str, prefixes: &[Regex], suffix: &Regex) -> Option<(Tier, String)> {
+    let mut stripped = title;
+    let mut tier0_hit = false;
+    for re in prefixes {
+        if let Some(m) = re.find(stripped) {
+            stripped = &stripped[m.end()..];
+            tier0_hit = true;
+            break;
+        }
+    }
+    let tier1_hit = if let Some(m) = suffix.find(stripped) {
+        stripped = &stripped[..m.start()];
+        true
+    } else {
+        false
+    };
+    let proposed = stripped.trim();
+    if proposed.is_empty() || proposed == title || (!tier0_hit && !tier1_hit) {
+        return None;
+    }
+    Some((
+        if tier0_hit { Tier::Zero } else { Tier::One },
+        proposed.to_string(),
+    ))
+}
+
+fn book_title_suggestion(
+    id: i64,
+    uuid: String,
+    title: String,
+    proposed: String,
+    tier: Tier,
+) -> DetectedSuggestion {
+    let score = if tier == Tier::Zero { 1.0 } else { 0.75 };
+    DetectedSuggestion {
+        kind: CleanupKind::BookTitle,
+        action: CleanupAction::Rename,
+        tier,
+        score,
+        primary_name: title.clone(),
+        secondary_name: Some(proposed.clone()),
+        book_count: 1,
+        payload: CleanupPayload::Rename {
+            book_id: id,
+            book_uuid: uuid,
+            current_title: title,
+            proposed_title: proposed,
+        },
+    }
+}
+
+fn compile_all(patterns: &[&str]) -> Result<Vec<Regex>, regex::Error> {
+    patterns.iter().map(|p| Regex::new(p)).collect()
+}

--- a/db/src/cleanup/tests.rs
+++ b/db/src/cleanup/tests.rs
@@ -155,13 +155,13 @@ fn fuzzy_merge_suggestions_blocks_pairs_with_different_first_token() {
         id: 1,
         name: "A".into(),
         sort: None,
-        book_count: 0,
+        book_ids: HashSet::new(),
     };
     let row_b = EntityRow {
         id: 2,
         name: "B".into(),
         sort: None,
-        book_count: 0,
+        book_ids: HashSet::new(),
     };
     let singles = [(key_a, &row_a), (key_b, &row_b)];
     assert!(fuzzy_merge_suggestions(CleanupKind::Author, &singles).is_empty());
@@ -177,13 +177,13 @@ fn pick_canonical_prefers_more_books_then_lower_id() {
         id: 5,
         name: "Few".into(),
         sort: None,
-        book_count: 1,
+        book_ids: HashSet::from([101]),
     };
     let many_books = EntityRow {
         id: 9,
         name: "Many".into(),
         sort: None,
-        book_count: 4,
+        book_ids: HashSet::from([201, 202, 203, 204]),
     };
     let group = [&few_books, &many_books];
     assert_eq!(pick_canonical(&group).unwrap().id, many_books.id);
@@ -192,13 +192,13 @@ fn pick_canonical_prefers_more_books_then_lower_id() {
         id: 9,
         name: "High".into(),
         sort: None,
-        book_count: 1,
+        book_ids: HashSet::from([301]),
     };
     let tie_low_id = EntityRow {
         id: 2,
         name: "Low".into(),
         sort: None,
-        book_count: 1,
+        book_ids: HashSet::from([302]),
     };
     let tied = [&tie_high_id, &tie_low_id];
     assert_eq!(pick_canonical(&tied).unwrap().id, tie_low_id.id);
@@ -495,6 +495,28 @@ async fn detect_tags_merge_collapses_punctuation_variants_into_one_tier0_merge()
     // Both rows have equal (zero) book counts, so the lower id wins the tie.
     assert_eq!(canonical_id, canonical);
     assert_eq!(source_ids, [duplicate]);
+}
+
+#[tokio::test]
+async fn detect_tags_merge_book_count_is_distinct_not_summed_across_the_group() {
+    // A book linked to *both* the canonical and the duplicate tag (common
+    // for tags: a book often carries near-duplicate tag spellings at once)
+    // must be counted once, not twice.
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let canonical = insert_tag(&pool, "Sci-Fi").await;
+    let duplicate = insert_tag(&pool, "Sci Fi").await;
+    let shared = insert_book(&pool, lib, "u1", "Shared Book").await;
+    let only_canonical = insert_book(&pool, lib, "u2", "Canonical Only").await;
+    link_tag(&pool, shared, canonical).await;
+    link_tag(&pool, shared, duplicate).await;
+    link_tag(&pool, only_canonical, canonical).await;
+
+    let suggestions = detect_tags_merge(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    // Naively summing per-entity counts would give 3 (2 + 1); the correct
+    // distinct count is 2 (`shared` and `only_canonical`).
+    assert_eq!(suggestions[0].book_count, 2);
 }
 
 #[tokio::test]

--- a/db/src/cleanup/tests.rs
+++ b/db/src/cleanup/tests.rs
@@ -1,0 +1,660 @@
+//! Tests for the library-cleanup detectors: pure unit coverage for the
+//! normalized-key fold, Jaccard scoring, first-token blocking, and the
+//! regex heuristics, plus pool-backed coverage of each `detect_*` entry
+//! point's happy path, Tier-0/Tier-1 branches, and `CleanupError::Db`
+//! propagation.
+
+use sqlx::SqlitePool;
+
+use super::*;
+use crate::pool::init_db;
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+async fn new_pool() -> SqlitePool {
+    init_db("sqlite::memory:").await.unwrap()
+}
+
+async fn seed_root(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib') RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_book(pool: &SqlitePool, lib_id: i64, uuid: &str, title: &str) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, ?) RETURNING id",
+    )
+    .bind(uuid)
+    .bind(lib_id)
+    .bind(format!("/lib/{uuid}"))
+    .bind(title)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_author(pool: &SqlitePool, name: &str, sort: Option<&str>) -> i64 {
+    sqlx::query_scalar("INSERT INTO authors (name, sort) VALUES (?, ?) RETURNING id")
+        .bind(name)
+        .bind(sort)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn insert_series(pool: &SqlitePool, name: &str, sort: Option<&str>) -> i64 {
+    sqlx::query_scalar("INSERT INTO series (name, sort) VALUES (?, ?) RETURNING id")
+        .bind(name)
+        .bind(sort)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn insert_tag(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar("INSERT INTO tags (name) VALUES (?) RETURNING id")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn link_author(pool: &SqlitePool, book_id: i64, author_id: i64) {
+    sqlx::query("INSERT INTO books_authors_link (book, author, position) VALUES (?, ?, 0)")
+        .bind(book_id)
+        .bind(author_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn link_series(pool: &SqlitePool, book_id: i64, series_id: i64) {
+    sqlx::query("INSERT INTO books_series_link (book, series) VALUES (?, ?)")
+        .bind(book_id)
+        .bind(series_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn link_tag(pool: &SqlitePool, book_id: i64, tag_id: i64) {
+    sqlx::query("INSERT INTO books_tags_link (book, tag) VALUES (?, ?)")
+        .bind(book_id)
+        .bind(tag_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn merge_payload(s: &DetectedSuggestion) -> (&[i64], &[String], i64, &str) {
+    match &s.payload {
+        CleanupPayload::Merge {
+            source_ids,
+            source_names,
+            canonical_id,
+            canonical_name,
+        } => (source_ids, source_names, *canonical_id, canonical_name),
+        other => panic!("expected a Merge payload, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: tier0_key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tier0_key_collapses_last_first_swap_the_same_via_sort_or_name() {
+    let via_name = tier0_key("Sanderson, Brandon", None);
+    let via_plain = tier0_key("Brandon Sanderson", None);
+    let via_sort = tier0_key("junk display name", Some("Sanderson, Brandon"));
+    assert_eq!(via_name, Some("brandon sanderson".to_string()));
+    assert_eq!(via_name, via_plain);
+    assert_eq!(via_name, via_sort, "sort must win over name when present");
+}
+
+#[test]
+fn tier0_key_returns_none_when_nothing_survives() {
+    assert_eq!(tier0_key("---", None), None);
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: Jaccard + first-token blocking
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jaccard_scores_full_overlap_partial_overlap_and_disjoint_sets() {
+    let a = token_set("alpha bravo charlie");
+    let b = token_set("alpha bravo charlie");
+    assert_eq!(jaccard(&a, &b), 1.0);
+
+    let c = token_set("alpha bravo charlie delta echo foxtrot golf");
+    let d = token_set("alpha bravo charlie delta echo foxtrot golf hotel");
+    assert_eq!(jaccard(&c, &d), 7.0 / 8.0);
+
+    let e = token_set("alpha bravo");
+    let f = token_set("charlie delta");
+    assert_eq!(jaccard(&e, &f), 0.0);
+}
+
+#[test]
+fn fuzzy_merge_suggestions_blocks_pairs_with_different_first_token() {
+    // Both keys share 12 of 14 total tokens (>= 0.85 Jaccard if compared),
+    // but differ in their *first* token — first-token blocking must keep
+    // them in separate buckets and never compare them.
+    let key_a = "quebec charlie delta echo foxtrot golf hotel india juliet kilo lima mike november";
+    let key_b = "romeo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november";
+    assert!(jaccard(&token_set(key_a), &token_set(key_b)) >= FUZZY_JACCARD_THRESHOLD);
+
+    let row_a = EntityRow {
+        id: 1,
+        name: "A".into(),
+        sort: None,
+        book_count: 0,
+    };
+    let row_b = EntityRow {
+        id: 2,
+        name: "B".into(),
+        sort: None,
+        book_count: 0,
+    };
+    let singles = [(key_a, &row_a), (key_b, &row_b)];
+    assert!(fuzzy_merge_suggestions(CleanupKind::Author, &singles).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: pick_canonical
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pick_canonical_prefers_more_books_then_lower_id() {
+    let few_books = EntityRow {
+        id: 5,
+        name: "Few".into(),
+        sort: None,
+        book_count: 1,
+    };
+    let many_books = EntityRow {
+        id: 9,
+        name: "Many".into(),
+        sort: None,
+        book_count: 4,
+    };
+    let group = [&few_books, &many_books];
+    assert_eq!(pick_canonical(&group).unwrap().id, many_books.id);
+
+    let tie_high_id = EntityRow {
+        id: 9,
+        name: "High".into(),
+        sort: None,
+        book_count: 1,
+    };
+    let tie_low_id = EntityRow {
+        id: 2,
+        name: "Low".into(),
+        sort: None,
+        book_count: 1,
+    };
+    let tied = [&tie_high_id, &tie_low_id];
+    assert_eq!(pick_canonical(&tied).unwrap().id, tie_low_id.id);
+}
+
+#[test]
+fn pick_canonical_returns_none_for_an_empty_group() {
+    let empty: [&EntityRow; 0] = [];
+    assert!(pick_canonical(&empty).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: split_candidate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_candidate_detects_semicolon_soup_as_tier0() {
+    let (tier, delimiter, atoms) =
+        split_candidate("Fantasy Romance; Fantasy New Adult; Fantasy").unwrap();
+    assert_eq!(tier, Tier::Zero);
+    assert_eq!(delimiter, ";");
+    assert_eq!(
+        atoms,
+        vec!["Fantasy Romance", "Fantasy New Adult", "Fantasy"]
+    );
+}
+
+#[test]
+fn split_candidate_detects_long_embedded_comma_name_as_tier1() {
+    let name = "Epic High Fantasy, Sword and Sorcery, Heroic Journey Fiction";
+    assert!(name.len() >= TAG_SPLIT_LONG_LEN);
+    let (tier, delimiter, atoms) = split_candidate(name).unwrap();
+    assert_eq!(tier, Tier::One);
+    assert_eq!(delimiter, ",");
+    assert_eq!(
+        atoms,
+        vec![
+            "Epic High Fantasy",
+            "Sword and Sorcery",
+            "Heroic Journey Fiction"
+        ]
+    );
+}
+
+#[test]
+fn split_candidate_returns_none_for_a_short_plain_tag() {
+    assert_eq!(split_candidate("Fantasy"), None);
+    // A single short comma-pair isn't "long" enough for the tier-1 heuristic.
+    assert_eq!(split_candidate("Sci-Fi, Fantasy"), None);
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: strip_title_cruft
+// ---------------------------------------------------------------------------
+
+fn title_regexes() -> (Vec<Regex>, Regex) {
+    (
+        compile_all(TITLE_PREFIX_PATTERNS).unwrap(),
+        Regex::new(TITLE_SUFFIX_PATTERN).unwrap(),
+    )
+}
+
+#[test]
+fn strip_title_cruft_strips_last_first_dash_prefix_as_tier0() {
+    let (prefixes, suffix) = title_regexes();
+    let (tier, proposed) = strip_title_cruft(
+        "Maas, Sarah J - A Court of Thorns and Roses",
+        &prefixes,
+        &suffix,
+    )
+    .unwrap();
+    assert_eq!(tier, Tier::Zero);
+    assert_eq!(proposed, "A Court of Thorns and Roses");
+}
+
+#[test]
+fn strip_title_cruft_strips_series_bracket_prefix_as_tier0() {
+    let (prefixes, suffix) = title_regexes();
+    let (tier, proposed) =
+        strip_title_cruft("[Mistborn 01] The Final Empire", &prefixes, &suffix).unwrap();
+    assert_eq!(tier, Tier::Zero);
+    assert_eq!(proposed, "The Final Empire");
+}
+
+#[test]
+fn strip_title_cruft_strips_series_hash_prefix_as_tier0() {
+    let (prefixes, suffix) = title_regexes();
+    let (tier, proposed) =
+        strip_title_cruft("Mistborn #1 The Final Empire", &prefixes, &suffix).unwrap();
+    assert_eq!(tier, Tier::Zero);
+    assert_eq!(proposed, "The Final Empire");
+}
+
+#[test]
+fn strip_title_cruft_strips_acronym_index_dash_prefix_as_tier0() {
+    let (prefixes, suffix) = title_regexes();
+    let (tier, proposed) = strip_title_cruft("ToG04-Queen of Shadows", &prefixes, &suffix).unwrap();
+    assert_eq!(tier, Tier::Zero);
+    assert_eq!(proposed, "Queen of Shadows");
+}
+
+#[test]
+fn strip_title_cruft_strips_trailing_parenthetical_as_tier1() {
+    let (prefixes, suffix) = title_regexes();
+    let (tier, proposed) =
+        strip_title_cruft("The Final Empire (Mistborn, #1)", &prefixes, &suffix).unwrap();
+    assert_eq!(tier, Tier::One);
+    assert_eq!(proposed, "The Final Empire");
+}
+
+#[test]
+fn strip_title_cruft_returns_none_for_a_clean_title() {
+    let (prefixes, suffix) = title_regexes();
+    assert_eq!(strip_title_cruft("Elantris", &prefixes, &suffix), None);
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: pattern compilation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compile_all_compiles_every_valid_pattern() {
+    assert_eq!(compile_all(&["^a", "b$"]).unwrap().len(), 2);
+}
+
+#[test]
+#[allow(clippy::invalid_regex)] // deliberately malformed input under test
+fn compile_all_returns_err_for_an_invalid_pattern() {
+    assert!(compile_all(&["valid", "("]).is_err());
+}
+
+#[test]
+#[allow(clippy::invalid_regex)] // deliberately malformed input under test
+fn cleanup_error_pattern_variant_wraps_an_invalid_regex_error() {
+    let regex_err = Regex::new("(").unwrap_err();
+    let err: CleanupError = regex_err.into();
+    assert!(matches!(err, CleanupError::Pattern(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_authors
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_authors_collapses_last_first_swap_into_one_tier0_merge_suggestion() {
+    // AC1: `Brandon Sanderson` / `Sanderson, Brandon` collapse via the
+    // normalized-key swap.
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let canonical = insert_author(&pool, "Brandon Sanderson", None).await;
+    let duplicate = insert_author(&pool, "Sanderson, Brandon", None).await;
+    let b1 = insert_book(&pool, lib, "u1", "Book One").await;
+    let b2 = insert_book(&pool, lib, "u2", "Book Two").await;
+    let b3 = insert_book(&pool, lib, "u3", "Book Three").await;
+    link_author(&pool, b1, canonical).await;
+    link_author(&pool, b2, canonical).await;
+    link_author(&pool, b3, duplicate).await;
+
+    let suggestions = detect_authors(&pool).await.unwrap();
+    let merges: Vec<_> = suggestions
+        .iter()
+        .filter(|s| s.action == CleanupAction::Merge)
+        .collect();
+    assert_eq!(merges.len(), 1);
+    let s = merges[0];
+    assert_eq!(s.kind, CleanupKind::Author);
+    assert_eq!(s.tier, Tier::Zero);
+    assert_eq!(s.score, 1.0);
+    assert_eq!(s.book_count, 3);
+    assert_eq!(s.primary_name, "Brandon Sanderson");
+    assert_eq!(s.secondary_name.as_deref(), Some("Sanderson, Brandon"));
+    let (source_ids, source_names, canonical_id, canonical_name) = merge_payload(s);
+    assert_eq!(source_ids, [duplicate]);
+    assert_eq!(source_names, ["Sanderson, Brandon".to_string()]);
+    assert_eq!(canonical_id, canonical);
+    assert_eq!(canonical_name, "Brandon Sanderson");
+}
+
+#[tokio::test]
+async fn detect_authors_surfaces_tier1_fuzzy_merge_with_visible_score_at_or_above_085() {
+    // AC2: token-set Jaccard >= 0.85 surfaces with a visible score even
+    // though the two names never share a Tier-0 normalized key.
+    let pool = new_pool().await;
+    let shorter = insert_author(&pool, "Alpha Bravo Charlie Delta Echo Foxtrot Golf", None).await;
+    let _longer = insert_author(
+        &pool,
+        "Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel",
+        None,
+    )
+    .await;
+
+    let suggestions = detect_authors(&pool).await.unwrap();
+    let merges: Vec<_> = suggestions
+        .iter()
+        .filter(|s| s.action == CleanupAction::Merge)
+        .collect();
+    assert_eq!(merges.len(), 1);
+    let s = merges[0];
+    assert_eq!(s.tier, Tier::One);
+    assert!(s.score >= FUZZY_JACCARD_THRESHOLD, "score was {}", s.score);
+    // Both rows have 0 linked books; the lower id (inserted first) wins the tie.
+    let (_, _, canonical_id, _) = merge_payload(s);
+    assert_eq!(canonical_id, shorter);
+}
+
+#[tokio::test]
+async fn detect_authors_emits_delete_suggestions_for_junk_author_patterns() {
+    // AC3: junk-author regex emits Delete suggestions for known tooling
+    // artifacts, and leaves a real author alone.
+    let pool = new_pool().await;
+    let calibre = insert_author(&pool, "calibre (0.7.23) [http://calibre-ebook.com]", None).await;
+    let smashwords = insert_author(&pool, "Smashwords, Inc.", None).await;
+    insert_author(&pool, "Isaac Asimov", None).await;
+
+    let suggestions = detect_authors(&pool).await.unwrap();
+    let deletes: Vec<_> = suggestions
+        .iter()
+        .filter(|s| s.action == CleanupAction::Delete)
+        .collect();
+    assert_eq!(deletes.len(), 2);
+    for s in &deletes {
+        assert_eq!(s.kind, CleanupKind::Author);
+        assert_eq!(s.tier, Tier::Zero);
+        assert_eq!(s.score, 1.0);
+    }
+    let deleted_ids: Vec<i64> = deletes
+        .iter()
+        .map(|s| match &s.payload {
+            CleanupPayload::Delete { entity_id, .. } => *entity_id,
+            other => panic!("expected a Delete payload, got {other:?}"),
+        })
+        .collect();
+    assert!(deleted_ids.contains(&calibre));
+    assert!(deleted_ids.contains(&smashwords));
+}
+
+#[tokio::test]
+async fn detect_authors_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_authors(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_series
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_series_collapses_normalized_key_duplicates_into_one_tier0_merge() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let canonical = insert_series(&pool, "The Stormlight Archive", None).await;
+    let duplicate = insert_series(&pool, "Stormlight Archive, The", None).await;
+    let b1 = insert_book(&pool, lib, "u1", "Book One").await;
+    link_series(&pool, b1, canonical).await;
+
+    let suggestions = detect_series(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.kind, CleanupKind::Series);
+    assert_eq!(s.action, CleanupAction::Merge);
+    assert_eq!(s.tier, Tier::Zero);
+    let (source_ids, _, canonical_id, _) = merge_payload(s);
+    assert_eq!(source_ids, [duplicate]);
+    assert_eq!(canonical_id, canonical);
+}
+
+#[tokio::test]
+async fn detect_series_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_series(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_tags_merge
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_tags_merge_collapses_punctuation_variants_into_one_tier0_merge() {
+    let pool = new_pool().await;
+    let canonical = insert_tag(&pool, "Sci-Fi").await;
+    let duplicate = insert_tag(&pool, "Sci Fi").await;
+
+    let suggestions = detect_tags_merge(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.kind, CleanupKind::Tag);
+    assert_eq!(s.action, CleanupAction::Merge);
+    assert_eq!(s.tier, Tier::Zero);
+    let (source_ids, _, canonical_id, _) = merge_payload(s);
+    // Both rows have equal (zero) book counts, so the lower id wins the tie.
+    assert_eq!(canonical_id, canonical);
+    assert_eq!(source_ids, [duplicate]);
+}
+
+#[tokio::test]
+async fn detect_tags_merge_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_tags_merge(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_tags_split
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_tags_split_emits_a_tier0_suggestion_for_semicolon_soup_with_book_count() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let tag = insert_tag(&pool, "Fantasy Romance; Fantasy New Adult; Fantasy").await;
+    let b1 = insert_book(&pool, lib, "u1", "Book One").await;
+    let b2 = insert_book(&pool, lib, "u2", "Book Two").await;
+    link_tag(&pool, b1, tag).await;
+    link_tag(&pool, b2, tag).await;
+    insert_tag(&pool, "Fantasy").await; // too short to be a split candidate
+
+    let suggestions = detect_tags_split(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.action, CleanupAction::Split);
+    assert_eq!(s.tier, Tier::Zero);
+    assert_eq!(s.score, 1.0);
+    assert_eq!(s.book_count, 2);
+    match &s.payload {
+        CleanupPayload::Split {
+            source_id,
+            atoms,
+            delimiter,
+            ..
+        } => {
+            assert_eq!(*source_id, tag);
+            assert_eq!(delimiter, ";");
+            assert_eq!(
+                atoms,
+                &vec![
+                    "Fantasy Romance".to_string(),
+                    "Fantasy New Adult".to_string(),
+                    "Fantasy".to_string()
+                ]
+            );
+        }
+        other => panic!("expected a Split payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn detect_tags_split_emits_a_tier1_suggestion_for_a_long_embedded_comma_tag() {
+    let pool = new_pool().await;
+    let name = "Epic High Fantasy, Sword and Sorcery, Heroic Journey Fiction";
+    insert_tag(&pool, name).await;
+
+    let suggestions = detect_tags_split(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.tier, Tier::One);
+    assert_eq!(s.score, 0.75);
+    match &s.payload {
+        CleanupPayload::Split { delimiter, .. } => assert_eq!(delimiter, ","),
+        other => panic!("expected a Split payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn detect_tags_split_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_tags_split(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_book_titles
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_book_titles_strips_an_author_prefix_as_a_tier0_rename() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let cruft = insert_book(
+        &pool,
+        lib,
+        "u1",
+        "Maas, Sarah J - A Court of Thorns and Roses",
+    )
+    .await;
+    insert_book(&pool, lib, "u2", "Elantris").await; // clean, no suggestion
+
+    let suggestions = detect_book_titles(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.kind, CleanupKind::BookTitle);
+    assert_eq!(s.action, CleanupAction::Rename);
+    assert_eq!(s.tier, Tier::Zero);
+    assert_eq!(s.book_count, 1);
+    assert_eq!(
+        s.secondary_name.as_deref(),
+        Some("A Court of Thorns and Roses")
+    );
+    match &s.payload {
+        CleanupPayload::Rename { book_id, .. } => assert_eq!(*book_id, cruft),
+        other => panic!("expected a Rename payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn detect_book_titles_strips_a_trailing_parenthetical_as_a_tier1_rename() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    insert_book(&pool, lib, "u1", "The Final Empire (Mistborn, #1)").await;
+
+    let suggestions = detect_book_titles(&pool).await.unwrap();
+    assert_eq!(suggestions.len(), 1);
+    let s = &suggestions[0];
+    assert_eq!(s.tier, Tier::One);
+    assert_eq!(s.score, 0.75);
+    assert_eq!(s.secondary_name.as_deref(), Some("The Final Empire"));
+}
+
+#[tokio::test]
+async fn detect_book_titles_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_book_titles(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}
+
+// ---------------------------------------------------------------------------
+// detect_all
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detect_all_dispatches_every_detector_and_concatenates_results() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    insert_author(&pool, "Brandon Sanderson", None).await;
+    insert_author(&pool, "Sanderson, Brandon", None).await;
+    insert_tag(&pool, "Fantasy Romance; Fantasy New Adult").await;
+    insert_book(&pool, lib, "u1", "Maas, Sarah J - A Court of Mist and Fury").await;
+
+    let suggestions = detect_all(&pool).await.unwrap();
+    let kinds: std::collections::HashSet<CleanupKind> =
+        suggestions.iter().map(|s| s.kind).collect();
+    assert!(kinds.contains(&CleanupKind::Author));
+    assert!(kinds.contains(&CleanupKind::Tag));
+    assert!(kinds.contains(&CleanupKind::BookTitle));
+}
+
+#[tokio::test]
+async fn detect_all_propagates_db_error_when_pool_is_closed() {
+    let pool = new_pool().await;
+    pool.close().await;
+    let err = detect_all(&pool).await.unwrap_err();
+    assert!(matches!(err, CleanupError::Db(_)));
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -14,6 +14,7 @@ pub mod book_summary;
 pub mod bookmarks;
 pub mod books;
 pub mod browse;
+pub mod cleanup;
 pub mod comic;
 pub mod convert;
 pub mod covers;
@@ -80,6 +81,7 @@ pub use books::{
     IndexedRow, PageCursor, MAX_BOOKS_RETURNED,
 };
 pub use browse::*;
+pub use cleanup::*;
 pub use covers::{cover_mime_hint, covers_dir, get_cover, get_last_modified_epoch, CoversError};
 pub use deletion::{
     book_deletion_manifest, delete_book_items, DeleteError, DeleteOutcome, DeletionImpact,


### PR DESCRIPTION
## Summary
- Closes #962
- Adds `db/src/cleanup.rs` (re-exported from `db/src/lib.rs`) implementing the five F5.9 library-cleanup detectors: `detect_authors`, `detect_series`, `detect_tags_merge`, `detect_tags_split`, `detect_book_titles`, and a `detect_all` dispatcher, plus a junk-author delete detector folded into `detect_authors`.
- Merge detectors (authors/series/tags) share one shape: Tier 0 is a `GROUP BY` on a normalized key (lowercase, strip punctuation, collapse whitespace, `"Last, First"` → `"First Last"` via `COALESCE(sort, name)`, reusing the existing `normalize::normalize_author` fold); Tier 1 is token-set Jaccard ≥ 0.85, blocked by shared first token to stay sub-quadratic.
- Tag-split detects a `;`-delimited soup (Tier 0) or a long name with embedded commas (Tier 1). Book-title detection regex-strips `Last, First - `, `[SERIES NN] `, `Series #NN `, `ToG04-`-style prefixes (Tier 0), and trailing parenthetical editions (Tier 1). Junk-author detection regex-matches Calibre/Smashwords tooling artifacts and emits `Delete` suggestions.
- Detection only, per the sub-issue's scope — no writes to `dedup_suggestions` (the schema already landed in #961/migration `0069`) and no RPC/route wiring; those are separate follow-up issues.

## Test plan
- [x] `cargo fmt -p omnibus-db --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (1996 passed, 0 failed), including 34 new tests in `db/src/cleanup/tests.rs` covering: AC1 (`Brandon Sanderson` / `Sanderson, Brandon` Tier-0 collapse), AC2 (Tier-1 Jaccard ≥ 0.85 fuzzy match with a visible score, plus a dedicated test proving first-token blocking prevents an otherwise-qualifying pair from being compared), AC3 (tag-split atoms, book-title strip for every documented pattern, junk-author regex Delete suggestions), and AC4 (each detector's happy path plus its Tier-0/Tier-1 branches, inline in `#[cfg(test)]`).

## Notes
- The schema migration (`dedup_suggestions`/`cleanup_log`/`entity_aliases`, migration `0069`) and the shared wire types (`CleanupKind`/`CleanupAction`/`Decision`/`CleanupCounts`/`SuggestionCard` in `shared/src/cleanup.rs`) already landed from earlier sub-issues of #960 — this PR only adds the detection module itself.
- `regex` is added as a direct `db`-only dependency; it was already present transitively in `Cargo.lock` so this introduces no new download.
- `DetectedSuggestion`/`CleanupPayload` are new types local to `db/src/cleanup.rs`, not the persisted `SuggestionCard` — they carry the raw detection result (kind/action/tier/score/payload) that a future apply-primitives issue will persist into `dedup_suggestions`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Stb8DXkf8FDYjLe4PXoXX2)_