### PR TITLE
fix: preserve queued audiobook position across lost progress writes (#1860)

### DIFF
--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -557,6 +557,16 @@ final class AudioPlayer {
 
     // MARK: - Lifecycle
 
+    /// Whether a close-time flush is safe to write, mirroring the guard
+    /// `persistPosition` applies on every tick: nothing may leave this device
+    /// before the opening position has been reconciled against the server,
+    /// because every write carries a clock newer than anything already
+    /// stored and would beat a genuinely further-along position still in
+    /// flight from another device.
+    nonisolated static func shouldPersistOnClose(settled: Bool, finalPosition: Double) -> Bool {
+        settled && finalPosition > 0
+    }
+
     /// Stop playback and put the player away — what the mini bar's dismiss
     /// means. The position and the session are flushed before the book is
     /// released, since both are keyed on it.
@@ -570,6 +580,13 @@ final class AudioPlayer {
         let closing = book
         let finalPosition = position
         let finalFileID = fileID
+        // Captured before `teardown`, which resets it — matching the same
+        // guard `persistPosition` applies on every tick. Without it, closing
+        // during the open-time reconcile window stamps whatever the player
+        // happened to be sitting at (0, or a stale resume) with a fresh
+        // clock, which can beat — and coalesce-delete — a genuinely newer
+        // position still in flight from another device.
+        let settled = positionSettled
         let pending = takePendingReport()
 
         teardown()
@@ -582,7 +599,7 @@ final class AudioPlayer {
 
         guard let closing else { return }
         Task {
-            if finalPosition > 0 {
+            if Self.shouldPersistOnClose(settled: settled, finalPosition: finalPosition) {
                 await UserDataService.saveProgress(
                     ProgressUpdate(
                         bookUUID: closing.uuid, format: .audio,

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -501,6 +501,24 @@ struct ProgressRecord: Codable, Sendable {
     }
 }
 
+extension ProgressUpdate {
+    /// This write as the record it asserts, for comparing against what the
+    /// replica already holds. The device clock fills both timestamp fields —
+    /// this is the only clock the write carries until the server answers.
+    var asRecord: ProgressRecord {
+        ProgressRecord(
+            bookUUID: bookUUID,
+            format: format,
+            epubCFI: epubCFI,
+            audioPositionSeconds: audioPositionSeconds,
+            progressPercent: progressPercent,
+            updatedAt: clientUpdatedAt,
+            clientUpdatedAt: clientUpdatedAt,
+            bookFileID: bookFileID
+        )
+    }
+}
+
 struct ResumePoint: Codable, Sendable, Identifiable {
     var record: ProgressRecord
     var book: Book

--- a/omnibus-ios/omnibus/Offline/OfflineStore.swift
+++ b/omnibus-ios/omnibus/Offline/OfflineStore.swift
@@ -455,6 +455,27 @@ actor OfflineStore {
         )
     }
 
+    /// The newest queued op of one `kind`, held-aside rows included.
+    ///
+    /// A restore reading the outbox wants this device's last statement of the
+    /// value regardless of whether it will ever land — a position parked by a
+    /// terminal 4xx is still the newest place this device knows the listener
+    /// reached, and `last_error IS NULL` (as `listOps` filters on) would hide
+    /// exactly the row this exists to recover.
+    func latestOp(kind: String) -> PendingOp? {
+        guard isOpen else { return nil }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        let sql = """
+            SELECT id, kind, path, method, body, created_at, attempts, last_error
+            FROM ops WHERE kind = ? ORDER BY id DESC LIMIT 1
+            """
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        bind(stmt, 1, kind)
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        return readOp(stmt)
+    }
+
     func pendingCount() -> Int {
         count("SELECT COUNT(*) FROM ops WHERE last_error IS NULL")
     }

--- a/omnibus-ios/omnibus/Offline/PositionSync.swift
+++ b/omnibus-ios/omnibus/Offline/PositionSync.swift
@@ -37,6 +37,15 @@ enum PositionSync {
         return newest
     }
 
+    /// The further-along of two records for the same (book, format), by
+    /// `orderingClock`. Ties keep `a` — callers put the value they'd rather
+    /// keep metadata from (usually the replica row) first.
+    static func newest(_ a: ProgressRecord?, _ b: ProgressRecord?) -> ProgressRecord? {
+        guard let a else { return b }
+        guard let b else { return a }
+        return b.orderingClock > a.orderingClock ? b : a
+    }
+
     /// Whether a record actually names a place in the book. The endpoint answers
     /// with a row per `(book, format)`, and a row can exist with the position
     /// field for its format unset — which is not somewhere to send a reader.

--- a/omnibus-ios/omnibus/Offline/PositionSync.swift
+++ b/omnibus-ios/omnibus/Offline/PositionSync.swift
@@ -38,15 +38,12 @@ enum PositionSync {
     }
 
     /// The further-along of two records for the same (book, format), by
-    /// `orderingClock`. Ties keep `lhs` — callers put the value they'd rather
-    /// keep metadata from (usually the replica row) there.
-    static func newest(_ lhs: ProgressRecord?, _ rhs: ProgressRecord?) -> ProgressRecord? {
-        guard let lhsRecord = lhs else { return rhs }
-        guard let rhsRecord = rhs else { return lhsRecord }
-        if rhsRecord.orderingClock > lhsRecord.orderingClock {
-            return rhsRecord
-        }
-        return lhsRecord
+    /// `orderingClock`. Ties keep `a` — callers put the value they'd rather
+    /// keep metadata from (usually the replica row) first.
+    static func newest(_ a: ProgressRecord?, _ b: ProgressRecord?) -> ProgressRecord? {
+        guard let a else { return b }
+        guard let b else { return a }
+        return b.orderingClock > a.orderingClock ? b : a
     }
 
     /// Whether a record actually names a place in the book. The endpoint answers

--- a/omnibus-ios/omnibus/Offline/PositionSync.swift
+++ b/omnibus-ios/omnibus/Offline/PositionSync.swift
@@ -38,12 +38,15 @@ enum PositionSync {
     }
 
     /// The further-along of two records for the same (book, format), by
-    /// `orderingClock`. Ties keep `a` — callers put the value they'd rather
-    /// keep metadata from (usually the replica row) first.
-    static func newest(_ a: ProgressRecord?, _ b: ProgressRecord?) -> ProgressRecord? {
-        guard let a else { return b }
-        guard let b else { return a }
-        return b.orderingClock > a.orderingClock ? b : a
+    /// `orderingClock`. Ties keep `lhs` — callers put the value they'd rather
+    /// keep metadata from (usually the replica row) there.
+    static func newest(_ lhs: ProgressRecord?, _ rhs: ProgressRecord?) -> ProgressRecord? {
+        guard let lhsRecord = lhs else { return rhs }
+        guard let rhsRecord = rhs else { return lhsRecord }
+        if rhsRecord.orderingClock > lhsRecord.orderingClock {
+            return rhsRecord
+        }
+        return lhsRecord
     }
 
     /// Whether a record actually names a place in the book. The endpoint answers

--- a/omnibus-ios/omnibus/Offline/SyncEngine.swift
+++ b/omnibus-ios/omnibus/Offline/SyncEngine.swift
@@ -68,7 +68,8 @@ actor SyncEngine {
     /// the head of the queue forever, and because a non-empty queue also holds
     /// off replica revalidation, it freezes every server read in the app.
     /// Drains are triggered by lifecycle events, so six spans a good deal of
-    /// real time before anything is given up on.
+    /// real time before anything is given up on. [`isExemptFromReplayCap`]
+    /// carves out the kinds this bound must not apply to.
     private static let maxReplayAttempts: Int64 = 6
 
     /// Statuses that look like a client error but are really "ask again".
@@ -285,12 +286,33 @@ actor SyncEngine {
         guard op.kind.hasPrefix("progress:"),
               let record = try? JSONDecoder().decode(ProgressRecord.self, from: response)
         else { return }
+        // A drained answer can trail what the replica already holds: this
+        // reply was for a request sent minutes or hours ago, and a newer
+        // local write — or a newer answer another device's drain already
+        // folded in — may have landed in the meantime. Adopting it anyway
+        // would revert the replica to what this op said back when it was
+        // queued.
+        let held = await Cache.read(
+            CacheKey.progress(record.bookUUID, record.format), as: ProgressRecord.self
+        )
+        guard Self.responseSupersedesReplica(record, held: held) else { return }
         await Cache.write(CacheKey.progress(record.bookUUID, record.format), record)
         await UserDataService.noteResumePoint(record)
     }
 
+    /// Whether a drained position response may replace the replica's current
+    /// row. Equal clocks still adopt it — same position, but now carrying the
+    /// server's `updated_at`, which is the clock a later sync offer is judged
+    /// against.
+    static func responseSupersedesReplica(_ record: ProgressRecord, held: ProgressRecord?) -> Bool {
+        guard let held else { return true }
+        return record.orderingClock >= held.orderingClock
+    }
+
     /// Record one failed-but-retryable attempt, promoting the op to a held
-    /// failure once it has burned through [`maxReplayAttempts`].
+    /// failure once it has burned through [`maxReplayAttempts`] — except a
+    /// kind [`isExemptFromReplayCap`] excludes, which is left to retry
+    /// forever.
     private func noteRetryableFailure(_ op: PendingOp, _ error: Error) async {
         let message: String
         if case let APIError.http(status, detail) = error {
@@ -299,8 +321,20 @@ actor SyncEngine {
             message = (error as? APIError)?.errorDescription ?? error.localizedDescription
         }
         let attempts = await OfflineStore.shared.noteOpAttempt(op.id)
-        guard attempts >= Self.maxReplayAttempts else { return }
+        guard attempts >= Self.maxReplayAttempts, !Self.isExemptFromReplayCap(op.kind) else {
+            return
+        }
         await OfflineStore.shared.noteOpFailure(op.id, message: message)
+    }
+
+    /// Kinds [`maxReplayAttempts`] never parks. A position (and its playback
+    /// rate) is one coalesced, idempotent assertion of a value — it cannot
+    /// pile up in the queue the way a discrete event could, and parking it
+    /// trades away durable listening/reading progress for queue hygiene it
+    /// does not need. Everything else still parks: a poison op in any other
+    /// kind must not freeze every read in the app forever.
+    static func isExemptFromReplayCap(_ kind: String) -> Bool {
+        kind.hasPrefix("progress:") || kind.hasPrefix("playback_rate:")
     }
 
     /// The client-minted id a queued create carries, which every later op

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -63,9 +63,27 @@ enum UserDataService {
     ) async -> ProgressRecord? {
         guard let op = await OfflineStore.shared.latestOp(kind: OpKind.progress(uuid, format)),
               let body = op.body,
-              let update = try? JSONDecoder().decode(ProgressUpdate.self, from: body)
+              var update = try? JSONDecoder().decode(ProgressUpdate.self, from: body)
         else { return nil }
+        // `clientUpdatedAt` defaults to `Date()` in `ProgressUpdate`'s own
+        // decoding, so a body queued before the field existed — or any body
+        // that simply omits it — would otherwise decode as "just now" and
+        // make a stale op look newest, which is the exact failure this
+        // restore exists to prevent. `op.createdAt`, the outbox's own enqueue
+        // timestamp, is what the write actually happened on when the field
+        // itself is missing.
+        if !Self.bodyHasClientUpdatedAt(body) {
+            update.clientUpdatedAt = op.createdAt
+        }
         return update.asRecord
+    }
+
+    /// Whether a queued op's raw body carries `client_updated_at`, as opposed
+    /// to `ProgressUpdate`'s decoder silently filling the gap with now.
+    static func bodyHasClientUpdatedAt(_ body: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else { return false }
+        return object["client_updated_at"] != nil
     }
 
     static func recentProgress() -> AsyncThrowingStream<CacheRead<[ResumePoint]>, Error> {

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -38,8 +38,34 @@ enum UserDataService {
     /// The position this device last knew about, with no network in the path.
     /// The reader opens on this; anything the server has to add arrives through
     /// `progress(uuid:format:)` afterwards.
+    ///
+    /// Compares the replica row against a still-queued `progress:` op and
+    /// returns whichever is further along (#1860). The two can disagree: a
+    /// queued op that is later lost — a terminal rejection, six retryable
+    /// failures, a drained response whose body fails to decode — leaves the
+    /// replica holding whatever the server answered with last, while the
+    /// outbox row is still this device's own record of somewhere further on.
+    /// Reading the replica alone would open there and, worse, immediately
+    /// re-save it with a fresh clock — coalesce-deleting any surviving op that
+    /// still remembered the real position.
     static func localProgress(uuid: String, format: ProgressFormat) async -> ProgressRecord? {
-        await Cache.read(CacheKey.progress(uuid, format), as: ProgressRecord.self)
+        let replica = await Cache.read(CacheKey.progress(uuid, format), as: ProgressRecord.self)
+        let queued = await queuedProgress(uuid: uuid, format: format)
+        return PositionSync.newest(replica, queued)
+    }
+
+    /// The still-queued `progress:` op for (uuid, format), decoded as the
+    /// record it asserts. `nil` when nothing is queued, or the body no longer
+    /// decodes as a `ProgressUpdate` — the shape every write to this kind
+    /// encodes.
+    private static func queuedProgress(
+        uuid: String, format: ProgressFormat
+    ) async -> ProgressRecord? {
+        guard let op = await OfflineStore.shared.latestOp(kind: OpKind.progress(uuid, format)),
+              let body = op.body,
+              let update = try? JSONDecoder().decode(ProgressUpdate.self, from: body)
+        else { return nil }
+        return update.asRecord
     }
 
     static func recentProgress() -> AsyncThrowingStream<CacheRead<[ResumePoint]>, Error> {

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -327,6 +327,155 @@ struct ProgressClockTests {
     }
 }
 
+// MARK: - Audiobook position recovery (#1860)
+//
+// A listener who reaches chapter 19 offline and reopens to chapter 13 is
+// this bug: the newest position lived only in the replica plus one queued
+// `progress:` op, and losing that op (a terminal rejection, six retryable
+// failures, or an undecodable drained response) let a stale server row win,
+// which the player then re-saved with a fresh clock — permanently. These pin
+// the four guards that close the gap.
+
+@Suite("Restoring the newer of the replica and a queued position")
+struct PositionRestoreTests {
+    private func record(_ seconds: Double, clock: Int64) -> ProgressRecord {
+        ProgressRecord(
+            bookUUID: "book-1", format: .audio, epubCFI: nil,
+            audioPositionSeconds: seconds, updatedAt: clock, clientUpdatedAt: clock
+        )
+    }
+
+    @Test("AC1: a queued op ahead of the replica wins")
+    func queuedOpAheadOfReplicaWins() {
+        // The incident this reproduces: chapter 19 sits only in the queued
+        // op, chapter 13 is what a lost op left behind in the replica.
+        let replica = record(13 * 60, clock: 1_000)
+        let queued = record(19 * 60, clock: 2_000)
+        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == 19 * 60)
+    }
+
+    @Test("a replica ahead of a stale queued op wins")
+    func replicaAheadOfQueuedOpWins() {
+        // The other direction matters too: an op queued before the replica
+        // last moved must not drag a restore backwards.
+        let replica = record(19 * 60, clock: 2_000)
+        let queued = record(13 * 60, clock: 1_000)
+        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == 19 * 60)
+    }
+
+    @Test("a tie keeps the first argument")
+    func tieKeepsTheFirstArgument() {
+        let replica = record(19 * 60, clock: 2_000)
+        let queued = record(19 * 60, clock: 2_000)
+        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == replica.audioPositionSeconds)
+    }
+
+    @Test("nothing queued falls back to the replica, and vice versa")
+    func eitherSideMayBeAbsent() {
+        let replica = record(13 * 60, clock: 1_000)
+        #expect(PositionSync.newest(replica, nil)?.audioPositionSeconds == 13 * 60)
+        #expect(PositionSync.newest(nil, replica)?.audioPositionSeconds == 13 * 60)
+        #expect(PositionSync.newest(nil, nil) == nil)
+    }
+
+    @Test("a queued op decodes into the record it asserts")
+    func queuedOpDecodesIntoItsRecord() {
+        // What `UserDataService.localProgress` actually compares: the
+        // `ProgressUpdate` body a `progress:` op carries, converted with its
+        // own client clock filling both timestamp fields.
+        let update = ProgressUpdate(
+            bookUUID: "book-1", format: .audio, epubCFI: nil,
+            audioPositionSeconds: 19 * 60, clientUpdatedAt: 2_000, bookFileID: 7
+        )
+        let asRecord = update.asRecord
+        #expect(asRecord.bookUUID == "book-1")
+        #expect(asRecord.audioPositionSeconds == 19 * 60)
+        #expect(asRecord.bookFileID == 7)
+        #expect(asRecord.orderingClock == 2_000)
+    }
+}
+
+@Suite("Folding a drained progress response into the replica")
+struct ProgressResponseSupersessionTests {
+    private func record(clock: Int64) -> ProgressRecord {
+        ProgressRecord(
+            bookUUID: "book-1", format: .audio, epubCFI: nil,
+            audioPositionSeconds: 100, updatedAt: clock, clientUpdatedAt: clock
+        )
+    }
+
+    @Test("AC2: a response older than the replica's row is refused")
+    func olderResponseIsRefused() {
+        // The response answers a request this device sent minutes or hours
+        // ago; by the time it drains, a newer local write (or another
+        // device's answer) may already sit in the replica. Adopting the old
+        // answer would revert it.
+        let held = record(clock: 2_000)
+        let response = record(clock: 1_000)
+        #expect(!SyncEngine.responseSupersedesReplica(response, held: held))
+    }
+
+    @Test("a response at least as new as the replica's row is adopted")
+    func newerOrEqualResponseIsAdopted() {
+        let held = record(clock: 1_000)
+        #expect(SyncEngine.responseSupersedesReplica(record(clock: 2_000), held: held))
+        // Equal clocks still adopt: same position, but now carrying the
+        // server's `updated_at`, which a later sync offer is judged against.
+        #expect(SyncEngine.responseSupersedesReplica(record(clock: 1_000), held: held))
+    }
+
+    @Test("nothing held means nothing to be older than")
+    func noHeldRecordAlwaysAdopts() {
+        #expect(SyncEngine.responseSupersedesReplica(record(clock: 1_000), held: nil))
+    }
+}
+
+@Suite("Replay cap exemption for coalesced position kinds")
+struct ReplayCapExemptionTests {
+    @Test("AC3: progress and playback-rate kinds are exempt")
+    func positionKindsAreExempt() {
+        // Idempotent, coalesced to one op each — parking one trades away
+        // hours of listening for queue hygiene it does not need.
+        #expect(SyncEngine.isExemptFromReplayCap(OpKind.progress("book-1", .audio)))
+        #expect(SyncEngine.isExemptFromReplayCap(OpKind.progress("book-1", .epub)))
+        #expect(SyncEngine.isExemptFromReplayCap(OpKind.playbackRate("book-1")))
+    }
+
+    @Test("every other kind still parks at the cap")
+    func nonPositionKindsAreNotExempt() {
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.rating("book-1")))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.readStatus("book-1")))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.highlight))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.bookmark))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.journal))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.session))
+        #expect(!SyncEngine.isExemptFromReplayCap(OpKind.shelfMembership))
+    }
+}
+
+@Suite("Close-time position flush")
+struct ClosePositionFlushTests {
+    @Test("AC4: closing before the opening position has settled writes nothing")
+    func unsettledCloseWritesNothing() {
+        // The open-time reconcile window: the player may be sitting at 0, or
+        // a stale resume, and stamping either with a fresh clock can beat —
+        // and coalesce-delete — a genuinely newer position still in flight
+        // from another device.
+        #expect(!AudioPlayer.shouldPersistOnClose(settled: false, finalPosition: 42))
+    }
+
+    @Test("closing at position zero writes nothing, settled or not")
+    func zeroPositionWritesNothing() {
+        #expect(!AudioPlayer.shouldPersistOnClose(settled: true, finalPosition: 0))
+        #expect(!AudioPlayer.shouldPersistOnClose(settled: false, finalPosition: 0))
+    }
+
+    @Test("a settled close with real progress writes")
+    func settledCloseWithProgressWrites() {
+        #expect(AudioPlayer.shouldPersistOnClose(settled: true, finalPosition: 42))
+    }
+}
+
 // MARK: - Audiobook file selection
 
 @Suite("Progress file identity")

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -28,7 +28,7 @@ private func replayedValue(_ json: String, key: String) throws -> Any? {
     return object?[key]
 }
 
