### PR TITLE
feat: default the ebook reader typeface to Modern

### DIFF
--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -229,7 +229,7 @@ fn load_persisted_font_size() -> Option<i32> {
 }
 
 fn default_typeface() -> Typeface {
-    Typeface::Editorial
+    Typeface::Modern
 }
 
 #[cfg(feature = "web")]

--- a/frontend/src/pages/reader/prefs/tests.rs
+++ b/frontend/src/pages/reader/prefs/tests.rs
@@ -13,7 +13,7 @@ fn default_font_size_matches_the_documented_starting_size() {
 
 #[test]
 fn default_typeface_matches_the_documented_starting_typeface() {
-    assert_eq!(default_typeface(), Typeface::Editorial);
+    assert_eq!(default_typeface(), Typeface::Modern);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Switch the ebook reader's default typeface from `Editorial` (Instrument Serif) to `Modern` (Georgia/serif) in `default_typeface()`.
- A saved `omn.typeface` preference still overrides the default, so only readers who never picked a font see the change.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 743 passed, including the updated default-typeface pinning test.
- [x] `cargo fmt -p omnibus-frontend --check` clean.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.