### PR TITLE
[OMNI-1864] Reader Progress Groundwork

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -4,6 +4,9 @@
 //! time. Session inserts go to the per-format `reading_sessions` /
 //! `listening_sessions` tables; all rows soft-reference `books.uuid`.
 
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock, PoisonError};
+
 use omnibus_shared::{
     AudiobookPlaybackRateRecord, AudiobookPlaybackRateUpdate, ChapterInfo, ProgressFormat,
     ProgressRecord, ProgressUpdate, ResumePoint, SessionReport,
@@ -212,6 +215,130 @@ pub async fn attach_derived_kobo_location(
     .execute(pool)
     .await?;
     Ok(result.rows_affected() > 0)
+}
+
+/// Attach a server-derived whole-book percent to an existing epub row
+/// WITHOUT advancing any freshness clock — the same contract as
+/// [`attach_derived_kobo_location`]: the percent describes the position the
+/// row already holds, so bumping a clock would re-fire sync deltas.
+/// Optimistic: no-ops unless the row still has no percent and its event
+/// time is unchanged since the caller read it. Returns whether a row was
+/// updated.
+pub async fn attach_derived_percent(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+    percent: i64,
+    expected_client_updated_at: i64,
+) -> Result<bool, ProgressError> {
+    let book_uuid = resolve_canonical_book_uuid(pool, book_uuid)
+        .await?
+        .ok_or(ProgressError::BookNotFound)?;
+    let result = sqlx::query(
+        "UPDATE reading_progress
+            SET progress_percent = ?
+          WHERE user_id = ? AND book_uuid = ? AND format = 'epub'
+            AND progress_percent IS NULL
+            AND COALESCE(client_updated_at, updated_at) = ?",
+    )
+    .bind(percent)
+    .bind(user_id)
+    .bind(&book_uuid)
+    .bind(expected_client_updated_at)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Derive the whole-book visible-text percent for a stored epub CFI from
+/// the book's source EPUB alone (no kepub involved) and attach it via
+/// [`attach_derived_percent`]. `Ok(false)` covers every underivable case —
+/// no EPUB file row, an unparseable CFI, an unanchorable tail, or a row
+/// whose event time moved on since `expected_client_updated_at` was read —
+/// mirroring `kobo_position`'s rule of degrading to no derived value,
+/// never a wrong one. `Err` is reserved for I/O-level surprises.
+pub async fn derive_epub_percent(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+    cfi: &str,
+    expected_client_updated_at: i64,
+) -> anyhow::Result<bool> {
+    use anyhow::Context;
+
+    let Some(book_id) = crate::resolve_book_id_by_uuid(pool, book_uuid).await? else {
+        return Ok(false);
+    };
+    let Some(source) = crate::book_file_path(pool, book_id, "EPUB").await? else {
+        return Ok(false);
+    };
+    let cfi = cfi.to_owned();
+    let derived =
+        tokio::task::spawn_blocking(move || crate::kobo_position::cfi_to_span(None, &source, &cfi))
+            .await
+            .context("percent derivation task panicked")??;
+    let Some(percent) = derived.percent else {
+        return Ok(false);
+    };
+    match attach_derived_percent(
+        pool,
+        user_id,
+        book_uuid,
+        percent,
+        expected_client_updated_at,
+    )
+    .await
+    {
+        Ok(updated) => Ok(updated),
+        // The book vanished between the upsert and the attach; nothing left
+        // to annotate is a non-event, not a failure.
+        Err(ProgressError::BookNotFound) => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// In-flight guard for [`spawn_epub_percent_derivation`]: one spine walk per
+/// `(user, book)` at a time, so a page-turn burst costs one walk. Skipped
+/// writes self-heal — the next accepted write re-spawns after the running
+/// walk finishes.
+fn percent_derivations_in_flight() -> &'static Mutex<HashSet<(i64, String)>> {
+    static IN_FLIGHT: OnceLock<Mutex<HashSet<(i64, String)>>> = OnceLock::new();
+    IN_FLIGHT.get_or_init(Mutex::default)
+}
+
+/// Fire-and-forget percent derivation for an accepted epub write that landed
+/// without one (the web reader sends only a CFI). Runs off the request path:
+/// the caller responds immediately and the percent attaches clock-neutrally
+/// when the walk completes. No-op for audio rows, rows already carrying a
+/// percent (Kobo bookmarks, comic anchors), and CFI-less rows.
+pub fn spawn_epub_percent_derivation(pool: SqlitePool, user_id: i64, record: &ProgressRecord) {
+    if record.format != ProgressFormat::Epub || record.progress_percent.is_some() {
+        return;
+    }
+    let Some(cfi) = record.epub_cfi.clone() else {
+        return;
+    };
+    let key = (user_id, record.book_uuid.clone());
+    {
+        let mut in_flight = percent_derivations_in_flight()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if !in_flight.insert(key.clone()) {
+            return;
+        }
+    }
+    let book_uuid = record.book_uuid.clone();
+    let expected = record.client_updated_at;
+    tokio::spawn(async move {
+        let result = derive_epub_percent(&pool, user_id, &book_uuid, &cfi, expected).await;
+        percent_derivations_in_flight()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&key);
+        if let Err(e) = result {
+            tracing::warn!(%book_uuid, error = %e, "epub percent derivation failed");
+        }
+    });
 }
 
 /// The device's own `Statistics` counters, mirrored so sync-out can hand

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -306,6 +306,23 @@ fn percent_derivations_in_flight() -> &'static Mutex<HashSet<(i64, String)>> {
     IN_FLIGHT.get_or_init(Mutex::default)
 }
 
+/// Removes its key from the in-flight set on drop, so the slot frees even
+/// when the derivation future panics or is dropped mid-flight — a leaked
+/// key would suppress every later derivation for that `(user, book)` until
+/// process restart.
+struct InFlightGuard {
+    key: (i64, String),
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        percent_derivations_in_flight()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&self.key);
+    }
+}
+
 /// Fire-and-forget percent derivation for an accepted epub write that landed
 /// without one (the web reader sends only a CFI). Runs off the request path:
 /// the caller responds immediately and the percent attaches clock-neutrally
