### PR TITLE
test: cover convert_outcome's safe-passthrough and stderr-scrubbing (#1854)

### DIFF
--- a/db/src/worker/handlers/tests.rs
+++ b/db/src/worker/handlers/tests.rs
@@ -2,7 +2,8 @@
 //! foreign-system internal (SMTP/lettre, subprocess stderr, a DB driver)
 //! must never let that text reach the returned [`TaskOutcome::Err`].
 
-use super::{anyhow_outcome, kepub_outcome, kindle_outcome, sanitized_err};
+use super::{anyhow_outcome, convert_outcome, kepub_outcome, kindle_outcome, sanitized_err};
+use crate::convert::ConvertError;
 use crate::kepub::KepubError;
 use crate::kindle::KindleError;
 use crate::worker::TaskOutcome;
@@ -99,4 +100,44 @@ fn kepub_outcome_sanitizes_subprocess_stderr() {
     )))));
     assert!(!msg.contains("0xdeadbeef"));
     assert!(msg.contains("kepub conversion"));
+}
+
+#[test]
+fn convert_outcome_returns_ok_none_on_success() {
+    assert!(matches!(
+        convert_outcome(Ok(std::path::PathBuf::from("/tmp/book.mobi"))),
+        TaskOutcome::Ok(None)
+    ));
+}
+
+#[test]
+fn convert_outcome_passes_through_the_safe_enumerable_variants() {
+    let msg = err_text(convert_outcome(Err(ConvertError::SourceMissing {
+        book_id: 1,
+        format: "MOBI".into(),
+    })));
+    assert_eq!(msg, "book 1 has no MOBI file to convert");
+
+    let msg = err_text(convert_outcome(Err(ConvertError::BinaryUnavailable)));
+    assert_eq!(msg, "ebook-convert is not installed or not runnable");
+
+    let msg = err_text(convert_outcome(Err(ConvertError::Timeout(300))));
+    assert_eq!(msg, "conversion timed out after 300s");
+
+    let msg = err_text(convert_outcome(Err(ConvertError::InvalidFormat {
+        field: "target_format",
+    })));
+    assert_eq!(
+        msg,
+        "invalid target_format: must be 1-16 ASCII alphanumeric characters"
+    );
+}
+
+#[test]
+fn convert_outcome_sanitizes_the_failed_variant() {
+    let msg = err_text(convert_outcome(Err(ConvertError::Failed(anyhow::anyhow!(
+        "ebook-convert exited with 1: stack trace at /srv/lib/book.epub"
+    )))));
+    assert!(!msg.contains("/srv/lib/book.epub"));
+    assert!(msg.contains("format conversion"));
 }


### PR DESCRIPTION
## Summary
- Closes #1854
- `convert_outcome` in `db/src/worker/handlers.rs` was the one sibling of `kepub_outcome`/`kindle_outcome` with no direct test coverage. Adds `db/src/worker/handlers/tests.rs` coverage for all four safe, enumerable `ConvertError` variants (`SourceMissing`, `BinaryUnavailable`, `Timeout`, `InvalidFormat`) passing their message through verbatim, plus the collapsed `Failed` variant having its subprocess stderr / internal path scrubbed before it reaches the client-facing `TaskOutcome::Err`.
- **No leak found/fixed.** Per the issue's own note to verify before assuming this is only a coverage gap: I read `convert_outcome` closely — its catch-all `Err(e) => sanitized_err("format conversion", e)` arm already routes `ConvertError::Failed` (and anything else not explicitly listed as safe) through the same sanitizer `kepub_outcome`/`kindle_outcome` use, so no raw internal string was ever reaching the client. This PR is coverage-only, proving that behavior in a test rather than fixing a bug.

## Test plan
- [x] `cargo fmt -p omnibus-db` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 2019 passed, 1 failed (unrelated: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails only because this sandbox has no `just`/fixture download to populate `test_data/audiobooks/`; pre-existing and untouched by this change). All `worker::handlers::tests::*` pass, including the 3 new `convert_outcome_*` tests.

## Notes
- No fix required — see the "No leak found/fixed" callout above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Xe72dn7JTMBSR99rKbff)_