### PR TITLE
fix: avoid SQLITE_BUSY_SNAPSHOT 500s on concurrent progress writes (#1862)

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -89,18 +89,7 @@ pub async fn upsert_progress(
     user_id: i64,
     update: &ProgressUpdate,
 ) -> Result<ProgressRecord, ProgressError> {
-    // `BEGIN IMMEDIATE`, not plain `pool.begin()`: `upsert_progress_tx`
-    // reads (`resolve_canonical_book_uuid_exec`) before it writes, so a
-    // DEFERRED transaction takes its snapshot on that read and only
-    // requests the write lock later, on the `INSERT ... ON CONFLICT`. Two
-    // devices racing a position write for the same book can then have the
-    // loser's snapshot go stale the instant the winner commits, which
-    // SQLite reports as `SQLITE_BUSY_SNAPSHOT` (code 517) rather than
-    // retrying — `busy_timeout` only covers lock *acquisition*, not a
-    // stale-snapshot upgrade, so the loser 500s instead of queueing (#1862).
-    // Taking the write lock up front removes the upgrade entirely: the
-    // second writer just queues behind `busy_timeout` like any other lock
-    // wait.
+    // BEGIN IMMEDIATE avoids a stale-snapshot 517 on concurrent writes (#1862).
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let record = upsert_progress_tx(&mut tx, user_id, update).await?;
     tx.commit().await?;
@@ -664,10 +653,7 @@ pub async fn record_session(
     user_id: i64,
     report: &SessionReport,
 ) -> Result<bool, ProgressError> {
-    // Same `BEGIN IMMEDIATE` reasoning as `upsert_progress`:
-    // `record_session_tx` resolves the book uuid (a read) before its
-    // `INSERT OR IGNORE`, so a plain `pool.begin()` risks the same
-    // stale-snapshot 517 under concurrent session reports for one user.
+    // Same BEGIN IMMEDIATE reasoning as `upsert_progress` above (#1862).
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let result = record_session_tx(&mut tx, user_id, report).await?;
     tx.commit().await?;

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -89,7 +89,19 @@ pub async fn upsert_progress(
     user_id: i64,
     update: &ProgressUpdate,
 ) -> Result<ProgressRecord, ProgressError> {
-    let mut tx = pool.begin().await?;
+    // `BEGIN IMMEDIATE`, not plain `pool.begin()`: `upsert_progress_tx`
+    // reads (`resolve_canonical_book_uuid_exec`) before it writes, so a
+    // DEFERRED transaction takes its snapshot on that read and only
+    // requests the write lock later, on the `INSERT ... ON CONFLICT`. Two
+    // devices racing a position write for the same book can then have the
+    // loser's snapshot go stale the instant the winner commits, which
+    // SQLite reports as `SQLITE_BUSY_SNAPSHOT` (code 517) rather than
+    // retrying — `busy_timeout` only covers lock *acquisition*, not a
+    // stale-snapshot upgrade, so the loser 500s instead of queueing (#1862).
+    // Taking the write lock up front removes the upgrade entirely: the
+    // second writer just queues behind `busy_timeout` like any other lock
+    // wait.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let record = upsert_progress_tx(&mut tx, user_id, update).await?;
     tx.commit().await?;
     Ok(record)
@@ -652,7 +664,11 @@ pub async fn record_session(
     user_id: i64,
     report: &SessionReport,
 ) -> Result<bool, ProgressError> {
-    let mut tx = pool.begin().await?;
+    // Same `BEGIN IMMEDIATE` reasoning as `upsert_progress`:
+    // `record_session_tx` resolves the book uuid (a read) before its
+    // `INSERT OR IGNORE`, so a plain `pool.begin()` risks the same
+    // stale-snapshot 517 under concurrent session reports for one user.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let result = record_session_tx(&mut tx, user_id, report).await?;
     tx.commit().await?;
     Ok(result)

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -2430,26 +2430,7 @@ fn kobo_statistics_is_empty_only_when_both_counters_are_absent() {
     .is_empty());
 }
 
-// ---------------------------------------------------------------------------
-// #1862: concurrent writers must not surface SQLITE_BUSY_SNAPSHOT (517)
-// ---------------------------------------------------------------------------
-//
-// `upsert_progress_tx` and `record_session_tx` both read (resolving the
-// canonical book uuid) before they write. Under a plain `pool.begin()`
-// (DEFERRED), that read seeds the transaction's snapshot; if a concurrent
-// writer commits before this transaction's later INSERT runs, SQLite can't
-// upgrade the stale snapshot to a write lock and returns
-// `SQLITE_BUSY_SNAPSHOT` immediately — `PRAGMA busy_timeout` only retries
-// *lock acquisition*, not a snapshot upgrade, so the caller sees a 500
-// within single-digit milliseconds (the production incident this issue
-// reports). `upsert_progress` / `record_session` now open with
-// `BEGIN IMMEDIATE`, taking the write lock before the read runs, so a
-// losing writer queues behind `busy_timeout` instead of erroring.
-//
-// Several rounds of many overlapping writers — some contending on the same
-// row (forcing the `ON CONFLICT` path), some on distinct rows (still
-// contending for SQLite's single writer lock) — give the underlying race a
-// real chance to have fired without the fix.
+// Regression tests for the BEGIN IMMEDIATE stale-snapshot 517 fix (#1862).
 const CONCURRENT_ROUNDS: i64 = 5;
 const CONCURRENT_WRITERS_PER_ROUND: usize = 5;
 

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -2429,3 +2429,117 @@ fn kobo_statistics_is_empty_only_when_both_counters_are_absent() {
     }
     .is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// #1862: concurrent writers must not surface SQLITE_BUSY_SNAPSHOT (517)
+// ---------------------------------------------------------------------------
+//
+// `upsert_progress_tx` and `record_session_tx` both read (resolving the
+// canonical book uuid) before they write. Under a plain `pool.begin()`
+// (DEFERRED), that read seeds the transaction's snapshot; if a concurrent
+// writer commits before this transaction's later INSERT runs, SQLite can't
+// upgrade the stale snapshot to a write lock and returns
+// `SQLITE_BUSY_SNAPSHOT` immediately — `PRAGMA busy_timeout` only retries
+// *lock acquisition*, not a snapshot upgrade, so the caller sees a 500
+// within single-digit milliseconds (the production incident this issue
+// reports). `upsert_progress` / `record_session` now open with
+// `BEGIN IMMEDIATE`, taking the write lock before the read runs, so a
+// losing writer queues behind `busy_timeout` instead of erroring.
+//
+// Several rounds of many overlapping writers — some contending on the same
+// row (forcing the `ON CONFLICT` path), some on distinct rows (still
+// contending for SQLite's single writer lock) — give the underlying race a
+// real chance to have fired without the fix.
+const CONCURRENT_ROUNDS: i64 = 5;
+const CONCURRENT_WRITERS_PER_ROUND: usize = 5;
+
+#[tokio::test]
+async fn upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, shared_uuid) = seed(&pool, "/lib", "Shared Book").await;
+    let mut solo_uuids = Vec::new();
+    for i in 0..CONCURRENT_WRITERS_PER_ROUND - 1 {
+        let (_, uuid) = seed(&pool, "/lib", &format!("Solo Book {i}")).await;
+        solo_uuids.push(uuid);
+    }
+
+    for round in 0..CONCURRENT_ROUNDS {
+        let mut handles = Vec::new();
+        for (i, book_uuid) in std::iter::once(shared_uuid.clone())
+            .chain(solo_uuids.iter().cloned())
+            .enumerate()
+        {
+            let pool = pool.clone();
+            handles.push(tokio::spawn(async move {
+                upsert_progress(
+                    &pool,
+                    user,
+                    &ProgressUpdate {
+                        book_uuid,
+                        format: ProgressFormat::Epub,
+                        epub_cfi: Some(format!("epubcfi(/6/4!/4/{i}/1:0)")),
+                        audio_position_seconds: None,
+                        progress_percent: None,
+                        kobo_location: None,
+                        book_file_id: None,
+                        client_updated_at: Some(1_700_000_000 + round * 10 + i as i64),
+                    },
+                )
+                .await
+            }));
+        }
+        for handle in handles {
+            handle
+                .await
+                .expect("writer task panicked")
+                .expect("concurrent upsert_progress must not surface a database error");
+        }
+    }
+}
+
+#[tokio::test]
+async fn record_session_succeeds_for_many_concurrent_writers_on_one_pool() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, shared_uuid) = seed(&pool, "/lib", "Shared Book").await;
+    let mut solo_uuids = Vec::new();
+    for i in 0..CONCURRENT_WRITERS_PER_ROUND - 1 {
+        let (_, uuid) = seed(&pool, "/lib", &format!("Solo Session Book {i}")).await;
+        solo_uuids.push(uuid);
+    }
+
+    for round in 0..CONCURRENT_ROUNDS {
+        let mut handles = Vec::new();
+        for (i, book_uuid) in std::iter::once(shared_uuid.clone())
+            .chain(solo_uuids.iter().cloned())
+            .enumerate()
+        {
+            let pool = pool.clone();
+            let started_at = round * 1000 + i as i64;
+            handles.push(tokio::spawn(async move {
+                record_session(
+                    &pool,
+                    user,
+                    &SessionReport {
+                        book_uuid,
+                        format: ProgressFormat::Epub,
+                        started_at,
+                        ended_at: started_at + 60,
+                        progress_units: 60,
+                        device_id: None,
+                        client_id: None,
+                    },
+                )
+                .await
+            }));
+        }
+        for handle in handles {
+            let inserted = handle
+                .await
+                .expect("writer task panicked")
+                .expect("concurrent record_session must not surface a database error");
+            assert!(inserted, "known uuid must always insert");
+        }
+    }
+}

