### PR TITLE
feat: add metadata-edit suggestion dropdowns on iOS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,6 +269,9 @@ Design/             — Theme (Atrium tokens), OKLCH↔sRGB conversion for
                       Components/ (BookCover, RemoteImage, Plate, SearchField,
                       OmnibusTabBar, Masthead, BrandMark — the stoat, a copy of
                       the web's omnibus-stoat.png — FlowLayout, TopEdgeScrim,
+                      SuggestionDropdown — autocomplete pool + rows for the
+                      metadata editor's chip and series fields, the native twin
+                      of the web's `components/suggestion_dropdown/` —
                       UserAvatar — a user's picture or monogram, the native twin
                       of the web's `components/user_avatar.rs`)
 Features/           — one directory per surface: Account, AddBooks, Auth,

--- a/omnibus-ios/omnibus/Design/Components/Plate.swift
+++ b/omnibus-ios/omnibus/Design/Components/Plate.swift
@@ -147,9 +147,22 @@ struct PlateField: View {
     /// Focus this field as soon as the form appears — for the one field a sheet
     /// exists to collect.
     var autofocus = false
+    /// Autocomplete pool. Non-empty turns the field into the single-value
+    /// counterpart of the chip editor's dropdown (the web's `SuggestField`):
+    /// picking a row overwrites the value, and there is no "+ Create" row
+    /// since typing already edits the value directly.
+    var suggestions: [SuggestionItem] = []
 
     @Environment(\.palette) private var palette
     @FocusState private var focused: Bool
+    /// Whether the dropdown may show — reopened by focus or a keystroke,
+    /// closed by a pick. Needed because the just-picked value is often a
+    /// substring of other pool entries, so "filtered is non-empty" alone
+    /// would keep the dropdown open forever.
+    @State private var open = false
+    /// The name a pick just wrote into `text`, so its `onChange` echo can be
+    /// told apart from a keystroke and not reopen the dropdown.
+    @State private var lastPicked: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -193,10 +206,34 @@ struct PlateField: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .animation(Motion.snap, value: isEdited)
+
+            if open, !suggestions.isEmpty {
+                let rows = SuggestionPool.filtered(
+                    pool: suggestions, current: [text], query: text
+                )
+                if !rows.isEmpty {
+                    SuggestionList(items: rows) { name in
+                        lastPicked = name
+                        text = name
+                        open = false
+                    }
+                    .padding(.bottom, 6)
+                }
+            }
         }
         .onAppear {
             guard autofocus else { return }
             focused = true
+        }
+        .onChange(of: focused) { _, isFocused in
+            open = isFocused
+        }
+        .onChange(of: text) { _, newValue in
+            if newValue == lastPicked {
+                lastPicked = nil
+                return
+            }
+            if focused { open = true }
         }
     }
 }

