### PR TITLE
[OMNI-1888] Fix web multi-file audiobook resume and write-back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2051,7 +2051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2480,7 +2480,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -4214,7 +4214,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5760,7 +5760,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5819,7 +5819,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6239,7 +6239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6723,7 +6723,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7645,15 +7645,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -7813,7 +7813,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/db/src/hls/mod.rs
+++ b/db/src/hls/mod.rs
@@ -20,7 +20,9 @@ pub use fs::{
     read_ffmpeg_manifest, read_progress, segment_dir,
 };
 pub use manifest::{build_manifest, ffmpeg_progress_fraction, parse_ffmpeg_progress_us};
-pub use query::{get_chapters, get_parts, resolve_audiobook, resolve_audiobook_file};
+pub use query::{
+    count_audio_files, get_chapters, get_parts, resolve_audiobook, resolve_audiobook_file,
+};
 pub use transcode::{evict_if_over_cap, transcode_book, used_bytes};
 
 /// Errors returned by the HLS DB queries. `transcode_book` uses

--- a/db/src/hls/query.rs
+++ b/db/src/hls/query.rs
@@ -64,6 +64,20 @@ pub async fn resolve_audiobook_file(
     )
 }
 
+/// Number of audio-format `book_files` rows `book_id` carries. The format
+/// list mirrors [`resolve_audiobook_file`] — this counts the candidates that
+/// resolver chooses between, so `> 1` marks a multi-file audiobook whose
+/// positions are only meaningful together with a `book_file_id`.
+pub async fn count_audio_files(pool: &SqlitePool, book_id: i64) -> Result<i64, HlsError> {
+    Ok(sqlx::query_scalar(
+        "SELECT COUNT(*) FROM book_files \
+         WHERE book_id = ? AND format IN ('M4B', 'M4A', 'MP3')",
+    )
+    .bind(book_id)
+    .fetch_one(pool)
+    .await?)
+}
+
 /// Fetch ordered `book_file_parts` for `book_file_id`.
 pub async fn get_parts(pool: &SqlitePool, book_file_id: i64) -> Result<Vec<HlsPart>, HlsError> {
     let rows = sqlx::query_as::<_, (i64, String, f64)>(

--- a/db/src/hls/tests.rs
+++ b/db/src/hls/tests.rs
@@ -418,6 +418,49 @@ async fn transcode_book_clears_orphan_progress_on_restart() {
 }
 
 #[tokio::test]
+async fn count_audio_files_counts_only_audio_rows_for_the_book() {
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind("/lib")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id = sqlx::query(
+        "INSERT INTO books (uuid, library_id, path, title) VALUES ('u', ?, '/lib', 't')",
+    )
+    .bind(lib_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    // Two audio files plus an EPUB on the same book — only the audio rows
+    // count toward the multi-file total.
+    for (format, ordinal) in [("M4B", 0), ("M4B", 1), ("EPUB", 0)] {
+        sqlx::query(
+            "INSERT INTO book_files (book_id, format, filename, size_bytes, ordinal) \
+             VALUES (?, ?, 'f', 0, ?)",
+        )
+        .bind(book_id)
+        .bind(format)
+        .bind(ordinal)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    assert_eq!(count_audio_files(&pool, book_id).await.unwrap(), 2);
+    assert_eq!(count_audio_files(&pool, book_id + 1).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn count_audio_files_propagates_db_error_when_pool_is_closed() {
+    let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = count_audio_files(&pool, 1).await.unwrap_err();
+    assert!(matches!(err, HlsError::Db(_)));
+}
+
+#[tokio::test]
 async fn get_parts_propagates_db_error_when_pool_is_closed() {
     let pool = crate::pool::init_db("sqlite::memory:").await.unwrap();
     pool.close().await;

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -84,6 +84,16 @@ fn parse_format(raw: &str) -> ProgressFormat {
 /// derivable CFI, a web CFI with no span) stays NULL as "not known", and
 /// the Kobo sync-out derives the missing half on demand rather than
 /// trusting a stale leftover.
+///
+/// One backstop narrows that rule: an **audio** write naming no
+/// `book_file_id`, landing on a row that names one, for a book carrying
+/// more than one audio file, is rejected wholly — same shape as a
+/// stale-clock rejection, the re-read returns the surviving row. Audio
+/// seconds are only meaningful within one file, so accepting such a write
+/// would turn the row into "N seconds within an unknown file" and destroy a
+/// position another client (e.g. iOS) recorded correctly (#1888). On a
+/// single-file book a fileless write still applies — the server resolves
+/// the same default file the manifest serves, so nothing is ambiguous.
 pub async fn upsert_progress(
     pool: &SqlitePool,
     user_id: i64,
@@ -132,7 +142,16 @@ pub async fn upsert_progress_tx(
              updated_at = strftime('%s','now'),
              client_updated_at = excluded.client_updated_at
          WHERE excluded.client_updated_at >=
-             COALESCE(reading_progress.client_updated_at, reading_progress.updated_at)",
+             COALESCE(reading_progress.client_updated_at, reading_progress.updated_at)
+           AND NOT (
+             excluded.format = 'audio'
+             AND excluded.book_file_id IS NULL
+             AND reading_progress.book_file_id IS NOT NULL
+             AND (SELECT COUNT(*) FROM book_files bf
+                    JOIN books b ON b.id = bf.book_id
+                   WHERE b.uuid = excluded.book_uuid
+                     AND bf.format IN ('M4B', 'M4A', 'MP3')) > 1
+           )",
     )
     .bind(user_id)
     .bind(&book_uuid)

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -265,6 +265,126 @@ async fn upsert_rejects_a_stale_write_wholly_without_field_bleed() {
     assert_eq!(survived.kobo_location, None);
 }
 
+/// Insert `n` audio `book_files` rows for `book_id`, returning their ids.
+/// Gives the multi-file guard in `upsert_progress_tx` real audio rows to
+/// count (the `seed` helper's EPUB file doesn't participate).
+async fn seed_audio_files(pool: &SqlitePool, book_id: i64, n: usize) -> Vec<i64> {
+    let mut ids = Vec::with_capacity(n);
+    for ordinal in 0..n {
+        let id = sqlx::query_scalar::<_, i64>(
+            "INSERT INTO book_files (book_id, format, filename, size_bytes, ordinal)
+             VALUES (?, 'M4B', ?, 1, ?) RETURNING id",
+        )
+        .bind(book_id)
+        .bind(format!("part-{ordinal}.m4b"))
+        .bind(ordinal as i64)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        ids.push(id);
+    }
+    ids
+}
+
+/// Shorthand for an audio `ProgressUpdate` in the multi-file guard tests.
+fn audio_update(
+    uuid: &str,
+    seconds: f64,
+    book_file_id: Option<i64>,
+    client_updated_at: i64,
+) -> ProgressUpdate {
+    ProgressUpdate {
+        book_uuid: uuid.to_string(),
+        format: ProgressFormat::Audio,
+        epub_cfi: None,
+        audio_position_seconds: Some(seconds),
+        progress_percent: None,
+        kobo_location: None,
+        book_file_id,
+        client_updated_at: Some(client_updated_at),
+    }
+}
+
+#[tokio::test]
+async fn upsert_rejects_fileless_audio_write_that_would_blank_a_named_file_on_multi_file_book() {
+    // #1888: a web player that lost track of which file it loaded must not
+    // be able to replace "23,718 s within file 4" with "23,718 s within an
+    // unknown file". The whole write is rejected — seconds included — and
+    // the surviving row is returned, mirroring a stale-clock rejection.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 2).await;
+
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 23_718.0, Some(files[1]), 100),
+    )
+    .await
+    .unwrap();
+    let survived = upsert_progress(&pool, user, &audio_update(&uuid, 60.0, None, 200))
+        .await
+        .unwrap();
+
+    assert_eq!(survived.book_file_id, Some(files[1]));
+    assert_eq!(survived.audio_position_seconds, Some(23_718.0));
+    let stored = get_progress(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.book_file_id, Some(files[1]));
+    assert_eq!(stored.audio_position_seconds, Some(23_718.0));
+    assert_eq!(stored.client_updated_at, 100);
+}
+
+#[tokio::test]
+async fn upsert_applies_fileless_audio_write_on_a_single_file_book() {
+    // Legacy single-file behavior is untouched: with one audio file there
+    // is nothing ambiguous about a fileless write, so it still replaces
+    // the whole row (file id included).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 1).await;
+
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 500.0, Some(files[0]), 100),
+    )
+    .await
+    .unwrap();
+    let record = upsert_progress(&pool, user, &audio_update(&uuid, 600.0, None, 200))
+        .await
+        .unwrap();
+
+    assert_eq!(record.audio_position_seconds, Some(600.0));
+    assert_eq!(record.book_file_id, None);
+}
+
+#[tokio::test]
+async fn upsert_applies_multi_file_audio_write_that_names_its_file() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 2).await;
+
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 23_718.0, Some(files[1]), 100),
+    )
+    .await
+    .unwrap();
+    let record = upsert_progress(&pool, user, &audio_update(&uuid, 30.0, Some(files[0]), 200))
+        .await
+        .unwrap();
+
+    assert_eq!(record.book_file_id, Some(files[0]));
+    assert_eq!(record.audio_position_seconds, Some(30.0));
+}
+
 #[tokio::test]
 async fn attach_derived_kobo_location_fills_the_span_without_touching_clocks() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/frontend/src/contexts/mod.rs
+++ b/frontend/src/contexts/mod.rs
@@ -298,6 +298,12 @@ pub struct PlaybackState {
     /// backend pick the lowest-ordinal audio file. Tracked as a signal so the
     /// App-level driver reboots when the *same* book's selected file changes.
     pub file_id: Signal<Option<i64>>,
+    /// The `book_files` row the manifest actually resolved for the current
+    /// boot — `file_id` is the *request* (picker selection, often `None`),
+    /// this is the answer. Progress posts read it so a multi-file book's
+    /// writes always name the file playback is really in (#1888). `None`
+    /// until a manifest lands, and reset on every book swap.
+    pub loaded_file_id: Signal<Option<i64>>,
     pub book: Signal<Option<omnibus_shared::EbookMetadata>>,
     pub loading: Signal<bool>,
     pub error: Signal<Option<String>>,
@@ -322,6 +328,7 @@ impl PlaybackState {
         Self {
             uuid: Signal::new(None),
             file_id: Signal::new(None),
+            loaded_file_id: Signal::new(None),
             book: Signal::new(None),
             loading: Signal::new(false),
             error: Signal::new(None),

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -47,6 +47,13 @@ pub(super) fn BdImmersiveButton(uuid: String) -> Element {
         // the previous book's metadata/error and flag loading first so the dock
         // can't flash the old book under the new reader before the driver reloads.
         let mut uuid_sig = playback.uuid;
+        let mut file_sig = playback.file_id;
+        // Default file selection, published before the uuid so the driver
+        // reads it when the load kicks off (mirrors the mobile variant and
+        // `use_retarget_playback`). Without this a stale picker selection
+        // from a previously-played book would override the bootstrap's
+        // progress-row file resolution — or 404 the new book's manifest.
+        file_sig.set(None);
         if uuid_sig.peek().as_deref() != Some(uuid.as_str()) {
             let mut book_sig = playback.book;
             let mut error_sig = playback.error;

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -9,7 +9,7 @@
 use dioxus::prelude::*;
 use wasm_bindgen::prelude::*;
 
-use super::helpers::post_audio_progress;
+use super::helpers::{post_audio_progress, resolve_boot_file, resolve_boot_position};
 use crate::data;
 
 mod js;
@@ -21,14 +21,11 @@ use js::{control_surface_js, eval_hls_init, inject_hls_script};
 /// closure that registers them.
 type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Closure<dyn FnMut(f64)>>>>;
 
-// Below: the pure Rust decision surface, extracted so it can be unit-tested.
-// The rest of the module is JS/WASM interop (`eval`, `window.*` callbacks).
-
-/// Select the resume position: prefer the server-authoritative value when
-/// available, fall back to the locally cached initial position.
-fn resolve_resume_pos(server_pos: Option<f64>, local_pos: f64) -> f64 {
-    server_pos.unwrap_or(local_pos)
-}
+// The pure resume-decision helpers (`resolve_boot_file`,
+// `resolve_boot_position`) live in `super::helpers` — this module is
+// web-gated, so tests here never run under the crate's test matrix (which
+// exercises the `server` + `mobile` features). The rest of this module is
+// JS/WASM interop (`eval`, `window.*` callbacks).
 
 /// Whether the driver must (re)load for a newly-requested `(uuid, file_id)`.
 ///
@@ -158,7 +155,7 @@ fn boot_new_book(
     register_js_callbacks(
         cb_holder,
         uuid.to_string(),
-        file_id,
+        playback.loaded_file_id,
         playback.duration,
         playback.elapsed,
         playback.playing,
@@ -197,7 +194,9 @@ fn reset_per_book_signals(playback: &crate::PlaybackState, user_id: Option<i64>,
     let mut book = playback.book;
     let mut error = playback.error;
     let mut chapters = playback.chapters;
+    let mut loaded_file_id = playback.loaded_file_id;
 
+    loaded_file_id.set(None);
     duration.set(0.0_f64);
     elapsed.set(0.0_f64);
     playing.set(false);
@@ -271,13 +270,16 @@ fn spawn_manifest_init(
 /// Registered before the JS bootstrap so a fast `loadedmetadata` always finds
 /// them.
 ///
-/// `file_id` is the file this boot loaded; it rides along on every position
-/// POST. Re-registered on each boot, and a file switch always re-boots (see
-/// [`needs_reload`]), so the captured value can't outlive its file.
+/// `loaded_file_id` is the shared signal `run_manifest_init` fills once the
+/// manifest names the file it resolved; every position POST reads it live,
+/// so writes name the file playback is actually in even though these
+/// closures are registered before the manifest lands (#1888). A file switch
+/// always re-boots (see [`needs_reload`]), which resets the signal before
+/// the next manifest fills it again.
 fn register_js_callbacks(
     cb_holder: &JsCallbackHolder,
     uuid_cb: String,
-    file_id: Option<i64>,
+    loaded_file_id: Signal<Option<i64>>,
     mut duration: Signal<f64>,
     mut elapsed: Signal<f64>,
     mut playing: Signal<bool>,
@@ -295,7 +297,7 @@ fn register_js_callbacks(
         }
         last_saved = secs;
         crate::audiobook_progress::save(&uuid_for_save, secs);
-        post_audio_progress(uuid_for_save.clone(), file_id, secs);
+        post_audio_progress(uuid_for_save.clone(), *loaded_file_id.peek(), secs);
     });
     let on_duration = Closure::<dyn FnMut(f64)>::new(move |d: f64| {
         duration.set(d);
@@ -331,7 +333,7 @@ fn register_js_callbacks(
     let on_pause = Closure::<dyn FnMut(f64)>::new(move |secs: f64| {
         playing.set(false);
         crate::audiobook_progress::save(&uuid_for_pause, secs);
-        post_audio_progress(uuid_for_pause.clone(), file_id, secs);
+        post_audio_progress(uuid_for_pause.clone(), *loaded_file_id.peek(), secs);
     });
     // Fired from the init-poll's `n >= 200` branch when
     // `window.OmnibusAudio` never appears (mount loop gave
@@ -395,8 +397,10 @@ fn install_control_surface(uuid: &str, initial_rate: f64, initial_volume: f64) {
     let _ = dioxus::document::eval(&control_surface_js(&rate_lit, &vol_lit, &uuid_lit));
 }
 
-/// Fetch `/api/audiobooks/{uuid}/manifest` (with optional `?file_id`)
-/// and either:
+/// Fetch `/api/audiobooks/{uuid}/manifest` — targeting the picker's
+/// `file_id` when one was selected, else the progress row's stored
+/// `book_file_id` so multi-file books resume in the file the seconds were
+/// recorded in (#1888) — then either:
 /// * **Direct mode** — call `initDirect` with the parts list and flip
 ///   `hls_ready` true (instant playback for m4b/m4a/mp3/aac).
 /// * **HLS mode** — poll `/status` until `ready` (call `initHls` + flip
@@ -433,15 +437,13 @@ async fn run_manifest_init(
             user_id,
         )
     };
-    // Reconcile resume position with the server upfront so
-    // both init paths see the same starting point.
-    let server_pos = data::get_progress("", &uuid_for_fetch, omnibus_shared::ProgressFormat::Audio)
+    // Reconcile resume state with the server upfront: the row carries both
+    // the seconds and the `book_files` row they were recorded in, and the
+    // file decides which manifest to fetch before any position applies.
+    let server_row = data::get_progress("", &uuid_for_fetch, omnibus_shared::ProgressFormat::Audio)
         .await
         .ok()
-        .flatten()
-        .and_then(|r| r.audio_position_seconds);
-    let resume_pos = resolve_resume_pos(server_pos, initial_position);
-    let pos_lit = serde_json::to_string(&resume_pos).unwrap_or_else(|_| "0".into());
+        .flatten();
 
     let server_rate = data::get_playback_rate("", &uuid_for_fetch).await;
     if !is_current() {
@@ -472,7 +474,17 @@ async fn run_manifest_init(
         }
     }
 
-    let manifest = fetch_manifest(&uuid_for_fetch, file_id).await;
+    let row_file = server_row.as_ref().and_then(|r| r.book_file_id);
+    let boot_file = resolve_boot_file(file_id, row_file);
+    let mut manifest = fetch_manifest(&uuid_for_fetch, boot_file).await;
+    // The row's stored id is a soft reference — a reindex may have replaced
+    // the `book_files` row since the position was saved. Fall back to the
+    // server's default file rather than a failure overlay, mirroring
+    // `db::progress::resume_points`. Never applied to an explicit picker
+    // selection: a dead `?file_id=` should fail loudly, not play another file.
+    if manifest.is_none() && file_id.is_none() && boot_file.is_some() {
+        manifest = fetch_manifest(&uuid_for_fetch, None).await;
+    }
 
     // A newer book may have been selected while the manifest was in flight.
     // The Direct + None arms below are synchronous, so this single guard covers
@@ -481,11 +493,37 @@ async fn run_manifest_init(
         return;
     }
 
+    let Some(manifest) = manifest else {
+        // Manifest unreachable (network failure, 5xx,
+        // 404 between settings save and reindex). Show
+        // the same failure overlay as a terminal HLS
+        // transcode failure — a manual refresh is the
+        // recovery path either way.
+        playback_failed.set(true);
+        return;
+    };
+
+    let (loaded_file, audio_file_count) = manifest.file_identity();
+    // `0` = a server predating the identity fields; keep posting no file id
+    // rather than inventing one (`resolve_boot_position` degrades the same
+    // way via `audio_file_count == 0`).
+    let mut loaded_file_sig = playback.loaded_file_id;
+    loaded_file_sig.set((loaded_file > 0).then_some(loaded_file));
+    let resume_pos = resolve_boot_position(
+        server_row
+            .as_ref()
+            .map(|r| (r.book_file_id, r.audio_position_seconds)),
+        initial_position,
+        loaded_file,
+        audio_file_count,
+    );
+    let pos_lit = serde_json::to_string(&resume_pos).unwrap_or_else(|_| "0".into());
+
     match manifest {
-        Some(omnibus_shared::AudiobookManifest::Direct {
+        omnibus_shared::AudiobookManifest::Direct {
             parts, chapters, ..
-        }) => init_direct_play(parts, chapters, &pos_lit, chapters_sig, hls_ready),
-        Some(omnibus_shared::AudiobookManifest::Hls { playlist_url }) => {
+        } => init_direct_play(parts, chapters, &pos_lit, chapters_sig, hls_ready),
+        omnibus_shared::AudiobookManifest::Hls { playlist_url, .. } => {
             init_hls(
                 &uuid_for_fetch,
                 &playlist_url,
@@ -495,14 +533,6 @@ async fn run_manifest_init(
                 playback_failed,
             )
             .await;
-        }
-        None => {
-            // Manifest unreachable (network failure, 5xx,
-            // 404 between settings save and reindex). Show
-            // the same failure overlay as a terminal HLS
-            // transcode failure — a manual refresh is the
-            // recovery path either way.
-            playback_failed.set(true);
         }
     }
 }
@@ -607,21 +637,6 @@ async fn fetch_hls_status(uuid: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn resolve_resume_pos_prefers_server_position_when_present() {
-        assert!((resolve_resume_pos(Some(120.0), 5.0) - 120.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn resolve_resume_pos_falls_back_to_local_when_server_absent() {
-        assert!((resolve_resume_pos(None, 42.5) - 42.5).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn resolve_resume_pos_returns_zero_local_when_both_absent() {
-        assert!((resolve_resume_pos(None, 0.0)).abs() < f64::EPSILON);
-    }
 
     #[test]
     fn needs_reload_when_nothing_booted_or_book_changed() {

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -105,6 +105,55 @@ pub(super) fn seek_to(secs: f64) {
     let _ = secs;
 }
 
+// The resume-decision trio below is only *called* from the web bootstrap
+// (`bootstrap::run_manifest_init`), but lives here un-gated-on-web so its
+// tests run under the crate's test matrix (`server` feature) — the
+// bootstrap module itself is `#![cfg(feature = "web")]` and its tests
+// never execute there.
+
+/// Select the resume position: prefer the server-authoritative value when
+/// available, fall back to the locally cached initial position.
+#[cfg(not(feature = "mobile"))]
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+fn resolve_resume_pos(server_pos: Option<f64>, local_pos: f64) -> f64 {
+    server_pos.unwrap_or(local_pos)
+}
+
+/// The file to request the manifest with: an explicit picker selection wins;
+/// otherwise the progress row's stored `book_file_id`, so resume lands in
+/// the file the seconds were recorded in (#1888); `None` (the server's
+/// lowest-ordinal default) only when neither names one.
+#[cfg(not(feature = "mobile"))]
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+pub(super) fn resolve_boot_file(requested: Option<i64>, row_file: Option<i64>) -> Option<i64> {
+    requested.or(row_file)
+}
+
+/// Seconds to seed playback with, given the file the manifest actually
+/// resolved. On a single-file book — or when a legacy server reports no
+/// file identity (`audio_file_count == 0`) — this is the historic behavior:
+/// server seconds, else the locally cached position. On a multi-file book
+/// an offset is applied only when the progress row names the loaded file:
+/// seconds recorded in another file, or in no named file at all (the local
+/// cache never names one), start playback at zero rather than splicing one
+/// file's offset into another (#1888).
+#[cfg(not(feature = "mobile"))]
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+pub(super) fn resolve_boot_position(
+    row: Option<(Option<i64>, Option<f64>)>,
+    local_pos: f64,
+    loaded_file_id: i64,
+    audio_file_count: i64,
+) -> f64 {
+    if audio_file_count <= 1 {
+        return resolve_resume_pos(row.and_then(|(_, seconds)| seconds), local_pos);
+    }
+    match row {
+        Some((Some(row_file), Some(seconds))) if row_file == loaded_file_id => seconds,
+        _ => 0.0,
+    }
+}
+
 /// localStorage key for the persisted session volume preference.
 #[cfg(feature = "web")]
 const VOLUME_KEY: &str = "omnibus.listen.volume";
@@ -238,11 +287,13 @@ pub(super) fn format_hms(seconds: f64) -> String {
 
 /// Fire-and-forget POST `/api/rpc/progress` with the audio update.
 ///
-/// `file_id` is the `book_files` row currently playing — recorded so the
-/// Continue surfaces reopen *this* audiobook on a book that carries several,
-/// instead of the first one by ordinal at this one's timestamp. `None` (the
-/// player was entered without a `?file_id=`) leaves the resume path on the
-/// same first-file default the manifest itself served.
+/// `file_id` is the `book_files` row currently playing — the id the
+/// manifest itself resolved (`PlaybackState::loaded_file_id`), so multi-file
+/// writes always name their file and the Continue surfaces reopen *this*
+/// audiobook rather than the first one by ordinal. `None` (no manifest
+/// resolved yet, or a server predating the identity fields) omits the field;
+/// the server-side guard then refuses to blank a named file on a multi-file
+/// row (#1888).
 #[cfg(feature = "web")]
 pub(super) fn post_audio_progress(uuid: String, file_id: Option<i64>, seconds: f64) {
     wasm_bindgen_futures::spawn_local(async move {
@@ -364,6 +415,75 @@ mod tests {
         assert_eq!(format_hms(-12.0), "0:00");
         assert_eq!(format_hms(f64::NAN), "0:00");
         assert_eq!(format_hms(f64::INFINITY), "0:00");
+    }
+}
+
+// The resume-decision helpers don't exist on mobile (the web bootstrap is
+// their only caller), so their tests live in a separately-gated module.
+#[cfg(all(test, not(feature = "mobile")))]
+mod boot_resume_tests {
+    use super::{resolve_boot_file, resolve_boot_position, resolve_resume_pos};
+
+    #[test]
+    fn resolve_resume_pos_prefers_server_position_when_present() {
+        assert!((resolve_resume_pos(Some(120.0), 5.0) - 120.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_resume_pos_falls_back_to_local_when_server_absent() {
+        assert!((resolve_resume_pos(None, 42.5) - 42.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_resume_pos_returns_zero_local_when_both_absent() {
+        assert!((resolve_resume_pos(None, 0.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_boot_file_prefers_explicit_picker_selection() {
+        assert_eq!(resolve_boot_file(Some(917), Some(919)), Some(917));
+    }
+
+    #[test]
+    fn resolve_boot_file_falls_back_to_the_progress_rows_file() {
+        assert_eq!(resolve_boot_file(None, Some(919)), Some(919));
+        assert_eq!(resolve_boot_file(None, None), None);
+    }
+
+    #[test]
+    fn resolve_boot_position_applies_row_seconds_when_the_row_names_the_loaded_file() {
+        let row = Some((Some(919), Some(23_718.0)));
+        assert!((resolve_boot_position(row, 5.0, 919, 5) - 23_718.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_boot_position_starts_at_zero_when_multi_file_seconds_are_unattributable() {
+        // Row names a different file than the one loaded.
+        let other_file = Some((Some(919), Some(23_718.0)));
+        assert_eq!(resolve_boot_position(other_file, 5.0, 917, 5), 0.0);
+        // Row names no file at all — seconds can't be attributed.
+        let fileless = Some((None, Some(23_718.0)));
+        assert_eq!(resolve_boot_position(fileless, 5.0, 917, 5), 0.0);
+        // No row; the local cache never names a file either.
+        assert_eq!(resolve_boot_position(None, 5.0, 917, 5), 0.0);
+    }
+
+    #[test]
+    fn resolve_boot_position_keeps_single_file_resume_behavior() {
+        // Server seconds win; the stored file id (even a stale one from a
+        // replaced `book_files` row) doesn't gate a single-file book.
+        let row = Some((Some(1), Some(120.0)));
+        assert!((resolve_boot_position(row, 5.0, 2, 1) - 120.0).abs() < f64::EPSILON);
+        // No server row → locally cached position, as before.
+        assert!((resolve_boot_position(None, 42.5, 2, 1) - 42.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_boot_position_treats_legacy_server_without_identity_as_single_file() {
+        // `audio_file_count == 0` = a server predating the identity fields;
+        // degrade to the historic resume behavior rather than zeroing.
+        let row = Some((None, Some(300.0)));
+        assert!((resolve_boot_position(row, 5.0, 0, 0) - 300.0).abs() < f64::EPSILON);
     }
 }
 

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -248,6 +248,7 @@ async fn load_and_drain(
             parts,
             total_duration_seconds,
             chapters,
+            ..
         } => {
             // Same fail-fast as the reader's offline guard: with no completed
             // audio download, the <audio> element would stall against the

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -147,6 +147,13 @@ pub(super) async fn get_audiobook_manifest(
         return axum::http::StatusCode::NOT_FOUND.into_response();
     }
 
+    // How many audio files the book carries rides along so clients know
+    // whether a stored position needs a `book_file_id` to be meaningful.
+    let audio_file_count = match hls::count_audio_files(&state.pool, resolved.book_id).await {
+        Ok(count) => count,
+        Err(e) => return internal("count_audio_files", e),
+    };
+
     let filenames: Vec<&str> = parts.iter().map(|p| p.filename.as_str()).collect();
     let file_id_suffix = query
         .file_id
@@ -172,12 +179,16 @@ pub(super) async fn get_audiobook_manifest(
                 Err(e) => return internal("get_chapters", e),
             };
             AudiobookManifest::Direct {
+                book_file_id: resolved.book_file_id,
+                audio_file_count,
                 parts: manifest_parts,
                 total_duration_seconds,
                 chapters,
             }
         }
         PlaybackMode::Hls => AudiobookManifest::Hls {
+            book_file_id: resolved.book_file_id,
+            audio_file_count,
             playlist_url: format!("/api/audiobooks/{uuid}/playlist.m3u8"),
         },
     };

--- a/server/src/backend/audiobooks/tests.rs
+++ b/server/src/backend/audiobooks/tests.rs
@@ -528,6 +528,78 @@ async fn api_get_audiobook_manifest_returns_direct_for_mp3_folder() {
 }
 
 #[tokio::test]
+async fn api_get_audiobook_manifest_reports_resolved_file_and_audio_file_count() {
+    let (_, _, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let uuid = seed_audiobook_with_parts(
+        &pool,
+        "/audiobooks",
+        "M4B",
+        &[(0, "Author/Book/Part1.m4b", 3600.0)],
+    )
+    .await;
+    // Second audio file on the same book — the multi-file shape (#1888).
+    let book_id = sqlx::query_scalar::<_, i64>("SELECT id FROM books WHERE uuid = ?")
+        .bind(&uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let second_file_id = sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, ordinal) \
+         VALUES (?, 'M4B', 'book-2', 0, 1)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_file_parts (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds) \
+         VALUES (?, 0, 'Author/Book/Part2.m4b', 0, 0, 1800.0)",
+    )
+    .bind(second_file_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = crate::backend::rest_router(AppState::new(pool));
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/audiobooks/{uuid}/manifest?file_id={second_file_id}"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["book_file_id"].as_i64(), Some(second_file_id));
+    assert_eq!(json["audio_file_count"].as_i64(), Some(2));
+
+    // Without `?file_id=` the manifest resolves — and names — the default
+    // (lowest-ordinal) file.
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/audiobooks/{uuid}/manifest"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_ne!(json["book_file_id"].as_i64(), Some(second_file_id));
+    assert!(json["book_file_id"].as_i64().unwrap() > 0);
+    assert_eq!(json["audio_file_count"].as_i64(), Some(2));
+}
+
+#[tokio::test]
 async fn api_get_audiobook_manifest_returns_hls_when_any_part_is_flac() {
     let (_, _, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;

--- a/shared/src/audiobook.rs
+++ b/shared/src/audiobook.rs
@@ -64,18 +64,52 @@ pub struct ChapterInfo {
 /// works for any source the browser / native player decodes natively
 /// (m4b, m4a, mp3, aac). `hls` falls back to the segmented transcode
 /// path for codecs that need conversion (flac, ac3, eac3, …).
+/// Both variants carry the identity of the file the server resolved:
+/// `book_file_id` is the `book_files` row this manifest describes (what a
+/// progress write for the session must name), and `audio_file_count` is how
+/// many audio files the book carries — `> 1` means a stored position is only
+/// meaningful together with its file id. Both are `#[serde(default)]` (0) so
+/// a payload from a server predating them still decodes; clients treat 0 as
+/// "identity unknown".
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "mode", rename_all = "lowercase")]
 pub enum AudiobookManifest {
     Direct {
+        #[serde(default)]
+        book_file_id: i64,
+        #[serde(default)]
+        audio_file_count: i64,
         parts: Vec<ManifestPart>,
         total_duration_seconds: f64,
         #[serde(default)]
         chapters: Vec<ChapterInfo>,
     },
     Hls {
+        #[serde(default)]
+        book_file_id: i64,
+        #[serde(default)]
+        audio_file_count: i64,
         playlist_url: String,
     },
+}
+
+impl AudiobookManifest {
+    /// The `(book_file_id, audio_file_count)` identity pair, zero-valued
+    /// when the serving server predates those fields.
+    pub fn file_identity(&self) -> (i64, i64) {
+        match self {
+            AudiobookManifest::Direct {
+                book_file_id,
+                audio_file_count,
+                ..
+            }
+            | AudiobookManifest::Hls {
+                book_file_id,
+                audio_file_count,
+                ..
+            } => (*book_file_id, *audio_file_count),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -104,6 +138,31 @@ mod tests {
             let update = AudiobookPlaybackRateUpdate { playback_rate };
             assert!(update.validate().is_err());
         }
+    }
+
+    #[test]
+    fn manifest_decodes_legacy_payload_without_file_identity_as_zeros() {
+        let legacy = r#"{"mode":"direct","parts":[],"total_duration_seconds":1.5}"#;
+        let manifest: AudiobookManifest = serde_json::from_str(legacy).unwrap();
+        assert_eq!(manifest.file_identity(), (0, 0));
+    }
+
+    #[test]
+    fn manifest_file_identity_reads_both_variants() {
+        let direct = AudiobookManifest::Direct {
+            book_file_id: 919,
+            audio_file_count: 5,
+            parts: vec![],
+            total_duration_seconds: 1.0,
+            chapters: vec![],
+        };
+        let hls = AudiobookManifest::Hls {
+            book_file_id: 7,
+            audio_file_count: 2,
+            playlist_url: "/x.m3u8".into(),
+        };
+        assert_eq!(direct.file_identity(), (919, 5));
+        assert_eq!(hls.file_identity(), (7, 2));
     }
 
     #[test]

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -375,6 +375,7 @@ test("persists listening progress when the audio element pauses", async ({
   request,
 }) => {
   const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  const bookFileId = await fetchAudioFileId(request, uuid);
   await gotoReady(page, `/listen/${uuid}`);
   await waitForPlayerReady(page);
 
@@ -383,7 +384,12 @@ test("persists listening progress when the audio element pauses", async ({
   const PAUSE_AT_SEC = 7.5;
   await expectMutationProgress(
     page,
-    { uuid, audioPositionSeconds: PAUSE_AT_SEC, expectedStatus: 200 },
+    {
+      uuid,
+      audioPositionSeconds: PAUSE_AT_SEC,
+      bookFileId,
+      expectedStatus: 200,
+    },
     async () => {
       await page.evaluate((secs) => {
         const cb = (
@@ -413,6 +419,7 @@ test("surfaces a 5xx progress POST without crashing the player", async ({
   request,
 }) => {
   const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  const bookFileId = await fetchAudioFileId(request, uuid);
   await gotoReady(page, `/listen/${uuid}`);
   await waitForPlayerReady(page);
 
@@ -432,7 +439,12 @@ test("surfaces a 5xx progress POST without crashing the player", async ({
   const PAUSE_AT_SEC = 12.25;
   await expectMutationProgress(
     page,
-    { uuid, audioPositionSeconds: PAUSE_AT_SEC, expectedStatus: 500 },
+    {
+      uuid,
+      audioPositionSeconds: PAUSE_AT_SEC,
+      bookFileId,
+      expectedStatus: 500,
+    },
     async () => {
       await page.evaluate((secs) => {
         const cb = (
@@ -736,7 +748,34 @@ test("opens chapters drawer and shows played/current/upcoming row states", async
 interface ProgressMutationOpts {
   uuid: string;
   audioPositionSeconds: number;
+  /** The `book_files` row the player loaded — every audio progress POST
+   * names the file the manifest resolved (#1888). */
+  bookFileId: number;
   expectedStatus: number;
+}
+
+/**
+ * The first audio `book_files` id for a book, from `GET /api/ebooks/:uuid`
+ * (returned in ordinal order — the same default the manifest resolves for a
+ * bare `/listen/:uuid`). This is the id the player's progress POSTs must
+ * carry, so the specs fetch it rather than hard-coding an AUTOINCREMENT id.
+ */
+async function fetchAudioFileId(
+  request: import("@playwright/test").APIRequestContext,
+  uuid: string,
+): Promise<number> {
+  const resp = await request.get(`/api/ebooks/${uuid}`);
+  expect(resp.status(), "GET /api/ebooks/:uuid failed").toBe(200);
+  const detail = (await resp.json()) as {
+    book_files: { id: number; format: string }[];
+  };
+  const audio = detail.book_files.find((f) =>
+    /^(mp3|m4b|m4a)$/i.test(f.format),
+  );
+  if (!audio) {
+    throw new Error(`book ${uuid} has no audio book_files row`);
+  }
+  return audio.id;
 }
 
 const PROGRESS_URL = /\/api\/rpc\/progress(?:\?|$)/;
@@ -759,6 +798,7 @@ async function expectMutationProgress(
           book_uuid: opts.uuid,
           format: "audio",
           audio_position_seconds: opts.audioPositionSeconds,
+          book_file_id: opts.bookFileId,
         },
       },
     },


### PR DESCRIPTION
## Summary
- Web listen / Immersive Read resume for a multi-file audiobook now resolves the manifest from the progress row's `book_file_id` (an explicit picker selection still wins) and applies the stored seconds only when they are attributable to the loaded file — never splicing one file's offset into another.
- Every web audio progress write names the file the manifest actually resolved: `AudiobookManifest` gains `book_file_id` + `audio_file_count` (serde-defaulted), and the bootstrap publishes them through a new `PlaybackState::loaded_file_id` signal that the position posts read live.
- `upsert_progress` now refuses an audio write that would replace a non-NULL `book_file_id` with NULL on a multi-file book — the whole write is rejected and the surviving row returned, mirroring the existing stale-clock rejection.
- A stale stored file id falls back to the server's default file instead of the failure overlay; single-file resume behavior (including the localStorage fallback) is unchanged.

Closes #1888

## Test plan
- [x] `just check` green locally (fmt + clippy incl. wasm32 + mobile + stylelint, full test matrix).
- [x] New coverage: 3 db-guard tests, 9 resume-helper tests (relocated to `helpers.rs` so they execute under the `server`-feature matrix — the web-gated bootstrap module's tests never run), manifest identity tests in shared + server, `count_audio_files` happy/error.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The Android hybrid player shares this bug class (its resume ignores the row's file and `persist_position` posts the entered — often absent — file id); out of scope per the issue, flagged as a follow-up.