### PR TITLE
feat: live-update the admin health page (#955)

### DIFF
--- a/frontend/src/pages/admin_health.rs
+++ b/frontend/src/pages/admin_health.rs
@@ -1,8 +1,9 @@
 //! Admin server-health page — the first admin route in the app. Five
-//! read-only sections over one [`AdminHealthReport`] fetch, refreshed once
-//! on mount in a post-mount `use_effect` (never the render body, for
-//! hydration parity). Web/SSR-only; the real authorization boundary is the
-//! `AdminUser` extractor on `rpc_get_admin_health`.
+//! read-only sections over one [`AdminHealthReport`] fetch, polled every
+//! [`POLL_INTERVAL_MS`] from a post-mount `use_future` loop (never the
+//! render body, for hydration parity — see #955). Web/SSR-only; the real
+//! authorization boundary is the `AdminUser` extractor on
+//! `rpc_get_admin_health`.
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
@@ -12,7 +13,14 @@ use omnibus_shared::admin_health::{
 use omnibus_shared::error_ring::CapturedError;
 
 use crate::components::worker_status::kind_label;
-use crate::data;
+use crate::data::{self, DataError};
+use crate::platform_sleep::async_sleep_ms;
+
+/// Polling cadence in milliseconds — AC1 asks for "approximately a
+/// 5-second cadence". Same self-hosted-single-admin reasoning as
+/// `worker_status::POLL_INTERVAL_MS`: no idle-throttling, the report is
+/// small and this page has one viewer at a time.
+const POLL_INTERVAL_MS: u32 = 5_000;
 
 /// The `/admin/health` page.
 #[component]
@@ -42,22 +50,44 @@ pub fn AdminHealthPage() -> Element {
     }
 }
 
-/// Fetch the combined report on mount, mapping success/failure onto the
-/// result/error signals — same shape as `LastErrorsSection`'s
-/// `spawn_last_errors_fetch` in `pages::settings::health`.
+/// Poll the combined report every [`POLL_INTERVAL_MS`] from a post-mount
+/// `use_future` loop (#955 AC1/AC2) — fetch, apply, sleep, repeat. Dioxus
+/// cancels the future when the page unmounts (AC4), same guarantee
+/// `components::worker_status::WorkerStatusIndicator` relies on for its own
+/// 1 Hz loop, so no explicit `use_drop` teardown is needed.
 fn spawn_admin_health_fetch(
     mut result: Signal<Option<AdminHealthReport>>,
     mut error: Signal<bool>,
 ) {
-    use_effect(move || {
-        error.set(false);
-        spawn(async move {
-            match data::get_admin_health().await {
-                Ok(report) => result.set(Some(report)),
-                Err(_) => error.set(true),
-            }
-        });
+    use_future(move || async move {
+        loop {
+            let outcome = data::get_admin_health().await;
+            apply_poll_result(outcome, &mut result, &mut error);
+            async_sleep_ms(POLL_INTERVAL_MS).await;
+        }
     });
+}
+
+/// Merge one poll's outcome into the `result`/`error` signals. A success
+/// always replaces the report and clears any prior error. A failure only
+/// flips the page to its error state when there is no report to keep
+/// showing yet (the first load) — a later transient blip leaves the last
+/// known-good report on screen rather than flashing the whole page to an
+/// error, mirroring `WorkerStatusIndicator`'s "keep the last known
+/// snapshot" behavior.
+fn apply_poll_result(
+    outcome: Result<AdminHealthReport, DataError>,
+    result: &mut Signal<Option<AdminHealthReport>>,
+    error: &mut Signal<bool>,
+) {
+    match outcome {
+        Ok(report) => {
+            result.set(Some(report));
+            error.set(false);
+        }
+        Err(_) if result.peek().is_none() => error.set(true),
+        Err(_) => {}
+    }
 }
 
 /// The result region: loading / error / populated states.

--- a/frontend/src/pages/admin_health.rs
+++ b/frontend/src/pages/admin_health.rs
@@ -1,9 +1,8 @@
 //! Admin server-health page — the first admin route in the app. Five
-//! read-only sections over one [`AdminHealthReport`] fetch, polled every
+//! read-only sections over one [`AdminHealthReport`], polled every
 //! [`POLL_INTERVAL_MS`] from a post-mount `use_future` loop (never the
-//! render body, for hydration parity — see #955). Web/SSR-only; the real
-//! authorization boundary is the `AdminUser` extractor on
-//! `rpc_get_admin_health`.
+//! render body, for hydration parity). Web/SSR-only; the real
+//! authorization boundary is the `AdminUser` extractor on `rpc_get_admin_health`.
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
@@ -29,7 +28,7 @@ pub fn AdminHealthPage() -> Element {
     let result = use_signal(|| None::<AdminHealthReport>);
     let error = use_signal(|| false);
 
-    spawn_admin_health_fetch(result, error);
+    spawn_admin_health_fetch(is_admin, result, error);
 
     rsx! {
         div { class: "ah-page", "data-testid": "admin-health-page",
@@ -51,21 +50,37 @@ pub fn AdminHealthPage() -> Element {
 }
 
 /// Poll the combined report every [`POLL_INTERVAL_MS`] from a post-mount
-/// `use_future` loop (#955 AC1/AC2) — fetch, apply, sleep, repeat. Dioxus
-/// cancels the future when the page unmounts (AC4), same guarantee
+/// `use_future` loop — fetch, apply, sleep, repeat. Dioxus cancels the future
+/// when the page unmounts, the same guarantee
 /// `components::worker_status::WorkerStatusIndicator` relies on for its own
-/// 1 Hz loop, so no explicit `use_drop` teardown is needed.
+/// 1 Hz loop, so no explicit `use_drop` teardown is needed. Always runs (the
+/// hook itself can't be conditional without breaking Dioxus's hook-order
+/// rule), but [`should_poll`] gates the fetch each tick so a non-admin
+/// visitor never hits the admin-gated RPC.
 fn spawn_admin_health_fetch(
+    is_admin: ReadSignal<bool>,
     mut result: Signal<Option<AdminHealthReport>>,
     mut error: Signal<bool>,
 ) {
     use_future(move || async move {
         loop {
-            let outcome = data::get_admin_health().await;
-            apply_poll_result(outcome, &mut result, &mut error);
+            if should_poll(is_admin()) {
+                let outcome = data::get_admin_health().await;
+                apply_poll_result(outcome, &mut result, &mut error);
+            }
             async_sleep_ms(POLL_INTERVAL_MS).await;
         }
     });
+}
+
+/// Whether a poll tick should fetch. The RPC itself already 403s a
+/// non-admin, but the page must not even attempt it — a visitor who isn't
+/// admin (or whose `CurrentUser` hasn't resolved yet) would otherwise
+/// generate a 401/403 every [`POLL_INTERVAL_MS`] for as long as the page
+/// stays open. Re-checked every tick, not just once at mount, so admin
+/// status flipping mid-session starts or stops polling within one interval.
+fn should_poll(is_admin: bool) -> bool {
+    is_admin
 }
 
 /// Merge one poll's outcome into the `result`/`error` signals. A success

--- a/frontend/src/pages/admin_health/tests.rs
+++ b/frontend/src/pages/admin_health/tests.rs
@@ -1,11 +1,22 @@
-//! Tests for the admin server-health page: the pure formatters, the live-poll
-//! merge logic (#955), and a render assertion per section (rendered output
-//! contains the expected content, per
+//! Tests for the admin server-health page: the pure formatters, the
+//! live-poll merge logic, and a render assertion per section (rendered
+//! output contains the expected content, per
 //! `.claude/rules/03-unit-testing.md`'s frontend guidance).
 
 use omnibus_shared::worker::TaskKind;
 
 use super::*;
+
+// ---------- poll gating ----------
+
+#[test]
+fn should_poll_fetches_only_for_an_admin_viewer() {
+    assert!(should_poll(true));
+    assert!(
+        !should_poll(false),
+        "a non-admin viewer must never trigger the admin-gated RPC"
+    );
+}
 
 // ---------- live-poll merge logic (#955) ----------
 //

--- a/frontend/src/pages/admin_health/tests.rs
+++ b/frontend/src/pages/admin_health/tests.rs
@@ -1,10 +1,111 @@
-//! Tests for the admin server-health page: the pure formatters, and a
-//! render assertion per section (rendered output contains the expected
-//! content, per `.claude/rules/03-unit-testing.md`'s frontend guidance).
+//! Tests for the admin server-health page: the pure formatters, the live-poll
+//! merge logic (#955), and a render assertion per section (rendered output
+//! contains the expected content, per
+//! `.claude/rules/03-unit-testing.md`'s frontend guidance).
 
 use omnibus_shared::worker::TaskKind;
 
 use super::*;
+
+// ---------- live-poll merge logic (#955) ----------
+//
+// `apply_poll_result` reads/writes `Signal`s, which need an active Dioxus
+// scope (same reasoning as `read_status_auto::tests`'s
+// `apply_fetched_status` cases) — so each case runs inside a mounted dummy
+// component via `VirtualDom::rebuild_in_place` rather than constructing
+// bare `Signal`s at the top of a `#[test] fn`.
+
+fn sample_report(book_count: i64) -> AdminHealthReport {
+    AdminHealthReport {
+        index: IndexStatus {
+            book_count,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn apply_poll_result_populates_result_and_clears_error_on_first_success() {
+    #[component]
+    fn AssertFirstSuccessPopulates() -> Element {
+        let mut result = Signal::new(None::<AdminHealthReport>);
+        let mut error = Signal::new(false);
+
+        apply_poll_result(Ok(sample_report(1)), &mut result, &mut error);
+
+        assert_eq!(result().map(|r| r.index.book_count), Some(1));
+        assert!(!error());
+        rsx! {}
+    }
+    VirtualDom::new(AssertFirstSuccessPopulates).rebuild_in_place();
+}
+
+#[test]
+fn apply_poll_result_sets_error_when_the_first_fetch_fails() {
+    #[component]
+    fn AssertFirstFailureSetsError() -> Element {
+        let mut result = Signal::new(None::<AdminHealthReport>);
+        let mut error = Signal::new(false);
+
+        apply_poll_result(
+            Err(DataError::Other("boom".to_string())),
+            &mut result,
+            &mut error,
+        );
+
+        assert!(result().is_none());
+        assert!(error());
+        rsx! {}
+    }
+    VirtualDom::new(AssertFirstFailureSetsError).rebuild_in_place();
+}
+
+#[test]
+fn apply_poll_result_keeps_the_last_known_report_when_a_later_poll_fails() {
+    #[component]
+    fn AssertTransientFailureKeepsReport() -> Element {
+        let mut result = Signal::new(None::<AdminHealthReport>);
+        let mut error = Signal::new(false);
+        apply_poll_result(Ok(sample_report(7)), &mut result, &mut error);
+
+        apply_poll_result(
+            Err(DataError::Other("transient".to_string())),
+            &mut result,
+            &mut error,
+        );
+
+        assert_eq!(result().map(|r| r.index.book_count), Some(7));
+        assert!(
+            !error(),
+            "a transient poll failure must not flip an already-loaded page to the error state"
+        );
+        rsx! {}
+    }
+    VirtualDom::new(AssertTransientFailureKeepsReport).rebuild_in_place();
+}
+
+#[test]
+fn apply_poll_result_replaces_a_stale_report_on_the_next_success() {
+    #[component]
+    fn AssertNextSuccessReplacesStaleReport() -> Element {
+        let mut result = Signal::new(None::<AdminHealthReport>);
+        let mut error = Signal::new(false);
+        apply_poll_result(Ok(sample_report(7)), &mut result, &mut error);
+        apply_poll_result(
+            Err(DataError::Other("transient".to_string())),
+            &mut result,
+            &mut error,
+        );
+
+        apply_poll_result(Ok(sample_report(9)), &mut result, &mut error);
+
+        assert_eq!(result().map(|r| r.index.book_count), Some(9));
+        assert!(!error());
+        rsx! {}
+    }
+    VirtualDom::new(AssertNextSuccessReplacesStaleReport).rebuild_in_place();
+}
 
 // ---------- pure formatters ----------
 

--- a/frontend/src/rpc/admin_health.rs
+++ b/frontend/src/rpc/admin_health.rs
@@ -12,9 +12,10 @@ use omnibus_shared::admin_health::AdminHealthReport;
 #[cfg(feature = "server")]
 use super::{internal_rpc_error, AdminUser, PoolExt, WorkerExt};
 
-/// Admin-only: the full `/admin/health` report in one request. No polling —
-/// the page fetches this once on load (see issue #955 for a future
-/// live-updating variant).
+/// Admin-only: the full `/admin/health` report in one request. Called both
+/// on the page's first load and on its 5-second live-update poll (#955) —
+/// this endpoint itself stays a plain point-in-time fetch; the interval
+/// lives client-side in `pages::admin_health`.
 #[post("/api/rpc/admin-health", pool: PoolExt, worker: WorkerExt, _admin: AdminUser)]
 pub async fn rpc_get_admin_health() -> Result<AdminHealthReport> {
     Ok(db::admin_health::build_report(&pool.0, &worker.0)

--- a/server/src/backend/admin_health.rs
+++ b/server/src/backend/admin_health.rs
@@ -14,9 +14,9 @@ use omnibus_db as db;
 use super::{internal, AppState};
 use crate::auth::AdminUser;
 
-/// `GET /api/admin/health` — the combined server-health report. Read-only;
-/// no polling built in here (see issue #955 for a future live-updating
-/// variant).
+/// `GET /api/admin/health` — the combined server-health report. Read-only
+/// point-in-time fetch; the web page's 5-second live-update loop (#955) is
+/// client-side polling of `rpc_get_admin_health`, not this REST twin.
 pub(super) async fn get_admin_health(_admin: AdminUser, State(state): State<AppState>) -> Response {
     match db::admin_health::build_report(state.pool(), state.worker()).await {
         Ok(report) => Json(report).into_response(),

--- a/shared/src/admin_health.rs
+++ b/shared/src/admin_health.rs
@@ -59,8 +59,8 @@ pub struct StorageStats {
 
 /// Full report backing `/admin/health`'s five sections, returned in one
 /// request by `GET /api/admin/health` (REST) / `rpc_get_admin_health`
-/// (web). No polling — a fresh report is fetched once on page load; see
-/// issue #955 for a future live-updating variant.
+/// (web). The web page re-fetches this on a 5-second live-update poll
+/// (#955) in addition to its initial page-load fetch.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct AdminHealthReport {
     pub index: IndexStatus,


### PR DESCRIPTION
## Summary
- Closes #955
- The `/admin/health` page now polls its report every 5 seconds from a post-mount `use_future` loop (`frontend/src/pages/admin_health.rs`), instead of fetching once on load, so index status, worker queue depth, storage, and error counts stay current without a manual reload (AC1).
- The interop is entirely inside the post-mount effect — the render body is unchanged, so SSR and first-paint markup still match (AC2, `.claude/rules/07-hydration.md`).
- Dioxus cancels the polling future when the page unmounts, the same guarantee `components::worker_status::WorkerStatusIndicator`'s 1 Hz loop already relies on, so there's no leaked timer (AC4).
- A transient poll failure keeps the last known-good report on screen instead of flashing the whole page to an error state; the very first load still shows the existing error state on failure. This merge decision is pulled into a pure `apply_poll_result` helper so it's unit-testable without an async runtime.
- Went with polling rather than SSE (both are allowed by the issue): the existing `rpc_get_admin_health` / `GET /api/admin/health` handlers already return the whole report in one point-in-time call, so re-invoking the same fetch on an interval — the same `gloo_timers`-backed `platform_sleep::async_sleep_ms` pattern `WorkerStatusIndicator` already uses for its 1 Hz poll — needed no new backend route or streaming plumbing (AC3 doesn't apply).
- Refreshed the stale "no polling — see #955" doc comments left on `AdminHealthReport`, `rpc_get_admin_health`, and `GET /api/admin/health` now that the page polls.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (733 passed; includes new `apply_poll_result` coverage: first-load success, first-load failure, a later transient failure keeping the last known report, and a subsequent success replacing a stale report)
- [x] `cargo test -p omnibus admin_health` — PASS (4 passed; the existing `backend::admin_health` handler tests are untouched in behavior)
- [x] `cargo test -p omnibus` (full suite) — 810 passed, 2 pre-existing failures unrelated to this change (`backend::uploads::tests::{commit_rejects_read_only_library_with_400, audiobook_commit_rejects_read_only_library_with_400}`) — both `chmod 0o555` a directory and expect a write to fail with `PermissionDenied`, which doesn't hold when the test runs as root (root bypasses Unix permission bits); confirmed with a standalone `chmod 0555 && touch` repro in this container. Not touched by this diff.

## Notes
- No new environment variables, migrations, or dependencies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Stb8DXkf8FDYjLe4PXoXX2)_