--- a/omnibus-ios/omnibus/Design/Components/SuggestionDropdown.swift
+++ b/omnibus-ios/omnibus/Design/Components/SuggestionDropdown.swift
@@ -1,0 +1,142 @@
+//  SuggestionDropdown.swift
+//  Autocomplete pools + dropdown shared by the chip fields and `PlateField`,
+//  mirroring the web's `frontend/src/components/suggestion_dropdown/`: at most
+//  five case-insensitive substring matches, values already present excluded,
+//  an optional "+ Create" trailing row, and a name + book-count row layout.
+
+import SwiftUI
+
+/// One entry in an autocomplete pool: the canonical name plus the number of
+/// books currently linked to it. Counts are display-only — nothing branches
+/// on them.
+struct SuggestionItem: Hashable, Sendable {
+    let name: String
+    let count: Int
+}
+
+/// The pure half of the dropdown, shared by the chip fields and the series
+/// field. Ported from the web's `collect_suggestions` / `compute_suggestions`
+/// / `should_show_create_row` so both clients rank and filter identically.
+enum SuggestionPool {
+    /// Cap on visible rows — matches the web's `MAX_SUGGESTIONS`.
+    static let maxSuggestions = 5
+
+    /// Dedup raw `(name, count)` pairs into a sorted pool. Case-insensitive
+    /// on the name (first-seen casing wins); on collision the higher count
+    /// wins, so a freshly-linked row beats a stale empty one.
+    static func collect(_ items: [SuggestionItem]) -> [SuggestionItem] {
+        var seen: [String: SuggestionItem] = [:]
+        for item in items {
+            let key = item.name.lowercased()
+            if let existing = seen[key] {
+                if item.count > existing.count {
+                    seen[key] = SuggestionItem(name: existing.name, count: item.count)
+                }
+            } else {
+                seen[key] = item
+            }
+        }
+        return seen.sorted { $0.key < $1.key }.map(\.value)
+    }
+
+    /// The ≤`maxSuggestions` candidates for the current query: substring
+    /// match ignoring case, minus anything already in `current`. An empty
+    /// query surfaces the head of the pool (open-on-focus).
+    static func filtered(
+        pool: [SuggestionItem], current: [String], query: String
+    ) -> [SuggestionItem] {
+        guard !pool.isEmpty else { return [] }
+        let currentLC = Set(current.map { $0.lowercased() })
+        let queryLC = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let matches = pool.lazy.filter { item in
+            let lc = item.name.lowercased()
+            return (queryLC.isEmpty || lc.contains(queryLC)) && !currentLC.contains(lc)
+        }
+        return Array(matches.prefix(maxSuggestions))
+    }
+
+    /// Whether the trailing "+ Create" row shows: the user has typed
+    /// something, and no pool entry or already-chosen value is an exact
+    /// case-insensitive match. Checked against the *full* pool, not the
+    /// truncated view — an exact match pushed off the top five must still
+    /// suppress the row.
+    static func showsCreateRow(
+        pool: [SuggestionItem], current: [String], typed: String
+    ) -> Bool {
+        let trimmed = typed.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let lc = trimmed.lowercased()
+        return !pool.contains { $0.name.lowercased() == lc }
+            && !current.contains { $0.lowercased() == lc }
+    }
+}
+
+/// The dropdown itself: tappable rows under an entry field, each carrying the
+/// name and a quiet book count, plus the optional "+ Create" trailing row.
+/// Rendered inline inside the plate (content below shifts down) rather than
+/// floating — a popover under the keyboard is unreachable on touch.
+struct SuggestionList: View {
+    let items: [SuggestionItem]
+    /// Non-nil renders the "+ Create "…"" trailing row quoting this text.
+    var createText: String?
+    let onPick: (String) -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(items, id: \.name) { item in
+                row(item)
+            }
+            if let createText {
+                createRow(createText)
+            }
+        }
+    }
+
+    private func row(_ item: SuggestionItem) -> some View {
+        Button {
+            onPick(item.name)
+        } label: {
+            HStack(spacing: Spacing.sm) {
+                Text(item.name)
+                    .font(.ui(14))
+                    .foregroundStyle(palette.ink1Color)
+                    .lineLimit(1)
+
+                Spacer(minLength: Spacing.sm)
+
+                Text(item.count == 1 ? "1 book" : "\(item.count) books")
+                    .font(.ui(11))
+                    .foregroundStyle(palette.ink3Color)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .top) { Hairline().padding(.horizontal, 14) }
+    }
+
+    private func createRow(_ text: String) -> some View {
+        Button {
+            onPick(text)
+        } label: {
+            HStack(spacing: 0) {
+                Text("+ Create ")
+                    .font(.ui(14, weight: .medium))
+                    .foregroundStyle(palette.accentColor)
+                Text("\u{201c}\(text)\u{201d}")
+                    .font(.ui(14))
+                    .foregroundStyle(palette.ink1Color)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .top) { Hairline().padding(.horizontal, 14) }
+    }
+}

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -37,6 +37,13 @@ struct MetadataEditView: View {
     /// Same, for the genres field.
     @State private var pendingGenre = ""
 
+    /// Autocomplete pools for the chip and series fields, filled best-effort
+    /// while the editor is up — an empty pool just means no dropdown.
+    @State private var authorPool: [SuggestionItem] = []
+    @State private var tagPool: [SuggestionItem] = []
+    @State private var genrePool: [SuggestionItem] = []
+    @State private var seriesPool: [SuggestionItem] = []
+
     private var pendingAuthorName: String {
         pendingAuthor.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -45,8 +52,13 @@ struct MetadataEditView: View {
         pendingTag.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var pendingGenreName: String {
+        pendingGenre.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var isDirty: Bool {
         draft != loaded || !pendingAuthorName.isEmpty || !pendingTagName.isEmpty
+            || !pendingGenreName.isEmpty
     }
 
     var body: some View {
@@ -62,6 +74,7 @@ struct MetadataEditView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbar }
         .task { await load() }
+        .task { await loadSuggestionPools() }
     }
 
     private var content: some View {
@@ -77,14 +90,15 @@ struct MetadataEditView: View {
                             placeholder: "Add an author",
                             values: $draft.authors,
                             entry: $pendingAuthor,
-                            isEdited: draft.authors != loaded.authors
+                            isEdited: draft.authors != loaded.authors,
+                            suggestions: authorPool
                         )
                     }
                 }
 
                 group("Series") {
                     Plate {
-                        field("Series", \.series, isFirst: true)
+                        field("Series", \.series, isFirst: true, suggestions: seriesPool)
                         field("Index", \.seriesIndex, keyboard: .decimalPad)
                     }
                 }
@@ -107,7 +121,8 @@ struct MetadataEditView: View {
                             entry: $pendingTag,
                             isEdited: draft.tags != loaded.tags,
                             deduplicates: true,
-                            isFirst: true
+                            isFirst: true,
+                            suggestions: tagPool
                         )
                     }
                 }
@@ -121,7 +136,8 @@ struct MetadataEditView: View {
                             entry: $pendingGenre,
                             isEdited: draft.genres != loaded.genres,
                             deduplicates: true,
-                            isFirst: true
+                            isFirst: true,
+                            suggestions: genrePool
                         )
                     }
                 }
