### PR TITLE
fix: rate-adjust audiobook time-left readouts and iOS listening stats

### DIFF
--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -123,6 +123,9 @@ pub(super) struct ChapterMapProps {
     pub duration: f64,
     /// Seconds remaining in the whole book.
     pub remaining: f64,
+    /// Current playback rate — the remaining readout divides by it so "time
+    /// left" is wall-clock listening time, not book time.
+    pub rate: f64,
     /// Index of the currently-playing chapter.
     pub current_chapter_index: usize,
     /// Fired with the target time in seconds when the bar is clicked or a
@@ -240,6 +243,7 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
         elapsed,
         duration,
         remaining,
+        rate,
         current_chapter_index,
         on_seek,
     } = props;
@@ -320,7 +324,9 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
             div { class: "lp-scrub-times",
                 span { "{format_hms(effective)}" }
                 span { class: "lp-scrub-remaining",
-                    "\u{00b7} {format_hms(eff_remaining)} remaining"
+                    // Scaled after the scrub preview so a drag previews the
+                    // rate-adjusted time left too (matches the mobile player).
+                    "\u{00b7} {format_hms(helpers::remaining_at_rate(eff_remaining, rate))} remaining"
                 }
                 span { "{format_hms(duration)}" }
             }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -285,6 +285,17 @@ pub(super) fn format_hms(seconds: f64) -> String {
     }
 }
 
+/// Rate-adjusted "time left" for a real (1x) `remaining` duration; falls back
+/// to `remaining` unscaled when `rate` is non-finite or non-positive. Shared
+/// by the web and mobile players so every remaining-time readout scales the
+/// same way.
+pub(super) fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
+    if !rate.is_finite() || rate <= 0.0 {
+        return remaining;
+    }
+    remaining / rate
+}
+
 /// Fire-and-forget POST `/api/rpc/progress` with the audio update.
 ///
 /// `file_id` is the `book_files` row currently playing — the id the
