### PR TITLE
[OMNI-1892] Sync Points & Follow Mode — "Synced Here" Keeps Formats in Line

### DIFF
--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -13,7 +13,7 @@ works in production.
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
    number after the highest existing file (latest is
-   `0072_cross_format_links.sql`). The number is the version
+   `0073_cross_format_follow.sql`). The number is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere

--- a/db/migrations/0073_cross_format_follow.sql
+++ b/db/migrations/0073_cross_format_follow.sql
@@ -1,0 +1,8 @@
+-- Follow mode + user-declared sync points on the per-user link record.
+-- `follow` switches the link from offer-based prompts to resolve-at-read
+-- (every surface resumes at the freshest position across both formats).
+-- `user_anchors` stores "synced here" declarations as a JSON array of
+-- [ebook_fraction, audio_global_seconds] pairs; they outrank chapter
+-- anchors in the mapping and re-declaring nearby replaces the old pair.
+ALTER TABLE cross_format_links ADD COLUMN follow INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE cross_format_links ADD COLUMN user_anchors TEXT NOT NULL DEFAULT '[]';

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -194,9 +194,11 @@ pub async fn set_follow(
     book_uuid: &str,
     enabled: bool,
 ) -> Result<bool, CrossFormatError> {
-    let Some(book_uuid) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
-        return Ok(false);
-    };
+    // Unknown book is 404 territory; `Ok(false)` is reserved for a known
+    // book with no link to flip.
+    let book_uuid = resolve_canonical_book_uuid(pool, book_uuid)
+        .await?
+        .ok_or(CrossFormatError::BookNotFound)?;
     let result =
         sqlx::query("UPDATE cross_format_links SET follow = ? WHERE user_id = ? AND book_uuid = ?")
             .bind(enabled as i64)

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -26,6 +26,10 @@ pub enum CrossFormatError {
     BookNotFound,
     #[error("audio files changed since the alignment loaded")]
     AudioSetMismatch,
+    #[error("confirm the alignment first — this book has several audio files")]
+    LinkRequired,
+    #[error("the other format has no position to pair with yet")]
+    CounterpartMissing,
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
 }
@@ -76,6 +80,17 @@ pub struct CrossFormatLink {
     pub primary_book_file_id: Option<i64>,
     pub audio_snapshot: String,
     pub confirmed_at: i64,
+    /// Follow mode: resolve-at-read instead of offer-based prompts.
+    pub follow: bool,
+    /// "Synced here" declarations as `(ebook_fraction, audio_global
+    /// seconds)` pairs, sorted by fraction; they outrank chapter anchors.
+    pub user_anchors: Vec<(f64, f64)>,
+}
+
+fn parse_user_anchors(raw: &str) -> Vec<(f64, f64)> {
+    // A row this module didn't write (or a corrupt one) degrades to no
+    // user anchors rather than an error — mapping still works.
+    serde_json::from_str::<Vec<(f64, f64)>>(raw).unwrap_or_default()
 }
 
 fn mode_str(mode: CrossFormatLinkMode) -> &'static str {