@@ -327,15 +344,14 @@ pub fn spawn_epub_percent_derivation(pool: SqlitePool, user_id: i64, record: &Pr
             return;
         }
     }
+    // The guard exists from here on, so the key leaves the set no matter
+    // how the future ends — completion, panic, or being dropped unrun.
+    let guard = InFlightGuard { key };
     let book_uuid = record.book_uuid.clone();
     let expected = record.client_updated_at;
     tokio::spawn(async move {
-        let result = derive_epub_percent(&pool, user_id, &book_uuid, &cfi, expected).await;
-        percent_derivations_in_flight()
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(&key);
-        if let Err(e) = result {
+        let _guard = guard;
+        if let Err(e) = derive_epub_percent(&pool, user_id, &book_uuid, &cfi, expected).await {
             tracing::warn!(%book_uuid, error = %e, "epub percent derivation failed");
         }
     });

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -2429,3 +2429,183 @@ fn kobo_statistics_is_empty_only_when_both_counters_are_absent() {
     }
     .is_empty());
 }
+
+// ── derived-percent attachment (#1864) ──────────────────────────────
+
+/// One-paragraph chapter used twice so the whole-book percent at the start
+/// of chapter 2 is exactly 50 (identical visible-text counts per chapter).
+const PERCENT_CHAPTER: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>C</title></head>
+<body>
+  <p>First sentence here. Second sentence follows.</p>
+</body>
+</html>"#;
+
+/// Seed one book whose two-chapter EPUB really exists on disk in a per-test
+/// library dir, plus a user; returns `(pool, user_id, book_uuid)`.
+async fn seed_epub_on_disk(tag: &str) -> (SqlitePool, i64, String) {
+    let dir = crate::test_support::make_test_dir(&format!("derive_percent_{tag}"));
+    std::fs::write(
+        dir.join("book.epub"),
+        crate::test_support::build_test_epub(&[
+            ("c1.xhtml", PERCENT_CHAPTER),
+            ("c2.xhtml", PERCENT_CHAPTER),
+        ]),
+    )
+    .unwrap();
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let (_, uuid) = seed_named_file(&pool, dir.to_str().unwrap(), "Book", "book.epub").await;
+    let user = seed_user(&pool, "alice").await;
+    (pool, user, uuid)
+}
+
+/// Like [`seed`] but with an explicit on-disk filename, so `book_file_path`
+/// resolves to a file the test actually wrote.
+async fn seed_named_file(
+    pool: &SqlitePool,
+    library: &str,
+    title: &str,
+    filename: &str,
+) -> (i64, String) {
+    replace_books(
+        pool,
+        library,
+        vec![crate::ebook::IndexedBook {
+            metadata: EbookMetadata {
+                filename: filename.to_string(),
+                title: Some(title.to_string()),
+                ..Default::default()
+            },
+            cover: None,
+            mtime_epoch: 0,
+            size_bytes: 0,
+            word_count: None,
+        }],
+    )
+    .await
+    .expect("seed book");
+    let books = crate::list_books(pool, library).await.unwrap();
+    let book = books
+        .into_iter()
+        .find(|b| b.title.as_deref() == Some(title))
+        .unwrap();
+    (book.id, book.unique_identifier.clone().unwrap())
+}
+
+fn cfi_update(uuid: &str, cfi: &str, client_updated_at: i64) -> ProgressUpdate {
+    ProgressUpdate {
+        book_uuid: uuid.to_string(),
+        format: ProgressFormat::Epub,
+        epub_cfi: Some(cfi.to_string()),
+        audio_position_seconds: None,
+        progress_percent: None,
+        kobo_location: None,
+        book_file_id: None,
+        client_updated_at: Some(client_updated_at),
+    }
+}
+
+#[tokio::test]
+async fn attach_derived_percent_sets_percent_only_when_clock_matches() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    let saved = upsert_progress(
+        &pool,
+        user,
+        &cfi_update(&uuid, "epubcfi(/6/4!/4/2/1:0)", 1_000),
+    )
+    .await
+    .unwrap();
+    assert_eq!(saved.client_updated_at, 1_000);
+
+    // Stale expectation: the row's event time is 1_000, not 999.
+    let stale = attach_derived_percent(&pool, user, &uuid, 43, 999)
+        .await
+        .unwrap();
+    assert!(!stale, "a mismatched clock must not attach");
+
+    let attached = attach_derived_percent(&pool, user, &uuid, 43, 1_000)
+        .await
+        .unwrap();
+    assert!(attached);
+    let row = get_progress(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.progress_percent, Some(43));
+    // Clock-neutral: neither freshness clock moved.
+    assert_eq!(row.client_updated_at, saved.client_updated_at);
+    assert_eq!(row.updated_at, saved.updated_at);
+
+    // A percent already present is never overwritten by a derivation.
+    let second = attach_derived_percent(&pool, user, &uuid, 77, 1_000)
+        .await
+        .unwrap();
+    assert!(!second);
+    let row = get_progress(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.progress_percent, Some(43));
+}
+
+#[tokio::test]
+async fn derive_epub_percent_attaches_visible_text_percent_from_source_epub() {
+    let (pool, user, uuid) = seed_epub_on_disk("happy").await;
+    // Spine index 1 (`/6/4`), first text node, offset 0 — the first visible
+    // character of chapter 2 of two identical chapters: exactly 50%.
+    let cfi = "epubcfi(/6/4!/4/2/1:0)";
+    let saved = upsert_progress(&pool, user, &cfi_update(&uuid, cfi, 1_000))
+        .await
+        .unwrap();
+    assert_eq!(saved.progress_percent, None);
+
+    let derived = derive_epub_percent(&pool, user, &uuid, cfi, saved.client_updated_at)
+        .await
+        .unwrap();
+    assert!(derived);
+    let row = get_progress(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.progress_percent, Some(50));
+    assert_eq!(row.client_updated_at, saved.client_updated_at);
+}
+
+#[tokio::test]
+async fn derive_epub_percent_returns_false_when_book_has_no_epub_file() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    // A ghosted book: `books` row only, no `book_files` — the shape a
+    // removed file leaves behind (F2).
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib2', 'lib2')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort)
+         SELECT 'ghost-uuid', 'g.epub', id, '/lib2/g', 'Ghost', 'ghost'
+           FROM scan_roots WHERE path = '/lib2'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let derived = derive_epub_percent(&pool, user, "ghost-uuid", "epubcfi(/6/2!/4/2/1:0)", 1_000)
+        .await
+        .unwrap();
+    assert!(!derived, "a fileless book must degrade to no derivation");
+}
+
+#[tokio::test]
+async fn derive_epub_percent_returns_false_for_an_unparseable_cfi() {
+    let (pool, user, uuid) = seed_epub_on_disk("unparseable").await;
+    // A comic-page anchor reuses the CFI slot but is not a CFI; the parse
+    // refuses it and nothing attaches.
+    let derived = derive_epub_percent(&pool, user, &uuid, "comic-page:3", 1_000)
+        .await
+        .unwrap();
+    assert!(!derived);
+}

