### PR TITLE
[OMNI-1890] Carry Fractional Cross-Format Positions End-to-End

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -366,6 +366,47 @@ fn audio_fraction(timeline: &AudioTimeline, book_file_id: i64, seconds_within: f
     Some((global / timeline.total_seconds).clamp(0.0, 1.0))
 }
 
+/// Full-precision whole-book fraction of a reading row: derived from the
+/// stored CFI via spine stats when both exist (sub-percent, the same
+/// machinery as `derive_epub_percent`), else the stored integer percent.
+/// Every failure along the precise path — no stats yet, unreadable file,
+/// unanchorable CFI — degrades to the integer fallback rather than
+/// erroring: the caller is composing an offer, and a coarser offer beats
+/// no answer.
+async fn epub_source_fraction(
+    pool: &SqlitePool,
+    book_id: i64,
+    source: &omnibus_shared::ProgressRecord,
+) -> Option<f64> {
+    let fallback = source
+        .progress_percent
+        .filter(|p| (0..=100).contains(p))
+        .map(|p| p as f64 / 100.0);
+    let Some(cfi) = source.epub_cfi.clone() else {
+        return fallback;
+    };
+    let precise = async {
+        let (file_id, epub_path) = crate::book_file_with_id(pool, book_id, "EPUB")
+            .await
+            .ok()??;
+        let stats = crate::epub_structure::get_spine_stats(pool, file_id)
+            .await
+            .ok()?;
+        if stats.is_empty() {
+            return None;
+        }
+        let (spine_index, offset) = tokio::task::spawn_blocking(move || {
+            crate::kobo_position::cfi_spine_offset(&epub_path, &cfi)
+        })
+        .await
+        .ok()?
+        .ok()??;
+        crate::epub_structure::fraction_at(&stats, spine_index as i64, offset)
+    }
+    .await;
+    precise.or(fallback)
+}
+
 /// Compose the answer for `GET /api/books/{uuid}/cross-format-resume`:
 /// gate on the link (off until confirmed, paused while stale), compare the
 /// two rows' ordering clocks, and map the newer source onto `target`.
