### PR TITLE
[OMNI-1891] Equivalence Gate — No Offers When Formats Already Align

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -503,7 +503,7 @@ pub async fn resume_candidate(
                                 .map(|f| f * timeline.total_seconds)
                         });
                         let tol = (tol_frac * timeline.total_seconds)
-                            .max(AUDIO_EQUIVALENCE_FLOOR_SECONDS);
+                            .max(audio_equivalence_floor(timeline.total_seconds));
                         let aligned =
                             current_global.is_some_and(|cur| (mapped_global - cur).abs() <= tol);
                         let candidate = CrossFormatCandidate {
@@ -597,9 +597,12 @@ fn equivalence_fraction(total_chars: Option<i64>) -> f64 {
     BASE.max(location_slack).min(CAP)
 }
 
-/// The audio-side gate never tightens below a minute: sub-minute deltas
-/// are inside seek/heartbeat noise regardless of book length.
-const AUDIO_EQUIVALENCE_FLOOR_SECONDS: f64 = 60.0;
+/// Audio-side floor: sub-minute deltas are seek/heartbeat noise on a real
+/// audiobook — but the floor never exceeds 2% of the timeline, so a short
+/// book keeps meaningful offers instead of counting everything as aligned.
+fn audio_equivalence_floor(total_seconds: f64) -> f64 {
+    60.0f64.min(0.02 * total_seconds.max(0.0))
+}
 
 /// Total visible chars of the served EPUB's extracted spine stats;
 /// `None` until the structure backfill has reached the book.

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -468,62 +468,147 @@ pub async fn resume_candidate(
     } else {
         MappingConfidence::Linear
     };
-    let candidate = match target {
+    let tol_frac = equivalence_fraction(epub_total_chars(pool, book_id).await);
+    let (candidate, aligned) = match target {
         ProgressFormat::Audio => match epub_source_fraction(pool, book_id, &source).await {
-            None => None,
+            None => (None, false),
             Some(src_frac) => {
                 let frac = match &anchor_map {
                     Some(map) => anchors::interpolate(&map.anchors, src_frac, true),
                     None => src_frac,
                 };
-                map_fraction_to_audio(&timeline, frac).map(|(file_id, seconds)| {
-                    CrossFormatCandidate {
+                match map_fraction_to_audio(&timeline, frac) {
+                    None => (None, false),
+                    Some((file_id, seconds)) => {
+                        let mapped_global = timeline
+                            .files
+                            .iter()
+                            .find(|f| f.book_file_id == file_id)
+                            .map(|f| f.start_seconds + seconds)
+                            .unwrap_or(frac * timeline.total_seconds);
+                        // The target's own spot on the same timeline. A
+                        // file-less multi-file row can't be placed, so the
+                        // gate stands aside and the offer survives.
+                        let current_global = target_row.as_ref().and_then(|t| {
+                            let secs = t.audio_position_seconds?;
+                            let file = t.book_file_id.or_else(|| {
+                                (timeline.files.len() == 1).then(|| timeline.files[0].book_file_id)
+                            })?;
+                            audio_fraction(&timeline, file, secs)
+                                .map(|f| f * timeline.total_seconds)
+                        });
+                        let tol = (tol_frac * timeline.total_seconds)
+                            .max(AUDIO_EQUIVALENCE_FLOOR_SECONDS);
+                        let aligned =
+                            current_global.is_some_and(|cur| (mapped_global - cur).abs() <= tol);
+                        let candidate = CrossFormatCandidate {
+                            target,
+                            source_format,
+                            source_client_updated_at: source.client_updated_at,
+                            confidence,
+                            book_file_id: Some(file_id),
+                            audio_position_seconds: Some(seconds),
+                            total_duration_seconds: Some(timeline.total_seconds),
+                            percent: None,
+                            fraction: None,
+                            source_ahead: current_global.map(|cur| mapped_global > cur),
+                        };
+                        (Some(candidate), aligned)
+                    }
+                }
+            }
+        },
+        ProgressFormat::Epub => {
+            // The row's own file when recorded. A file-less row is only
+            // unambiguous on a single-file timeline — guessing the first
+            // of several would map another file's offset, so refuse.
+            let mapped = source.audio_position_seconds.and_then(|seconds| {
+                let file_id = source.book_file_id.or_else(|| {
+                    (timeline.files.len() == 1).then(|| timeline.files[0].book_file_id)
+                })?;
+                audio_fraction(&timeline, file_id, seconds)
+            });
+            match mapped {
+                None => (None, false),
+                Some(raw_frac) => {
+                    let frac = match &anchor_map {
+                        Some(map) => anchors::interpolate(&map.anchors, raw_frac, false),
+                        None => raw_frac,
+                    };
+                    let pct = ((100.0 * frac).floor() as i64).clamp(0, 100);
+                    let current = match &target_row {
+                        Some(t) => epub_source_fraction(pool, book_id, t).await,
+                        None => None,
+                    };
+                    let aligned = current.is_some_and(|cur| (frac - cur).abs() <= tol_frac);
+                    let candidate = CrossFormatCandidate {
                         target,
                         source_format,
                         source_client_updated_at: source.client_updated_at,
                         confidence,
-                        book_file_id: Some(file_id),
-                        audio_position_seconds: Some(seconds),
-                        total_duration_seconds: Some(timeline.total_seconds),
-                        percent: None,
-                        fraction: None,
-                    }
-                })
+                        book_file_id: None,
+                        audio_position_seconds: None,
+                        total_duration_seconds: None,
+                        percent: Some(pct),
+                        fraction: Some(frac.clamp(0.0, 1.0)),
+                        source_ahead: current.map(|cur| frac > cur),
+                    };
+                    (Some(candidate), aligned)
+                }
             }
-        },
-        ProgressFormat::Epub => source.audio_position_seconds.and_then(|seconds| {
-            // The row's own file when recorded. A file-less row is only
-            // unambiguous on a single-file timeline — guessing the first
-            // of several would map another file's offset, so refuse.
-            let file_id = source
-                .book_file_id
-                .or_else(|| (timeline.files.len() == 1).then(|| timeline.files[0].book_file_id))?;
-            let raw_frac = audio_fraction(&timeline, file_id, seconds)?;
-            let frac = match &anchor_map {
-                Some(map) => anchors::interpolate(&map.anchors, raw_frac, false),
-                None => raw_frac,
-            };
-            let pct = ((100.0 * frac).floor() as i64).clamp(0, 100);
-            Some(CrossFormatCandidate {
-                target,
-                source_format,
-                source_client_updated_at: source.client_updated_at,
-                confidence,
-                book_file_id: None,
-                audio_position_seconds: None,
-                total_duration_seconds: None,
-                percent: Some(pct),
-                fraction: Some(frac.clamp(0.0, 1.0)),
-            })
-        }),
+        }
     };
     Ok(match candidate {
+        // Same spot within tolerance: the mapped position still rides
+        // along (the hero's format-switch CTA wants it) but the state
+        // tells prompt surfaces to stay quiet — a jump would move the
+        // user nowhere, or worse, one quantization step backward.
+        Some(candidate) if aligned => CrossFormatResume {
+            state: CrossFormatResumeState::Aligned,
+            candidate: Some(candidate),
+        },
         Some(candidate) => CrossFormatResume {
             state: CrossFormatResumeState::Candidate,
             candidate: Some(candidate),
         },
         None => CrossFormatResume::empty(CrossFormatResumeState::NothingNewer),
     })
+}
+
+/// Positions closer than this fraction of the whole book count as "the
+/// same spot" — an offer inside it is quantization noise, not signal.
+/// Base 0.5%, widened to two reader locations (~1024 visible chars each,
+/// the epub.js jump granularity) on short books where one location is a
+/// large slice, and capped at 5% so a tiny book can't suppress every
+/// offer outright.
+fn equivalence_fraction(total_chars: Option<i64>) -> f64 {
+    const BASE: f64 = 0.005;
+    const READER_LOCATION_CHARS: f64 = 1024.0;
+    const CAP: f64 = 0.05;
+    let location_slack = total_chars
+        .filter(|c| *c > 0)
+        .map(|c| 2.0 * READER_LOCATION_CHARS / c as f64)
+        .unwrap_or(0.0);
+    BASE.max(location_slack).min(CAP)
+}
+
+/// The audio-side gate never tightens below a minute: sub-minute deltas
+/// are inside seek/heartbeat noise regardless of book length.
+const AUDIO_EQUIVALENCE_FLOOR_SECONDS: f64 = 60.0;
+
+/// Total visible chars of the served EPUB's extracted spine stats;
+/// `None` until the structure backfill has reached the book.
+async fn epub_total_chars(pool: &SqlitePool, book_id: i64) -> Option<i64> {
+    let (file_id, _) = crate::book_file_with_id(pool, book_id, "EPUB")
+        .await
+        .ok()??;
+    let stats = crate::epub_structure::get_spine_stats(pool, file_id)
+        .await
+        .ok()?;
+    let total = stats
+        .iter()
+        .fold(0i64, |a, s| a.saturating_add(s.visible_chars.max(0)));
+    (total > 0).then_some(total)
 }
 
 /// Assemble everything the alignment modal renders in one read: link +

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -468,7 +468,12 @@ pub async fn resume_candidate(
     } else {
         MappingConfidence::Linear
     };