@@ -319,7 +330,7 @@ pub(super) fn post_audio_progress(uuid: String, file_id: Option<i64>, seconds: f
 mod tests {
     use omnibus_shared::ChapterInfo;
 
-    use super::{effective_scrub_position, format_hms};
+    use super::{effective_scrub_position, format_hms, remaining_at_rate};
 
     fn ch(ordinal: i64, title: &str, start: f64, dur: f64) -> ChapterInfo {
         ChapterInfo {
@@ -415,6 +426,21 @@ mod tests {
         assert_eq!(format_hms(-12.0), "0:00");
         assert_eq!(format_hms(f64::NAN), "0:00");
         assert_eq!(format_hms(f64::INFINITY), "0:00");
+    }
+
+    #[test]
+    fn remaining_at_rate_divides_by_the_playback_rate() {
+        assert!((remaining_at_rate(600.0, 2.0) - 300.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, 0.5) - 1200.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, 1.0) - 600.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn remaining_at_rate_falls_back_unscaled_for_invalid_rates() {
+        assert!((remaining_at_rate(600.0, 0.0) - 600.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, -1.0) - 600.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, f64::NAN) - 600.0).abs() < f64::EPSILON);
+        assert!((remaining_at_rate(600.0, f64::INFINITY) - 600.0).abs() < f64::EPSILON);
     }
 }
 

--- a/frontend/src/pages/listen/mini_dock/popovers.rs
+++ b/frontend/src/pages/listen/mini_dock/popovers.rs
@@ -123,11 +123,12 @@ pub(super) fn DockSleep(open_panel: Signal<Option<DockPanel>>) -> Element {
     let on_end_of_chapter = {
         let chapters = playback.chapters;
         let elapsed = playback.elapsed;
+        let rate = playback.rate;
         move |_: ()| {
             let chs = chapters.peek().clone();
             let now = *elapsed.peek();
             let idx = chapter_index_for_elapsed(&chs, now);
-            if let Some(secs) = end_of_chapter_seconds(&chs, idx, now) {
+            if let Some(secs) = end_of_chapter_seconds(&chs, idx, now, *rate.peek()) {
                 sleep.select_end_of_chapter(secs);
             }
         }

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -10,7 +10,7 @@ use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{EbookMetadata, ProgressFormat, ProgressUpdate};
 
-use super::helpers::effective_scrub_position;
+use super::helpers::{effective_scrub_position, remaining_at_rate};
 use crate::components::atrium::Cover;
 use crate::contexts::use_server_url;
 use crate::data;
@@ -30,7 +30,7 @@ use bookmarks_sheet::{use_mobile_bookmarks, BookmarksSheet, MobileBookmarks};
 use effects::{use_marquee_title_refresh, use_retarget_playback};
 use sheets::{snap_rate, ChaptersSheet, SleepSheet, SpeedSheet};
 use state::{sleep_pill_label, use_mobile_playback, SleepState};
-use view::{chapter_index_for_elapsed, format_hms, format_ms, remaining_at_rate, PlayerView};
+use view::{chapter_index_for_elapsed, format_hms, format_ms, PlayerView};
 
 pub use host::MobileAudioHost;
 pub(crate) use mini::mobile_dock_is_active;

--- a/frontend/src/pages/listen/mobile/mini.rs
+++ b/frontend/src/pages/listen/mobile/mini.rs
@@ -10,8 +10,9 @@ use crate::components::atrium::Cover;
 use crate::contexts::use_server_url;
 use crate::Route;
 
+use super::super::helpers::remaining_at_rate;
 use super::state::use_mobile_playback;
-use super::view::{chapter_index_for_elapsed, format_hms, remaining_at_rate, PlayerView};
+use super::view::{chapter_index_for_elapsed, format_hms, PlayerView};
 use super::{cover_src, interop};
 
 /// The mini bar's render gate: the loaded view when it's playable, `None`

--- a/frontend/src/pages/listen/mobile/view.rs
+++ b/frontend/src/pages/listen/mobile/view.rs
@@ -142,15 +142,6 @@ pub fn remaining_in_chapter(chapters: &[ChapterInfo], idx: usize, elapsed: f64) 
     }
 }
 
-/// Rate-adjusted "time left" for a real (1x) `remaining` duration; falls back
-/// to `remaining` unscaled when `rate` is non-finite or non-positive.
-pub fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
-    if !rate.is_finite() || rate <= 0.0 {
-        return remaining;
-    }
-    remaining / rate
-}
-
 /// Resolve the "previous chapter" seek target:
 /// - >3s into the current chapter → its start;
 /// - within 3s of the start and not the first → the previous chapter's start;

--- a/frontend/src/pages/listen/mobile/view/tests.rs
+++ b/frontend/src/pages/listen/mobile/view/tests.rs
@@ -74,21 +74,6 @@ fn remaining_in_chapter_counts_down_to_zero() {
 }
 
 #[test]
-fn remaining_at_rate_divides_by_the_playback_rate() {
-    assert!((remaining_at_rate(600.0, 2.0) - 300.0).abs() < f64::EPSILON);
-    assert!((remaining_at_rate(600.0, 0.5) - 1200.0).abs() < f64::EPSILON);
-    assert!((remaining_at_rate(600.0, 1.0) - 600.0).abs() < f64::EPSILON);
-}
-
-#[test]
-fn remaining_at_rate_falls_back_to_unscaled_for_invalid_rate() {
-    assert_eq!(remaining_at_rate(600.0, 0.0), 600.0);
-    assert_eq!(remaining_at_rate(600.0, -1.0), 600.0);
-    assert_eq!(remaining_at_rate(600.0, f64::NAN), 600.0);
-    assert_eq!(remaining_at_rate(600.0, f64::INFINITY), 600.0);
-}
-
-#[test]
 fn chapter_prev_seek_none_when_empty_or_oob() {
     assert_eq!(chapter_prev_seek(&[], 10.0, 0), None);
     let chs = vec![ch(1, "Intro", 0.0, 300.0)];

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -66,6 +66,7 @@ fn build_sleep_panel_state(
     sleep: SleepController,
     chapters: Signal<Vec<ChapterInfo>>,
     elapsed: Signal<f64>,
+    rate: Signal<f64>,
     current_chapter_index: Memo<usize>,
     has_chapters: bool,
 ) -> (SleepPanelState, Option<i32>, bool) {
@@ -73,7 +74,7 @@ fn build_sleep_panel_state(
     let on_sleep_end_of_chapter = move |_: ()| {
         let chs_now = chapters.peek().clone();
         let idx = current_chapter_index();
-        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek()) {
+        if let Some(secs) = end_of_chapter_seconds(&chs_now, idx, *elapsed.peek(), *rate.peek()) {
             sleep.select_end_of_chapter(secs);
         }
     };
@@ -174,6 +175,7 @@ pub(super) fn ReadyPlayer(
         sleep,
         chapters,
         elapsed,
+        signals.rate,
         current_chapter_index,
         !chs.is_empty(),
     );
@@ -357,6 +359,7 @@ pub(super) fn PlayerStageBinding(
                 elapsed: elapsed_now,
                 duration: dur,
                 remaining: (dur - elapsed_now).max(0.0),
+                rate: (signals.rate)(),
                 scrub_max: scrub_max(dur),
                 current_chapter_index: current_chapter_index(),
             },

--- a/frontend/src/pages/listen/sleep.rs
+++ b/frontend/src/pages/listen/sleep.rs
@@ -68,16 +68,21 @@ pub(super) fn sleep_chip_label(remaining: Option<i32>, choice: SleepChoice) -> S
     }
 }
 
-/// Seconds left until the end of the current chapter, for the "End of
-/// chapter" option. `None` when `idx` is out of range (empty/stale list).
+/// Wall-clock seconds left until the end of the current chapter, for the
+/// "End of chapter" option. The countdown ticks in real time while the book
+/// plays at `rate`, so the book-time remainder is divided by the rate —
+/// otherwise a 2x listener's timer fires long after the chapter has ended.
+/// `None` when `idx` is out of range (empty/stale list).
 pub(super) fn end_of_chapter_seconds(
     chapters: &[ChapterInfo],
     idx: usize,
     elapsed: f64,
+    rate: f64,
 ) -> Option<i32> {
     let ch = chapters.get(idx)?;
     let end = ch.start_seconds + ch.duration_seconds;
-    let rem = (end - elapsed).max(0.0).min(f64::from(i32::MAX));
+    let rem =
+        super::helpers::remaining_at_rate((end - elapsed).max(0.0), rate).min(f64::from(i32::MAX));
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     Some(rem.ceil() as i32)
 }
@@ -290,19 +295,28 @@ mod tests {
     fn end_of_chapter_seconds_returns_remaining_in_current_chapter() {
         let chs = vec![ch(0.0, 300.0), ch(300.0, 600.0)];
         // 120 s into chapter 2 (start 300, dur 600 → ends 900); elapsed 420 → 480 left.
-        assert_eq!(end_of_chapter_seconds(&chs, 1, 420.0), Some(480));
+        assert_eq!(end_of_chapter_seconds(&chs, 1, 420.0, 1.0), Some(480));
+    }
+
+    #[test]
+    fn end_of_chapter_seconds_scales_to_wall_clock_at_playback_rate() {
+        let chs = vec![ch(0.0, 300.0), ch(300.0, 600.0)];
+        // 480 book-seconds left plays out in 240 wall-seconds at 2x.
+        assert_eq!(end_of_chapter_seconds(&chs, 1, 420.0, 2.0), Some(240));
+        // A non-positive rate falls back to the unscaled remainder.
+        assert_eq!(end_of_chapter_seconds(&chs, 1, 420.0, 0.0), Some(480));
     }
 
     #[test]
     fn end_of_chapter_seconds_floors_at_zero_past_end() {
         let chs = vec![ch(0.0, 300.0)];
-        assert_eq!(end_of_chapter_seconds(&chs, 0, 999.0), Some(0));
+        assert_eq!(end_of_chapter_seconds(&chs, 0, 999.0, 1.0), Some(0));
     }
 
     #[test]
     fn end_of_chapter_seconds_none_for_out_of_range_index() {
         let chs = vec![ch(0.0, 300.0)];
-        assert_eq!(end_of_chapter_seconds(&chs, 5, 10.0), None);
+        assert_eq!(end_of_chapter_seconds(&chs, 5, 10.0, 1.0), None);
     }
 
     #[test]

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -91,6 +91,8 @@ pub(super) struct PlaybackPosition {
     pub elapsed: f64,
     pub duration: f64,
     pub remaining: f64,
+    /// Playback rate, threaded to the scrubber's remaining-time readout.
+    pub rate: f64,
     pub scrub_max: f64,
     pub current_chapter_index: usize,
 }
@@ -191,6 +193,7 @@ pub(super) fn PlayerStage(
                     elapsed: position.elapsed,
                     duration: position.duration,
                     remaining: position.remaining,
+                    rate: position.rate,
                     current_chapter_index: position.current_chapter_index,
                     on_seek: callbacks.on_chapter_seek,
                 }

--- a/omnibus-ios/omnibus/Design/Components/Primitives.swift
+++ b/omnibus-ios/omnibus/Design/Components/Primitives.swift
@@ -497,6 +497,15 @@ enum Format {
             : String(format: "%d:%02d", m, s)
     }
 
+    /// Wall-clock seconds it takes to play `seconds` of audio at `rate` —
+    /// the rate-adjusted "time left" a 2x listener actually experiences.
+    /// Non-finite or non-positive rates fall back to the unscaled value,
+    /// mirroring `remaining_at_rate` in the web player.
+    static func atRate(_ seconds: Double, rate: Double) -> Double {
+        guard rate.isFinite, rate > 0 else { return seconds }
+        return seconds / rate
+    }
+
     /// Compact spoken form for stats and metadata rows — "4h 12m".
     static func humanDuration(_ seconds: Int64) -> String {
         guard seconds > 0 else { return "0m" }

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -654,7 +654,11 @@ final class AudioPlayer {
                 // back to stale for as long as the seek takes to settle.
                 guard self.pendingSeekCount == 0 else { return }
                 self.position = time.seconds
-                if self.isPlaying { self.listenedSeconds += 0.5 }
+                // The periodic observer ticks every 0.5 *media* seconds — at
+                // 2x that's twice per wall second — so each tick is converted
+                // to wall-clock before it accrues. Listening stats count the
+                // listener's real time, not the book time covered.
+                if self.isPlaying { self.listenedSeconds += Format.atRate(0.5, rate: self.rate) }
                 await self.persistPosition(force: false)
                 self.updateNowPlaying()
             }

--- a/omnibus-ios/omnibus/Features/Player/CarModeView.swift
+++ b/omnibus-ios/omnibus/Features/Player/CarModeView.swift
@@ -65,11 +65,17 @@ struct CarModeView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
 
-            Text(Format.humanDuration(Int64(max(0, player.duration - player.position))) + " left")
+            Text(Format.humanDuration(Int64(bookRemaining)) + " left")
                 .font(.ui(16))
                 .monospacedDigit()
                 .foregroundStyle(palette.ink2Color)
         }
+    }
+
+    /// Rate-adjusted book time left — the wall-clock wait, matching the full
+    /// player's readout.
+    private var bookRemaining: Double {
+        Format.atRate(max(0, player.duration - player.position), rate: player.rate)
     }
 
     private var transport: some View {

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -296,7 +296,7 @@ struct PlayerView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if player.hasChapters {
-                    Text(Format.humanDuration(Int64(bookRemaining)) + " left")
+                    Text(Format.humanDuration(Int64(Format.atRate(bookRemaining, rate: player.rate))) + " left")
                 }
 
                 Text(chapterRemainingLabel)
@@ -326,7 +326,9 @@ struct PlayerView: View {
     }
 
     private var chapterRemainingLabel: String {
-        let left = max(0, player.chapterDuration - displayedOffset)
+        // Rate-adjusted: "time left" is what the listener will wait through,
+        // not the 1x runtime of the rest of the chapter.
+        let left = Format.atRate(max(0, player.chapterDuration - displayedOffset), rate: player.rate)
         // No sign at the end of a chapter: "-0:00" reads as a broken clock.
         return left < 1 ? "0:00" : "- " + Format.duration(left)
     }

--- a/omnibus-ios/omnibusTests/RateAdjustedTimeTests.swift
+++ b/omnibus-ios/omnibusTests/RateAdjustedTimeTests.swift
@@ -1,0 +1,40 @@
+//  RateAdjustedTimeTests.swift
+//  Rate-adjusted time math behind the player's "left" labels and stats.
+//
+//  `Format.atRate` converts book-time seconds into the wall-clock time a
+//  listener at a given playback rate actually experiences. Two consumers
+//  depend on it staying exact: the player's remaining-time readouts, and the
+//  session tracker's per-tick accrual (the periodic observer fires in media
+//  time, so each 0.5s tick is divided by the rate before it counts toward
+//  listening stats).
+
+import Testing
+
+@testable import omnibus
+
+@Suite("Rate-adjusted time")
+struct RateAdjustedTimeTests {
+    @Test("divides remaining seconds by the playback rate")
+    func dividesByRate() {
+        #expect(Format.atRate(600, rate: 2.0) == 300)
+        #expect(Format.atRate(600, rate: 0.5) == 1200)
+        #expect(Format.atRate(600, rate: 1.0) == 600)
+    }
+
+    @Test("falls back to the unscaled value for invalid rates")
+    func fallsBackForInvalidRates() {
+        #expect(Format.atRate(600, rate: 0) == 600)
+        #expect(Format.atRate(600, rate: -1) == 600)
+        #expect(Format.atRate(600, rate: .nan) == 600)
+        #expect(Format.atRate(600, rate: .infinity) == 600)
+    }
+
+    @Test("a media-time observer tick accrues wall-clock stats time")
+    func observerTickAccruesWallClock() {
+        // One 0.5s media tick at 2x is a quarter second of real listening;
+        // an hour of 2x playback must total 30 wall-clock minutes.
+        #expect(Format.atRate(0.5, rate: 2.0) == 0.25)
+        let ticksPerBookHour = 7200.0
+        #expect(Format.atRate(0.5, rate: 2.0) * ticksPerBookHour == 1800)
+    }
+}


### PR DESCRIPTION
## Summary
- Rate-adjust every remaining-time readout the mobile player already scales (#1016): the web player's scrubber "remaining" label, and the iOS book/chapter "left" labels in the full player and Car Mode via a new `Format.atRate` helper.
- Arm the web sleep timer's "End of chapter" option with wall-clock seconds (book-time remainder ÷ rate) so it fires at the chapter boundary instead of ~2× late for a 2× listener.
- Count iOS listening stats in wall-clock time: the periodic observer ticks in media time, so each 0.5 s tick now divides by the playback rate before accruing to `listenedSeconds` (web/Android session reports were already wall-clock).
- Hoist `remaining_at_rate` from the mobile view into the shared `listen/helpers.rs` so web, mobile, and the sleep timer scale identically.

## Test plan
- [x] `cargo nextest run -p omnibus-frontend --features server` and `--features mobile` — 668 passed, incl. new `remaining_at_rate` + rate-scaled `end_of_chapter_seconds` cases
- [x] `just lint` — fmt, clippy matrix (wasm32 + mobile), stylelint
- [x] `just ios-test` — omnibusTests green, incl. new `RateAdjustedTimeTests`

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Historical iOS sessions recorded at ≠1× are inflated in `listening_sessions` and are not healed retroactively — only new sessions count wall-clock.
- The landing Continue hero (web `resume_meta.rs`) and iOS `ContinueHero` "left" labels still show 1× book time; scaling them needs the stored per-book playback rate threaded into those projections — follow-up candidate.