@@ -113,6 +128,9 @@ pub async fn upsert_link(
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
     let snapshot = snapshot_json(&audio_files(pool, book_id).await?);
+    // Re-confirmation keeps the follow opt-in; user anchors survive only
+    // when the audio set is unchanged — a new set is a new timeline, and
+    // the stored global seconds no longer mean anything on it.
     sqlx::query(
         "INSERT INTO cross_format_links
             (user_id, book_uuid, mode, primary_book_file_id, audio_snapshot, confirmed_at)
@@ -120,6 +138,9 @@ pub async fn upsert_link(
          ON CONFLICT(user_id, book_uuid) DO UPDATE SET
             mode = excluded.mode,
             primary_book_file_id = excluded.primary_book_file_id,
+            user_anchors = CASE
+                WHEN cross_format_links.audio_snapshot = excluded.audio_snapshot
+                THEN cross_format_links.user_anchors ELSE '[]' END,
             audio_snapshot = excluded.audio_snapshot,
             confirmed_at = excluded.confirmed_at",
     )
@@ -144,8 +165,8 @@ pub async fn get_link(
     let Some(book_uuid) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
         return Ok(None);
     };
-    let row: Option<(String, Option<i64>, String, i64)> = sqlx::query_as(
-        "SELECT mode, primary_book_file_id, audio_snapshot, confirmed_at
+    let row: Option<(String, Option<i64>, String, i64, i64, String)> = sqlx::query_as(
+        "SELECT mode, primary_book_file_id, audio_snapshot, confirmed_at, follow, user_anchors
          FROM cross_format_links WHERE user_id = ? AND book_uuid = ?",
     )
     .bind(user_id)
@@ -153,13 +174,149 @@ pub async fn get_link(
     .fetch_optional(pool)
     .await?;
     Ok(row.map(
-        |(mode, primary_book_file_id, audio_snapshot, confirmed_at)| CrossFormatLink {
-            mode: parse_mode(&mode),
-            primary_book_file_id,
-            audio_snapshot,
-            confirmed_at,
+        |(mode, primary_book_file_id, audio_snapshot, confirmed_at, follow, user_anchors)| {
+            CrossFormatLink {
+                mode: parse_mode(&mode),
+                primary_book_file_id,
+                audio_snapshot,
+                confirmed_at,
+                follow: follow != 0,
+                user_anchors: parse_user_anchors(&user_anchors),
+            }
         },
     ))
+}
+
+/// Flip follow mode on an existing link. Returns whether a link existed.
+pub async fn set_follow(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+    enabled: bool,
+) -> Result<bool, CrossFormatError> {
+    let Some(book_uuid) = resolve_canonical_book_uuid(pool, book_uuid).await? else {
+        return Ok(false);
+    };
+    let result =
+        sqlx::query("UPDATE cross_format_links SET follow = ? WHERE user_id = ? AND book_uuid = ?")
+            .bind(enabled as i64)
+            .bind(user_id)
+            .bind(&book_uuid)
+            .execute(pool)
+            .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Text-fraction slack inside which a new "synced here" declaration
+/// replaces an existing pair instead of stacking beside it.
+const SYNC_POINT_REPLACE_SLACK: f64 = 0.02;
+
+/// Record a "synced here" declaration: pair the declaring surface's
+/// position with the counterpart format's stored row, store it as a user
+/// anchor, and turn follow mode on. A single-audio-file book with no link
+/// yet is auto-confirmed as a sequence link (unambiguous); a multi-file
+/// book must confirm the alignment first — the declaration never guesses
+/// an order.
+pub async fn declare_sync_point(
+    pool: &SqlitePool,
+    user_id: i64,
+    decl: &omnibus_shared::cross_format::DeclareSyncPoint,
+) -> Result<CrossFormatLink, CrossFormatError> {
+    let book_uuid = resolve_canonical_book_uuid(pool, &decl.book_uuid)
+        .await?
+        .ok_or(CrossFormatError::BookNotFound)?;
+    let book_id = resolve_book_id_by_uuid(pool, &book_uuid)
+        .await?
+        .ok_or(CrossFormatError::BookNotFound)?;
+
+    let link = match get_link(pool, user_id, &book_uuid).await? {
+        Some(link) => link,
+        None => {
+            if audio_files(pool, book_id).await?.len() != 1 {
+                return Err(CrossFormatError::LinkRequired);
+            }
+            upsert_link(
+                pool,
+                user_id,
+                &book_uuid,
+                CrossFormatLinkMode::Sequence,
+                None,
+            )
+            .await?
+        }
+    };
+    if link_is_stale(pool, book_id, &link).await? {
+        return Err(CrossFormatError::AudioSetMismatch);
+    }
+    let timeline = audio_timeline(pool, book_id, &link)
+        .await?
+        .ok_or(CrossFormatError::LinkRequired)?;
+
+    let (text_frac, audio_global) = match decl.format {
+        ProgressFormat::Epub => {
+            let frac = decl
+                .ebook_fraction
+                .filter(|f| (0.0..=1.0).contains(f))
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let row = progress::get_progress(pool, user_id, &book_uuid, ProgressFormat::Audio)
+                .await?
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let seconds = row
+                .audio_position_seconds
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let file_id = row
+                .book_file_id
+                .or_else(|| (timeline.files.len() == 1).then(|| timeline.files[0].book_file_id))
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let global = audio_fraction(&timeline, file_id, seconds)
+                .ok_or(CrossFormatError::CounterpartMissing)?
+                * timeline.total_seconds;
+            (frac, global)
+        }
+        ProgressFormat::Audio => {
+            let seconds = decl
+                .audio_seconds
+                .filter(|s| *s >= 0.0)
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let file_id = decl
+                .audio_book_file_id
+                .or_else(|| (timeline.files.len() == 1).then(|| timeline.files[0].book_file_id))
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let global = audio_fraction(&timeline, file_id, seconds)
+                .ok_or(CrossFormatError::CounterpartMissing)?
+                * timeline.total_seconds;
+            let row = progress::get_progress(pool, user_id, &book_uuid, ProgressFormat::Epub)
+                .await?
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            let frac = epub_source_fraction(pool, book_id, &row)
+                .await
+                .ok_or(CrossFormatError::CounterpartMissing)?;
+            (frac, global)
+        }
+    };
+
+    let mut anchors: Vec<(f64, f64)> = link
+        .user_anchors
+        .iter()
+        .copied()
+        .filter(|(t, _)| (t - text_frac).abs() >= SYNC_POINT_REPLACE_SLACK)
+        .collect();
+    anchors.push((text_frac, audio_global));
+    anchors.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let json = serde_json::to_string(&anchors).unwrap_or_else(|_| "[]".into());
+
+    sqlx::query(
+        "UPDATE cross_format_links SET user_anchors = ?, follow = 1
+         WHERE user_id = ? AND book_uuid = ?",
+    )
+    .bind(&json)
+    .bind(user_id)
+    .bind(&book_uuid)
+    .execute(pool)
+    .await?;
+    get_link(pool, user_id, &book_uuid)
+        .await?
+        .ok_or(CrossFormatError::BookNotFound)
 }
 
 /// Remove a link (sync off). Returns whether a row existed.
@@ -458,16 +615,33 @@ pub async fn resume_candidate(
 
     // The anchored tier engages when the served EPUB has extracted
     // structure and its chapters match the audio marks; otherwise every
-    // path below falls through to the linear tier.
-    let anchor_map = match crate::book_file_with_id(pool, book_id, "EPUB").await? {
+    // path below falls through to the linear tier. User-declared sync
+    // points outrank both — they seed the anchor set and chapter anchors
+    // survive only where they agree.
+    let chapter_map = match crate::book_file_with_id(pool, book_id, "EPUB").await? {
         Some((ebook_file_id, _)) => anchors::anchor_map(pool, ebook_file_id, &timeline).await?,
         None => None,
     };
-    let confidence = if anchor_map.is_some() {
+    let user_anchors: Vec<anchors::Anchor> = if timeline.total_seconds > 0.0 {
+        link.user_anchors
+            .iter()
+            .map(|(t, s)| anchors::Anchor {
+                text_frac: t.clamp(0.0, 1.0),
+                audio_frac: (s / timeline.total_seconds).clamp(0.0, 1.0),
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let confidence = if !user_anchors.is_empty() {
+        MappingConfidence::UserAnchored
+    } else if chapter_map.is_some() {
         MappingConfidence::ChapterAnchored
     } else {
         MappingConfidence::Linear
     };
+    let anchor_map = anchors::merge_user_anchors(&user_anchors, chapter_map);
+    let follow = link.follow;
     // The gate only engages against an existing target position — skip the
     // stats query entirely on first-open targets.
     let tol_frac = match &target_row {
@@ -571,12 +745,18 @@ pub async fn resume_candidate(
         Some(candidate) if aligned => CrossFormatResume {
             state: CrossFormatResumeState::Aligned,
             candidate: Some(candidate),
+            follow,
         },
         Some(candidate) => CrossFormatResume {
             state: CrossFormatResumeState::Candidate,
             candidate: Some(candidate),
+            follow,
         },
-        None => CrossFormatResume::empty(CrossFormatResumeState::NothingNewer),
+        None => CrossFormatResume {
+            state: CrossFormatResumeState::NothingNewer,
+            candidate: None,
+            follow,
+        },
     })
 }
 
@@ -643,6 +823,8 @@ pub async fn alignment_view(
                 primary_book_file_id: link.primary_book_file_id,
                 stale,
                 confirmed_at: link.confirmed_at,
+                follow: link.follow,
+                user_anchors: link.user_anchors.len() as i64,
             })
         }
         None => None,
@@ -659,6 +841,8 @@ pub async fn alignment_view(
             primary_book_file_id: None,
             audio_snapshot: String::new(),
             confirmed_at: 0,
+            follow: false,
+            user_anchors: Vec::new(),
         });
         match audio_timeline(pool, book_id, &preview).await? {
             Some(timeline) => {

--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -448,3 +448,37 @@ pub(super) fn interpolate(anchors: &[Anchor], frac: f64, text_to_audio: bool) ->
     }
     frac
 }
+
+/// Fold user-declared sync points into the anchor set. User pairs are
+/// ground truth: they seed the set, and chapter anchors survive only where
+/// they stay strictly monotonic between the user pairs on both axes.
+pub(super) fn merge_user_anchors(user: &[Anchor], chapter: Option<AnchorMap>) -> Option<AnchorMap> {
+    if user.is_empty() {
+        return chapter;
+    }
+    let mut merged: Vec<Anchor> = user.to_vec();
+    merged.sort_by(|a, b| a.text_frac.total_cmp(&b.text_frac));
+    let merged = monotonic(merged);
+    let (chapter_anchors, matched, ebook_chapters) = match &chapter {
+        Some(m) => (m.anchors.as_slice(), m.matched, m.ebook_chapters),
+        None => (&[][..], 0, 0),
+    };
+    let mut out: Vec<Anchor> = merged.clone();
+    for c in chapter_anchors {
+        // Strictly between its would-be neighbors on both axes, measured
+        // against the set built so far.
+        let pos = out.partition_point(|a| a.text_frac < c.text_frac);
+        let below_ok = pos == 0
+            || (out[pos - 1].text_frac < c.text_frac && out[pos - 1].audio_frac < c.audio_frac);
+        let above_ok = pos == out.len()
+            || (c.text_frac < out[pos].text_frac && c.audio_frac < out[pos].audio_frac);
+        if below_ok && above_ok {
+            out.insert(pos, *c);
+        }
+    }
+    Some(AnchorMap {
+        anchors: out,
+        matched,
+        ebook_chapters,
+    })
+}

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -2,6 +2,7 @@
 //! snapshot staleness, sequence/narrations timelines, percent ↔ seconds
 //! mapping with inverse consistency, and the resume-candidate state machine.
 
+use omnibus_shared::cross_format::DeclareSyncPoint;
 use omnibus_shared::ProgressUpdate;
 use sqlx::SqlitePool;
 
@@ -1299,4 +1300,188 @@ async fn anchoring_still_refuses_junk_encoder_labels() {
     let view = alignment_view(&pool, user, &uuid).await.unwrap();
     assert!(view.anchor_match.is_none());
     assert_eq!(view.audio_chapter_marks, 3);
+}
+
+fn declare_audio(uuid: &str, file_id: Option<i64>, seconds: f64) -> DeclareSyncPoint {
+    DeclareSyncPoint {
+        book_uuid: uuid.to_string(),
+        format: ProgressFormat::Audio,
+        ebook_fraction: None,
+        audio_book_file_id: file_id,
+        audio_seconds: Some(seconds),
+    }
+}
+
+#[tokio::test]
+async fn declare_sync_point_records_the_anchor_and_turns_follow_on() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    // Single audio file: the declaration may auto-confirm a sequence link.
+    let (_, uuid, _) = seed_dual_book(&pool, &[1_000.0]).await;
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 1_000))
+        .await
+        .unwrap();
+
+    let link = declare_sync_point(&pool, user, &declare_audio(&uuid, None, 500.0))
+        .await
+        .unwrap();
+    assert!(link.follow);
+    assert_eq!(link.user_anchors.len(), 1);
+    let (t, s) = link.user_anchors[0];
+    assert!((t - 0.40).abs() < 1e-9);
+    assert!((s - 500.0).abs() < 1e-9);
+
+    // The anchor bends the mapping: reading at 40% now maps to 500s
+    // (linear would say 400s), and the resume carries follow + the
+    // user-anchored confidence.
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 2_000))
+        .await
+        .unwrap();
+    let r = resume_candidate(&pool, user, &uuid, ProgressFormat::Audio)
+        .await
+        .unwrap();
+    assert!(r.follow);
+    let c = r.candidate.unwrap();
+    assert_eq!(
+        c.confidence,
+        omnibus_shared::cross_format::MappingConfidence::UserAnchored
+    );
+    let secs = c.audio_position_seconds.unwrap();
+    assert!(
+        (495.0..=505.0).contains(&secs),
+        "user anchor must pin 40% to ≈500s, got {secs}"
+    );
+
+    // Re-declaring nearby replaces the pair instead of stacking.
+    let link = declare_sync_point(&pool, user, &declare_audio(&uuid, None, 520.0))
+        .await
+        .unwrap();
+    assert_eq!(link.user_anchors.len(), 1);
+    assert!((link.user_anchors[0].1 - 520.0).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn declare_sync_point_refuses_what_it_cannot_pair() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0, 400.0]).await;
+
+    // Multi-file with no link: never guess an order.
+    let err = declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 100.0))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrossFormatError::LinkRequired));
+
+    // Linked, but the counterpart has no reading position to pair with.
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    let err = declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 100.0))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrossFormatError::CounterpartMissing));
+
+    // A stale audio set pauses declarations exactly like offers.
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 10, 1_000))
+        .await
+        .unwrap();
+    sqlx::query("UPDATE book_files SET mtime_epoch = 4242 WHERE id = ?")
+        .bind(audio[0])
+        .execute(&pool)
+        .await
+        .unwrap();
+    let err = declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 100.0))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrossFormatError::AudioSetMismatch));
+}
+
+#[tokio::test]
+async fn reconfirm_keeps_follow_and_clears_anchors_only_when_the_audio_set_changed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[1_000.0]).await;
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 1_000))
+        .await
+        .unwrap();
+    declare_sync_point(&pool, user, &declare_audio(&uuid, None, 500.0))
+        .await
+        .unwrap();
+
+    // Same audio set: re-confirming keeps follow and the anchors.
+    let link = upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    assert!(link.follow);
+    assert_eq!(link.user_anchors.len(), 1);
+
+    // Changed audio set: anchors' global seconds mean nothing on the new
+    // timeline — cleared; the follow opt-in survives.
+    sqlx::query("UPDATE book_files SET mtime_epoch = 777 WHERE id = ?")
+        .bind(audio[0])
+        .execute(&pool)
+        .await
+        .unwrap();
+    let link = upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    assert!(link.follow);
+    assert!(link.user_anchors.is_empty());
+}
+
+#[tokio::test]
+async fn set_follow_flips_only_existing_links() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, _) = seed_dual_book(&pool, &[600.0]).await;
+    assert!(!set_follow(&pool, user, &uuid, true).await.unwrap());
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    assert!(set_follow(&pool, user, &uuid, true).await.unwrap());
+    assert!(get_link(&pool, user, &uuid).await.unwrap().unwrap().follow);
+    assert!(set_follow(&pool, user, &uuid, false).await.unwrap());
+    assert!(!get_link(&pool, user, &uuid).await.unwrap().unwrap().follow);
+}
+
+#[test]
+fn merge_user_anchors_outranks_conflicting_chapter_anchors() {
+    use super::anchors::{merge_user_anchors, Anchor, AnchorMap};
+    let user = [Anchor {
+        text_frac: 0.5,
+        audio_frac: 0.7,
+    }];
+    let chapter = AnchorMap {
+        anchors: vec![
+            // Fits strictly before the user pair on both axes: kept.
+            Anchor {
+                text_frac: 0.2,
+                audio_frac: 0.3,
+            },
+            // Violates monotonicity against the user pair (audio side
+            // sits past it while text sits before): dropped.
+            Anchor {
+                text_frac: 0.4,
+                audio_frac: 0.8,
+            },
+            // Fits strictly after: kept.
+            Anchor {
+                text_frac: 0.9,
+                audio_frac: 0.95,
+            },
+        ],
+        matched: 3,
+        ebook_chapters: 10,
+    };
+    let merged = merge_user_anchors(&user, Some(chapter)).unwrap();
+    assert_eq!(
+        merged
+            .anchors
+            .iter()
+            .map(|a| (a.text_frac, a.audio_frac))
+            .collect::<Vec<_>>(),
+        vec![(0.2, 0.3), (0.5, 0.7), (0.9, 0.95)]
+    );
+    // No user anchors → chapter map passes through untouched.
+    assert!(merge_user_anchors(&[], None).is_none());
 }