@@ -428,25 +469,28 @@ pub async fn resume_candidate(
         MappingConfidence::Linear
     };
     let candidate = match target {
-        ProgressFormat::Audio => source.progress_percent.and_then(|pct| {
-            if !(0..=100).contains(&pct) {
-                return None;
+        ProgressFormat::Audio => match epub_source_fraction(pool, book_id, &source).await {
+            None => None,
+            Some(src_frac) => {
+                let frac = match &anchor_map {
+                    Some(map) => anchors::interpolate(&map.anchors, src_frac, true),
+                    None => src_frac,
+                };
+                map_fraction_to_audio(&timeline, frac).map(|(file_id, seconds)| {
+                    CrossFormatCandidate {
+                        target,
+                        source_format,
+                        source_client_updated_at: source.client_updated_at,
+                        confidence,
+                        book_file_id: Some(file_id),
+                        audio_position_seconds: Some(seconds),
+                        total_duration_seconds: Some(timeline.total_seconds),
+                        percent: None,
+                        fraction: None,
+                    }
+                })
             }
-            let frac = match &anchor_map {
-                Some(map) => anchors::interpolate(&map.anchors, (pct as f64) / 100.0, true),
-                None => (pct as f64) / 100.0,
-            };
-            map_fraction_to_audio(&timeline, frac).map(|(file_id, seconds)| CrossFormatCandidate {
-                target,
-                source_format,
-                source_client_updated_at: source.client_updated_at,
-                confidence,
-                book_file_id: Some(file_id),
-                audio_position_seconds: Some(seconds),
-                total_duration_seconds: Some(timeline.total_seconds),
-                percent: None,
-            })
-        }),
+        },
         ProgressFormat::Epub => source.audio_position_seconds.and_then(|seconds| {
             // The row's own file when recorded. A file-less row is only
             // unambiguous on a single-file timeline — guessing the first
@@ -469,6 +513,7 @@ pub async fn resume_candidate(
                 audio_position_seconds: None,
                 total_duration_seconds: None,
                 percent: Some(pct),
+                fraction: Some(frac.clamp(0.0, 1.0)),
             })
         }),
     };

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -303,7 +303,10 @@ async fn resume_candidate_walks_the_state_machine() {
         .await
         .unwrap();
     assert_eq!(r.state, CrossFormatResumeState::Candidate);
-    assert_eq!(r.candidate.unwrap().percent, Some(65));
+    let c = r.candidate.unwrap();
+    assert_eq!(c.percent, Some(65));
+    // The wire also carries the un-floored fraction (global 650s of 1000s).
+    assert!((c.fraction.unwrap() - 0.65).abs() < 1e-9);
 
     // Target newer than source → nothing newer.
     let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
@@ -820,5 +823,149 @@ async fn resume_points_collapse_marks_a_stale_link_without_a_counterpart() {
     assert!(
         points[0].cross_format.is_none(),
         "mapping is paused while stale — no counterpart affordance"
+    );
+}
+
+/// One-paragraph chapter with an odd visible-char count, so mid-chapter
+/// fractions never collapse to exact hundredths (which would make the
+/// precision assertions vacuous).
+const FRACTION_CHAPTER: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>C</title></head>
+<body>
+  <p>First sentence here. Second sentence follows.</p>
+</body>
+</html>"#;
+
+#[tokio::test]
+async fn resume_candidate_audio_target_derives_the_fraction_from_the_stored_cfi() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+
+    // A dual-format book whose EPUB really exists on disk, so the spine
+    // stats backfill and the CFI walk have a file to read.
+    let dir = crate::test_support::make_test_dir("cross_format_cfi_fraction");
+    std::fs::create_dir_all(dir.join("sub")).unwrap();
+    std::fs::write(
+        dir.join("sub").join("book.epub"),
+        crate::test_support::build_test_epub(&[
+            ("c1.xhtml", FRACTION_CHAPTER),
+            ("c2.xhtml", FRACTION_CHAPTER),
+        ]),
+    )
+    .unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(dir.to_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+    let library_id: i64 =
+        sqlx::query_scalar("SELECT id FROM scan_roots WHERE display_name = 'lib'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort)
+         VALUES ('cfi-uuid-1', 'sub/book.epub', ?, 'sub', 'Precise', 'precise') RETURNING id",
+    )
+    .bind(library_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key)
+         VALUES (?, 'EPUB', 'book', 10, 10, 'sub/book.epub')",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let audio_id: i64 = sqlx::query_scalar(
+        "INSERT INTO book_files
+            (book_id, format, filename, size_bytes, mtime_epoch, scan_key, ordinal)
+         VALUES (?, 'M4B', 'part0', 100, 1000, 'a0.m4b', 0) RETURNING id",
+    )
+    .bind(book_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_file_parts
+            (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds)
+         VALUES (?, 0, 'a0.m4b', 100, 1000, 1000.0)",
+    )
+    .bind(audio_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    crate::indexer::backfill_epub_structure(&pool, dir.to_str().unwrap(), |_, _, _| {})
+        .await
+        .unwrap();
+    let (epub_file_id, _) = crate::book_file_with_id(&pool, book_id, "EPUB")
+        .await
+        .unwrap()
+        .unwrap();
+    let stats = crate::epub_structure::get_spine_stats(&pool, epub_file_id)
+        .await
+        .unwrap();
+    assert!(!stats.is_empty(), "precondition: stats extracted");
+
+    upsert_link(
+        &pool,
+        user,
+        "cfi-uuid-1",
+        CrossFormatLinkMode::Sequence,
+        None,
+    )
+    .await
+    .unwrap();
+    // A CFI-only reading row (no integer percent): 5 visible chars into
+    // chapter 2 of two identical chapters — a shade past 50%.
+    progress::upsert_progress(
+        &pool,
+        user,
+        &ProgressUpdate {
+            book_uuid: "cfi-uuid-1".to_string(),
+            format: ProgressFormat::Epub,
+            epub_cfi: Some("epubcfi(/6/4!/4/2/1:5)".to_string()),
+            audio_position_seconds: None,
+            progress_percent: None,
+            kobo_location: None,
+            book_file_id: None,
+            client_updated_at: Some(2_000),
+        },
+    )
+    .await
+    .unwrap();
+
+    let r = resume_candidate(&pool, user, "cfi-uuid-1", ProgressFormat::Audio)
+        .await
+        .unwrap();
+    // The old integer-percent source would refuse here (the row has no
+    // percent); a candidate at all proves the CFI path engaged.
+    assert_eq!(r.state, CrossFormatResumeState::Candidate);
+    let c = r.candidate.unwrap();
+    let seconds = c.audio_position_seconds.unwrap();
+    // Expected fraction via the same walk the candidate path runs, so the
+    // assertion can't disagree with the walk's own offset accounting.
+    let (_, epub_path) = crate::book_file_with_id(&pool, book_id, "EPUB")
+        .await
+        .unwrap()
+        .unwrap();
+    let (si, off) = crate::kobo_position::cfi_spine_offset(&epub_path, "epubcfi(/6/4!/4/2/1:5)")
+        .unwrap()
+        .unwrap();
+    let frac = crate::epub_structure::fraction_at(&stats, si as i64, off).unwrap();
+    assert!(
+        frac > 0.5 && frac < 0.6,
+        "mid-chapter-2 offset should sit just past half: {frac}"
+    );
+    assert!(
+        (frac * 100.0).fract() > f64::EPSILON,
+        "fixture must produce a non-integer percent or the precision claim is vacuous: {frac}"
+    );
+    assert!(
+        (seconds - frac * 1000.0).abs() < 0.01,
+        "mapped seconds {seconds} must carry the CFI fraction {frac} at full precision"
     );
 }

--- a/db/src/epub_structure.rs
+++ b/db/src/epub_structure.rs
@@ -137,24 +137,34 @@ pub async fn get_chapters(
     .await?)
 }
 