-    let tol_frac = equivalence_fraction(epub_total_chars(pool, book_id).await);
+    // The gate only engages against an existing target position — skip the
+    // stats query entirely on first-open targets.
+    let tol_frac = match &target_row {
+        Some(_) => equivalence_fraction(epub_total_chars(pool, book_id).await),
+        None => equivalence_fraction(None),
+    };
     let (candidate, aligned) = match target {
         ProgressFormat::Audio => match epub_source_fraction(pool, book_id, &source).await {
             None => (None, false),

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1001,8 +1001,7 @@ async fn resume_candidate_aligns_when_the_target_already_sits_at_the_mapped_spot
     // The mapped position still rides along for navigation affordances.
     assert_eq!(r.candidate.as_ref().unwrap().percent, Some(19));
 
-    // Just outside the tolerance (60s floor on a 1000s book → 6% of
-    // duration): a genuine advance still offers, marked ahead.
+    // Well outside the tolerance: a genuine advance still offers, ahead.
     progress::upsert_progress(
         &pool,
         user,
@@ -1097,4 +1096,14 @@ fn equivalence_fraction_widens_for_short_books_and_caps() {
     assert!((short - 2.0 * 1024.0 / 200_000.0).abs() < 1e-12);
     // …and a tiny one caps at 5% so offers can still exist at all.
     assert!((equivalence_fraction(Some(10_000)) - 0.05).abs() < 1e-12);
+}
+
+#[test]
+fn audio_equivalence_floor_scales_down_for_short_books() {
+    // Real audiobook: the full minute of seek noise.
+    assert!((audio_equivalence_floor(36_000.0) - 60.0).abs() < 1e-9);
+    // Short book: 2% of the timeline, so a fixture-length file still
+    // distinguishes "same spot" from a genuine offer.
+    assert!((audio_equivalence_floor(60.0) - 1.2).abs() < 1e-9);
+    assert_eq!(audio_equivalence_floor(0.0), 0.0);
 }

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -291,11 +291,12 @@ async fn resume_candidate_walks_the_state_machine() {
     assert_eq!(c.total_duration_seconds, Some(1_000.0));
     assert_eq!(c.source_client_updated_at, 2_000);
 
-    // The other direction: listening moved past reading → epub candidate.
+    // The other direction: listening moved well past reading (global 850s
+    // = 85% vs the reader's 65%) → epub candidate, marked ahead.
     progress::upsert_progress(
         &pool,
         user,
-        &audio_update(&uuid, 50.0, Some(audio[1]), 3_000),
+        &audio_update(&uuid, 250.0, Some(audio[1]), 3_000),
     )
     .await
     .unwrap();
@@ -304,9 +305,10 @@ async fn resume_candidate_walks_the_state_machine() {
         .unwrap();
     assert_eq!(r.state, CrossFormatResumeState::Candidate);
     let c = r.candidate.unwrap();
-    assert_eq!(c.percent, Some(65));
-    // The wire also carries the un-floored fraction (global 650s of 1000s).
-    assert!((c.fraction.unwrap() - 0.65).abs() < 1e-9);
+    assert_eq!(c.percent, Some(85));
+    // The wire also carries the un-floored fraction (global 850s of 1000s).
+    assert!((c.fraction.unwrap() - 0.85).abs() < 1e-9);
+    assert_eq!(c.source_ahead, Some(true));
 
     // Target newer than source → nothing newer.
     let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
@@ -968,4 +970,131 @@ async fn resume_candidate_audio_target_derives_the_fraction_from_the_stored_cfi(
         (seconds - frac * 1000.0).abs() < 0.01,
         "mapped seconds {seconds} must carry the CFI fraction {frac} at full precision"
     );
+}
+
+#[tokio::test]
+async fn resume_candidate_aligns_when_the_target_already_sits_at_the_mapped_spot() {
+    // The live We Are Legion case: reader at 19%, listener at the mapped
+    // equivalent, audio clock newer — the old clock-only gate offered
+    // "jump to ≈19%" while at 19%.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[1_000.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 19, 1_000))
+        .await
+        .unwrap();
+    progress::upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 190.0, Some(audio[0]), 2_000),
+    )
+    .await
+    .unwrap();
+
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap();
+    assert_eq!(r.state, CrossFormatResumeState::Aligned);
+    // The mapped position still rides along for navigation affordances.
+    assert_eq!(r.candidate.as_ref().unwrap().percent, Some(19));
+
+    // Just outside the tolerance (60s floor on a 1000s book → 6% of
+    // duration): a genuine advance still offers, marked ahead.
+    progress::upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 400.0, Some(audio[0]), 3_000),
+    )
+    .await
+    .unwrap();
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap();
+    assert_eq!(r.state, CrossFormatResumeState::Candidate);
+    assert_eq!(r.candidate.unwrap().source_ahead, Some(true));
+}
+
+#[tokio::test]
+async fn resume_candidate_marks_backward_offers_instead_of_claiming_further() {
+    // A newer-clocked source that sits *behind* the target (deliberate
+    // re-listening) survives the gate but is flagged, so prompt copy can
+    // say "back" instead of the false "past this page".
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[1_000.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 60, 1_000))
+        .await
+        .unwrap();
+    progress::upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 100.0, Some(audio[0]), 2_000),
+    )
+    .await
+    .unwrap();
+
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Epub)
+        .await
+        .unwrap();
+    assert_eq!(r.state, CrossFormatResumeState::Candidate);
+    assert_eq!(r.candidate.unwrap().source_ahead, Some(false));
+}
+
+#[tokio::test]
+async fn resume_candidate_audio_target_aligns_and_stands_aside_without_a_placeable_row() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0, 300.0, 100.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    // Reader at 65% (newer); listener already at the mapped global 650s.
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 65, 2_000))
+        .await
+        .unwrap();
+    progress::upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 50.0, Some(audio[1]), 1_000),
+    )
+    .await
+    .unwrap();
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    assert_eq!(r.state, CrossFormatResumeState::Aligned);
+    assert_eq!(r.candidate.as_ref().unwrap().book_file_id, Some(audio[1]));
+
+    // A file-less audio row on a multi-file timeline can't be placed, so
+    // the gate stands aside rather than guessing: the offer survives.
+    progress::upsert_progress(&pool, user, &audio_update(&uuid, 50.0, None, 1_500))
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 65, 2_500))
+        .await
+        .unwrap();
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    assert_eq!(r.state, CrossFormatResumeState::Candidate);
+    assert_eq!(r.candidate.unwrap().source_ahead, None);
+}
+
+#[test]
+fn equivalence_fraction_widens_for_short_books_and_caps() {
+    // No stats → the 0.5% base.
+    assert!((equivalence_fraction(None) - 0.005).abs() < 1e-12);
+    // A long book keeps the base (two locations are a sliver).
+    assert!((equivalence_fraction(Some(1_000_000)) - 0.005).abs() < 1e-12);
+    // A short book widens to two reader locations…
+    let short = equivalence_fraction(Some(200_000));
+    assert!((short - 2.0 * 1024.0 / 200_000.0).abs() < 1e-12);
+    // …and a tiny one caps at 5% so offers can still exist at all.
+    assert!((equivalence_fraction(Some(10_000)) - 0.05).abs() < 1e-12);
 }

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -114,11 +114,17 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
     let target_file = c.book_file_id;
     let total = c.total_duration_seconds.unwrap_or(0.0);
 