--- a/db/src/epub_structure.rs
+++ b/db/src/epub_structure.rs
@@ -160,6 +160,27 @@ pub fn fraction_at(stats: &[SpineStatRow], spine_index: i64, offset_in_file: u64
     Some((at as f64 / total as f64).clamp(0.0, 1.0))
 }
 
+/// Inverse of [`fraction_at`]: the `(spine_index, offset_in_file)` whose
+/// visible character sits at `frac` of the whole book. `None` when the
+/// stats are empty or the book measured empty.
+pub fn position_at_fraction(stats: &[SpineStatRow], frac: f64) -> Option<(i64, u64)> {
+    let total: i64 = stats
+        .iter()
+        .fold(0i64, |acc, s| acc.saturating_add(s.visible_chars.max(0)));
+    if total <= 0 {
+        return None;
+    }
+    let at = ((frac.clamp(0.0, 1.0) * total as f64) as i64).clamp(0, total - 1);
+    let row = stats
+        .iter()
+        .filter(|s| s.visible_chars > 0 && s.chars_before.max(0) <= at)
+        .max_by_key(|s| s.chars_before)?;
+    Some((
+        row.spine_index,
+        (at - row.chars_before.max(0)).max(0) as u64,
+    ))
+}
+
 /// Whole-book visible-text percent for a position, from stored stats alone:
 /// floor semantics and clamping identical to `kobo_position`'s
 /// `book_percent`, so the two derivation paths cannot disagree. `None`

--- a/db/src/epub_structure/tests.rs
+++ b/db/src/epub_structure/tests.rs
@@ -280,3 +280,26 @@ fn percent_at_saturates_on_absurd_offsets_and_ignores_slice_order() {
     // A u64 offset beyond i64 saturates and clamps instead of overflowing.
     assert_eq!(percent_at(&stats, 1, u64::MAX), Some(100));
 }
+
+#[test]
+fn position_at_fraction_inverts_fraction_at() {
+    let stats = vec![
+        SpineStatRow {
+            spine_index: 0,
+            href: "c1.xhtml".into(),
+            visible_chars: 40,
+            chars_before: 0,
+        },
+        SpineStatRow {
+            spine_index: 1,
+            href: "c2.xhtml".into(),
+            visible_chars: 60,
+            chars_before: 40,
+        },
+    ];
+    assert_eq!(position_at_fraction(&stats, 0.0), Some((0, 0)));
+    assert_eq!(position_at_fraction(&stats, 0.73), Some((1, 33)));
+    // 1.0 clamps to the last visible char, never past the end.
+    assert_eq!(position_at_fraction(&stats, 1.0), Some((1, 59)));
+    assert_eq!(position_at_fraction(&[], 0.5), None);
+}

--- a/db/src/kobo_position/mod.rs
+++ b/db/src/kobo_position/mod.rs
@@ -280,6 +280,37 @@ pub fn cfi_to_span(
     })
 }
 
+/// Derive a KoboSpan location for a raw spine position — the follow-mode
+/// down-sync lane, where the position comes from an audio mapping (via
+/// spine stats) rather than a CFI. Same snippet-equality proof as
+/// [`cfi_to_span`]; every failure degrades to `None`, never a wrong span.
+pub fn span_at_spine_offset(
+    kepub: &Path,
+    source_epub: &Path,
+    spine_index: usize,
+    offset_in_file: u64,
+) -> anyhow::Result<Option<String>> {
+    let mut sdoc = book::open_doc(source_epub)?;
+    if spine_index >= sdoc.spine.len() {
+        return Ok(None);
+    }
+    let Some(href) = book::spine_href(&sdoc, spine_index) else {
+        return Ok(None);
+    };
+    let s_bytes = book::read_spine_entry(&mut sdoc, spine_index)?;
+    let s_index = walk::index_file(&s_bytes)?;
+    let count = s_index.visible_char_count();
+    if count == 0 {
+        return Ok(None);
+    }
+    let norm_offset = offset_in_file.min(count - 1);
+    let anchor = walk::Anchor {
+        norm_offset,
+        snippet: s_index.snippet_at(norm_offset),
+    };
+    derive_span_half(kepub, &href, &anchor)
+}
+
 /// The kepub half of [`cfi_to_span`]: find the span covering the source
 /// anchor and prove alignment by snippet at the same offset.
 fn derive_span_half(

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -732,8 +732,12 @@ async fn collapse_linked_points(
 /// routine (treated as no link by the caller).
 fn sqlx_of(e: crate::cross_format::CrossFormatError) -> ProgressError {
     match e {
-        crate::cross_format::CrossFormatError::BookNotFound => ProgressError::BookNotFound,
-        crate::cross_format::CrossFormatError::AudioSetMismatch => ProgressError::BookNotFound,
+        crate::cross_format::CrossFormatError::BookNotFound
+        | crate::cross_format::CrossFormatError::AudioSetMismatch
+        // Declaration-only refusals; the read paths this module calls
+        // never produce them, but fold them safely rather than panic.
+        | crate::cross_format::CrossFormatError::LinkRequired
+        | crate::cross_format::CrossFormatError::CounterpartMissing => ProgressError::BookNotFound,
         crate::cross_format::CrossFormatError::Sqlx(inner) => ProgressError::Sqlx(inner),
     }
 }

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -169,6 +169,9 @@
   function buildRelocateData(location) {
     var cfi = location && location.start ? location.start.cfi : undefined;
     var pct = location && location.start ? Math.round((location.start.percentage || 0) * 100) : 0;
+    // Full-precision twin of `pct` for the "synced here" declaration —
+    // an anchor pair is only as good as the fraction it records.
+    var frac = location && location.start ? (location.start.percentage || 0) : 0;
     // `displayed` is the visual column epub.js just rendered in the current
     // paginated flow — 1-indexed, and always exactly one away from the
     // previous relocate's page after a next()/prev() turn. This replaced a
@@ -188,6 +191,7 @@
       page: page,
       totalPages: totalPages,
       pct: pct,
+      frac: frac,
       // epub.js sets `atEnd` when the displayed range reaches the last page
       // of the last spine item — `pct` alone tops out below 100 because it
       // tracks the *start* of the visible range.

--- a/frontend/src/data/cross_format.rs
+++ b/frontend/src/data/cross_format.rs
@@ -60,3 +60,50 @@ pub async fn unlink_cross_format(_server_url: &str, _uuid: &str) -> Result<bool,
         "alignment is not available in the mobile shell".into(),
     ))
 }
+
+/// Declare a "synced here" sync point from the reader or player.
+#[cfg(not(feature = "mobile"))]
+pub async fn declare_sync_point(
+    _server_url: &str,
+    decl: omnibus_shared::cross_format::DeclareSyncPoint,
+) -> Result<(), DataError> {
+    crate::rpc::rpc_declare_sync_point(decl)
+        .await
+        .map_err(note_server_fn_err)
+}
+
+/// Flip follow mode on an existing link.
+#[cfg(not(feature = "mobile"))]
+pub async fn set_follow_mode(
+    _server_url: &str,
+    uuid: &str,
+    enabled: bool,
+) -> Result<(), DataError> {
+    crate::rpc::rpc_set_follow_mode(
+        uuid.to_string(),
+        omnibus_shared::cross_format::SetFollowMode { enabled },
+    )
+    .await
+    .map_err(note_server_fn_err)
+}
+
+#[cfg(feature = "mobile")]
+pub async fn declare_sync_point(
+    _server_url: &str,
+    _decl: omnibus_shared::cross_format::DeclareSyncPoint,
+) -> Result<(), DataError> {
+    Err(DataError::Other(
+        "alignment is not available in the mobile shell".into(),
+    ))
+}
+
+#[cfg(feature = "mobile")]
+pub async fn set_follow_mode(
+    _server_url: &str,
+    _uuid: &str,
+    _enabled: bool,
+) -> Result<(), DataError> {
+    Err(DataError::Other(
+        "alignment is not available in the mobile shell".into(),
+    ))
+}