-/// Whole-book visible-text percent for a position, from stored stats alone:
-/// floor semantics and clamping identical to `kobo_position`'s
-/// `book_percent`, so the two derivation paths cannot disagree. `None`
-/// when the stats don't cover `spine_index` or the book measured empty.
-pub fn percent_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64) -> Option<i64> {
+/// Whole-book visible-text fraction (`0.0..=1.0`) for a position, from
+/// stored stats alone. The full-precision half of [`percent_at`], exposed
+/// for the cross-format mapping where integer-percent quantization would
+/// cost up to 1% of a book (~30 minutes of a long audiobook). `None` when
+/// the stats don't cover `spine_index`.
+pub fn fraction_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64) -> Option<f64> {
     let row = stats.iter().find(|s| s.spine_index == spine_index)?;
     // Order-independent total (never trusts slice order) and saturating
-    // arithmetic throughout: a corrupt or absurd offset clamps to 100
-    // rather than overflowing the multiply.
+    // arithmetic throughout: a corrupt or absurd offset clamps rather
+    // than overflowing.
     let total: i64 = stats
         .iter()
         .fold(0i64, |acc, s| acc.saturating_add(s.visible_chars.max(0)));
     if total <= 0 {
-        return Some(0);
+        return Some(0.0);
     }
     let at = row
         .chars_before
         .max(0)
         .saturating_add(i64::try_from(offset_in_file).unwrap_or(i64::MAX));
-    Some((100i64.saturating_mul(at) / total).clamp(0, 100))
+    Some((at as f64 / total as f64).clamp(0.0, 1.0))
+}
+
+/// Whole-book visible-text percent for a position, from stored stats alone:
+/// floor semantics and clamping identical to `kobo_position`'s
+/// `book_percent`, so the two derivation paths cannot disagree. `None`
+/// when the stats don't cover `spine_index` or the book measured empty.
+pub fn percent_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64) -> Option<i64> {
+    fraction_at(stats, spine_index, offset_in_file)
+        .map(|f| ((100.0 * f).floor() as i64).clamp(0, 100))
 }

