### PR TITLE
[OMNI-1894] Anchor Matcher Learns Real-Library Chapter Shapes

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -650,6 +650,7 @@ pub async fn alignment_view(
     // Anchor preview: for an unlinked book, evaluate against the default
     // sequence declaration so the modal can honestly say whether anchoring
     // would engage; a stale link stays quiet (mapping is paused anyway).
+    let mut audio_chapter_marks = 0i64;
     let anchor_match = if link.as_ref().is_some_and(|l| l.stale) {
         None
     } else {
@@ -660,16 +661,19 @@ pub async fn alignment_view(
             confirmed_at: 0,
         });
         match audio_timeline(pool, book_id, &preview).await? {
-            Some(timeline) => match crate::book_file_with_id(pool, book_id, "EPUB").await? {
-                Some((ebook_file_id, _)) => anchors::anchor_map(pool, ebook_file_id, &timeline)
-                    .await?
-                    .map(|m| AlignmentMatch {
-                        matched: m.matched,
-                        ebook_chapters: m.ebook_chapters,
-                        confidence: MappingConfidence::ChapterAnchored,
-                    }),
-                None => None,
-            },
+            Some(timeline) => {
+                audio_chapter_marks = anchors::usable_audio_marks(pool, &timeline).await?;
+                match crate::book_file_with_id(pool, book_id, "EPUB").await? {
+                    Some((ebook_file_id, _)) => anchors::anchor_map(pool, ebook_file_id, &timeline)
+                        .await?
+                        .map(|m| AlignmentMatch {
+                            matched: m.matched,
+                            ebook_chapters: m.ebook_chapters,
+                            confidence: MappingConfidence::ChapterAnchored,
+                        }),
+                    None => None,
+                }
+            }
             None => None,
         }
     };
@@ -741,6 +745,7 @@ pub async fn alignment_view(
         audio_files: audio,
         reading,
         listening,
+        audio_chapter_marks,
     })
 }
 

