### PR TITLE
refactor: fix import order and re-render guard from indexer/admin-health audit (#1856)

### DIFF
--- a/db/src/indexer/audiobooks.rs
+++ b/db/src/indexer/audiobooks.rs
@@ -6,12 +6,13 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
+use crate::{audiobook, books, sync};
+
 use super::{
     check_mass_missing, diff_library, diff_tallies, enumeration_is_trustworthy,
     gc_missing_files_best_effort, report_parse_progress, report_sync_progress, root_display_name,
     ReindexDiff, ReindexStats, ScanUpdate, PHASE_WALKING,
 };
-use crate::{audiobook, books, sync};
 
 /// Audiobook-library sibling of [`super::reindex`]. Groups audio files by
 /// folder, reads multi-part tags, then calls [`sync::sync_audiobooks`] to

--- a/db/src/indexer/ebooks.rs
+++ b/db/src/indexer/ebooks.rs
@@ -6,12 +6,13 @@ use std::path::PathBuf;
 
 use sqlx::SqlitePool;
 
+use crate::{books, ebook, sync};
+
 use super::{
     check_mass_missing, diff_library, diff_tallies, enumeration_is_trustworthy,
     gc_missing_files_best_effort, report_parse_progress, report_sync_progress, root_display_name,
     ReindexDiff, ReindexStats, ScanUpdate, PHASE_WALKING,
 };
-use crate::{books, ebook, sync};
 
 /// Scan `library_path`, diff against the existing index, and apply only
 /// the per-book changes the diff demands. Runs the scan on the blocking

--- a/frontend/src/pages/admin_health.rs
+++ b/frontend/src/pages/admin_health.rs
@@ -97,7 +97,9 @@ fn apply_poll_result(
 ) {
     match outcome {
         Ok(report) => {
-            result.set(Some(report));
+            if result.peek().as_ref() != Some(&report) {
+                result.set(Some(report));
+            }
             error.set(false);
         }
         Err(_) if result.peek().is_none() => error.set(true),

--- a/frontend/src/rpc/admin_health.rs
+++ b/frontend/src/rpc/admin_health.rs
@@ -3,6 +3,7 @@
 //! REST twin serves. `POST` (not `GET`) because the body needs
 //! `WorkerExt` — see `rpc_worker_status`'s doc comment in `settings.rs`
 //! for why a `WorkerExt`-carrying `#[get]` route silently 404s.
+
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
 #[cfg(feature = "server")]


### PR DESCRIPTION
## Summary
- Closes #1856
- Reorders imports in `db/src/indexer/ebooks.rs` and `db/src/indexer/audiobooks.rs` so `use crate::{...}` precedes `use super::{...}`, matching the documented block order (rule 05-rust-style.md § Mechanics) and the precedent in `db/src/sync/audiobooks/mod.rs` / `db/src/sync/books/mod.rs`.
- Adds the missing blank line between the module `//!` doc block and the first `use` in `frontend/src/rpc/admin_health.rs`, matching every sibling in `frontend/src/rpc/`.
- Adds an equality guard (`if result.peek().as_ref() != Some(&report)`) before `result.set(...)` in `frontend/src/pages/admin_health.rs`'s poll handler, so `AdminHealthBody` and its four cards don't re-render on every 5s tick when the server state hasn't changed (`AdminHealthReport` already derives `PartialEq`).

## Test plan
- [x] `cargo fmt` then `cargo fmt --check` — PASS (no diff)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (2017 passed, 0 failed)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (734 passed, 0 failed)

## Version
- [x] **Patch** — default, left unlabeled.

## Notes
Pure drive-by cleanup, no behavior change beyond fewer redundant re-renders on `/admin/health`. Per the issue, item 3 (unconditional signal write) also applies to `components/worker_status.rs`, but that file is explicitly out of scope for this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFznAFBkDMZKD4Yhmf2BT6)_