### PR TITLE
chore: triage RUSTSEC-2026-0253 lru advisory in deny.toml (#1859)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,17 @@ ignore = [
     # to the Dioxus pin. See Cargo.lock.
     { id = "RUSTSEC-2024-0429", reason = "glib 0.18.5 VariantStrIter unsoundness — mobile/desktop only via wry→gtk→glib (patched in glib 0.20, forced by upstream gtk-rs 0.18 pin under wry); not reachable in the server build" },
     { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 unsoundness — aliased mutable reference when a custom `log` logger calls rand::rng()/thread_rng() and ThreadRng reseeds mid-log; build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry), never links into any runtime binary and that logger-reseed path is not exercised in a build script" },
+
+    # ---- Unsound (informational) advisory reachable in the DEFAULT (server)
+    # build — unlike the two mobile/desktop-confined entries just above, `lru`
+    # is pulled in transitively via the git-pinned `dioxus-server` -> `dioxus`
+    # (see #522 for the pin itself; `cargo tree -i lru` shows
+    # `dioxus-server -> dioxus -> omnibus`/`omnibus-frontend`). Triggering the
+    # unsoundness requires `catch_unwind` plus a panicking `Drop` on a cached
+    # key during `LruCache::pop()`, which `dioxus-server`'s internal use does
+    # not exercise. Triaged 2026-08-12 (issue #1859). Revisit when Dioxus
+    # bumps its `lru` dependency to >= 0.18.2.
+    { id = "RUSTSEC-2026-0253", reason = "lru 0.16.4 LruCache::pop() use-after-free under a panicking Drop — reachable via the git-pinned dioxus-server -> dioxus dependency (see #522 for the pin); requires catch_unwind plus a panicking key Drop during a cache pop, which dioxus-server's internal use does not trigger" },
 ]
 
 # NB: RUSTSEC-2026-0221 (event-listener unsoundness, reachable via sqlx-core)

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -37,6 +37,16 @@ this list.
 
 - `thiserror` in `db/Cargo.toml` and `frontend/Cargo.toml` aligned to `thiserror.workspace = true` (workspace declares `thiserror = "2"`). Previously both crates pinned `thiserror = "1"` independently. The workspace now acts as a single source of truth — new crates must use `.workspace = true`.
 
+## Accepted advisories
+
+- `lru 0.16.4` — RUSTSEC-2026-0253 (unsound: use-after-free in
+  `LruCache::pop()` under a panicking `Drop`). Reaches the production graph
+  via the git-pinned `dioxus-server` → `dioxus` (see #522 for the pin
+  itself); not independently bumpable. Accepted — exploiting it requires
+  `catch_unwind` plus a panicking `Drop` on a cached key during a pop, which
+  `dioxus-server`'s internal use does not trigger. `deny.toml` ignores it
+  with a matching comment. Revisit when Dioxus bumps `lru` to >= 0.18.2.
+
 ## Yanked crates
 
 - `spin 0.9.8` — flagged by `cargo audit` as yanked from crates.io (no


### PR DESCRIPTION
## Summary
- Closes #1859
- `cargo audit` reports RUSTSEC-2026-0253 against `lru` 0.16.4 (unsound `LruCache::pop()` use-after-free under a panicking `Drop`), pulled in transitively via the git-pinned `dioxus-server` -> `dioxus`. Unlike the two already-accepted unsound advisories in `deny.toml` (RUSTSEC-2024-0429, RUSTSEC-2026-0097), which are confined to the mobile/desktop wry/gtk subtree, `lru` is reachable in the default (server) build.
- Adds a `[[advisories.ignore]]` entry for `RUSTSEC-2026-0253` in `deny.toml` with an inline reasoning comment (reachable-but-low-risk: requires `catch_unwind` plus a panicking `Drop` on a cached key during a pop, which `dioxus-server`'s internal use does not trigger), mirroring the exact style of the neighboring unsound entries.
- Adds a matching one-line note to `docs/dependency-audit.md` under a new "Accepted advisories" section, with a "revisit when Dioxus bumps `lru`" pointer.

## Test plan
- [ ] `cargo deny check advisories` — not runnable locally (`cargo-deny` is not installed in this environment and crates.io downloads are blocked by the sandbox's egress policy); the new `deny.toml` entry was verified to parse cleanly as TOML and matches the exact shape of the existing accepted-unsound entries. Will be verified by CI's `security` job.

## Version
- [x] **No release** — this only touches `deny.toml` and `docs/dependency-audit.md` (tech-debt/audit triage, no code or behavior change).

## Notes
- Requesting the `tech-debt` label be applied (no label-write tool available to me in this session).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Xe72dn7JTMBSR99rKbff)_