--- a/frontend/src/pages/listen/controls.rs
+++ b/frontend/src/pages/listen/controls.rs
@@ -254,6 +254,7 @@ pub(super) fn Toolbar(state: ToolbarState) -> Element {
                 onclick: move |evt| on_chapters.call(evt),
                 "{ch_label}"
             }
+            super::sync_prompt::SyncHereButton {}
         }
     }
 }

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -197,13 +197,20 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
 pub(super) fn SyncHereButton() -> Element {
     let playback = crate::use_playback();
     let mut label = use_signal(|| "Synced here");
+    // Seeded online for SSR parity (rule 07); reconciled post-mount.
+    let mut online = use_signal(|| true);
+    use_effect(move || online.set(browser_online()));
     rsx! {
         button {
             class: "btn sm lp-toolbar-btn",
             r#type: "button",
             "data-testid": "listen-sync-here",
             title: "Declare the ebook and audiobook aligned at this spot",
+            disabled: !online(),
             onclick: move |_| {
+                if !browser_online() {
+                    return;
+                }
                 let Some(uuid) = (playback.uuid)() else { return };
                 let decl = omnibus_shared::cross_format::DeclareSyncPoint {
                     book_uuid: uuid,
@@ -222,5 +229,20 @@ pub(super) fn SyncHereButton() -> Element {
             },
             "{label}"
         }
+    }
+}
+
+/// Whether the browser reports connectivity — the "synced here" controls
+/// disable offline (rule 08). Always `true` off-web.
+pub(crate) fn browser_online() -> bool {
+    #[cfg(feature = "web")]
+    {
+        web_sys::window()
+            .map(|w| w.navigator().on_line())
+            .unwrap_or(true)
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        true
     }
 }

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -7,9 +7,7 @@
 
 use dioxus::prelude::*;
 use dioxus_router::Link;
-use omnibus_shared::cross_format::CrossFormatCandidate;
-#[cfg(feature = "web")]
-use omnibus_shared::cross_format::CrossFormatResumeState;
+use omnibus_shared::cross_format::{CrossFormatCandidate, CrossFormatResumeState};
 
 use crate::components::alignment_modal::fmt_hm;
 use crate::routes::Route;
@@ -49,11 +47,14 @@ pub(crate) fn store_dismissed_clock(uuid: &str, target: &str, clock: i64) {
     }
 }
 
-/// Fetch the mapped resume candidate for `(uuid, target)` — raw REST over
-/// the same-origin cookie session (the `fetch_manifest` pattern). Returns
-/// `None` for every non-candidate state and any transport failure: the
-/// prompt is best-effort chrome, never an error surface.
-pub(crate) async fn fetch_candidate(uuid: &str, target: &str) -> Option<CrossFormatCandidate> {
+/// Fetch the full cross-format resume for `(uuid, target)` — raw REST
+/// over the same-origin cookie session (the `fetch_manifest` pattern).
+/// `None` on any transport failure: the surfaces this feeds are
+/// best-effort chrome, never an error surface.
+pub(crate) async fn fetch_resume(
+    uuid: &str,
+    target: &str,
+) -> Option<omnibus_shared::cross_format::CrossFormatResume> {
     #[cfg(feature = "web")]
     {
         let url = format!("/api/books/{uuid}/cross-format-resume?target={target}");
@@ -61,11 +62,7 @@ pub(crate) async fn fetch_candidate(uuid: &str, target: &str) -> Option<CrossFor
         if resp.status() != 200 {
             return None;
         }
-        let resume: omnibus_shared::cross_format::CrossFormatResume = resp.json().await.ok()?;
-        if resume.state != CrossFormatResumeState::Candidate {
-            return None;
-        }
-        resume.candidate
+        resp.json().await.ok()
     }
     #[cfg(not(feature = "web"))]
     {
@@ -86,9 +83,35 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
     use_effect(move || {
         let uuid = fetch_uuid.clone();
         spawn(async move {
-            let Some(c) = fetch_candidate(&uuid, "audio").await else {
+            let Some(resume) = fetch_resume(&uuid, "audio").await else {
                 return;
             };
+            if resume.state != CrossFormatResumeState::Candidate {
+                return;
+            }
+            let Some(c) = resume.candidate else {
+                return;
+            };
+            if resume.follow {
+                // Follow mode: resolve-at-open. Apply the mapped position
+                // silently — same seek-vs-navigate file guard as an
+                // accepted offer, no card, no dismissal bookkeeping.
+                let seconds = c.audio_position_seconds.unwrap_or(0.0);
+                let loaded = (playback.file_id)();
+                let same_file = loaded == c.book_file_id
+                    || (loaded.is_none()
+                        && ((playback.duration)() - c.total_duration_seconds.unwrap_or(0.0)).abs()
+                            < 1.0);
+                if same_file {
+                    super::helpers::seek_to(seconds);
+                } else {
+                    dioxus_router::navigator().push(Route::BookListen {
+                        uuid: uuid.clone(),
+                        file_id: c.book_file_id,
+                    });
+                }
+                return;
+            }
             // Re-arm rule: an already-declined source position stays quiet
             // until the reading position advances past it.
             if dismissed_clock(&uuid, "audio")
@@ -163,6 +186,41 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
                 "data-testid": "sync-prompt-alignment",
                 "View alignment \u{2192}"
             }
+        }
+    }
+}
+
+/// "Synced here" toolbar control: declares the current listening position
+/// as a sync point and turns follow mode on. Configuration-shaped (rule
+/// 08): direct call, never queued, failure shown in place.
+#[component]
+pub(super) fn SyncHereButton() -> Element {
+    let playback = crate::use_playback();
+    let mut label = use_signal(|| "Synced here");
+    rsx! {
+        button {
+            class: "btn sm lp-toolbar-btn",
+            r#type: "button",
+            "data-testid": "listen-sync-here",
+            title: "Declare the ebook and audiobook aligned at this spot",
+            onclick: move |_| {
+                let Some(uuid) = (playback.uuid)() else { return };
+                let decl = omnibus_shared::cross_format::DeclareSyncPoint {
+                    book_uuid: uuid,
+                    format: omnibus_shared::ProgressFormat::Audio,
+                    ebook_fraction: None,
+                    audio_book_file_id: (playback.file_id)(),
+                    audio_seconds: Some((playback.elapsed)()),
+                };
+                spawn(async move {
+                    label.set("Syncing\u{2026}");
+                    match crate::data::declare_sync_point("", decl).await {
+                        Ok(()) => label.set("Synced \u{2713}"),
+                        Err(_) => label.set("Sync failed"),
+                    }
+                });
+            },
+            "{label}"
         }
     }
 }

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -157,6 +157,7 @@ pub fn BookReadPage(uuid: String) -> Element {
                 title_sub,
                 pct,
                 status: status(),
+                loc,
             },
             panels: ReaderPanelSignals {
                 show_aa,
@@ -452,6 +453,9 @@ pub(super) struct ReaderProgress {
     /// shown only by the phone breakpoint.
     pub title_sub: String,
     pub pct: u32,
+    /// The live relocation signal itself — the "synced here" pill reads
+    /// the full-precision fraction at click time.
+    pub loc: Signal<RelocateData>,
     pub status: ReaderStatus,
 }
 
@@ -506,6 +510,7 @@ fn ReaderLayout(
         title_sub,
         pct,
         status,
+        loc,
     } = progress;
     let ReaderNavHandlers {
         on_keydown,
@@ -569,6 +574,7 @@ fn ReaderLayout(
                 class: "rd-bottom",
                 "data-testid": "reader-footer",
                 span { class: "rd-bottom-page", style: "color:var(--ink-2);", "{page_str}" }
+                {sync_here_slot(&uuid, loc)}
                 div { style: "flex:1; text-align:center; letter-spacing:.08em;", "{chapter_str}" }
                 // The phone footer moves the chapter position to the right
                 // edge (the centred div above is hidden there) — rendered on
@@ -625,5 +631,19 @@ fn sync_banner_slot(uuid: &str) -> Element {
 
 #[cfg(feature = "mobile")]
 fn sync_banner_slot(_uuid: &str) -> Element {
+    rsx! {}
+}
+
+/// Web-only slot for the "synced here" footer pill (same split as
+/// [`sync_banner_slot`] — native iOS owns the gesture on mobile).
+#[cfg(not(feature = "mobile"))]
+fn sync_here_slot(uuid: &str, loc: Signal<RelocateData>) -> Element {
+    rsx! {
+        sync_banner::SyncHerePill { uuid: uuid.to_string(), loc }
+    }
+}
+
+#[cfg(feature = "mobile")]
+fn sync_here_slot(_uuid: &str, _loc: Signal<RelocateData>) -> Element {
     rsx! {}
 }

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -41,6 +41,12 @@ pub(crate) struct RelocateData {
     pub(crate) page: u32,
     pub(crate) total_pages: u32,
     pub(crate) pct: u32,
+    /// Full-precision twin of `pct` (0.0..=1.0) — the "synced here"
+    /// declaration records this, not the rounded display value. Read only
+    /// by the web pill; native iOS owns the gesture on mobile.
+    #[serde(default)]
+    #[cfg_attr(feature = "mobile", allow(dead_code))]
+    pub(crate) frac: f64,
     // True when the rendered range reaches the book's end (epub.js
     // `location.atEnd`) — the auto `Finished` trigger. `pct` can't stand in:
     // it tracks the start of the visible range, so it tops out below 100.
@@ -170,6 +176,7 @@ mod tests {
             page: 42,
             total_pages: 300,
             pct: 14,
+            frac: 0.14,
             at_end: false,
             chapter: 3,
             total_chapters: 24,
@@ -269,6 +276,7 @@ mod tests {
             page: 0,
             total_pages: 0,
             pct: 7,
+            frac: 0.07,
             at_end: false,
             chapter: 0,
             total_chapters: 0,

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -8,7 +8,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::cross_format::CrossFormatCandidate;
 
-use crate::pages::listen::sync_prompt::{dismissed_clock, fetch_candidate, store_dismissed_clock};
+use crate::pages::listen::sync_prompt::{dismissed_clock, store_dismissed_clock};
 
 /// The banner. Renders nothing until the post-mount fetch finds an
 /// undismissed candidate, so SSR and the first WASM paint agree.
@@ -21,9 +21,31 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     use_effect(move || {
         let uuid = fetch_uuid.clone();
         spawn(async move {
-            let Some(c) = fetch_candidate(&uuid, "epub").await else {
+            let Some(resume) = crate::pages::listen::sync_prompt::fetch_resume(&uuid, "epub").await
+            else {
                 return;
             };
+            if resume.state != omnibus_shared::cross_format::CrossFormatResumeState::Candidate {
+                return;
+            }
+            let Some(c) = resume.candidate else {
+                return;
+            };
+            if resume.follow {
+                // Follow mode: resolve-at-open — move the text to the
+                // mapped spot silently, full precision, no banner.
+                #[cfg(feature = "web")]
+                {
+                    let jump = c
+                        .fraction
+                        .map(|f| (f * 100.0).clamp(0.0, 100.0))
+                        .or(c.percent.map(|p| p as f64));
+                    if let Some(pct) = jump {
+                        super::reader_call("displayPercentage", &pct.to_string());
+                    }
+                }
+                return;
+            }
             if dismissed_clock(&uuid, "epub").is_some_and(|seen| c.source_client_updated_at <= seen)
             {
                 return;
@@ -87,6 +109,41 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
                 },
                 "Stay here"
             }
+        }
+    }
+}
+
+/// "Synced here" footer pill: declares the current reading position (full
+/// precision) as a sync point and turns follow mode on. Configuration-
+/// shaped (rule 08): direct call, never queued, failure shown in place.
+#[component]
+pub(super) fn SyncHerePill(uuid: String, loc: Signal<super::signals::RelocateData>) -> Element {
+    let mut label = use_signal(|| "Synced here");
+    rsx! {
+        button {
+            class: "btn ghost sm rd-sync-here",
+            r#type: "button",
+            "data-testid": "reader-sync-here",
+            title: "Declare the ebook and audiobook aligned at this spot",
+            onclick: move |_| {
+                let uuid = uuid.clone();
+                let frac = loc.peek().frac;
+                spawn(async move {
+                    label.set("Syncing\u{2026}");
+                    let decl = omnibus_shared::cross_format::DeclareSyncPoint {
+                        book_uuid: uuid,
+                        format: omnibus_shared::ProgressFormat::Epub,
+                        ebook_fraction: Some(frac.clamp(0.0, 1.0)),
+                        audio_book_file_id: None,
+                        audio_seconds: None,
+                    };
+                    match crate::data::declare_sync_point("", decl).await {
+                        Ok(()) => label.set("Synced \u{2713}"),
+                        Err(_) => label.set("Sync failed"),
+                    }
+                });
+            },
+            "{label}"
         }
     }
 }

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -119,13 +119,20 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
 #[component]
 pub(super) fn SyncHerePill(uuid: String, loc: Signal<super::signals::RelocateData>) -> Element {
     let mut label = use_signal(|| "Synced here");
+    // Seeded online for SSR parity (rule 07); reconciled post-mount.
+    let mut online = use_signal(|| true);
+    use_effect(move || online.set(crate::pages::listen::sync_prompt::browser_online()));
     rsx! {
         button {
             class: "btn ghost sm rd-sync-here",
             r#type: "button",
             "data-testid": "reader-sync-here",
             title: "Declare the ebook and audiobook aligned at this spot",
+            disabled: !online(),
             onclick: move |_| {
+                if !crate::pages::listen::sync_prompt::browser_online() {
+                    return;
+                }
                 let uuid = uuid.clone();
                 let frac = loc.peek().frac;
                 spawn(async move {

--- a/frontend/src/rpc/cross_format.rs
+++ b/frontend/src/rpc/cross_format.rs
@@ -1,9 +1,11 @@
-//! Cross-format sync link RPC: the alignment read the modal renders plus
-//! the confirm/unlink writes that turn sync on and off. All three are
-//! configuration-shaped (rule 08) — called directly, never queued.
+//! Cross-format sync link RPC: the alignment read the modal renders, the
+//! confirm/unlink writes that turn sync on and off, and the "synced here"
+//! declaration + follow toggle. All are configuration-shaped (rule 08) —
+//! called directly, never queued.
 
 use dioxus::fullstack::post;
 use dioxus::prelude::*;
+use omnibus_shared::cross_format::{DeclareSyncPoint, SetFollowMode};
 use omnibus_shared::{AlignmentView, ConfirmCrossFormatLink};
 
 #[cfg(feature = "server")]
@@ -12,22 +14,27 @@ use omnibus_db as db;
 #[cfg(feature = "server")]
 use super::{internal_rpc_error, AuthUser, PoolExt};
 
+/// One error mapping for every RPC in this module; the refusal variants
+/// carry user-renderable messages.
+#[cfg(feature = "server")]
+fn rpc_error(op: &'static str, e: db::cross_format::CrossFormatError) -> ServerFnError {
+    use db::cross_format::CrossFormatError as E;
+    match e {
+        E::BookNotFound => ServerFnError::new("book not found"),
+        e @ (E::AudioSetMismatch | E::LinkRequired | E::CounterpartMissing) => {
+            ServerFnError::new(e.to_string())
+        }
+        E::Sqlx(e) => internal_rpc_error(op, e),
+    }
+}
+
 /// Alignment payload for one book: link state + staleness, both lanes'
 /// raw material, and both current positions.
 #[post("/api/rpc/cross-format/alignment", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_get_alignment(uuid: String) -> Result<AlignmentView> {
-    match db::cross_format::alignment_view(&pool.0, user.id, &uuid).await {
-        Ok(view) => Ok(view),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            Err(ServerFnError::new("book not found").into())
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            Err(ServerFnError::new(e.to_string()).into())
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => {
-            Err(internal_rpc_error("get alignment", e).into())
-        }
-    }
+    db::cross_format::alignment_view(&pool.0, user.id, &uuid)
+        .await
+        .map_err(|e| rpc_error("get alignment", e).into())
 }
 
 /// Confirm (or re-confirm) the link, optionally persisting an audio
@@ -44,20 +51,20 @@ pub async fn rpc_confirm_cross_format_link(update: ConfirmCrossFormatLink) -> Re
                 ServerFnError::new("reordering audio files requires edit permission").into(),
             );
         }
-        match db::cross_format::set_audio_order(&pool.0, &update.book_uuid, order).await {
-            Ok(()) => {}
-            Err(db::cross_format::CrossFormatError::BookNotFound) => {
-                return Err(ServerFnError::new("book not found").into());
-            }
-            Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-                return Err(ServerFnError::new(format!("{e} — reopen and retry")).into());
-            }
-            Err(db::cross_format::CrossFormatError::Sqlx(e)) => {
-                return Err(internal_rpc_error("set audio order", e).into());
-            }
+        if let Err(e) = db::cross_format::set_audio_order(&pool.0, &update.book_uuid, order).await {
+            let msg = match &e {
+                db::cross_format::CrossFormatError::AudioSetMismatch => {
+                    Some(format!("{e} — reopen and retry"))
+                }
+                _ => None,
+            };
+            return Err(match msg {
+                Some(msg) => ServerFnError::new(msg).into(),
+                None => rpc_error("set audio order", e).into(),
+            });
         }
     }
-    match db::cross_format::upsert_link(
+    db::cross_format::upsert_link(
         &pool.0,
         user.id,
         &update.book_uuid,
@@ -65,33 +72,39 @@ pub async fn rpc_confirm_cross_format_link(update: ConfirmCrossFormatLink) -> Re
         update.primary_book_file_id,
     )
     .await
-    {
-        Ok(_) => Ok(()),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            Err(ServerFnError::new("book not found").into())
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            Err(ServerFnError::new(e.to_string()).into())
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => {
-            Err(internal_rpc_error("confirm cross-format link", e).into())
-        }
-    }
+    .map(|_| ())
+    .map_err(|e| rpc_error("confirm cross-format link", e).into())
 }
 
 /// Turn sync off for one book; returns whether a link existed.
 #[post("/api/rpc/cross-format/unlink", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_unlink_cross_format(uuid: String) -> Result<bool> {
-    match db::cross_format::delete_link(&pool.0, user.id, &uuid).await {
-        Ok(existed) => Ok(existed),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            Err(ServerFnError::new("book not found").into())
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            Err(ServerFnError::new(e.to_string()).into())
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => {
-            Err(internal_rpc_error("unlink cross-format", e).into())
-        }
+    db::cross_format::delete_link(&pool.0, user.id, &uuid)
+        .await
+        .map_err(|e| rpc_error("unlink cross-format", e).into())
+}
+
+/// A "synced here" declaration from the reader or the player: records a
+/// user anchor at the declaring surface's position and turns follow mode
+/// on. Refusals (no link on a multi-file book, stale audio set, no
+/// counterpart position) come back as renderable messages.
+#[post("/api/rpc/cross-format/sync-point", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_declare_sync_point(decl: DeclareSyncPoint) -> Result<()> {
+    if let Err(msg) = decl.validate() {
+        return Err(ServerFnError::new(msg).into());
+    }
+    db::cross_format::declare_sync_point(&pool.0, user.id, &decl)
+        .await
+        .map(|_| ())
+        .map_err(|e| rpc_error("declare sync point", e).into())
+}
+
+/// Flip follow mode on an existing link.
+#[post("/api/rpc/cross-format/follow", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_set_follow_mode(uuid: String, body: SetFollowMode) -> Result<()> {
+    match db::cross_format::set_follow(&pool.0, user.id, &uuid, body.enabled).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(ServerFnError::new("confirm the alignment first").into()),
+        Err(e) => Err(rpc_error("set follow mode", e).into()),
     }
 }

--- a/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
+++ b/omnibus-ios/omnibus/Features/Player/AudioPlayer.swift
@@ -382,12 +382,38 @@ final class AudioPlayer {
                       candidate: candidate.bookFileID
                   )
             else { return }
+            if resume.follow == true, let seconds = candidate.audioPositionSeconds {
+                // Follow mode: resolve-at-open — apply the mapped position
+                // silently, no banner, no dismissal bookkeeping.
+                await seek(to: seconds)
+                return
+            }
             let seen = await SyncPromptStore.dismissedClock(uuid: uuid, target: .audio)
             guard SyncPromptStore.shouldOffer(
                 sourceClock: candidate.sourceClientUpdatedAt,
                 dismissed: seen
             ) else { return }
             withAnimation(Motion.settle) { crossFormatOffer = candidate }
+        }
+    }
+
+    /// "Synced here": declare the current listening position as a sync
+    /// point (rule 08 — direct call, never queued; the control is disabled
+    /// offline). Returns whether the declaration was accepted.
+    func declareSyncPoint() async -> Bool {
+        guard let uuid = book?.uuid else { return false }
+        let decl = DeclareSyncPoint(
+            bookUUID: uuid,
+            format: .audio,
+            ebookFraction: nil,
+            audioBookFileID: fileID ?? book?.audioFiles.first?.id,
+            audioSeconds: position
+        )
+        do {
+            try await UserDataService.declareSyncPoint(decl)
+            return true
+        } catch {
+            return false
         }
     }
 

--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -22,6 +22,7 @@ struct PlayerView: View {
     @State private var showSleepTimer = false
     @State private var showSpeed = false
     @State private var showBookmarks = false
+    @State private var syncedHere = false
     @State private var showCarMode = false
 
     private static let rates: [Double] = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
@@ -404,6 +405,18 @@ struct PlayerView: View {
             }
             utilityCell("Bookmark") { addBookmark() } glyph: {
                 Image(systemName: "bookmark").font(.system(size: 22))
+            }
+            // "Synced here" (rule 08: direct call, disabled offline) —
+            // dual-format books only; others have nothing to pair with.
+            if book.hasEbook {
+                utilityCell(syncedHere ? "Synced ✓" : "Sync here") {
+                    guard Connectivity.shared.isOnline else { return }
+                    Task { syncedHere = await player.declareSyncPoint() }
+                } glyph: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 22))
+                }
+                .opacity(Connectivity.shared.isOnline ? 1 : 0.4)
             }
         }
     }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1449,6 +1449,7 @@ enum CrossFormatResumeState: String, Codable, Sendable {
 enum MappingConfidence: String, Codable, Sendable {
     case linear
     case chapterAnchored = "chapter_anchored"
+    case userAnchored = "user_anchored"
 }
 
 enum CrossFormatLinkMode: String, Codable, Sendable {
@@ -1489,6 +1490,8 @@ struct CrossFormatCandidate: Codable, Hashable, Sendable {
 struct CrossFormatResume: Codable, Hashable, Sendable {
     var state: CrossFormatResumeState
     var candidate: CrossFormatCandidate?
+    /// Follow mode: apply a candidate silently instead of offering.
+    var follow: Bool?
 }
 
 struct AlignmentLink: Codable, Hashable, Sendable {
@@ -1496,12 +1499,34 @@ struct AlignmentLink: Codable, Hashable, Sendable {
     var primaryBookFileID: Int64?
     var stale: Bool
     var confirmedAt: Int64
+    var follow: Bool?
+    var userAnchors: Int64?
 
     enum CodingKeys: String, CodingKey {
         case mode
         case primaryBookFileID = "primary_book_file_id"
         case stale
         case confirmedAt = "confirmed_at"
+        case follow
+        case userAnchors = "user_anchors"
+    }
+}
+
+/// Body of `POST /api/books/{uuid}/sync-point` — the declaring surface
+/// names its own position; the counterpart comes from the server's row.
+struct DeclareSyncPoint: Codable, Sendable {
+    var bookUUID: String
+    var format: ProgressFormat
+    var ebookFraction: Double?
+    var audioBookFileID: Int64?
+    var audioSeconds: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case bookUUID = "book_uuid"
+        case format
+        case ebookFraction = "ebook_fraction"
+        case audioBookFileID = "audio_book_file_id"
+        case audioSeconds = "audio_seconds"
     }
 }
 

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -48,6 +48,7 @@ struct ReaderView: View {
     /// Live position while the Contents row is being scrubbed, driving the
     /// chapter/page readout above it.
     @State private var scrubFraction: Double?
+    @State private var syncHereLabel = "Synced here"
     /// Flips the ribbon solid for a beat after saving a bookmark — the only
     /// confirmation that an instant, invisible action actually happened.
     @State private var justBookmarked = false
@@ -607,6 +608,38 @@ struct ReaderView: View {
             showSettings = true
         }
         .transition(.opacity.combined(with: .move(edge: .bottom)))
+
+        // "Synced here": declare the current spot as a cross-format sync
+        // point (rule 08 — direct call, disabled offline). Dual-format
+        // books only; others have nothing to pair with.
+        if book.hasAudiobook, book.hasEbook {
+            ReaderMenuRow(
+                title: syncHereLabel,
+                icon: "arrow.triangle.2.circlepath",
+                ink: barInk
+            ) {
+                guard Connectivity.shared.isOnline else { return }
+                let frac = controller.location?.fraction ?? 0
+                Task {
+                    syncHereLabel = "Syncing…"
+                    let decl = DeclareSyncPoint(
+                        bookUUID: book.uuid,
+                        format: .epub,
+                        ebookFraction: min(max(frac, 0.0), 1.0),
+                        audioBookFileID: nil,
+                        audioSeconds: nil
+                    )
+                    do {
+                        try await UserDataService.declareSyncPoint(decl)
+                        syncHereLabel = "Synced ✓"
+                    } catch {
+                        syncHereLabel = "Sync failed"
+                    }
+                }
+            }
+            .opacity(Connectivity.shared.isOnline ? 1 : 0.4)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
     }
 
     private var quickActions: some View {
@@ -755,6 +788,14 @@ struct ReaderView: View {
                     let candidate = resume.candidate,
                     candidate.percent != nil
                 else { return }
+                if resume.follow == true {
+                    // Follow mode: resolve-at-open — move the text to the
+                    // mapped spot silently, full precision, no banner.
+                    let frac = candidate.fraction
+                        ?? Double(candidate.percent ?? 0) / 100.0
+                    controller.seek(toFraction: min(max(frac, 0.0), 1.0))
+                    return
+                }
                 let seen = await SyncPromptStore.dismissedClock(uuid: book.uuid, target: .epub)
                 guard SyncPromptStore.shouldOffer(
                     sourceClock: candidate.sourceClientUpdatedAt,

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -833,4 +833,15 @@ extension UserDataService {
     static func unlinkCrossFormat(uuid: String) async throws {
         let _: Empty = try await APIClient.shared.delete("/api/books/\(uuid)/cross-format-link")
     }
+
+    /// A "synced here" declaration: records the declaring surface's own
+    /// position as a user anchor and turns follow mode on. Rule 08: a
+    /// deferred declaration would calibrate positions that no longer
+    /// correspond — direct call only, disabled offline at the control.
+    static func declareSyncPoint(_ decl: DeclareSyncPoint) async throws {
+        let _: Empty = try await APIClient.shared.post(
+            "/api/books/\(decl.bookUUID)/sync-point",
+            body: decl
+        )
+    }
 }

--- a/omnibus-ios/omnibusTests/CrossFormatTests.swift
+++ b/omnibus-ios/omnibusTests/CrossFormatTests.swift
@@ -40,6 +40,43 @@ struct CrossFormatCodecTests {
         #expect(c.fraction == 0.12752)
     }
 
+    @Test("follow mode and link anchors decode from the wire")
+    func followDecodes() throws {
+        let json = """
+        {"state":"candidate","follow":true,"candidate":{"target":"epub",
+         "source_format":"audio","source_client_updated_at":1,"confidence":"user_anchored",
+         "percent":40,"fraction":0.405}}
+        """
+        let resume = try JSONDecoder().decode(CrossFormatResume.self, from: Data(json.utf8))
+        #expect(resume.follow == true)
+        #expect(resume.candidate?.confidence == .userAnchored)
+
+        let linkJSON = """
+        {"mode":"sequence","stale":false,"confirmed_at":9,"follow":true,"user_anchors":2}
+        """
+        let link = try JSONDecoder().decode(AlignmentLink.self, from: Data(linkJSON.utf8))
+        #expect(link.follow == true)
+        #expect(link.userAnchors == 2)
+    }
+
+    @Test("sync point declaration encodes snake_case keys")
+    func declarationEncodes() throws {
+        let decl = DeclareSyncPoint(
+            bookUUID: "u-1",
+            format: .audio,
+            ebookFraction: nil,
+            audioBookFileID: 7,
+            audioSeconds: 123.5
+        )
+        let data = try JSONEncoder().encode(decl)
+        let obj = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(obj["book_uuid"] as? String == "u-1")
+        #expect(obj["audio_book_file_id"] as? Int == 7)
+        #expect(obj["audio_seconds"] as? Double == 123.5)
+    }
+
     @Test("candidate-less states decode without a candidate")
     func statesDecode() throws {
         for (raw, state) in [

--- a/server/src/backend/cross_format.rs
+++ b/server/src/backend/cross_format.rs
@@ -23,6 +23,20 @@ pub(super) struct ResumeQuery {
     target: ProgressFormat,
 }
 
+/// One error mapping for every handler in this module: 404 for an unknown
+/// book, 409 for declaration refusals the client can act on, 500 for the
+/// rest.
+fn error_response(op: &'static str, e: db::cross_format::CrossFormatError) -> Response {
+    use db::cross_format::CrossFormatError as E;
+    match e {
+        E::BookNotFound => (axum::http::StatusCode::NOT_FOUND, "book not found").into_response(),
+        e @ (E::AudioSetMismatch | E::LinkRequired | E::CounterpartMissing) => {
+            (axum::http::StatusCode::CONFLICT, e.to_string()).into_response()
+        }
+        E::Sqlx(e) => internal(op, e),
+    }
+}
+
 /// `GET /api/books/{uuid}/cross-format-resume?target=` — the mapped resume
 /// candidate plus the state that explains a missing one (`not_linked`,
 /// `link_stale`, `nothing_newer`). 404 only for a book the server has
@@ -35,13 +49,7 @@ pub(super) async fn get_cross_format_resume(
 ) -> Response {
     match db::cross_format::resume_candidate(&state.pool, user.id, &uuid, q.target).await {
         Ok(resume) => Json(resume).into_response(),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            (axum::http::StatusCode::CONFLICT, e.to_string()).into_response()
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => internal("cross_format_resume", e),
+        Err(e) => error_response("cross_format_resume", e),
     }
 }
 
@@ -54,13 +62,7 @@ pub(super) async fn get_alignment(
 ) -> Response {
     match db::cross_format::alignment_view(&state.pool, user.id, &uuid).await {
         Ok(view) => Json(view).into_response(),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            (axum::http::StatusCode::CONFLICT, e.to_string()).into_response()
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => internal("get_alignment", e),
+        Err(e) => error_response("get_alignment", e),
     }
 }
 
@@ -88,15 +90,7 @@ pub(super) async fn post_cross_format_link(
         }
         match db::cross_format::set_audio_order(&state.pool, &update.book_uuid, order).await {
             Ok(()) => {}
-            Err(db::cross_format::CrossFormatError::BookNotFound) => {
-                return (axum::http::StatusCode::NOT_FOUND, "book not found").into_response();
-            }
-            Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-                return (axum::http::StatusCode::CONFLICT, e.to_string()).into_response();
-            }
-            Err(db::cross_format::CrossFormatError::Sqlx(e)) => {
-                return internal("set_audio_order", e);
-            }
+            Err(e) => return error_response("set_audio_order", e),
         }
     }
     match db::cross_format::upsert_link(
@@ -109,13 +103,7 @@ pub(super) async fn post_cross_format_link(
     .await
     {
         Ok(_) => axum::http::StatusCode::NO_CONTENT.into_response(),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            (axum::http::StatusCode::CONFLICT, e.to_string()).into_response()
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => internal("confirm_cross_format", e),
+        Err(e) => error_response("confirm_cross_format", e),
     }
 }
 
@@ -129,12 +117,47 @@ pub(super) async fn delete_cross_format_link(
 ) -> Response {
     match db::cross_format::delete_link(&state.pool, user.id, &uuid).await {
         Ok(_) => axum::http::StatusCode::NO_CONTENT.into_response(),
-        Err(db::cross_format::CrossFormatError::BookNotFound) => {
-            (axum::http::StatusCode::NOT_FOUND, "book not found").into_response()
-        }
-        Err(e @ db::cross_format::CrossFormatError::AudioSetMismatch) => {
-            (axum::http::StatusCode::CONFLICT, e.to_string()).into_response()
-        }
-        Err(db::cross_format::CrossFormatError::Sqlx(e)) => internal("unlink_cross_format", e),
+        Err(e) => error_response("unlink_cross_format", e),
+    }
+}
+
+/// `POST /api/books/{uuid}/sync-point` — a "synced here" declaration: the
+/// path uuid is authoritative; the body names the declaring surface's own
+/// position and the counterpart comes from its stored row. Turns follow
+/// mode on. 409 when the alignment must be confirmed first (multi-file,
+/// no link), when the audio set went stale, or when the counterpart has
+/// no position to pair with.
+pub(super) async fn post_sync_point(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(uuid): Path<String>,
+    Json(mut decl): Json<omnibus_shared::cross_format::DeclareSyncPoint>,
+) -> Response {
+    decl.book_uuid = uuid;
+    if let Err(msg) = decl.validate() {
+        return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
+    }
+    match db::cross_format::declare_sync_point(&state.pool, user.id, &decl).await {
+        Ok(_) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Err(e) => error_response("declare_sync_point", e),
+    }
+}
+
+/// `POST /api/books/{uuid}/cross-format-follow` — flip follow mode on an
+/// existing link. 409 when no link exists to flip.
+pub(super) async fn post_cross_format_follow(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(uuid): Path<String>,
+    Json(body): Json<omnibus_shared::cross_format::SetFollowMode>,
+) -> Response {
+    match db::cross_format::set_follow(&state.pool, user.id, &uuid, body.enabled).await {
+        Ok(true) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => (
+            axum::http::StatusCode::CONFLICT,
+            "confirm the alignment first",
+        )
+            .into_response(),
+        Err(e) => error_response("set_follow", e),
     }
 }

--- a/server/src/backend/cross_format/tests.rs
+++ b/server/src/backend/cross_format/tests.rs
@@ -247,3 +247,139 @@ async fn api_cross_format_link_gates_reorder_on_edit_permission() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::FORBIDDEN);
 }
+
+/// Bearer-authed JSON POST, shared by the declaration/follow tests.
+fn post_json_with_bearer(
+    uri: &str,
+    token: &str,
+    body: &serde_json::Value,
+) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .uri(uri)
+        .method("POST")
+        .header("content-type", "application/json")
+        .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn api_sync_point_declares_and_conflicts_map_to_409() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (book_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Dual").await;
+    attach_audio(&pool, book_id).await;
+    db::progress::upsert_progress(
+        &pool,
+        user.id,
+        &ProgressUpdate {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Epub,
+            epub_cfi: None,
+            audio_position_seconds: None,
+            progress_percent: Some(40),
+            kobo_location: None,
+            book_file_id: None,
+            client_updated_at: Some(1_000),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Happy path: single-file book auto-links, records the anchor, and
+    // the follow flag reaches the resume payload.
+    let body = serde_json::json!({
+        "book_uuid": "ignored",
+        "format": "audio",
+        "audio_seconds": 300.0,
+    });
+    let res = app
+        .clone()
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/sync-point"),
+            &token,
+            &body,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/api/books/{uuid}/cross-format-resume?target=audio"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let resume = body_json(res).await;
+    assert!(resume.follow);
+
+    // A declaration with no counterpart position → 409 with a renderable
+    // message (fresh user, no reading row).
+    let bob = auth_test_support::create_user(&pool, "bob").await;
+    let bob_token = auth_test_support::bearer_token(&pool, bob.id).await;
+    let res = app
+        .clone()
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/sync-point"),
+            &bob_token,
+            &body,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+
+    // Malformed declaration (audio without seconds) → 422.
+    let res = app
+        .clone()
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/sync-point"),
+            &token,
+            &serde_json::json!({"book_uuid": "x", "format": "audio"}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn api_cross_format_follow_flips_and_conflicts_without_a_link() {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (book_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Dual").await;
+    attach_audio(&pool, book_id).await;
+
+    let res = app
+        .clone()
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/cross-format-follow"),
+            &token,
+            &serde_json::json!({"enabled": true}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+
+    db::cross_format::upsert_link(&pool, user.id, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    let res = app
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/cross-format-follow"),
+            &token,
+            &serde_json::json!({"enabled": true}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    assert!(
+        db::cross_format::get_link(&pool, user.id, &uuid)
+            .await
+            .unwrap()
+            .unwrap()
+            .follow
+    );
+}

--- a/server/src/backend/kobo/sync.rs
+++ b/server/src/backend/kobo/sync.rs
@@ -158,6 +158,37 @@ async fn enrich_states_with_derived_spans(
         let Some(s) = states.get(&book.uuid) else {
             continue;
         };
+        // Follow-mode lane: when the audiobook holds the freshest position
+        // on a follow link, serve the mapped spot instead of the reader's
+        // older CFI. Response-only — the progress row keeps its real
+        // provenance; the device's own PUT makes the position real once
+        // the reader picks it up there.
+        if let Ok(resume) = db::cross_format::resume_candidate(
+            state.pool(),
+            user_id,
+            &book.uuid,
+            omnibus_shared::ProgressFormat::Epub,
+        )
+        .await
+        {
+            if resume.follow
+                && resume.state == omnibus_shared::cross_format::CrossFormatResumeState::Candidate
+            {
+                if let Some(c) = &resume.candidate {
+                    if let Some(frac) = c.fraction {
+                        budget -= 1;
+                        let loc = derive_span_for_fraction(state, book.id, &book.uuid, frac).await;
+                        if let Some(s) = states.get_mut(&book.uuid) {
+                            if let Some(loc) = loc {
+                                s.kobo_location = Some(loc);
+                            }
+                            s.percent = c.percent.or(s.percent);
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
         let Some(cfi) = (s.kobo_location.is_none())
             .then(|| s.epub_cfi.clone())
             .flatten()
@@ -188,6 +219,47 @@ async fn enrich_states_with_derived_spans(
             // empty bookmark. Not persisted — the row keeps meaning "no
             // span known" so a later sync retries the full derivation.
             s.percent = s.percent.or(derived.percent);
+        }
+    }
+}
+
+/// Best-effort fraction→KoboSpan derivation for the follow-mode lane:
+/// spine stats invert the fraction to a `(spine, offset)` position, and
+/// the kepub walk proves alignment before emitting a span. `None` serves
+/// percent-only — truthful, just less precise — and queues the kepub
+/// conversion for a later sync, mirroring [`derive_span_for_cfi`].
+async fn derive_span_for_fraction(
+    state: &AppState,
+    book_id: i64,
+    uuid: &str,
+    frac: f64,
+) -> Option<String> {
+    let (file_id, source) = db::book_file_with_id(state.pool(), book_id, "EPUB")
+        .await
+        .ok()??;
+    let stats = db::epub_structure::get_spine_stats(state.pool(), file_id)
+        .await
+        .ok()?;
+    let (spine_index, offset) = db::epub_structure::position_at_fraction(&stats, frac)?;
+    let kepub = db::kepub_path(book_id);
+    if !tokio::fs::try_exists(&kepub).await.unwrap_or(false) {
+        state.worker().post(Task::KepubConvert { book_id });
+        return None;
+    }
+    let uuid = uuid.to_owned();
+    let result = tokio::task::spawn_blocking(move || {
+        db::kobo_position::span_at_spine_offset(&kepub, &source, spine_index as usize, offset)
+    })
+    .await;
+    match result {
+        Ok(Ok(loc)) => loc,
+        Ok(Err(e)) => {
+            tracing::warn!(%uuid, error = %e, "kobo fraction→span derivation failed");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(%uuid, error = %e, "kobo fraction→span task panicked");
+            None
         }
     }
 }

--- a/server/src/backend/routes.rs
+++ b/server/src/backend/routes.rs
@@ -177,6 +177,14 @@ fn progress_routes() -> Router<AppState> {
             post(cross_format::post_cross_format_link)
                 .delete(cross_format::delete_cross_format_link),
         )
+        .route(
+            "/api/books/{uuid}/sync-point",
+            post(cross_format::post_sync_point),
+        )
+        .route(
+            "/api/books/{uuid}/cross-format-follow",
+            post(cross_format::post_cross_format_follow),
+        )
 }
 
 /// F2.4b highlight annotations — mobile-facing REST. Web hits the analogous

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -27,6 +27,9 @@ pub enum MappingConfidence {
     Linear,
     /// Piecewise interpolation through matched chapter anchors.
     ChapterAnchored,
+    /// At least one user-declared sync point backs the interpolation —
+    /// ground truth that outranks chapter matching.
+    UserAnchored,
 }
 
 /// Why (or whether) the endpoint has a candidate to offer.
@@ -55,6 +58,10 @@ pub struct CrossFormatResume {
     pub state: CrossFormatResumeState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate: Option<CrossFormatCandidate>,
+    /// Follow mode on the link: a `Candidate` should be applied silently
+    /// (resolve-at-read) instead of offered as a prompt.
+    #[serde(default)]
+    pub follow: bool,
 }
 
 impl CrossFormatResume {
@@ -63,6 +70,7 @@ impl CrossFormatResume {
         Self {
             state,
             candidate: None,
+            follow: false,
         }
     }
 }
@@ -149,6 +157,13 @@ pub struct AlignmentLink {
     pub primary_book_file_id: Option<i64>,
     pub stale: bool,
     pub confirmed_at: i64,
+    /// Follow mode: surfaces resolve the freshest position across both
+    /// formats instead of offering prompts.
+    #[serde(default)]
+    pub follow: bool,
+    /// How many "synced here" declarations back the mapping.
+    #[serde(default)]
+    pub user_anchors: i64,
 }
 
 /// Text-side lane: total visible chars plus chapter tick positions.
@@ -206,6 +221,49 @@ pub struct ConfirmCrossFormatLink {
     pub primary_book_file_id: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_order: Option<Vec<i64>>,
+}
+
+/// One "synced here" declaration: the declaring surface names its own
+/// position; the counterpart half of the anchor pair comes from the
+/// server's stored row for the other format at declaration time.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeclareSyncPoint {
+    pub book_uuid: String,
+    /// The surface making the declaration.
+    pub format: ProgressFormat,
+    /// Reading surface: whole-book fraction (`0.0..=1.0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ebook_fraction: Option<f64>,
+    /// Listening surface: the playing file and seconds within it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio_book_file_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio_seconds: Option<f64>,
+}
+
+impl DeclareSyncPoint {
+    /// Boundary validation: the declaring surface must name its own
+    /// position in its own coordinates.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.format {
+            ProgressFormat::Epub => match self.ebook_fraction {
+                Some(f) if (0.0..=1.0).contains(&f) => Ok(()),
+                Some(_) => Err("ebook_fraction must be within 0..=1".into()),
+                None => Err("a reading declaration needs ebook_fraction".into()),
+            },
+            ProgressFormat::Audio => match self.audio_seconds {
+                Some(s) if s >= 0.0 => Ok(()),
+                Some(_) => Err("audio_seconds must be non-negative".into()),
+                None => Err("a listening declaration needs audio_seconds".into()),
+            },
+        }
+    }
+}
+
+/// Body of `POST /api/books/{uuid}/cross-format-follow`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SetFollowMode {
+    pub enabled: bool,
 }
 
 impl ConfirmCrossFormatLink {

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "../fixtures/dual_format";
 import { FIXTURE_BOOKS } from "../fixtures/epubs";
 import { expect, test } from "../fixtures/test";
+import { expectMutation } from "../utils/api";
 import { gotoReady } from "../utils/nav";
 import {
   audiobookFixturesDir,
@@ -210,4 +211,34 @@ test("the hero shows one synced card with the counterpart affordance", async ({
   await expect(cards).toHaveCount(1);
   await expect(cards).toContainText("synced");
   await expect(page.getByTestId(`hero-crossformat-${uuid}`)).toBeVisible();
+});
+
+test("declaring a sync point turns on follow and the reader auto-applies", async ({
+  page,
+  request,
+}) => {
+  // Fresh positions: reading behind, listening ahead — then declare from
+  // the player so follow mode engages.
+  await writeEpubPercent(request, 85);
+  await writeAudioSeconds(request, 1);
+
+  await gotoReady(page, `/listen/${uuid}`);
+  await expectMutation(
+    page,
+    {
+      method: "POST",
+      url: `/api/rpc/cross-format/sync-point`,
+      expectedStatus: 200,
+    },
+    async () => page.getByTestId("listen-sync-here").click(),
+  );
+  await expect(page.getByTestId("listen-sync-here")).toContainText("Synced");
+
+  // Listening advances past the declared pair; the reader then opens at
+  // the mapped spot silently — no banner, and the relocation writes the
+  // followed position into the epub row.
+  await writeAudioSeconds(request, 2);
+  await gotoReady(page, `/read/${uuid}`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByTestId("sync-banner")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- Migration `0073`: `cross_format_links` gains `follow` + `user_anchors`; re-confirm keeps the follow opt-in and clears anchors only when the audio set changed.
- `declare_sync_point` pairs the declaring surface's position with the counterpart's stored row (single-file books auto-link; multi-file unlinked, stale sets, and missing counterparts refuse with renderable 409s); nearby re-declarations replace their pair; user anchors outrank chapter anchors in the interpolation (`UserAnchored` confidence).
- Resolve-at-read everywhere: `CrossFormatResume.follow` makes web reader/player and iOS reader/player apply a candidate silently (no prompts, no dismissal bookkeeping); Kobo sync serves the mapped fraction as an exact KoboSpan (response-only — no derived positions are ever stored) when audio is freshest on a follow link.
- "Synced here" gestures: web reader footer pill (full-precision `frac` now on the relocation payload) + listen toolbar button; iOS reader menu row + player utility cell, both disabled offline (rule 08 — direct-only, never queued).
- New endpoints: `POST /api/books/{uuid}/sync-point`, `POST /api/books/{uuid}/cross-format-follow`, plus matching RPCs.

Closes #1892

## Test plan
- [x] `just test` full matrix green (2087 / 823 / 735 / 669 / 298) — declaration + refusals, anchor merge precedence, re-confirm semantics, `position_at_fraction`, REST 204/409/422
- [x] E2E: 8/8 cross-format specs against a live dev server, incl. new declare → follow → reader-auto-apply flow
- [x] `just lint` clean; `just ios-build` + `just ios-test` green (264 cases, new decode/encode tests)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release**