--- a/frontend/src/offline/outbox.rs
+++ b/frontend/src/offline/outbox.rs
@@ -283,6 +283,13 @@ pub(crate) async fn remap_queued(temp_id: i64, real_id: i64) {
 /// Queue a reading/listening position write.
 pub(crate) async fn queue_save_progress(update: &ProgressUpdate) -> Option<ProgressRecord> {
     let now = store::now_secs();
+    // Stamp capture time into the queued op itself, not just the optimistic
+    // record — a drained op with no client event time is arbitrated as
+    // "drain-time" by the server, which un-ages every position written
+    // offline (#1864).
+    let mut update = update.clone();
+    let client_updated_at = update.client_updated_at.unwrap_or(now);
+    update.client_updated_at = Some(client_updated_at);
     let record = ProgressRecord {
         book_uuid: update.book_uuid.clone(),
         format: update.format,
@@ -295,7 +302,7 @@ pub(crate) async fn queue_save_progress(update: &ProgressUpdate) -> Option<Progr
         // Optimistic local record: mirrors the server's own COALESCE (issue
         // #1362) — the update's own client event time when it sent one,
         // else "now".
-        client_updated_at: update.client_updated_at.unwrap_or(now),
+        client_updated_at,
     };
     let queued = enqueue(Op::SaveProgress {
         update: update.clone(),

--- a/frontend/src/pages/landing/resume_meta.rs
+++ b/frontend/src/pages/landing/resume_meta.rs
@@ -1,6 +1,6 @@
 //! Resume-point meta formatting shared by the mobile resume card and the web
 //! continue-reading hero: percent/remaining labels for audio, and the plain
-//! continue affordance for epub (whose CFI position has no honest percentage).
+//! continue affordance for epub rows that lack a stored percent.
 
 use omnibus_shared::{ProgressFormat, ResumePoint};
 
@@ -9,8 +9,9 @@ use omnibus_shared::{ProgressFormat, ResumePoint};
 /// the raw position; epub rows read as a plain continue affordance.
 pub(super) fn resume_meta(point: &ResumePoint) -> (String, Option<i64>) {
     if point.record.format == ProgressFormat::Epub {
-        // A stored whole-book percent (a Kobo's write, or the comic pager's
-        // page/count mapping) is honest enough for a bar; a bare CFI is not.
+        // A stored whole-book percent (a Kobo's write, the comic pager's
+        // page/count mapping, or the percent the server derives for a web
+        // CFI write) is honest enough for a bar; a bare CFI is not.
         return match point.record.progress_percent {
             Some(pct) => (format!("{pct}% \u{00b7} Continue reading"), Some(pct)),
             None => ("Continue reading".to_string(), None),

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -132,11 +132,15 @@ fn register_window_callbacks(
                 let uuid_for_post = uuid_for_save.clone();
                 let cfi_for_post = cfi.clone();
                 wasm_bindgen_futures::spawn_local(async move {
+                    // `client_updated_at` is the event time the server's
+                    // conditional upsert arbitrates on; without it a write
+                    // degrades to receipt-time last-write-wins (#1864).
                     let body = serde_json::json!({
                         "update": {
                             "book_uuid": uuid_for_post,
                             "format": "epub",
                             "epub_cfi": cfi_for_post,
+                            "client_updated_at": crate::time::now_unix(),
                         }
                     });
                     if let Ok(req) = gloo_net::http::Request::post("/api/rpc/progress").json(&body)

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -22,13 +22,19 @@ use super::{internal_rpc_error, AuthUser, PoolExt};
 /// `server::backend::progress`. POST because Dioxus `#[get]` server
 /// functions can't carry an argument body — same rationale as
 /// `rpc_get_ebook`; the next two endpoints follow the same pattern.
+/// An accepted epub CFI write that carries no percent gets one derived and
+/// attached asynchronously (`spawn_epub_percent_derivation`), so the
+/// returned record may predate the percent by one read.
 #[post("/api/rpc/progress", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_save_progress(update: ProgressUpdate) -> Result<ProgressRecord> {
     if let Err(msg) = update.validate() {
         return Err(ServerFnError::new(msg).into());
     }
     match db::progress::upsert_progress(&pool.0, user.id, &update).await {
-        Ok(rec) => Ok(rec),
+        Ok(rec) => {
+            db::progress::spawn_epub_percent_derivation(pool.0.clone(), user.id, &rec);
+            Ok(rec)
+        }
         Err(db::progress::ProgressError::BookNotFound) => {
             Err(ServerFnError::new("book not found").into())
         }

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -52,7 +52,12 @@ pub(super) async fn post_progress(
         return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
     }
     match db::progress::upsert_progress(&state.pool, user.id, &update).await {
-        Ok(rec) => Json(rec).into_response(),
+        Ok(rec) => {
+            // Epub CFI writes without a percent get one derived off-path;
+            // the response carries the record as stored, percent follows.
+            db::progress::spawn_epub_percent_derivation(state.pool.clone(), user.id, &rec);
+            Json(rec).into_response()
+        }
         Err(ProgressError::BookNotFound) => {
             (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
         }


### PR DESCRIPTION
## Summary
- The web reader's relocate POST now stamps `client_updated_at`, so web reading writes arbitrate on event time like every other surface instead of degrading to receipt-time last-write-wins.
- An accepted epub CFI write that lands without a whole-book percent gets one derived from the source EPUB off the request path and attached clock-neutrally (`spawn_epub_percent_derivation`, single-flight per user/book, never overwrites a stored percent, degrades to no value rather than a wrong one).
- The offline outbox stamps capture time into the queued op itself, so positions written offline keep their age when drained.

Closes #1864

## Test plan
- [x] `cargo test -p omnibus-db` — 4 new derivation/attach tests, 74 progress tests green
- [x] `cargo test -p omnibus` (812) and `cargo test -p omnibus-frontend --features server` (734)
- [x] `just lint` — fmt, clippy across the matrix incl. wasm32, stylelint

## Version
N/A — merges into `feat/OMNI-1863`; no release is cut off the feature branch.