--- a/db/src/read_status/mod.rs
+++ b/db/src/read_status/mod.rs
@@ -57,16 +57,7 @@ pub async fn set_read_status(
     user_id: i64,
     update: &SetReadStatus,
 ) -> Result<ReadStatusRecord, ReadStatusError> {
-    // `BEGIN IMMEDIATE`, not plain `pool.begin()`: `set_read_status_tx` reads
-    // (`resolve_canonical_book_uuid_exec`) before it writes, same shape as
-    // `progress::upsert_progress_tx`. A DEFERRED transaction takes its
-    // snapshot on that read and only requests the write lock on the later
-    // `INSERT ... ON CONFLICT`; a concurrent writer (a second device, or a
-    // reader auto-marking status on the same book) committing in between
-    // leaves the snapshot stale, and SQLite reports `SQLITE_BUSY_SNAPSHOT`
-    // (517) instead of retrying — `busy_timeout` only covers lock
-    // *acquisition*, not a snapshot upgrade (#1862). Taking the write lock
-    // up front removes the upgrade entirely.
+    // Same BEGIN IMMEDIATE reasoning as `progress::upsert_progress` (#1862).
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let record = set_read_status_tx(&mut tx, user_id, update).await?;
     tx.commit().await?;

--- a/db/src/read_status/mod.rs
+++ b/db/src/read_status/mod.rs
@@ -57,7 +57,17 @@ pub async fn set_read_status(
     user_id: i64,
     update: &SetReadStatus,
 ) -> Result<ReadStatusRecord, ReadStatusError> {
-    let mut tx = pool.begin().await?;
+    // `BEGIN IMMEDIATE`, not plain `pool.begin()`: `set_read_status_tx` reads
+    // (`resolve_canonical_book_uuid_exec`) before it writes, same shape as
+    // `progress::upsert_progress_tx`. A DEFERRED transaction takes its
+    // snapshot on that read and only requests the write lock on the later
+    // `INSERT ... ON CONFLICT`; a concurrent writer (a second device, or a
+    // reader auto-marking status on the same book) committing in between
+    // leaves the snapshot stale, and SQLite reports `SQLITE_BUSY_SNAPSHOT`
+    // (517) instead of retrying — `busy_timeout` only covers lock
+    // *acquisition*, not a snapshot upgrade (#1862). Taking the write lock
+    // up front removes the upgrade entirely.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     let record = set_read_status_tx(&mut tx, user_id, update).await?;
     tx.commit().await?;
     Ok(record)

--- a/db/src/read_status/tests.rs
+++ b/db/src/read_status/tests.rs
@@ -223,11 +223,7 @@ async fn set_read_status_resolves_merged_uuid_to_surviving_book() {
     assert_eq!(got.status, ReadStatus::Finished);
 }
 
-/// #1862: `set_read_status_tx` reads (resolves the canonical uuid) before it
-/// writes, the same shape that made `progress::upsert_progress_tx` vulnerable
-/// to `SQLITE_BUSY_SNAPSHOT` under a plain `pool.begin()`. Several rounds of
-/// overlapping writers — on the same row and on distinct rows — give that
-/// race a real chance to have fired without the `BEGIN IMMEDIATE` fix.
+/// Regression test for the BEGIN IMMEDIATE stale-snapshot 517 fix (#1862).
 #[tokio::test]
 async fn set_read_status_succeeds_for_many_concurrent_writers_on_one_pool() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/read_status/tests.rs
+++ b/db/src/read_status/tests.rs
@@ -222,3 +222,36 @@ async fn set_read_status_resolves_merged_uuid_to_surviving_book() {
         .unwrap();
     assert_eq!(got.status, ReadStatus::Finished);
 }
+
+/// #1862: `set_read_status_tx` reads (resolves the canonical uuid) before it
+/// writes, the same shape that made `progress::upsert_progress_tx` vulnerable
+/// to `SQLITE_BUSY_SNAPSHOT` under a plain `pool.begin()`. Several rounds of
+/// overlapping writers — on the same row and on distinct rows — give that
+/// race a real chance to have fired without the `BEGIN IMMEDIATE` fix.
+#[tokio::test]
+async fn set_read_status_succeeds_for_many_concurrent_writers_on_one_pool() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "reader").await;
+    let (_, shared_uuid) = seed(&pool, "/lib", "Shared Book").await;
+    let mut solo_uuids = Vec::new();
+    for i in 0..4 {
+        let (_, uuid) = seed(&pool, "/lib", &format!("Solo Status Book {i}")).await;
+        solo_uuids.push(uuid);
+    }
+
+    for _round in 0..5 {
+        let mut handles = Vec::new();
+        for book_uuid in std::iter::once(shared_uuid.clone()).chain(solo_uuids.iter().cloned()) {
+            let pool = pool.clone();
+            handles.push(tokio::spawn(async move {
+                set_read_status(&pool, user, &set(&book_uuid, ReadStatus::Reading)).await
+            }));
+        }
+        for handle in handles {
+            handle
+                .await
+                .expect("writer task panicked")
+                .expect("concurrent set_read_status must not surface a database error");
+        }
+    }
+}

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -130,8 +130,14 @@ async fn record_sessions_batch(
     user_id: i64,
     reports: &[SessionReport],
 ) -> Result<u64, ServerFnError> {
+    // `BEGIN IMMEDIATE`: this is the web/mobile path behind the
+    // `POST /api/rpc/progress/sessions` 500 in #1862 — the bulk-resolve
+    // below reads before the insert loop writes, so a DEFERRED transaction
+    // risks `SQLITE_BUSY_SNAPSHOT` (517) when two devices post batches
+    // concurrently. See the matching comment on
+    // `db::progress::upsert_progress`.
     let mut tx = pool
-        .begin()
+        .begin_with("BEGIN IMMEDIATE")
         .await
         .map_err(|e| internal_rpc_error("begin sessions batch", e))?;
     let batch_uuids: Vec<String> = reports.iter().map(|r| r.book_uuid.clone()).collect();

--- a/frontend/src/rpc/progress.rs
+++ b/frontend/src/rpc/progress.rs
@@ -130,12 +130,7 @@ async fn record_sessions_batch(
     user_id: i64,
     reports: &[SessionReport],
 ) -> Result<u64, ServerFnError> {
-    // `BEGIN IMMEDIATE`: this is the web/mobile path behind the
-    // `POST /api/rpc/progress/sessions` 500 in #1862 — the bulk-resolve
-    // below reads before the insert loop writes, so a DEFERRED transaction
-    // risks `SQLITE_BUSY_SNAPSHOT` (517) when two devices post batches
-    // concurrently. See the matching comment on
-    // `db::progress::upsert_progress`.
+    // BEGIN IMMEDIATE avoids a stale-snapshot 517 on concurrent batches (#1862).
     let mut tx = pool
         .begin_with("BEGIN IMMEDIATE")
         .await

--- a/server/src/backend/kobo/state.rs
+++ b/server/src/backend/kobo/state.rs
@@ -49,7 +49,12 @@ pub async fn put_state(
     if let Some(rejected) = reject_oversized_state_request(&body) {
         return rejected;
     }
-    let mut tx = match state.pool().begin().await {
+    // `BEGIN IMMEDIATE`: each entry's `upsert_progress_tx` resolves the book
+    // uuid (a read) before its write, so a DEFERRED transaction risks
+    // `SQLITE_BUSY_SNAPSHOT` (517) when this batch races another writer on
+    // the same row (#1862) — see the matching comment on
+    // `db::progress::upsert_progress`.
+    let mut tx = match state.pool().begin_with("BEGIN IMMEDIATE").await {
         Ok(tx) => tx,
         Err(e) => return internal("kobo put_state begin", e),
     };

--- a/server/src/backend/kobo/state.rs
+++ b/server/src/backend/kobo/state.rs
@@ -49,11 +49,7 @@ pub async fn put_state(
     if let Some(rejected) = reject_oversized_state_request(&body) {
         return rejected;
     }
-    // `BEGIN IMMEDIATE`: each entry's `upsert_progress_tx` resolves the book
-    // uuid (a read) before its write, so a DEFERRED transaction risks
-    // `SQLITE_BUSY_SNAPSHOT` (517) when this batch races another writer on
-    // the same row (#1862) — see the matching comment on
-    // `db::progress::upsert_progress`.
+    // BEGIN IMMEDIATE avoids a stale-snapshot 517 on concurrent writers (#1862).
     let mut tx = match state.pool().begin_with("BEGIN IMMEDIATE").await {
         Ok(tx) => tx,
         Err(e) => return internal("kobo put_state begin", e),

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -122,7 +122,12 @@ pub(super) async fn post_sessions(
             return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
         }
     }
-    let mut tx = match state.pool.begin().await {
+    // `BEGIN IMMEDIATE`: the bulk-resolve below is a read that would
+    // otherwise seed a DEFERRED transaction's snapshot before the insert
+    // loop's writes, risking `SQLITE_BUSY_SNAPSHOT` (517) under concurrent
+    // session-report batches from two devices (#1862) — see the matching
+    // comment on `db::progress::upsert_progress`.
+    let mut tx = match state.pool.begin_with("BEGIN IMMEDIATE").await {
         Ok(tx) => tx,
         Err(e) => return internal("begin", e),
     };

--- a/server/src/backend/progress.rs
+++ b/server/src/backend/progress.rs
@@ -122,11 +122,7 @@ pub(super) async fn post_sessions(
             return (axum::http::StatusCode::BAD_REQUEST, msg).into_response();
         }
     }
-    // `BEGIN IMMEDIATE`: the bulk-resolve below is a read that would
-    // otherwise seed a DEFERRED transaction's snapshot before the insert
-    // loop's writes, risking `SQLITE_BUSY_SNAPSHOT` (517) under concurrent
-    // session-report batches from two devices (#1862) — see the matching
-    // comment on `db::progress::upsert_progress`.
+    // BEGIN IMMEDIATE avoids a stale-snapshot 517 on concurrent batches (#1862).
     let mut tx = match state.pool.begin_with("BEGIN IMMEDIATE").await {
         Ok(tx) => tx,
         Err(e) => return internal("begin", e),


### PR DESCRIPTION
## Summary
- Closes #1862
- On 2026-08-11 production served two 500s on progress routes caused by `SQLITE_BUSY_SNAPSHOT` (code 517): `upsert_progress_tx` (used by `POST /api/progress` and its web RPC equivalent), `record_sessions_batch`/`post_sessions` (`POST /api/rpc/progress/sessions` and `POST /api/progress/sessions`), `record_session_tx` (Kobo analytics), `set_read_status_tx` (read-status writes), and the Kobo `put_state` batch all resolve a book uuid — a **read** — before their write. A plain `pool.begin()` issues a DEFERRED transaction, which takes its snapshot on that read and only requests the write lock later; if a concurrent writer commits in between, the snapshot is stale and SQLite reports `SQLITE_BUSY_SNAPSHOT` immediately rather than retrying. `PRAGMA busy_timeout = 5000` doesn't help — it only retries *lock acquisition*, not a stale-snapshot upgrade, which is why both incident 500s returned in single-digit milliseconds.
- Fix: begin these transactions with `BEGIN IMMEDIATE` (via `pool.begin_with("BEGIN IMMEDIATE")`, the pattern already established in `db/src/auth/users.rs` and `db/src/metadata_overrides/`) so the write lock is taken up front, before the read runs. A losing concurrent writer now queues behind `busy_timeout` like any other lock wait, instead of erroring.
- Scope: `db/src/progress.rs` (`upsert_progress`, `record_session`), `db/src/read_status/mod.rs` (`set_read_status` — same read-then-write shape, reachable from the same concurrent-device surface), and the three request handlers that open their own transaction around these paths (`server/src/backend/progress.rs::post_sessions`, `frontend/src/rpc/progress.rs::record_sessions_batch`, `server/src/backend/kobo/state.rs::put_state`).
- Light audit of other `pool.begin()` sites in `db/`: the rest (`auth/session.rs::prune_expired_sessions`, `auth/device.rs::revoke_device`, `kobo_devices.rs::learn_kobo_device_id`, etc.) issue a write as their *first* statement, so a DEFERRED transaction acquires the write lock immediately there — no read-then-write snapshot race, so they're left alone. `author_photos_data.rs::delete_author` does read-then-write but is a rare, single-admin-initiated action, not a concurrent-multi-device hot path like progress/read-status, so it's out of scope for this focused fix (worth a follow-up if it ever proves practically racy).

## Test plan
- AC1 (two concurrent progress upserts against one pool both succeed): added `upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool`, `record_session_succeeds_for_many_concurrent_writers_on_one_pool` (`db/src/progress/tests.rs`), and `set_read_status_succeeds_for_many_concurrent_writers_on_one_pool` (`db/src/read_status/tests.rs`) — each spawns several rounds of overlapping `tokio::spawn` writers (mixed same-row and distinct-row contention) against one shared pool and asserts every writer succeeds.
- AC2 (no user-facing 500 from `SQLITE_BUSY_SNAPSHOT` on the progress write paths): covered by the same tests plus the existing `record_sessions_batch_skips_unknown_uuid_and_counts_only_inserted_rows` (frontend rpc) exercising the now-`BEGIN IMMEDIATE` batch path.
- `cargo fmt --check` — PASS (no diff)
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (0 warnings)
- `cargo clippy -p omnibus -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- `cargo test -p omnibus-db` — PASS, 2019/2020 (the 1 failure, `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, is a missing-fixture skip — `just fixtures` wasn't run in this sandbox — unrelated to this change)
- `cargo test -p omnibus-frontend --features server progress` — PASS, 25/25

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- No schema/migration change; this only changes how transactions begin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Xe72dn7JTMBSR99rKbff)_