--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -62,6 +62,7 @@ fn strip_track_prefix(raw: &str) -> &str {
 #[derive(Debug, Clone)]
 struct AudioMark {
     key: Option<String>,
+    chapter_no: Option<u32>,
     synthetic: bool,
     frac: f64,
 }
@@ -70,7 +71,76 @@ struct AudioMark {
 #[derive(Debug, Clone)]
 struct TextMark {
     key: Option<String>,
+    chapter_no: Option<u32>,
     frac: f64,
+}
+
+/// Chapter ordinal parsed from a `Chapter <n>[: subtitle]`-shaped title,
+/// arabic or spelled out — so a mark decorated with subtitles ("Chapter
+/// One: The Pigeon Drop: In Which…") pairs with a nav's terser "Chapter 1".
+pub(super) fn chapter_number(raw: &str) -> Option<u32> {
+    let lower = strip_track_prefix(raw).trim_start().to_lowercase();
+    let rest = lower.strip_prefix("chapter")?;
+    let rest = rest.trim_start_matches([' ', '.', '-', '_', ':']);
+    if rest.is_empty() || rest.len() == lower.len() - "chapter".len() {
+        // No separator after "chapter" ("chapterhouse") is a word, not a
+        // numbering — unless the ordinal follows immediately ("chapter1").
+        if !rest.starts_with(|c: char| c.is_ascii_digit()) {
+            return None;
+        }
+    }
+    let token: &str = rest
+        .split(|c: char| !(c.is_alphanumeric() || c == '-'))
+        .next()
+        .filter(|t| !t.is_empty())?;
+    token.parse::<u32>().ok().or_else(|| word_number(token))
+}
+
+/// Spelled-out ordinal → number, through ninety-nine ("twenty-one").
+fn word_number(word: &str) -> Option<u32> {
+    const UNITS: [(&str, u32); 19] = [
+        ("one", 1),
+        ("two", 2),
+        ("three", 3),
+        ("four", 4),
+        ("five", 5),
+        ("six", 6),
+        ("seven", 7),
+        ("eight", 8),
+        ("nine", 9),
+        ("ten", 10),
+        ("eleven", 11),
+        ("twelve", 12),
+        ("thirteen", 13),
+        ("fourteen", 14),
+        ("fifteen", 15),
+        ("sixteen", 16),
+        ("seventeen", 17),
+        ("eighteen", 18),
+        ("nineteen", 19),
+    ];
+    const TENS: [(&str, u32); 8] = [
+        ("twenty", 20),
+        ("thirty", 30),
+        ("forty", 40),
+        ("fifty", 50),
+        ("sixty", 60),
+        ("seventy", 70),
+        ("eighty", 80),
+        ("ninety", 90),
+    ];
+    let lookup = |w: &str| UNITS.iter().find(|(n, _)| *n == w).map(|(_, v)| *v);
+    if let Some(v) = lookup(word) {
+        return Some(v);
+    }
+    if let Some((tens_word, unit_word)) = word.split_once('-') {
+        let tens = TENS
+            .iter()
+            .find(|(n, _)| *n == tens_word)
+            .map(|(_, v)| *v)?;
+        return Some(tens + lookup(unit_word).filter(|v| *v < 10)?);
+    }
+    TENS.iter().find(|(n, _)| *n == word).map(|(_, v)| *v)
 }
 
 /// Build the anchor map for a linked book, or `None` when no trustworthy
@@ -93,6 +163,7 @@ pub(super) async fn anchor_map(
         .into_iter()
         .map(|c| TextMark {
             key: title_key(&c.title),
+            chapter_no: chapter_number(&c.title),
             frac: (c.start_chars.max(0) as f64 / total_chars as f64).clamp(0.0, 1.0),
         })
         .collect();
@@ -105,37 +176,137 @@ pub(super) async fn anchor_map(
         return Ok(None);
     }
 
-    // Rung 1: normalized title equality (synthetic titles excluded), taken
-    // in order so a duplicated chapter name pairs positionally.
-    let mut anchors = match_by_title(&text, &audio);
+    // The match bar scores against the *smaller* mark list: a nav padded
+    // with front matter (Cover, Copyright, Contents…) must not raise the
+    // bar past what the audio side could ever supply (#1894).
+    let usable_audio = audio
+        .iter()
+        .filter(|a| !a.synthetic && a.key.is_some())
+        .count();
+    let denom = text.len().min(usable_audio.max(1));
+    let passes = |a: &[Anchor]| {
+        a.len() >= MIN_ANCHORS && (a.len() as f64) >= MIN_MATCH_FRACTION * denom as f64
+    };
 
-    // Rung 2: count alignment — when every chapter lines up one-to-one
-    // (the per-chapter MP3 folder, or two editions wording titles
-    // differently), pair by index instead.
-    if anchors.len() < MIN_ANCHORS && text.len() == audio.len() {
-        anchors = text
-            .iter()
-            .zip(audio.iter())
-            .map(|(t, a)| Anchor {
-                text_frac: t.frac,
-                audio_frac: a.frac,
-            })
-            .collect();
+    // Rungs, most exact first; the first that clears the bar (after the
+    // monotonic filter, so the count reflects anchors the interpolation
+    // actually uses) wins. Junk encoder labels ("STORMLIGHT0501P01")
+    // clear none of them and fall through to an honest refusal.
+    let mut chosen: Option<Vec<Anchor>> = None;
+    for rung in [
+        match_by_title(&text, &audio),
+        match_by_chapter_number(&text, &audio),
+        match_by_title_prefix(&text, &audio),
+    ] {
+        let m = monotonic(rung);
+        if passes(&m) {
+            chosen = Some(m);
+            break;
+        }
     }
-
-    // Count after the monotonic filter so the modal's "X of Y matched"
-    // reflects the anchors the interpolation actually uses.
-    let anchors = monotonic(anchors);
-    if anchors.len() < MIN_ANCHORS
-        || (anchors.len() as f64) < MIN_MATCH_FRACTION * text.len() as f64
-    {
-        return Ok(None);
-    }
+    // Count alignment last: one-to-one lists pair positionally (the
+    // per-chapter MP3 folder, or two editions wording titles differently).
+    let anchors = match chosen {
+        Some(a) => a,
+        None if text.len() == audio.len() => {
+            let m = monotonic(
+                text.iter()
+                    .zip(audio.iter())
+                    .map(|(t, a)| Anchor {
+                        text_frac: t.frac,
+                        audio_frac: a.frac,
+                    })
+                    .collect(),
+            );
+            if !passes(&m) {
+                return Ok(None);
+            }
+            m
+        }
+        None => return Ok(None),
+    };
     Ok(Some(AnchorMap {
         matched: anchors.len() as i64,
         anchors,
         ebook_chapters: text.len() as i64,
     }))
+}
+
+/// Ordered pairing on parsed chapter numbers — the rung that survives
+/// subtitle decoration and numbering-style drift ("Chapter One: …" vs
+/// "Chapter 1").
+fn match_by_chapter_number(text: &[TextMark], audio: &[AudioMark]) -> Vec<Anchor> {
+    let mut anchors = Vec::new();
+    let mut ai = 0usize;
+    for t in text {
+        let Some(t_no) = t.chapter_no else { continue };
+        let mut j = ai;
+        while j < audio.len() {
+            let a = &audio[j];
+            if !a.synthetic && a.chapter_no == Some(t_no) {
+                anchors.push(Anchor {
+                    text_frac: t.frac,
+                    audio_frac: a.frac,
+                });
+                ai = j + 1;
+                break;
+            }
+            j += 1;
+        }
+    }
+    anchors
+}
+
+/// Minimum normalized-key length before a prefix counts as a match — one
+/// short word prefixing another title is coincidence, not correspondence.
+const MIN_PREFIX_CHARS: usize = 8;
+
+fn keys_prefix_match(a: &str, b: &str) -> bool {
+    let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    short.len() >= MIN_PREFIX_CHARS && long.starts_with(short)
+}
+
+/// Ordered pairing where one normalized title is a prefix of the other —
+/// the shape of a terse nav entry against a subtitle-decorated audio mark
+/// (or vice versa) when neither side carries a chapter number.
+fn match_by_title_prefix(text: &[TextMark], audio: &[AudioMark]) -> Vec<Anchor> {
+    let mut anchors = Vec::new();
+    let mut ai = 0usize;
+    for t in text {
+        let Some(t_key) = &t.key else { continue };
+        let mut j = ai;
+        while j < audio.len() {
+            let a = &audio[j];
+            if !a.synthetic
+                && a.key
+                    .as_ref()
+                    .is_some_and(|a_key| keys_prefix_match(a_key, t_key))
+            {
+                anchors.push(Anchor {
+                    text_frac: t.frac,
+                    audio_frac: a.frac,
+                });
+                ai = j + 1;
+                break;
+            }
+            j += 1;
+        }
+    }
+    anchors
+}
+
+/// How many usable (titled, non-synthetic) audio marks the timeline
+/// carries — lets the modal distinguish "no marks in the audio" from
+/// "marks exist but couldn't be aligned".
+pub(super) async fn usable_audio_marks(
+    pool: &SqlitePool,
+    timeline: &AudioTimeline,
+) -> Result<i64, CrossFormatError> {
+    Ok(audio_marks(pool, timeline)
+        .await?
+        .iter()
+        .filter(|a| !a.synthetic && a.key.is_some())
+        .count() as i64)
 }
 
 /// Audio anchor candidates across the timeline: real chapter marks carry
@@ -163,6 +334,7 @@ async fn audio_marks(
                     .unwrap_or(&part.filename);
                 marks.push(AudioMark {
                     key: title_key(stem),
+                    chapter_no: chapter_number(stem),
                     synthetic: false,
                     frac: ((file.start_seconds + start) / timeline.total_seconds).clamp(0.0, 1.0),
                 });
@@ -172,6 +344,7 @@ async fn audio_marks(
             for c in &chapters {
                 marks.push(AudioMark {
                     key: title_key(&c.title),
+                    chapter_no: chapter_number(&c.title),
                     synthetic: is_synthetic_title(&c.title),
                     frac: ((file.start_seconds + c.start_seconds) / timeline.total_seconds)
                         .clamp(0.0, 1.0),

--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -89,11 +89,25 @@ pub(super) fn chapter_number(raw: &str) -> Option<u32> {
             return None;
         }
     }
-    let token: &str = rest
+    // Unicode hyphen variants fold to ASCII so "twenty‑one" tokenizes as
+    // one composite word.
+    let cleaned = rest.replace(['\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}'], "-");
+    let mut tokens = cleaned
         .split(|c: char| !(c.is_alphanumeric() || c == '-'))
-        .next()
-        .filter(|t| !t.is_empty())?;
-    token.parse::<u32>().ok().or_else(|| word_number(token))
+        .filter(|t| !t.is_empty());
+    let first = tokens.next()?;
+    if let Ok(n) = first.parse::<u32>() {
+        return Some(n);
+    }
+    let value = word_number(first)?;
+    // A spaced composite ("Chapter Twenty One") spells its unit as the
+    // next token — prefer the combined value over the bare tens.
+    if value >= 20 && value % 10 == 0 {
+        if let Some(unit) = tokens.next().and_then(word_number).filter(|u| *u < 10) {
+            return Some(value + unit);
+        }
+    }
+    Some(value)
 }
 
 /// Spelled-out ordinal → number, through ninety-nine ("twenty-one").
@@ -259,11 +273,20 @@ fn match_by_chapter_number(text: &[TextMark], audio: &[AudioMark]) -> Vec<Anchor
 
 /// Minimum normalized-key length before a prefix counts as a match — one
 /// short word prefixing another title is coincidence, not correspondence.
+/// Multi-word keys qualify shorter ("Day One" ↔ "Day One: …"), since two
+/// words already carry structure a lone stem doesn't.
 const MIN_PREFIX_CHARS: usize = 8;
+const MIN_MULTIWORD_PREFIX_CHARS: usize = 5;
 
 fn keys_prefix_match(a: &str, b: &str) -> bool {
     let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
-    short.len() >= MIN_PREFIX_CHARS && long.starts_with(short)
+    let qualified = short.len() >= MIN_PREFIX_CHARS
+        || (short.contains(' ') && short.len() >= MIN_MULTIWORD_PREFIX_CHARS);
+    // The prefix must end on a word boundary in the longer key — "day one"
+    // must not pair with "day ones revenge".
+    qualified
+        && long.starts_with(short)
+        && (long.len() == short.len() || long.as_bytes().get(short.len()) == Some(&b' '))
 }
 
 /// Ordered pairing where one normalized title is a prefix of the other —

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1107,3 +1107,192 @@ fn audio_equivalence_floor_scales_down_for_short_books() {
     assert!((audio_equivalence_floor(60.0) - 1.2).abs() < 1e-9);
     assert_eq!(audio_equivalence_floor(0.0), 0.0);
 }
+
+#[test]
+fn chapter_number_parses_real_title_shapes_and_refuses_junk() {
+    use super::anchors::chapter_number;
+    assert_eq!(chapter_number("Chapter One: The Pigeon Drop"), Some(1));
+    assert_eq!(
+        chapter_number("Chapter One: The Pigeon Drop: In Which Saeldian Is Given an Offer"),
+        Some(1)
+    );
+    assert_eq!(chapter_number("Chapter 21 - The Long Road"), Some(21));
+    assert_eq!(chapter_number("chapter twenty-one"), Some(21));
+    assert_eq!(chapter_number("Chapter Ninety"), Some(90));
+    assert_eq!(chapter_number("03 - Chapter Three"), Some(3));
+    assert_eq!(chapter_number("Chapter1"), Some(1));
+    assert_eq!(chapter_number("Chapterhouse: Dune"), None);
+    assert_eq!(chapter_number("Part 1"), None);
+    assert_eq!(chapter_number("STORMLIGHT0501P01"), None);
+    assert_eq!(chapter_number("Prologue: To Live"), None);
+}
+
+#[tokio::test]
+async fn anchoring_pairs_subtitle_decorated_chapters_by_number_despite_front_matter() {
+    // The Feywild Job shape (#1894): audio marks carry full decorated
+    // titles, the nav is terser and front-matter-heavy — exact equality
+    // finds nothing, but the chapter-number rung pairs them.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0]).await;
+    seed_epub_chapters(
+        &pool,
+        &[
+            ("Cover", 0),
+            ("Title Page", 0),
+            ("Copyright", 0),
+            ("Contents", 0),
+            ("Chapter One: The Pigeon Drop", 0),
+            ("Chapter Two: A Better Liar", 40),
+            ("Chapter Three: Plan Faster", 80),
+            ("Chapter Four: The Feywild", 120),
+        ],
+        40,
+    )
+    .await;
+    seed_audio_chapters(
+        &pool,
+        audio[0],
+        &[
+            (
+                "Chapter One: The Pigeon Drop: In Which Saeldian Is Given an Offer",
+                0.0,
+            ),
+            (
+                "Chapter Two: A Better Liar than Anyone: In Which Kell Is Offered",
+                250.0,
+            ),
+            ("Chapter Three: Plan Faster: Wherein We Learn", 400.0),
+            ("Chapter Four: The Feywild: At Last", 520.0),
+        ],
+    )
+    .await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 25, 2_000))
+        .await
+        .unwrap();
+
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    let c = r.candidate.unwrap();
+    assert_eq!(
+        c.confidence,
+        omnibus_shared::cross_format::MappingConfidence::ChapterAnchored,
+        "the chapter-number rung must anchor the decorated-title shape"
+    );
+    // 25% of text = Chapter Three's start (80 of the 320 total chars —
+    // front-matter spine entries count) → ≈ 400s; linear would say 150s.
+    let secs = c.audio_position_seconds.unwrap();
+    assert!(
+        (395.0..=405.0).contains(&secs),
+        "expected the anchored map near 400s, got {secs}"
+    );
+}
+
+#[tokio::test]
+async fn anchoring_pairs_terse_nav_against_decorated_marks_by_prefix() {
+    // No chapter numbering at all — the prefix rung carries books whose
+    // marks decorate the nav's title with a subtitle.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0]).await;
+    seed_epub_chapters(
+        &pool,
+        &[
+            ("Once Long Ago", 0),
+            ("The Wishing Rock", 40),
+            ("Milkweed and Amulets", 80),
+            ("The Long Way Home", 120),
+        ],
+        40,
+    )
+    .await;
+    seed_audio_chapters(
+        &pool,
+        audio[0],
+        &[
+            ("Once Long Ago: A Prologue", 0.0),
+            ("The Wishing Rock: Where It Started", 250.0),
+            ("Milkweed and Amulets: A Bargain", 400.0),
+            ("The Long Way Home: An Ending", 520.0),
+        ],
+    )
+    .await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 25, 2_000))
+        .await
+        .unwrap();
+
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    let c = r.candidate.unwrap();
+    assert_eq!(
+        c.confidence,
+        omnibus_shared::cross_format::MappingConfidence::ChapterAnchored,
+        "the prefix rung must anchor subtitle-decorated titles"
+    );
+    let secs = c.audio_position_seconds.unwrap();
+    assert!(
+        (245.0..=255.0).contains(&secs),
+        "expected ≈250s, got {secs}"
+    );
+}
+
+#[tokio::test]
+async fn anchoring_still_refuses_junk_encoder_labels() {
+    // The Wind and Truth shape: rip-tool part labels are not titles; no
+    // rung may invent a match, and the modal learns marks exist anyway.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0]).await;
+    seed_epub_chapters(
+        &pool,
+        &[
+            ("Prologue: To Live", 0),
+            ("Day One", 30),
+            ("The Vow", 60),
+            ("Interlude", 90),
+            ("Day Two", 120),
+        ],
+        30,
+    )
+    .await;
+    seed_audio_chapters(
+        &pool,
+        audio[0],
+        &[
+            ("STORMLIGHT0501P01", 0.0),
+            ("STORMLIGHT0501P02", 200.0),
+            ("STORMLIGHT0501P03", 400.0),
+        ],
+    )
+    .await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 50, 2_000))
+        .await
+        .unwrap();
+
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    let c = r.candidate.unwrap();
+    assert_eq!(
+        c.confidence,
+        omnibus_shared::cross_format::MappingConfidence::Linear,
+        "junk labels must not anchor"
+    );
+
+    // The alignment view distinguishes "marks exist, couldn't align"
+    // (nonzero count, no match) from "no marks at all".
+    let view = alignment_view(&pool, user, &uuid).await.unwrap();
+    assert!(view.anchor_match.is_none());
+    assert_eq!(view.audio_chapter_marks, 3);
+}

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1118,6 +1118,10 @@ fn chapter_number_parses_real_title_shapes_and_refuses_junk() {
     );
     assert_eq!(chapter_number("Chapter 21 - The Long Road"), Some(21));
     assert_eq!(chapter_number("chapter twenty-one"), Some(21));