--- a/db/src/epub_structure.rs
+++ b/db/src/epub_structure.rs
@@ -163,7 +163,8 @@ pub fn fraction_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64
 /// Whole-book visible-text percent for a position, from stored stats alone:
 /// floor semantics and clamping identical to `kobo_position`'s
 /// `book_percent`, so the two derivation paths cannot disagree. `None`
-/// when the stats don't cover `spine_index` or the book measured empty.
+/// when the stats don't cover `spine_index`; a book that measured empty
+/// reports 0.
 pub fn percent_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64) -> Option<i64> {
     fraction_at(stats, spine_index, offset_in_file)
         .map(|f| ((100.0 * f).floor() as i64).clamp(0, 100))

--- a/db/src/epub_structure/tests.rs
+++ b/db/src/epub_structure/tests.rs
@@ -115,6 +115,40 @@ fn percent_at_uses_floor_semantics_and_clamps() {
 }
 
 #[test]
+fn fraction_at_keeps_sub_percent_precision_that_percent_at_floors() {
+    let stats = vec![
+        SpineStatRow {
+            spine_index: 0,
+            href: "c1.xhtml".into(),
+            visible_chars: 40,
+            chars_before: 0,
+        },
+        SpineStatRow {
+            spine_index: 1,
+            href: "c2.xhtml".into(),
+            visible_chars: 60,
+            chars_before: 40,
+        },
+    ];
+    // 73 of 100 chars → 0.73 exactly; 33 chars into c2 → 73%.
+    assert_eq!(fraction_at(&stats, 1, 33), Some(0.73));
+    // A position percent_at floors away: 45/100 vs 45.0%… but with a
+    // non-decimal total the fraction keeps what the integer loses.
+    let uneven = vec![SpineStatRow {
+        spine_index: 0,
+        href: "c1.xhtml".into(),
+        visible_chars: 90,
+        chars_before: 0,
+    }];
+    let f = fraction_at(&uneven, 0, 50).unwrap();
+    assert!((f - 50.0 / 90.0).abs() < 1e-12);
+    assert_eq!(percent_at(&uneven, 0, 50), Some(55)); // floor(55.55…)
+                                                      // Same refusal and clamp rules as percent_at.
+    assert_eq!(fraction_at(&stats, 7, 0), None);
+    assert_eq!(fraction_at(&stats, 1, 10_000), Some(1.0));
+}
+
+#[test]
 fn percent_at_reports_zero_for_an_empty_book() {
     let stats = vec![SpineStatRow {
         spine_index: 0,

--- a/db/src/epub_structure/tests.rs
+++ b/db/src/epub_structure/tests.rs
@@ -130,8 +130,8 @@ fn fraction_at_keeps_sub_percent_precision_that_percent_at_floors() {
             chars_before: 40,
         },
     ];
-    // 73 of 100 chars → 0.73 exactly; 33 chars into c2 → 73%.
-    assert_eq!(fraction_at(&stats, 1, 33), Some(0.73));
+    // 73 of 100 chars → 0.73; 33 chars into c2.
+    assert!((fraction_at(&stats, 1, 33).unwrap() - 0.73).abs() < 1e-12);
     // A position percent_at floors away: 45/100 vs 45.0%… but with a
     // non-decimal total the fraction keeps what the integer loses.
     let uneven = vec![SpineStatRow {

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -41,6 +41,12 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     let Some(pct) = c.percent else {
         return rsx! {};
     };
+    // Jump at full precision (the floored `pct` is display copy only) —
+    // integer percent alone lands up to a page early on a long book.
+    let jump_pct = c
+        .fraction
+        .map(|f| (f * 100.0).clamp(0.0, 100.0))
+        .unwrap_or(pct as f64);
     let source_clock = c.source_client_updated_at;
     let jump_uuid = uuid.clone();
     let dismiss_uuid = uuid.clone();
@@ -59,9 +65,9 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
                     // The glue only exists on interactive targets; SSR
                     // compiles this handler but never runs it.
                     #[cfg(feature = "web")]
-                    super::reader_call("displayPercentage", &pct.to_string());
+                    super::reader_call("displayPercentage", &jump_pct.to_string());
                     #[cfg(not(feature = "web"))]
-                    let _ = pct;
+                    let _ = jump_pct;
                 },
                 "Jump"
             }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1461,6 +1461,9 @@ struct CrossFormatCandidate: Codable, Hashable, Sendable {
     var audioPositionSeconds: Double?
     var totalDurationSeconds: Double?
     var percent: Int64?
+    /// Full-precision jump fraction (0...1) on epub targets; `percent` is
+    /// its floored display twin.
+    var fraction: Double?
 
     enum CodingKeys: String, CodingKey {
         case target
@@ -1471,6 +1474,7 @@ struct CrossFormatCandidate: Codable, Hashable, Sendable {
         case audioPositionSeconds = "audio_position_seconds"
         case totalDurationSeconds = "total_duration_seconds"
         case percent
+        case fraction
     }
 }
 

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -140,7 +140,8 @@ struct ReaderView: View {
                     title: "Listened further in the audiobook",
                     detail: "Your listening maps to about \(pct)% through.",
                     onGo: {
-                        controller.seek(toFraction: Double(pct) / 100.0)
+                        // Full-precision jump; the integer pct is display copy.
+                        controller.seek(toFraction: cross.fraction ?? Double(pct) / 100.0)
                         dismissCrossOffer(cross)
                     },
                     onDismiss: { dismissCrossOffer(cross) }

--- a/omnibus-ios/omnibusTests/CrossFormatTests.swift
+++ b/omnibus-ios/omnibusTests/CrossFormatTests.swift
@@ -24,6 +24,20 @@ struct CrossFormatCodecTests {
         #expect(c.bookFileID == 7)
         #expect(c.audioPositionSeconds == 312.5)
         #expect(c.percent == nil)
+        #expect(c.fraction == nil)
+    }
+
+    @Test("epub-target candidate carries the full-precision fraction")
+    func fractionDecodes() throws {
+        let json = """
+        {"state":"candidate","candidate":{"target":"epub","source_format":"audio",
+         "source_client_updated_at":1755000000,"confidence":"linear",
+         "percent":12,"fraction":0.12752}}
+        """
+        let resume = try JSONDecoder().decode(CrossFormatResume.self, from: Data(json.utf8))
+        let c = try #require(resume.candidate)
+        #expect(c.percent == 12)
+        #expect(c.fraction == 0.12752)
     }
 
     @Test("candidate-less states decode without a candidate")

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -82,6 +82,12 @@ pub struct CrossFormatCandidate {
     pub total_duration_seconds: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub percent: Option<i64>,
+    /// Full-precision position fraction (`0.0..=1.0`) for epub-target
+    /// candidates: the jump destination; `percent` is its floored display
+    /// twin. Absent on audio targets, whose seconds already carry
+    /// precision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fraction: Option<f64>,
 }
 
 /// Everything the alignment modal renders for one book, in one read:


### PR DESCRIPTION
## Summary
- `resume_candidate`'s epub→audio direction derives its source fraction from the stored CFI via spine stats (new `epub_source_fraction`), falling back to the integer percent — a CFI-only row now offers where it previously refused.
- `CrossFormatCandidate` gains a `fraction` field (epub targets); `percent` survives as floored display copy, and the web banner + iOS reader jump with the full-precision value.
- `epub_structure::fraction_at` is the new precision half of `percent_at`, which now floors through it so the two paths cannot disagree.

Closes #1890

## Test plan
- [x] `just test` — full matrix green (2072 / 821 / 735 / 669 / 298), including new `fraction_at`, CFI-derivation, and wire-fraction tests
- [x] `just lint` clean
- [x] `just ios-build` + `just ios-test` green (new `fraction` decode test)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release** — add the `no release` label to skip cutting a release.