### PR TITLE
fix: scope secondary_name to two-way cleanup merges only (#1855)

### DIFF
--- a/db/src/cleanup.rs
+++ b/db/src/cleanup.rs
@@ -80,7 +80,9 @@ pub struct DetectedSuggestion {
     /// split/rename/delete acts on.
     pub primary_name: String,
     /// The other name in a two-way merge, or the proposed title for a
-    /// rename. `None` when the suggestion has no single "other" name.
+    /// rename. `None` when the suggestion has no single "other" name —
+    /// including a merge group of 3+ duplicate names, where no single
+    /// source name can stand in for "the other one".
     pub secondary_name: Option<String>,
     /// How many *distinct* library books are affected if the suggestion is
     /// applied — a merge group's book is counted once even if it's linked
@@ -407,13 +409,20 @@ fn merge_suggestion(
         .flat_map(|r| r.book_ids.iter())
         .collect::<HashSet<_>>()
         .len() as i64;
+    // Only a genuine two-way merge has a single "other" name; a 3+-way
+    // group has no one source name that can stand in for the rest.
+    let secondary_name = if group.len() == 2 {
+        source_names.first().cloned()
+    } else {
+        None
+    };
     DetectedSuggestion {
         kind,
         action: CleanupAction::Merge,
         tier,
         score,
         primary_name: canonical.name.clone(),
-        secondary_name: source_names.first().cloned(),
+        secondary_name,
         book_count,
         payload: CleanupPayload::Merge {
             source_ids,

--- a/db/src/cleanup/tests.rs
+++ b/db/src/cleanup/tests.rs
@@ -378,6 +378,37 @@ async fn detect_authors_collapses_last_first_swap_into_one_tier0_merge_suggestio
 }
 
 #[tokio::test]
+async fn detect_authors_sets_secondary_name_none_for_a_three_way_merge_group() {
+    // #1855: a merge group of 3+ has no single "other" name, so
+    // secondary_name must be None even though the two-way case above sets
+    // it to the sole source name.
+    let pool = new_pool().await;
+    let canonical = insert_author(&pool, "Brandon Sanderson", None).await;
+    let dup_a = insert_author(&pool, "Sanderson, Brandon", None).await;
+    // `authors.name` is UNIQUE COLLATE NOCASE, so the third duplicate must
+    // differ from the other two by more than case — trailing punctuation
+    // folds away in `normalize_author` without changing the DB-level name.
+    let dup_b = insert_author(&pool, "Brandon Sanderson!!!", None).await;
+
+    let suggestions = detect_authors(&pool).await.unwrap();
+    let merges: Vec<_> = suggestions
+        .iter()
+        .filter(|s| s.action == CleanupAction::Merge)
+        .collect();
+    assert_eq!(merges.len(), 1);
+    let s = merges[0];
+    assert_eq!(s.secondary_name, None);
+    let (source_ids, source_names, canonical_id, _) = merge_payload(s);
+    // All three rows have zero linked books, so the tie breaks toward the
+    // lowest id — the first one inserted.
+    assert_eq!(canonical_id, canonical);
+    assert_eq!(source_ids.len(), 2);
+    assert!(source_ids.contains(&dup_a));
+    assert!(source_ids.contains(&dup_b));
+    assert_eq!(source_names.len(), 2);
+}
+
+#[tokio::test]
 async fn detect_authors_surfaces_tier1_fuzzy_merge_with_visible_score_at_or_above_085() {
     // AC2: token-set Jaccard >= 0.85 surfaces with a visible score even
     // though the two names never share a Tier-0 normalized key.


### PR DESCRIPTION
## Summary
- Closes #1855
- `db/src/cleanup.rs`'s `merge_suggestion` set `secondary_name` unconditionally to `source_names.first()` whenever the merge group was non-empty, even for merge groups of 3+ duplicate names — silently surfacing only the first extra name as if the merge were two-way, contradicting the field's own doc comment ("the other name in a two-way merge... `None` when the suggestion has no single 'other' name").
- Chose **option (a)** from the issue (honor the doc): `secondary_name` is now `None` whenever `group.len() != 2`, and only set to the sole source name for a genuine two-way merge. This is the conservative, doc-matching choice, and nothing downstream currently consumes `secondary_name` for a 3+-way group (no apply/UI layer exists yet per the module's own doc), so there's no unbuilt-UI intent to guess at.
- `merge_suggestion` is the single call site that builds the `Merge` variant of `DetectedSuggestion` — shared by the author/series/tag detectors (both the Tier-0 groupby path, where a group can be 3+, and the Tier-1 fuzzy path, which always compares pairs of exactly 2) — so one fix covers every detector.
- Updated the `secondary_name` doc comment to spell out the 3+-way case explicitly.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-db cleanup` — PASS (39 passed, 0 failed), including a new test asserting a 3-way author merge group (`Brandon Sanderson` / `Sanderson, Brandon` / `Brandon Sanderson!!!`, all normalizing to the same Tier-0 key) reports `secondary_name: None` while the existing 2-way tests still assert `Some(...)`.

## Version
- [x] **Patch** — the default; small bugfix, no behavior change for existing 2-way merges.

## Notes
- No frontend/UI layer consumes `secondary_name` yet (detection-engine-only module per its own doc; apply/UI is future roadmap work, see #963/#966), so this change has no observable effect outside the detection engine and its tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFznAFBkDMZKD4Yhmf2BT6)_