+    // Direction-truthful copy: a backward offer (the reader deliberately
+    // went back in the text) must not claim "further".
+    let copy = if c.source_ahead == Some(false) {
+        format!("You're re-reading earlier in the ebook — jump back to \u{2248} {label}?")
+    } else {
+        format!("You read further in the ebook — jump to \u{2248} {label}?")
+    };
+
     rsx! {
         div { class: "lp-sync-prompt card", role: "status", "data-testid": "sync-prompt",
-            span { class: "lp-sync-copy",
-                "You read further in the ebook — jump to \u{2248} {label}?"
-            }
+            span { class: "lp-sync-copy", "{copy}" }
             button {
                 class: "btn sm",
                 "data-testid": "sync-prompt-accept",

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -114,8 +114,7 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
     let target_file = c.book_file_id;
     let total = c.total_duration_seconds.unwrap_or(0.0);
 
-    // Direction-truthful copy: a backward offer (the reader deliberately
-    // went back in the text) must not claim "further".
+    // A backward offer must not claim "further".
     let copy = if c.source_ahead == Some(false) {
         format!("You're re-reading earlier in the ebook — jump back to \u{2248} {label}?")
     } else {

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -51,11 +51,19 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     let jump_uuid = uuid.clone();
     let dismiss_uuid = uuid.clone();
 
+    // A surviving backward offer (the listener deliberately went back)
+    // must not claim "past this page" — say where the jump actually goes.
+    let behind = c.source_ahead == Some(false);
+    let copy = if behind {
+        format!("Your audiobook sits earlier — jump back to \u{2248} {pct}%?")
+    } else {
+        format!("You listened past this page — jump to \u{2248} {pct}%?")
+    };
+    let jump_label = if behind { "Jump back" } else { "Jump" };
+
     rsx! {
         div { class: "rd-sync-banner card", role: "status", "data-testid": "sync-banner",
-            span { class: "rd-sync-copy",
-                "You listened past this page — jump to \u{2248} {pct}%?"
-            }
+            span { class: "rd-sync-copy", "{copy}" }
             button {
                 class: "btn sm",
                 "data-testid": "sync-banner-jump",
@@ -69,7 +77,7 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
                     #[cfg(not(feature = "web"))]
                     let _ = jump_pct;
                 },
-                "Jump"
+                "{jump_label}"
             }
             button {
                 class: "btn ghost sm",

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -51,8 +51,7 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     let jump_uuid = uuid.clone();
     let dismiss_uuid = uuid.clone();
 
-    // A surviving backward offer (the listener deliberately went back)
-    // must not claim "past this page" — say where the jump actually goes.
+    // A backward offer must not claim "past this page".
     let behind = c.source_ahead == Some(false);
     let copy = if behind {
         format!("Your audiobook sits earlier — jump back to \u{2248} {pct}%?")

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -58,7 +58,9 @@ struct PlayerView: View {
             } else if let cross = player.crossFormatOffer,
                       let seconds = cross.audioPositionSeconds {
                 SyncOfferBanner(
-                    title: "Read further in the ebook",
+                    title: cross.sourceAhead == false
+                        ? "Re-reading earlier in the ebook"
+                        : "Read further in the ebook",
                     detail: "Your reading maps to about \(Format.duration(seconds)).",
                     onGo: { Task { await player.acceptCrossFormatOffer() } },
                     onDismiss: { Task { await player.dismissCrossFormatOffer() } }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1440,6 +1440,10 @@ enum CrossFormatResumeState: String, Codable, Sendable {
     case linkStale = "link_stale"
     case nothingNewer = "nothing_newer"
     case candidate
+    /// Both formats already sit within the server's equivalence tolerance:
+    /// the candidate rides along for navigation affordances, but prompt
+    /// surfaces stay quiet.
+    case aligned
 }
 
 enum MappingConfidence: String, Codable, Sendable {
@@ -1464,6 +1468,9 @@ struct CrossFormatCandidate: Codable, Hashable, Sendable {
     /// Full-precision jump fraction (0...1) on epub targets; `percent` is
     /// its floored display twin.
     var fraction: Double?
+    /// `false` marks a backward offer (the source regressed) — copy must
+    /// not claim "further". Absent means ahead.
+    var sourceAhead: Bool?
 
     enum CodingKeys: String, CodingKey {
         case target
@@ -1475,6 +1482,7 @@ struct CrossFormatCandidate: Codable, Hashable, Sendable {
         case totalDurationSeconds = "total_duration_seconds"
         case percent
         case fraction
+        case sourceAhead = "source_ahead"
     }
 }
 

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -137,8 +137,12 @@ struct ReaderView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             } else if let cross = crossOffer, let pct = cross.percent {
                 SyncOfferBanner(
-                    title: "Listened further in the audiobook",
-                    detail: "Your listening maps to about \(pct)% through.",
+                    title: cross.sourceAhead == false
+                        ? "Audiobook is earlier in the book"
+                        : "Listened further in the audiobook",
+                    detail: cross.sourceAhead == false
+                        ? "Your listening maps to about \(pct)% — before this page."
+                        : "Your listening maps to about \(pct)% through.",
                     onGo: {
                         // Full-precision jump; the integer pct is display copy.
                         controller.seek(toFraction: cross.fraction ?? Double(pct) / 100.0)

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -42,6 +42,11 @@ pub enum CrossFormatResumeState {
     NothingNewer,
     /// A mapped position is available in `candidate`.
     Candidate,
+    /// The two formats already sit within the equivalence tolerance of
+    /// each other. `candidate` still carries the mapped position (the
+    /// hero's format-switch affordance wants it), but prompt surfaces
+    /// must not offer a jump — it would move the user nowhere.
+    Aligned,
 }
 
 /// Response shape of the cross-format resume read.
@@ -88,6 +93,12 @@ pub struct CrossFormatCandidate {
     /// precision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fraction: Option<f64>,
+    /// Whether the mapped source position sits ahead of the target's own
+    /// current position — `Some(false)` marks a backward offer (the source
+    /// regressed), so prompt copy must not claim "further". `None` when
+    /// the target has no comparable position (treat as ahead).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ahead: Option<bool>,
 }
 
 /// Everything the alignment modal renders for one book, in one read:

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -124,7 +124,10 @@ test("the player offers the mapped jump when reading is ahead", async ({
   page,
   request,
 }) => {
-  await writeAudioSeconds(request, 2);
+  // Audio parked at the start: on the 2-second fixture MP3, any later
+  // position would sit at/past the mapped reading spot and read as a
+  // backward offer under the equivalence gate's direction flag.
+  await writeAudioSeconds(request, 0);
   await writeEpubPercent(request, 50);
 
   await gotoReady(page, `/listen/${uuid}`);


### PR DESCRIPTION
## Summary
- `resume_candidate` compares the mapped source position against the target's own current position and returns a new `Aligned` state inside tolerance — candidate still attached (the hero's format-switch CTA keeps working), while every prompt surface goes quiet through its existing `state == candidate` guard.
- Tolerance: 0.5% of the book, widened to two reader locations on short books, capped at 5%, with a 60s audio-side floor (`equivalence_fraction`, documented in-module).
- Surviving offers carry `source_ahead`; web + iOS copy is now direction-truthful ("jump back to…" instead of falsely claiming "past this page").

Closes #1891

## Test plan
- [x] `just test` full matrix green; new tests cover both live repro cases (align at same spot, 78s-delta suppression), backward offers, the file-less stand-aside, and `equivalence_fraction` boundaries
- [x] `just lint` clean
- [x] `just ios-build` + `just ios-test` green (262 cases; `aligned` state + `sourceAhead` decode)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release**