-@Suite("Outbox body re-encoding", .serialized)
+@Suite("Outbox body re-encoding")
 struct RawJSONTests {
     @Test("one-star rating survives replay as a number, not a boolean")
     func oneStarRatingStaysNumeric() throws {
@@ -89,7 +89,7 @@ struct RawJSONTests {
 
 // MARK: - Revalidation scoping
 
-@Suite("Outbox scope", .serialized)
+@Suite("Outbox scope")
 struct OutboxScopeTests {
     private let uuid = "11111111-2222-3333-4444-555555555555"
 
@@ -188,7 +188,7 @@ struct OutboxScopeTests {
 
 // MARK: - Reachability signals
 
-@Suite("Cancellation is not a reachability signal", .serialized)
+@Suite("Cancellation is not a reachability signal")
 struct CancellationTests {
     @Test("a cancelled URL task is recognised as cancellation")
     func urlCancellationIsRecognised() {
@@ -210,7 +210,7 @@ struct CancellationTests {
 
 // MARK: - Replay outcome classification
 
-@Suite("Replay outcomes", .serialized)
+@Suite("Replay outcomes")
 struct ReplayOutcomeTests {
     @Test("a payload the server refuses on its merits is never retried")
     func refusalsAreTerminal() {
@@ -247,7 +247,7 @@ struct ReplayOutcomeTests {
 
 // MARK: - Position wire contract
 
-@Suite("Progress client clock", .serialized)
+@Suite("Progress client clock")
 struct ProgressClockTests {
     private func encoded(_ update: ProgressUpdate) throws -> [String: Any] {
         let data = try JSONEncoder().encode(update)
@@ -336,8 +336,17 @@ struct ProgressClockTests {
 // which the player then re-saved with a fresh clock — permanently. These pin
 // the four guards that close the gap.
 
-@Suite("Restoring the newer of the replica and a queued position", .serialized)
+@Suite("Restoring the newer of the replica and a queued position")
 struct PositionRestoreTests {
+    // `audioPositionSeconds` is a `Double`, and these must be declared as one
+    // rather than written as a bare `19 * 60` inside an `#expect`: the macro
+    // captures each side of a comparison through a generic, which severs the
+    // literal's inference from the `Double?` it is being compared against and
+    // lets it default to `Int`. The resulting heterogeneous compare comes back
+    // `false` however well the numbers agree — "(→ 1140.0) == (→ 1140)".
+    private static let chapter13Position: Double = 13 * 60
+    private static let chapter19Position: Double = 19 * 60
+
     private func record(_ seconds: Double, clock: Int64) -> ProgressRecord {
         ProgressRecord(
             bookUUID: "book-1", format: .audio, epubCFI: nil,
@@ -349,18 +358,24 @@ struct PositionRestoreTests {
     func queuedOpAheadOfReplicaWins() {
         // The incident this reproduces: chapter 19 sits only in the queued
         // op, chapter 13 is what a lost op left behind in the replica.
-        let replica = record(13 * 60, clock: 1_000)
-        let queued = record(19 * 60, clock: 2_000)
-        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == 19 * 60)
+        let replica = record(Self.chapter13Position, clock: 1_000)
+        let queued = record(Self.chapter19Position, clock: 2_000)
+        #expect(
+            PositionSync.newest(replica, queued)?.audioPositionSeconds
+                == Self.chapter19Position
+        )
     }
 
     @Test("a replica ahead of a stale queued op wins")
     func replicaAheadOfQueuedOpWins() {
         // The other direction matters too: an op queued before the replica
         // last moved must not drag a restore backwards.
-        let replica = record(19 * 60, clock: 2_000)
-        let queued = record(13 * 60, clock: 1_000)
-        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == 19 * 60)
+        let replica = record(Self.chapter19Position, clock: 2_000)
+        let queued = record(Self.chapter13Position, clock: 1_000)
+        #expect(
+            PositionSync.newest(replica, queued)?.audioPositionSeconds
+                == Self.chapter19Position
+        )
     }
 
     @Test("a tie keeps the first argument")
@@ -368,18 +383,24 @@ struct PositionRestoreTests {
         // `bookFileID` is the field that distinguishes the two records here —
         // `audioPositionSeconds` alone would still match even if the tie-break
         // picked the wrong side, since both share the same position.
-        var replica = record(19 * 60, clock: 2_000)
+        var replica = record(Self.chapter19Position, clock: 2_000)
         replica.bookFileID = 1
-        var queued = record(19 * 60, clock: 2_000)
+        var queued = record(Self.chapter19Position, clock: 2_000)
         queued.bookFileID = 2
         #expect(PositionSync.newest(replica, queued)?.bookFileID == 1)
     }
 
     @Test("nothing queued falls back to the replica, and vice versa")
     func eitherSideMayBeAbsent() {
-        let replica = record(13 * 60, clock: 1_000)
-        #expect(PositionSync.newest(replica, nil)?.audioPositionSeconds == 13 * 60)
-        #expect(PositionSync.newest(nil, replica)?.audioPositionSeconds == 13 * 60)
+        let replica = record(Self.chapter13Position, clock: 1_000)
+        #expect(
+            PositionSync.newest(replica, nil)?.audioPositionSeconds
+                == Self.chapter13Position
+        )
+        #expect(
+            PositionSync.newest(nil, replica)?.audioPositionSeconds
+                == Self.chapter13Position
+        )
         #expect(PositionSync.newest(nil, nil) == nil)
     }
 
@@ -390,11 +411,12 @@ struct PositionRestoreTests {
         // own client clock filling both timestamp fields.
         let update = ProgressUpdate(
             bookUUID: "book-1", format: .audio, epubCFI: nil,
-            audioPositionSeconds: 19 * 60, clientUpdatedAt: 2_000, bookFileID: 7
+            audioPositionSeconds: Self.chapter19Position, clientUpdatedAt: 2_000,
+            bookFileID: 7
         )
         let asRecord = update.asRecord
         #expect(asRecord.bookUUID == "book-1")
-        #expect(asRecord.audioPositionSeconds == 19 * 60)
+        #expect(asRecord.audioPositionSeconds == Self.chapter19Position)
         #expect(asRecord.bookFileID == 7)
         #expect(asRecord.orderingClock == 2_000)
     }
@@ -422,7 +444,7 @@ struct PositionRestoreTests {
     }
 }
 
-@Suite("Folding a drained progress response into the replica", .serialized)
+@Suite("Folding a drained progress response into the replica")
 struct ProgressResponseSupersessionTests {
     private func record(clock: Int64) -> ProgressRecord {
         ProgressRecord(
@@ -457,7 +479,7 @@ struct ProgressResponseSupersessionTests {
     }
 }
 
-@Suite("Replay cap exemption for coalesced position kinds", .serialized)
+@Suite("Replay cap exemption for coalesced position kinds")
 struct ReplayCapExemptionTests {
     @Test("AC3: progress and playback-rate kinds are exempt")
     func positionKindsAreExempt() {
@@ -480,7 +502,7 @@ struct ReplayCapExemptionTests {
     }
 }
 
-@Suite("Close-time position flush", .serialized)
+@Suite("Close-time position flush")
 struct ClosePositionFlushTests {
     @Test("AC4: closing before the opening position has settled writes nothing")
     func unsettledCloseWritesNothing() {
@@ -505,7 +527,7 @@ struct ClosePositionFlushTests {
 
 // MARK: - Audiobook file selection
 
-@Suite("Progress file identity", .serialized)
+@Suite("Progress file identity")
 struct ProgressFileIdentityTests {
     private func encoded(_ update: ProgressUpdate) throws -> [String: Any] {
         let data = try JSONEncoder().encode(update)
@@ -555,7 +577,7 @@ struct ProgressFileIdentityTests {
     }
 }
 
-@Suite("Selectable audio files", .serialized)
+@Suite("Selectable audio files")
 struct AudioFileSelectionTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64
@@ -609,7 +631,7 @@ struct AudioFileSelectionTests {
 
 // MARK: - Optimistic journal authorship (#1740)
 
-@Suite("Optimistic journal entry", .serialized)
+@Suite("Optimistic journal entry")
 struct OptimisticJournalEntryTests {
     private let payload = CreateJournalEntry(
         bookUUID: "11111111-2222-3333-4444-555555555555",
@@ -671,7 +693,7 @@ struct OptimisticJournalEntryTests {
 
 // MARK: - Account scoping
 
-@Suite("User-scoped cache wipe", .serialized)
+@Suite("User-scoped cache wipe")
 struct UserScopedPrefixTests {
     private let uuid = "11111111-2222-3333-4444-555555555555"
 
@@ -729,7 +751,7 @@ struct UserScopedPrefixTests {
 
 // MARK: - Content validators (#1231)
 
-@Suite("Download staleness", .serialized)
+@Suite("Download staleness")
 struct DownloadStalenessTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64, etag: String?
@@ -818,7 +840,7 @@ struct DownloadStalenessTests {
     }
 }
 
-@Suite("Book file validator wire shape", .serialized)
+@Suite("Book file validator wire shape")
 struct BookFileEtagCodecTests {
     @Test("the validator decodes from the server's snake_case payload")
     func etagDecodes() throws {
@@ -840,7 +862,7 @@ struct BookFileEtagCodecTests {
     }
 }
 
-@Suite("Downloaded-file selection", .serialized)
+@Suite("Downloaded-file selection")
 struct DownloadTargetFileTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64, etag: String?

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -365,9 +365,14 @@ struct PositionRestoreTests {
 
     @Test("a tie keeps the first argument")
     func tieKeepsTheFirstArgument() {
-        let replica = record(19 * 60, clock: 2_000)
-        let queued = record(19 * 60, clock: 2_000)
-        #expect(PositionSync.newest(replica, queued)?.audioPositionSeconds == replica.audioPositionSeconds)
+        // `bookFileID` is the field that distinguishes the two records here —
+        // `audioPositionSeconds` alone would still match even if the tie-break
+        // picked the wrong side, since both share the same position.
+        var replica = record(19 * 60, clock: 2_000)
+        replica.bookFileID = 1
+        var queued = record(19 * 60, clock: 2_000)
+        queued.bookFileID = 2
+        #expect(PositionSync.newest(replica, queued)?.bookFileID == 1)
     }
 
     @Test("nothing queued falls back to the replica, and vice versa")
@@ -392,6 +397,28 @@ struct PositionRestoreTests {
         #expect(asRecord.audioPositionSeconds == 19 * 60)
         #expect(asRecord.bookFileID == 7)
         #expect(asRecord.orderingClock == 2_000)
+    }
+
+    @Test("a body carrying client_updated_at is recognised as such")
+    func bodyWithClientUpdatedAtIsDetected() {
+        let body = Data(#"{"book_uuid":"b","format":"audio","client_updated_at":2000}"#.utf8)
+        #expect(UserDataService.bodyHasClientUpdatedAt(body))
+    }
+
+    @Test("a body missing client_updated_at is not mistaken for one that has it")
+    func bodyWithoutClientUpdatedAtIsDetected() {
+        // `ProgressUpdate.clientUpdatedAt` defaults to `Date()`, so decoding
+        // this body directly would silently stamp "now" — this is the check
+        // that catches it before the fallback to `op.createdAt` runs (#1874
+        // review).
+        let body = Data(#"{"book_uuid":"b","format":"audio"}"#.utf8)
+        #expect(!UserDataService.bodyHasClientUpdatedAt(body))
+    }
+
+    @Test("an explicit null still counts as the key being present")
+    func explicitNullIsPresent() {
+        let body = Data(#"{"book_uuid":"b","format":"audio","client_updated_at":null}"#.utf8)
+        #expect(UserDataService.bodyHasClientUpdatedAt(body))
     }
 }
 

--- a/omnibus-ios/omnibusTests/OfflineSyncTests.swift
+++ b/omnibus-ios/omnibusTests/OfflineSyncTests.swift
@@ -28,7 +28,7 @@ private func replayedValue(_ json: String, key: String) throws -> Any? {
     return object?[key]
 }
 
-@Suite("Outbox body re-encoding")
+@Suite("Outbox body re-encoding", .serialized)
 struct RawJSONTests {
     @Test("one-star rating survives replay as a number, not a boolean")
     func oneStarRatingStaysNumeric() throws {
@@ -89,7 +89,7 @@ struct RawJSONTests {
 
 // MARK: - Revalidation scoping
 
-@Suite("Outbox scope")
+@Suite("Outbox scope", .serialized)
 struct OutboxScopeTests {
     private let uuid = "11111111-2222-3333-4444-555555555555"
 
@@ -188,7 +188,7 @@ struct OutboxScopeTests {
 
 // MARK: - Reachability signals
 
-@Suite("Cancellation is not a reachability signal")
+@Suite("Cancellation is not a reachability signal", .serialized)
 struct CancellationTests {
     @Test("a cancelled URL task is recognised as cancellation")
     func urlCancellationIsRecognised() {
@@ -210,7 +210,7 @@ struct CancellationTests {
 
 // MARK: - Replay outcome classification
 
-@Suite("Replay outcomes")
+@Suite("Replay outcomes", .serialized)
 struct ReplayOutcomeTests {
     @Test("a payload the server refuses on its merits is never retried")
     func refusalsAreTerminal() {
@@ -247,7 +247,7 @@ struct ReplayOutcomeTests {
 
 // MARK: - Position wire contract
 
-@Suite("Progress client clock")
+@Suite("Progress client clock", .serialized)
 struct ProgressClockTests {
     private func encoded(_ update: ProgressUpdate) throws -> [String: Any] {
         let data = try JSONEncoder().encode(update)
@@ -336,7 +336,7 @@ struct ProgressClockTests {
 // which the player then re-saved with a fresh clock — permanently. These pin
 // the four guards that close the gap.
 
-@Suite("Restoring the newer of the replica and a queued position")
+@Suite("Restoring the newer of the replica and a queued position", .serialized)
 struct PositionRestoreTests {
     private func record(_ seconds: Double, clock: Int64) -> ProgressRecord {
         ProgressRecord(
@@ -422,7 +422,7 @@ struct PositionRestoreTests {
     }
 }
 
-@Suite("Folding a drained progress response into the replica")
+@Suite("Folding a drained progress response into the replica", .serialized)
 struct ProgressResponseSupersessionTests {
     private func record(clock: Int64) -> ProgressRecord {
         ProgressRecord(
@@ -457,7 +457,7 @@ struct ProgressResponseSupersessionTests {
     }
 }
 
-@Suite("Replay cap exemption for coalesced position kinds")
+@Suite("Replay cap exemption for coalesced position kinds", .serialized)
 struct ReplayCapExemptionTests {
     @Test("AC3: progress and playback-rate kinds are exempt")
     func positionKindsAreExempt() {
@@ -480,7 +480,7 @@ struct ReplayCapExemptionTests {
     }
 }
 
-@Suite("Close-time position flush")
+@Suite("Close-time position flush", .serialized)
 struct ClosePositionFlushTests {
     @Test("AC4: closing before the opening position has settled writes nothing")
     func unsettledCloseWritesNothing() {
@@ -505,7 +505,7 @@ struct ClosePositionFlushTests {
 
 // MARK: - Audiobook file selection
 
-@Suite("Progress file identity")
+@Suite("Progress file identity", .serialized)
 struct ProgressFileIdentityTests {
     private func encoded(_ update: ProgressUpdate) throws -> [String: Any] {
         let data = try JSONEncoder().encode(update)
@@ -555,7 +555,7 @@ struct ProgressFileIdentityTests {
     }
 }
 
-@Suite("Selectable audio files")
+@Suite("Selectable audio files", .serialized)
 struct AudioFileSelectionTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64
@@ -609,7 +609,7 @@ struct AudioFileSelectionTests {
 
 // MARK: - Optimistic journal authorship (#1740)
 
-@Suite("Optimistic journal entry")
+@Suite("Optimistic journal entry", .serialized)
 struct OptimisticJournalEntryTests {
     private let payload = CreateJournalEntry(
         bookUUID: "11111111-2222-3333-4444-555555555555",
@@ -671,7 +671,7 @@ struct OptimisticJournalEntryTests {
 
 // MARK: - Account scoping
 
-@Suite("User-scoped cache wipe")
+@Suite("User-scoped cache wipe", .serialized)
 struct UserScopedPrefixTests {
     private let uuid = "11111111-2222-3333-4444-555555555555"
 
@@ -729,7 +729,7 @@ struct UserScopedPrefixTests {
 
 // MARK: - Content validators (#1231)
 
-@Suite("Download staleness")
+@Suite("Download staleness", .serialized)
 struct DownloadStalenessTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64, etag: String?
@@ -818,7 +818,7 @@ struct DownloadStalenessTests {
     }
 }
 
-@Suite("Book file validator wire shape")
+@Suite("Book file validator wire shape", .serialized)
 struct BookFileEtagCodecTests {
     @Test("the validator decodes from the server's snake_case payload")
     func etagDecodes() throws {
@@ -840,7 +840,7 @@ struct BookFileEtagCodecTests {
     }
 }
 
-@Suite("Downloaded-file selection")
+@Suite("Downloaded-file selection", .serialized)
 struct DownloadTargetFileTests {
     private func file(
         _ id: Int64, format: String, ordinal: Int64, etag: String?


### PR DESCRIPTION
## Summary
- Closes #1860
- `UserDataService.localProgress` now restores the newer of the replica row and a still-queued `progress:` op (compared on `orderingClock`), so a queued op lost to a terminal rejection, six retryable failures, or an undecodable drained response no longer silently reverts the listener to a stale server position.
- `SyncEngine.applyResponse` no longer folds a drained progress response into the replica when it is older than the replica's current row.
- `SyncEngine.noteRetryableFailure` exempts coalesced `progress:` / `playback_rate:` kinds from the six-attempt retry cap — a position write is idempotent and cannot pile up in the queue, so parking it only trades away durable progress for queue hygiene it doesn't need.
- `AudioPlayer.close()` now respects `positionSettled` the same way `persistPosition` already does, so it can no longer flush a pre-reconcile position with a fresh clock.

## Test plan
- [x] Added `omnibusTests/OfflineSyncTests.swift` coverage for AC1–AC4: `PositionRestoreTests`, `ProgressResponseSupersessionTests`, `ReplayCapExemptionTests`, `ClosePositionFlushTests`.
- [ ] **Not executed in this environment** — no Xcode/xcodebuild toolchain is available here, so the new and existing tests were not run locally. Please verify via CI's `ios-tests.yml` workflow (`omnibusTests` suite) before merging.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Native iOS only (`omnibus-ios/`); no Cargo crate touched.
- I read the orphaned `OMNI-1860/audiobook-position-revert` branch's abandoned commit for context (per task instructions) but did not merge from or build on it — this PR's implementation was written independently against current `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Xe72dn7JTMBSR99rKbff)_