+    // Spaced and Unicode-hyphen composites must not truncate to the tens.
+    assert_eq!(chapter_number("Chapter Twenty One"), Some(21));
+    assert_eq!(chapter_number("chapter twenty\u{2011}one"), Some(21));
+    assert_eq!(chapter_number("Chapter Twenty: The Storm"), Some(20));
     assert_eq!(chapter_number("Chapter Ninety"), Some(90));
     assert_eq!(chapter_number("03 - Chapter Three"), Some(3));
     assert_eq!(chapter_number("Chapter1"), Some(1));

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -147,10 +147,16 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                         "\u{2713} {m.matched} of {m.ebook_chapters} chapters matched — "
                         "jumps land chapter-accurately."
                     }
+                } else if v.audio_chapter_marks > 0 {
+                    p { class: "al-lowconf", role: "note", "data-testid": "alignment-lowconf",
+                        "The audio's chapter marks couldn't be aligned with this ebook's "
+                        "contents — this mapping is a straight percent-for-percent estimate, "
+                        "so jumps land close, not exact."
+                    }
                 } else {
                     p { class: "al-lowconf", role: "note", "data-testid": "alignment-lowconf",
-                        "No chapter anchors yet — this mapping is a straight percent-for-percent "
-                        "estimate, so jumps land close, not exact."
+                        "No chapter marks in the audio — this mapping is a straight "
+                        "percent-for-percent estimate, so jumps land close, not exact."
                     }
                 }
             } else if error().is_none() {

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -142,7 +142,14 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                 if multi {
                     {render_choice(v.audio_files.clone(), mode, primary, order)}
                 }
-                if let Some(m) = v.anchor_match {
+                if v.link.as_ref().is_some_and(|l| l.stale) {
+                    // Anchoring (and the marks count) is suppressed while
+                    // stale — say so instead of misreading the zeros.
+                    p { class: "al-lowconf", role: "note", "data-testid": "alignment-lowconf",
+                        "The audio files changed since you linked — sync is paused, and "
+                        "the alignment re-checks when you confirm again."
+                    }
+                } else if let Some(m) = v.anchor_match {
                     p { class: "al-matched", role: "note", "data-testid": "alignment-match",
                         "\u{2713} {m.matched} of {m.ebook_chapters} chapters matched — "
                         "jumps land chapter-accurately."

--- a/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
@@ -237,8 +237,12 @@ struct AlignmentSheet: View {
                 Text("\u{2713} \(match.matched) of \(match.ebookChapters) chapters matched — jumps land chapter-accurately.")
                     .font(.ui(12))
                     .foregroundStyle(palette.ink2Color)
+            } else if (view.audioChapterMarks ?? 0) > 0 {
+                Text("The audio's chapter marks couldn't be aligned with this ebook — the mapping is a straight percent-for-percent estimate, so jumps land close, not exact.")
+                    .font(.ui(12))
+                    .foregroundStyle(palette.ink2Color)
             } else {
-                Text("No chapter anchors yet — the mapping is a straight percent-for-percent estimate, so jumps land close, not exact.")
+                Text("No chapter marks in the audio — the mapping is a straight percent-for-percent estimate, so jumps land close, not exact.")
                     .font(.ui(12))
                     .foregroundStyle(palette.ink2Color)
             }

--- a/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
@@ -233,7 +233,13 @@ struct AlignmentSheet: View {
 
     private func matchNote(_ view: AlignmentView) -> some View {
         Group {
-            if let match = view.anchorMatch {
+            if view.link?.stale == true {
+                // Anchoring (and the marks count) is suppressed while
+                // stale — say so instead of misreading the zeros.
+                Text("The audio files changed since you linked — sync is paused, and the alignment re-checks when you confirm again.")
+                    .font(.ui(12))
+                    .foregroundStyle(palette.ink2Color)
+            } else if let match = view.anchorMatch {
                 Text("\u{2713} \(match.matched) of \(match.ebookChapters) chapters matched — jumps land chapter-accurately.")
                     .font(.ui(12))
                     .foregroundStyle(palette.ink2Color)

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1577,6 +1577,9 @@ struct AlignmentView: Codable, Hashable, Sendable {
     var audioFiles: [AlignmentAudioFile]
     var reading: AlignmentPosition?
     var listening: AlignmentAudioPosition?
+    /// Usable audio chapter marks: with no anchor match, zero means "no
+    /// marks" and nonzero means "marks exist but couldn't be aligned".
+    var audioChapterMarks: Int64?
 
     enum CodingKeys: String, CodingKey {
         case link
@@ -1585,6 +1588,7 @@ struct AlignmentView: Codable, Hashable, Sendable {
         case audioFiles = "audio_files"
         case reading
         case listening
+        case audioChapterMarks = "audio_chapter_marks"
     }
 }
 

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -122,9 +122,11 @@ pub struct AlignmentView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub listening: Option<AlignmentAudioPosition>,
     /// Usable (titled, non-synthetic) audio chapter marks on the preview
-    /// timeline. With `anchor_match` absent, zero means "no marks in the
-    /// audio" and nonzero means "marks exist but couldn't be aligned" —
-    /// two different linear notices.
+    /// timeline. With `anchor_match` absent on a *non-stale* view, zero
+    /// means "no marks in the audio" and nonzero means "marks exist but
+    /// couldn't be aligned" — two different linear notices. On a stale
+    /// link the whole preview (this count included) is suppressed at 0;
+    /// check `link.stale` before interpreting it.
     #[serde(default)]
     pub audio_chapter_marks: i64,
 }

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -121,6 +121,12 @@ pub struct AlignmentView {
     pub reading: Option<AlignmentPosition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub listening: Option<AlignmentAudioPosition>,
+    /// Usable (titled, non-synthetic) audio chapter marks on the preview
+    /// timeline. With `anchor_match` absent, zero means "no marks in the
+    /// audio" and nonzero means "marks exist but couldn't be aligned" —
+    /// two different linear notices.
+    #[serde(default)]
+    pub audio_chapter_marks: i64,
 }
 
 /// How well the two chapter structures matched, for the modal's readout


### PR DESCRIPTION
## Summary
- Two new matching rungs between exact-equality and count-alignment: chapter-number pairing (`Chapter One: The Pigeon Drop: In Which…` ↔ `Chapter 1`, arabic or spelled ordinals through ninety-nine) and normalized-prefix containment (terse nav entries vs subtitle-decorated marks), tried most-exact-first with the same monotonic filter and refusal guards.
- The match bar now scores against the smaller mark list, so front-matter-padded navs (Cover/Copyright/Contents…) stop raising the threshold past what the audio side could ever supply.
- Junk encoder labels (`STORMLIGHT0501P01`) still clear no rung — refusal preserved and regression-tested.
- `AlignmentView` gains `audio_chapter_marks` so the modal (web + iOS) distinguishes "no chapter marks in the audio" from "marks exist but couldn't be aligned".

Closes #1894

## Test plan
- [x] `just test` full matrix green; new tests cover the Feywild decorated-title shape, the prefix shape, junk-label refusal, `chapter_number` parsing (incl. `Chapterhouse`/`Part 1`/`Prologue` refusals)
- [x] `just lint` clean
- [x] `just ios-build` + `just ios-test` green (262 cases)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release**