@@ -195,7 +211,8 @@ struct MetadataEditView: View {
         isFirst: Bool = false,
         hint: String? = nil,
         keyboard: UIKeyboardType = .default,
-        multiline: Bool = false
+        multiline: Bool = false,
+        suggestions: [SuggestionItem] = []
     ) -> some View {
         PlateField(
             label: label,
@@ -207,7 +224,8 @@ struct MetadataEditView: View {
             isFirst: isFirst,
             hint: hint,
             keyboard: keyboard,
-            multiline: multiline
+            multiline: multiline,
+            suggestions: suggestions
         )
     }
 
@@ -251,6 +269,50 @@ struct MetadataEditView: View {
         loaded = MetadataDraft(book: book)
         draft = loaded
         isLoading = false
+    }
+
+    /// Fill the four autocomplete pools, mirroring the web editor's
+    /// `use_suggestion_pools`. Each pool streams replica-first (`Cache.live`),
+    /// so a cached listing paints suggestions immediately and the server's
+    /// answer refines them; a failed read just leaves that pool empty.
+    private func loadSuggestionPools() async {
+        async let authors: Void = collectAuthorPool()
+        async let tags: Void = collectTagPool()
+        async let genres: Void = collectGenrePool()
+        async let series: Void = collectSeriesPool()
+        _ = await (authors, tags, genres, series)
+    }
+
+    private func collectAuthorPool() async {
+        for await authors in LibraryService.authors().values() {
+            authorPool = SuggestionPool.collect(
+                authors.map { SuggestionItem(name: $0.name, count: $0.bookCount) }
+            )
+        }
+    }
+
+    private func collectTagPool() async {
+        for await tags in LibraryService.tags().values() {
+            tagPool = SuggestionPool.collect(
+                tags.map { SuggestionItem(name: $0.name, count: $0.count) }
+            )
+        }
+    }
+
+    private func collectGenrePool() async {
+        for await genres in LibraryService.genres().values() {
+            genrePool = SuggestionPool.collect(
+                genres.map { SuggestionItem(name: $0.name, count: $0.count) }
+            )
+        }
+    }
+
+    private func collectSeriesPool() async {
+        for await series in LibraryService.series().values() {
+            seriesPool = SuggestionPool.collect(
+                series.map { SuggestionItem(name: $0.name, count: $0.bookCount) }
+            )
+        }
     }
 
     private func save() async {
@@ -322,8 +384,17 @@ private struct ChipListField: View {
     var deduplicates = false
     /// First row of its plate — no leading hairline.
     var isFirst = false
+    /// Autocomplete pool for the entry field. Empty → free-text entry only,
+    /// same as the web chip editor.
+    var suggestions: [SuggestionItem] = []
 
     @Environment(\.palette) private var palette
+    @FocusState private var entryFocused: Bool
+    /// Whether the dropdown may show. Tracks focus, but stays closed after a
+    /// commit until the next keystroke or refocus — mirroring the web
+    /// editor's `suppress_open`, so the just-emptied entry doesn't instantly
+    /// re-surface the pool.
+    @State private var open = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -372,6 +443,7 @@ private struct ChipListField: View {
                         .autocorrectionDisabled()
                         .submitLabel(.done)
                         .tint(palette.accentColor)
+                        .focused($entryFocused)
                         .onSubmit(commit)
 
                     if !entry.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -385,6 +457,28 @@ private struct ChipListField: View {
             .padding(.vertical, 12)
             .animation(Motion.snap, value: isEdited)
             .animation(Motion.snap, value: values)
+
+            if open {
+                let rows = SuggestionPool.filtered(
+                    pool: suggestions, current: values, query: entry
+                )
+                let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+                let create = SuggestionPool.showsCreateRow(
+                    pool: suggestions, current: values, typed: entry
+                ) ? trimmed : nil
+                if !rows.isEmpty || create != nil {
+                    SuggestionList(items: rows, createText: create) { pick($0) }
+                        .padding(.bottom, 6)
+                }
+            }
+        }
+        .onChange(of: entryFocused) { _, focused in
+            open = focused
+        }
+        .onChange(of: entry) { _, newValue in
+            // Only a keystroke reopens: the commit path clears the entry
+            // programmatically, and that clear must not resurface the pool.
+            if !newValue.isEmpty { open = true }
         }
     }
 
@@ -413,11 +507,20 @@ private struct ChipListField: View {
     }
 
     private func commit() {
-        // A refused duplicate still clears the field: the input was
-        // understood, and leaving the text sitting there reads as a failure.
-        defer { entry = "" }
+        pick(entry)
+    }
+
+    /// Commit `name` as a chip — from the entry field, a suggestion row, or
+    /// the "+ Create" row. The entry always clears and the dropdown closes:
+    /// a refused duplicate was still understood, and leaving the text (or
+    /// the pool) sitting there reads as a failure.
+    private func pick(_ name: String) {
+        defer {
+            entry = ""
+            open = false
+        }
         guard let chip = ChipEntry.committed(
-            from: entry, existing: values, deduplicating: deduplicates
+            from: name, existing: values, deduplicating: deduplicates
         ) else { return }
         Haptics.select()
         values.append(chip)

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -250,6 +250,15 @@ struct TagWeight: Codable, Hashable, Sendable, Identifiable {
     var id: String { name }
 }
 
+/// Structurally a `TagWeight`, kept a distinct type because `/api/genres` and
+/// `/api/tags` are two different vocabularies — mirroring the server's
+/// `GenreWeight` / `TagWeight` split.
+struct GenreWeight: Codable, Hashable, Sendable, Identifiable {
+    var name: String
+    var count: Int
+    var id: String { name }
+}
+
 // MARK: - Search palette
 
 struct PaletteBookHit: Codable, Hashable, Sendable, Identifiable {

--- a/omnibus-ios/omnibus/Offline/Cache.swift
+++ b/omnibus-ios/omnibus/Offline/Cache.swift
@@ -14,6 +14,7 @@ enum CacheKey {
     static let authors = "authors"
     static let series = "series"
     static let tags = "tags"
+    static let genres = "genres"
     static let shelves = "shelves"
     static let shelfPreviews = "shelf_previews"
 

--- a/omnibus-ios/omnibus/Services/LibraryService.swift
+++ b/omnibus-ios/omnibus/Services/LibraryService.swift
@@ -296,6 +296,12 @@ enum LibraryService {
         }
     }
 
+    static func genres() -> AsyncThrowingStream<CacheRead<[GenreWeight]>, Error> {
+        Cache.live(CacheKey.genres) {
+            try await APIClient.shared.get("/api/genres")
+        }
+    }
+
     /// One settled `Book`, for callers with nowhere to put a provisional one.
     static func settledBook(uuid: String) async throws -> Book {
         try await Cache.settled(CacheKey.book(uuid)) {

--- a/omnibus-ios/omnibusTests/SuggestionPoolTests.swift
+++ b/omnibus-ios/omnibusTests/SuggestionPoolTests.swift
@@ -1,0 +1,88 @@
+//  SuggestionPoolTests.swift
+//  The pure half of the autocomplete dropdown: pool collection, query
+//  filtering, and the "+ Create" row gate — ported behavior from the web's
+//  suggestion_dropdown, so the two clients must keep agreeing.
+
+import Testing
+
+@testable import omnibus
+
+struct SuggestionPoolTests {
+    @Test func collectDedupsCaseInsensitivelyAndKeepsHigherCount() {
+        let pool = SuggestionPool.collect([
+            SuggestionItem(name: "Sarah J. Maas", count: 8),
+            SuggestionItem(name: "sarah j. maas", count: 3),
+            SuggestionItem(name: "Brandon Sanderson", count: 12),
+        ])
+        #expect(pool.count == 2)
+        let maas = pool.first { $0.name == "Sarah J. Maas" }
+        #expect(maas?.count == 8)
+        #expect(pool.contains { $0.name == "Brandon Sanderson" && $0.count == 12 })
+    }
+
+    @Test func collectSortsAlphabeticallyIgnoringCase() {
+        let pool = SuggestionPool.collect([
+            SuggestionItem(name: "zelda", count: 0),
+            SuggestionItem(name: "Ada", count: 5),
+            SuggestionItem(name: "Mira", count: 1),
+        ])
+        #expect(pool.map(\.name) == ["Ada", "Mira", "zelda"])
+    }
+
+    @Test func filteredMatchesSubstringIgnoringCase() {
+        let pool = [
+            SuggestionItem(name: "Science Fiction", count: 4),
+            SuggestionItem(name: "Historical Fiction", count: 2),
+            SuggestionItem(name: "Poetry", count: 1),
+        ]
+        let rows = SuggestionPool.filtered(pool: pool, current: [], query: "fic")
+        #expect(rows.map(\.name) == ["Science Fiction", "Historical Fiction"])
+    }
+
+    @Test func filteredExcludesValuesAlreadyPresent() {
+        let pool = [
+            SuggestionItem(name: "Fantasy", count: 6),
+            SuggestionItem(name: "Fantasy Romance", count: 2),
+        ]
+        let rows = SuggestionPool.filtered(pool: pool, current: ["fantasy"], query: "fan")
+        #expect(rows.map(\.name) == ["Fantasy Romance"])
+    }
+
+    @Test func filteredEmptyQueryReturnsPoolHeadMinusPresent() {
+        let pool = (1...8).map { SuggestionItem(name: "Tag \($0)", count: $0) }
+        let rows = SuggestionPool.filtered(pool: pool, current: ["Tag 1"], query: "  ")
+        #expect(rows.count == SuggestionPool.maxSuggestions)
+        #expect(rows.first?.name == "Tag 2")
+    }
+
+    @Test func filteredCapsAtFiveMatches() {
+        let pool = (1...9).map { SuggestionItem(name: "Series \($0)", count: 1) }
+        let rows = SuggestionPool.filtered(pool: pool, current: [], query: "series")
+        #expect(rows.count == 5)
+    }
+
+    @Test func createRowShowsForNovelTypedText() {
+        let pool = [SuggestionItem(name: "Fantasy", count: 6)]
+        #expect(SuggestionPool.showsCreateRow(pool: pool, current: [], typed: " Cozy Fantasy "))
+    }
+
+    @Test func createRowHiddenWhenPoolHasExactMatchIgnoringCase() {
+        let pool = [SuggestionItem(name: "Fantasy", count: 6)]
+        #expect(!SuggestionPool.showsCreateRow(pool: pool, current: [], typed: "fantasy"))
+    }
+
+    @Test func createRowHiddenWhenValueAlreadyChosenOrBlank() {
+        #expect(!SuggestionPool.showsCreateRow(pool: [], current: ["Fantasy"], typed: "FANTASY"))
+        #expect(!SuggestionPool.showsCreateRow(pool: [], current: [], typed: "   "))
+    }
+
+    @Test func createRowChecksFullPoolNotTruncatedView() {
+        // "tag" matches every entry, so the exact match "Tag" falls past the
+        // top-five cut — it must still suppress the Create row.
+        var pool = (1...6).map { SuggestionItem(name: "Tag \($0)", count: 1) }
+        pool.append(SuggestionItem(name: "Tag", count: 1))
+        let rows = SuggestionPool.filtered(pool: pool, current: [], query: "tag")
+        #expect(!rows.contains { $0.name == "Tag" })
+        #expect(!SuggestionPool.showsCreateRow(pool: pool, current: [], typed: "Tag"))
+    }
+}


### PR DESCRIPTION
## Summary
- iOS metadata editor's authors/tags/genres chip fields and the series field now surface the web editor's autocomplete dropdown: ≤5 case-insensitive substring matches with book counts, already-present values excluded, and a "+ Create" trailing row on the chip fields.
- New `SuggestionDropdown` design component ports the web's `suggestion_dropdown` filter/dedup/create-row logic; pools stream replica-first from `/api/{authors,tags,genres,series}` (new `GenreWeight` model + `genres()` fetch).
- Drive-by: a pending genre entry now counts toward the editor's dirty check, matching the save path that already flushes it.

## Test plan
- [x] `just ios-build` compiles clean.
- [x] `just ios-test` — 266 passed, 0 failed, including 10 new `SuggestionPoolTests` covering dedup, filtering, the five-row cap, and the create-row gates.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.