### PR TITLE
[OMNI-1893] Bring the Sync Surfaces Up to the Format Sync Design

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -692,6 +692,7 @@ pub async fn resume_candidate(
                             total_duration_seconds: Some(timeline.total_seconds),
                             percent: None,
                             fraction: None,
+                            source_position_seconds: None,
                             source_ahead: current_global.map(|cur| mapped_global > cur),
                         };
                         (Some(candidate), aligned)
@@ -732,6 +733,7 @@ pub async fn resume_candidate(
                         total_duration_seconds: None,
                         percent: Some(pct),
                         fraction: Some(frac.clamp(0.0, 1.0)),
+                        source_position_seconds: Some(raw_frac * timeline.total_seconds),
                         source_ahead: current.map(|cur| frac > cur),
                     };
                     (Some(candidate), aligned)
@@ -835,6 +837,7 @@ pub async fn alignment_view(
     // sequence declaration so the modal can honestly say whether anchoring
     // would engage; a stale link stays quiet (mapping is paused anyway).
     let mut audio_chapter_marks = 0i64;
+    let mut anchor_pairs: Vec<(f64, f64)> = Vec::new();
     let anchor_match = if link.as_ref().is_some_and(|l| l.stale) {
         None
     } else {
@@ -850,13 +853,39 @@ pub async fn alignment_view(
             Some(timeline) => {
                 audio_chapter_marks = anchors::usable_audio_marks(pool, &timeline).await?;
                 match crate::book_file_with_id(pool, book_id, "EPUB").await? {
-                    Some((ebook_file_id, _)) => anchors::anchor_map(pool, ebook_file_id, &timeline)
-                        .await?
-                        .map(|m| AlignmentMatch {
-                            matched: m.matched,
-                            ebook_chapters: m.ebook_chapters,
+                    Some((ebook_file_id, _)) => {
+                        // User anchors fold in exactly as the jump path
+                        // does, so the preview's threads and interpolation
+                        // are the pairs the mapping will really use.
+                        let chapter_map =
+                            anchors::anchor_map(pool, ebook_file_id, &timeline).await?;
+                        let user: Vec<anchors::Anchor> = raw_link
+                            .as_ref()
+                            .filter(|_| timeline.total_seconds > 0.0)
+                            .map(|l| {
+                                l.user_anchors
+                                    .iter()
+                                    .map(|(t, s)| anchors::Anchor {
+                                        text_frac: t.clamp(0.0, 1.0),
+                                        audio_frac: (s / timeline.total_seconds).clamp(0.0, 1.0),
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        let stats = chapter_map.as_ref().map(|m| (m.matched, m.ebook_chapters));
+                        if let Some(merged) = anchors::merge_user_anchors(&user, chapter_map) {
+                            anchor_pairs = merged
+                                .anchors
+                                .iter()
+                                .map(|a| (a.text_frac, a.audio_frac))
+                                .collect();
+                        }
+                        stats.map(|(matched, ebook_chapters)| AlignmentMatch {
+                            matched,
+                            ebook_chapters,
                             confidence: MappingConfidence::ChapterAnchored,
-                        }),
+                        })
+                    }
                     None => None,
                 }
             }
@@ -931,6 +960,7 @@ pub async fn alignment_view(
         audio_files: audio,
         reading,
         listening,
+        anchor_pairs,
         audio_chapter_marks,
     })
 }

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1485,3 +1485,66 @@ fn merge_user_anchors_outranks_conflicting_chapter_anchors() {
     // No user anchors → chapter map passes through untouched.
     assert!(merge_user_anchors(&[], None).is_none());
 }
+
+#[tokio::test]
+async fn alignment_view_serves_the_anchor_pairs_the_jump_uses() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0]).await;
+    seed_epub_chapters(&pool, &[("Alpha", 0), ("Bravo", 40), ("Charlie", 80)], 40).await;
+    seed_audio_chapters(
+        &pool,
+        audio[0],
+        &[("Alpha", 0.0), ("Bravo", 300.0), ("Charlie", 480.0)],
+    )
+    .await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+
+    // Chapter-anchored: the modal preview interpolates through exactly
+    // these pairs — the mapping the jump runs.
+    let view = alignment_view(&pool, user, &uuid).await.unwrap();
+    assert_eq!(
+        view.anchor_pairs
+            .iter()
+            .map(|(t, a)| ((t * 120.0).round(), (a * 600.0).round()))
+            .collect::<Vec<_>>(),
+        // Ticks at chapter starts: Alpha (0,0), Bravo (40/120 chars,
+        // 300s), Charlie (80/120, 480s).
+        vec![(0.0, 0.0), (40.0, 300.0), (80.0, 480.0)]
+    );
+
+    // A user anchor joins (and outranks) the served pairs.
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 50, 1_000))
+        .await
+        .unwrap();
+    progress::upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 390.0, Some(audio[0]), 2_000),
+    )
+    .await
+    .unwrap();
+    declare_sync_point(
+        &pool,
+        user,
+        &DeclareSyncPoint {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Epub,
+            ebook_fraction: Some(0.5),
+            audio_book_file_id: None,
+            audio_seconds: None,
+        },
+    )
+    .await
+    .unwrap();
+    let view = alignment_view(&pool, user, &uuid).await.unwrap();
+    assert!(
+        view.anchor_pairs
+            .iter()
+            .any(|(t, a)| (t - 0.5).abs() < 1e-9 && (a - 0.65).abs() < 1e-9),
+        "the declared (0.5, 390s/600s) pair must be served: {:?}",
+        view.anchor_pairs
+    );
+}

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -9253,7 +9253,9 @@ html {
   border-top: 1px solid var(--line, rgba(127, 127, 127, 0.25));
 }
 .al-foot-spacer { flex: 1; }
-.bd-sync-panel { margin: 10px 0 0; }
+/* Contained per the Format Sync design: the entry is a compact card in
+   the progress cluster, never a full-bleed strip. */
+.bd-sync-panel { margin: 14px 0 0; max-width: 560px; }
 .al-entry {
   display: flex;
   align-items: center;
@@ -9316,3 +9318,121 @@ html {
 }
 .rd-sync-copy { flex: 1; }
 .ch-cta-alt { opacity: 0.85; }
+
+/* ── Cross-format sync: design-fidelity additions (Format Sync design) ── */
+.al-modal { width: min(880px, calc(100vw - 48px)); }
+.al-kicker-glyph { display: inline-flex; margin-right: 6px; vertical-align: -2px; color: var(--accent, #6a8bd7); }
+.al-identity {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  font-size: 13px;
+}
+.al-identity-title { font-style: italic; }
+.al-identity-author { font-size: 11px; opacity: 0.6; }
+.al-identity-spacer { flex: 1; }
+.al-pair-mark { display: inline-flex; align-items: center; gap: 5px; opacity: 0.7; }
+.al-entry-glyph { display: inline-flex; opacity: 0.75; }
+.al-entry-linked .al-entry-glyph { color: var(--accent, #6a8bd7); opacity: 1; }
+.al-warn-badge {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 17px;
+  border-radius: 999px;
+  border: 1.5px solid rgba(214, 158, 46, 0.9);
+  color: rgba(214, 158, 46, 0.95);
+  display: grid;
+  place-items: center;
+  font-size: 10.5px;
+  font-weight: 700;
+  margin-top: 1px;
+}
+.al-lowconf-callout {
+  display: flex;
+  gap: 12px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  border: 1px solid rgba(214, 158, 46, 0.5);
+  background: rgba(214, 158, 46, 0.08);
+  border-radius: 10px;
+  padding: 11px 13px;
+  margin: 14px 0 0;
+}
+.al-chip-row { position: relative; height: 26px; }
+.al-chip-row-tall { height: 54px; }
+.al-chip {
+  position: absolute;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-size: 10.5px;
+  border: 1px solid var(--line, rgba(127, 127, 127, 0.35));
+  background: var(--bg-1, rgba(127, 127, 127, 0.1));
+  z-index: 3;
+}
+.al-chip-accent {
+  border-color: color-mix(in oklch, var(--accent, #6a8bd7) 55%, transparent);
+  background: color-mix(in oklch, var(--accent, #6a8bd7) 18%, var(--bg-1, transparent));
+}
+.al-chip-dashed { border-style: dashed; }
+.al-chip-staggered { top: 28px; }
+.al-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: color-mix(in oklch, var(--accent, #6a8bd7) 13%, transparent);
+  pointer-events: none;
+}
+.al-connector { height: 44px; margin: 2px 0; }
+.al-connector svg { display: block; width: 100%; height: 100%; }
+.al-thread {
+  stroke: var(--line, rgba(127, 127, 127, 0.4));
+  stroke-opacity: 0.35;
+  vector-effect: non-scaling-stroke;
+}
+.al-thread-mapped {
+  stroke: var(--accent, #6a8bd7);
+  stroke-width: 1.6;
+  stroke-dasharray: 5 4;
+  vector-effect: non-scaling-stroke;
+}
+.al-lane-overlay { position: absolute; inset: 0; pointer-events: none; }
+.al-lane-audio { position: relative; }
+.al-foot-note { font-size: 10.5px; opacity: 0.6; }
+.al-file-row-dim { opacity: 0.55; }
+.al-primary-pill {
+  font-size: 9.5px;
+  color: var(--accent, #6a8bd7);
+  border: 1px solid color-mix(in oklch, var(--accent, #6a8bd7) 45%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+.al-narr-note { font-size: 10.5px; opacity: 0.6; margin: 10px 0 0; }
+.rd-sync-here { font-size: 10.5px; }
+.lp-sync-kicker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent, #6a8bd7);
+}
+.lp-sync-kicker-spacer { flex: 1; }
+.ch-eyebrow-glyph { display: inline-flex; margin-left: 6px; vertical-align: -2px; color: var(--accent, #6a8bd7); opacity: 0.9; }
+.ch-link-invite {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  border: 1px dashed var(--line, rgba(127, 127, 127, 0.4));
+  border-radius: 10px;
+  font-size: 12px;
+}

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -1,16 +1,18 @@
 //! Cross-format alignment modal: the activation surface for position sync.
-//! Shows the text and audio lanes with chapter ticks and both current
-//! positions, the sequence-vs-narrations declaration for multi-file audio,
-//! and the linear mapped preview — sync turns on only when the user
-//! confirms here. Mirrors `MergeDialog`'s shell: busy-guarded dismissal,
-//! scrolling body, pinned foot, `role="alert"` error banner.
+//! Carries its own book identity (it also opens from the merge dialog),
+//! draws both lanes with chapter ticks, position chips, and the connector
+//! field whose dashed thread is the "do these line up?" judgement, and
+//! previews the mapped position through the same anchor pairs the jump
+//! uses. Sync turns on only when the user confirms here. Mirrors
+//! `MergeDialog`'s shell: busy-guarded dismissal, `role="alert"` errors.
 
 use dioxus::prelude::*;
 use omnibus_shared::{
-    AlignmentAudioFile, AlignmentView, ConfirmCrossFormatLink, CrossFormatLinkMode,
+    AlignmentAudioFile, AlignmentView, ConfirmCrossFormatLink, CrossFormatLinkMode, EbookMetadata,
 };
 
 use crate::components::confirm_modal::ConfirmModal;
+use crate::components::sync_glyph::SyncGlyph;
 use crate::data;
 
 /// `"6h 31m"` / `"41m"` for lane labels and the mapped preview. Floor
@@ -22,6 +24,83 @@ pub(crate) fn fmt_hm(seconds: f64) -> String {
         format!("{h}h {m:02}m")
     } else {
         format!("{m}m")
+    }
+}
+
+/// Coarse recency for sync copy ("yesterday"), from a client event clock.
+/// Empty off-web (these surfaces render post-mount only, so SSR never
+/// sees it — rule 07 holds).
+#[cfg_attr(feature = "mobile", allow(dead_code))]
+pub(crate) fn recency(clock_epoch_secs: i64) -> String {
+    #[cfg(feature = "web")]
+    {
+        let now = (web_sys::js_sys::Date::now() / 1000.0) as i64;
+        let d = (now - clock_epoch_secs).max(0);
+        if d < 90 {
+            "just now".into()
+        } else if d < 3_600 {
+            format!("{}m ago", d / 60)
+        } else if d < 86_400 {
+            format!("{}h ago", d / 3_600)
+        } else if d < 172_800 {
+            "yesterday".into()
+        } else {
+            format!("{}d ago", d / 86_400)
+        }
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        let _ = clock_epoch_secs;
+        String::new()
+    }
+}
+
+/// Piecewise-linear map of a text fraction through the served anchor pairs
+/// (implicit `(0,0)`/`(1,1)` endpoints) — the same interpolation the jump
+/// runs server-side, so the preview cannot disagree with it.
+fn interpolate_pairs(pairs: &[(f64, f64)], frac: f64) -> f64 {
+    let frac = frac.clamp(0.0, 1.0);
+    let mut prev = (0.0f64, 0.0f64);
+    for (t, a) in pairs.iter().copied().chain(std::iter::once((1.0, 1.0))) {
+        if frac <= t {
+            if (t - prev.0).abs() < f64::EPSILON {
+                return prev.1;
+            }
+            let k = (frac - prev.0) / (t - prev.0);
+            return (prev.1 + k * (a - prev.1)).clamp(0.0, 1.0);
+        }
+        prev = (t, a);
+    }
+    frac
+}
+
+/// The distinguishing tail of a library-relative label: real libraries
+/// nest under `Author/Book/…`, so the shared prefix carries nothing and
+/// ellipsis truncation would hide the part that differs.
+fn basename(label: &str) -> &str {
+    label.rsplit('/').next().unwrap_or(label)
+}
+
+/// Thinning step so a 196-chapter nav renders a legible lane instead of a
+/// tick barcode.
+const MAX_LANE_TICKS: usize = 48;
+
+fn tick_step(len: usize) -> usize {
+    len.div_ceil(MAX_LANE_TICKS).max(1)
+}
+
+/// Two chip centres closer than this fraction of the lane width collide —
+/// stagger the mapped chip onto a second row.
+const CHIP_COLLISION_FRACTION: f64 = 0.34;
+
+/// Horizontal translate keeping a chip inside the lane at the edges.
+fn chip_translate(frac: f64) -> &'static str {
+    if frac < 0.09 {
+        "0%"
+    } else if frac > 0.91 {
+        "-100%"
+    } else {
+        "-50%"
     }
 }
 
@@ -42,9 +121,9 @@ fn ordered<'v>(view: &'v AlignmentView, order: &[i64]) -> Vec<&'v AlignmentAudio
     files
 }
 
-/// Whole-timeline percent of the current listening position, given the
+/// Whole-timeline fraction of the current listening position, given the
 /// working order; `None` when the position's file isn't on the timeline.
-fn listening_pct(view: &AlignmentView, files: &[&AlignmentAudioFile]) -> Option<f64> {
+fn listening_frac(view: &AlignmentView, files: &[&AlignmentAudioFile]) -> Option<f64> {
     let pos = view.listening.as_ref()?;
     let total: f64 = files.iter().map(|f| f.duration_seconds).sum();
     if total <= 0.0 {
@@ -59,18 +138,20 @@ fn listening_pct(view: &AlignmentView, files: &[&AlignmentAudioFile]) -> Option<
     for f in files {
         if f.book_file_id == file_id {
             let global = start + pos.seconds.clamp(0.0, f.duration_seconds);
-            return Some((100.0 * global / total).clamp(0.0, 100.0));
+            return Some((global / total).clamp(0.0, 1.0));
         }
         start += f.duration_seconds;
     }
     None
 }
 
-/// The alignment modal. Fetches its view on open; `on_changed` fires after
-/// a confirmed link or unlink so the parent can refresh its entry row.
+/// The alignment modal. Fetches its view (and the book's identity) on
+/// open; `on_changed` fires after a confirmed link or unlink so the parent
+/// can refresh its entry row.
 #[component]
 pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler<()>) -> Element {
     let mut view = use_signal(|| None::<AlignmentView>);
+    let mut book = use_signal(|| None::<EbookMetadata>);
     let mut busy = use_signal(|| false);
     let mut error = use_signal(|| None::<String>);
     let mut mode = use_signal(|| CrossFormatLinkMode::Sequence);
@@ -86,6 +167,11 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
         view.set(None);
         error.set(None);
         spawn(async move {
+            // Identity is best-effort chrome; the alignment payload is the
+            // load-bearing fetch.
+            if let Ok(b) = data::get_ebook("", &uuid).await {
+                book.set(b);
+            }
             match data::get_alignment("", &uuid).await {
                 Ok(v) => {
                     let stored_mode = v
@@ -115,6 +201,28 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
     let confirm_uuid = uuid.clone();
     let has_link = view().as_ref().is_some_and(|v| v.link.is_some());
     let multi = view().as_ref().is_some_and(|v| v.audio_files.len() > 1);
+    let low_conf = view()
+        .as_ref()
+        .is_some_and(|v| v.anchor_match.is_none() && !v.link.as_ref().is_some_and(|l| l.stale));
+    let reordered = view().as_ref().is_some_and(|v| {
+        order()
+            != v.audio_files
+                .iter()
+                .map(|f| f.book_file_id)
+                .collect::<Vec<_>>()
+    });
+    let confirm_label = if reordered && mode() == CrossFormatLinkMode::Sequence {
+        "Save order & turn on sync"
+    } else if low_conf {
+        "Turn on sync anyway"
+    } else {
+        "Looks right — turn on sync"
+    };
+    let foot_note = if low_conf {
+        "It's approximate — Omnibus will always say ≈ when it jumps."
+    } else {
+        "Sync stays off until you confirm. You can unlink any time."
+    };
 
     rsx! {
         ConfirmModal {
@@ -124,7 +232,10 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
             busy: busy(),
             on_dismiss: move |_| open.set(false),
             div { class: "al-head",
-                p { class: "al-kicker", "Cross-format sync" }
+                p { class: "al-kicker",
+                    span { class: "al-kicker-glyph", SyncGlyph { size: 13 } }
+                    "Cross-format sync"
+                }
                 h3 {
                     if multi {
                         "Several audio files — what are they?"
@@ -132,9 +243,9 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                         "Do these line up?"
                     }
                 }
+                {render_identity(&book())}
                 p { class: "al-sub",
-                    "Check that the mapped position lands about where it should, then confirm. "
-                    "Sync stays off until you do, and you can unlink any time."
+                    "Check that the mapped position lands about where it should, then confirm."
                 }
             }
             if let Some(v) = view() {
@@ -155,15 +266,24 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                         "jumps land chapter-accurately."
                     }
                 } else if v.audio_chapter_marks > 0 {
-                    p { class: "al-lowconf", role: "note", "data-testid": "alignment-lowconf",
-                        "The audio's chapter marks couldn't be aligned with this ebook's "
-                        "contents — this mapping is a straight percent-for-percent estimate, "
-                        "so jumps land close, not exact."
+                    div { class: "al-lowconf-callout", role: "note", "data-testid": "alignment-lowconf",
+                        span { class: "al-warn-badge", "!" }
+                        div {
+                            strong { "The audio's chapter marks couldn't be aligned with this ebook. " }
+                            "This mapping is a straight percent-for-percent estimate — jumps "
+                            "land close, not exact. A \"synced here\" declaration from the "
+                            "reader or player tightens it up."
+                        }
                     }
                 } else {
-                    p { class: "al-lowconf", role: "note", "data-testid": "alignment-lowconf",
-                        "No chapter marks in the audio — this mapping is a straight "
-                        "percent-for-percent estimate, so jumps land close, not exact."
+                    div { class: "al-lowconf-callout", role: "note", "data-testid": "alignment-lowconf",
+                        span { class: "al-warn-badge", "!" }
+                        div {
+                            strong { "No chapter marks in the audio. " }
+                            "This mapping is a straight percent-for-percent estimate — jumps "
+                            "land close, not exact. A \"synced here\" declaration from the "
+                            "reader or player tightens it up."
+                        }
                     }
                 }
             } else if error().is_none() {
@@ -173,6 +293,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                 p { role: "alert", class: "bd-merge-error", "{e}" }
             }
             div { class: "al-foot",
+                span { class: "al-foot-note", "{foot_note}" }
                 if has_link {
                     button {
                         class: "btn ghost sm",
@@ -249,16 +370,40 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                             }
                         });
                     },
-                    "Looks right — turn on sync"
+                    "{confirm_label}"
                 }
             }
         }
     }
 }
 
-/// Both lanes plus markers: text lane with chapter ticks and the reading
-/// marker, audio lane segments with the listening marker and the dashed
-/// linear mapped-preview marker (same global percent as the reading spot).
+/// The book identity row: the modal opens from the merge dialog too, so it
+/// must say which book it is about without referencing the page behind it.
+fn render_identity(book: &Option<EbookMetadata>) -> Element {
+    let Some(b) = book else {
+        return rsx! {};
+    };
+    let title = b.title.clone().unwrap_or_else(|| b.filename.clone());
+    let author = b
+        .creators
+        .first()
+        .map(|c| c.name.clone())
+        .unwrap_or_default();
+    rsx! {
+        div { class: "al-identity", "data-testid": "alignment-identity",
+            span { class: "al-identity-title", "{title}" }
+            if !author.is_empty() {
+                span { class: "al-identity-author", "{author}" }
+            }
+            span { class: "al-identity-spacer" }
+            span { class: "al-pair-mark", SyncGlyph { size: 13 } }
+        }
+    }
+}
+
+/// Both lanes plus the connector field between them: chapter ticks, fills,
+/// labelled position chips, the anchored mapped preview, and the delta
+/// sentence beneath.
 fn render_lanes(
     view: &AlignmentView,
     order: &[i64],
@@ -274,13 +419,42 @@ fn render_lanes(
             .collect(),
     };
     let total: f64 = files.iter().map(|f| f.duration_seconds).sum();
-    let reading_pct = view.reading.as_ref().and_then(|r| r.percent);
-    let listen_pct = listening_pct(view, &files);
+    let reading_frac = view
+        .reading
+        .as_ref()
+        .and_then(|r| r.percent)
+        .map(|p| (p as f64 / 100.0).clamp(0.0, 1.0));
+    let listen_frac = listening_frac(view, &files);
+    // The preview maps through the same anchor pairs the jump uses; with
+    // no pairs it is the honest linear identity.
+    let mapped_frac = reading_frac.map(|f| interpolate_pairs(&view.anchor_pairs, f));
     let ebook_chapters = view
         .ebook
         .as_ref()
         .map(|e| e.chapters.clone())
         .unwrap_or_default();
+    let text_step = tick_step(ebook_chapters.len());
+    // Audio ticks: per-file chapter starts as global timeline fractions.
+    let mut audio_ticks: Vec<f64> = Vec::new();
+    if total > 0.0 {
+        let mut start = 0.0f64;
+        for f in &files {
+            for s in &f.chapter_starts {
+                audio_ticks.push(((start + s) / total).clamp(0.0, 1.0));
+            }
+            start += f.duration_seconds;
+        }
+    }
+    let audio_step = tick_step(audio_ticks.len());
+    let stagger = match (listen_frac, mapped_frac) {
+        (Some(l), Some(m)) => (l - m).abs() < CHIP_COLLISION_FRACTION,
+        _ => false,
+    };
+    let delta = match (listen_frac, mapped_frac, total > 0.0) {
+        (Some(l), Some(m), true) => Some((m - l) * total),
+        _ => None,
+    };
+    let no_positions = reading_frac.is_none() && listen_frac.is_none();
 
     rsx! {
         div { class: "al-lanes", "data-testid": "alignment-lanes",
@@ -290,19 +464,113 @@ fn render_lanes(
                     " · {ebook_chapters.len()} chapters"
                 }
             }
-            div { class: "al-lane al-lane-text",
-                for ch in ebook_chapters.iter() {
-                    div {
-                        class: "al-tick",
-                        title: "{ch.title}",
-                        style: "left: {ch.percent}%",
+            if let Some(f) = reading_frac {
+                div { class: "al-chip-row",
+                    span {
+                        class: "al-chip al-chip-accent",
+                        style: "left: {f * 100.0}%; transform: translateX({chip_translate(f)});",
+                        "Reading · {view.reading.as_ref().and_then(|r| r.percent).unwrap_or(0)}%"
                     }
                 }
-                if let Some(pct) = reading_pct {
+            }
+            div { class: "al-lane al-lane-text",
+                if let Some(f) = reading_frac {
+                    div { class: "al-fill", style: "width: {f * 100.0}%" }
+                }
+                for (i, ch) in ebook_chapters.iter().enumerate() {
+                    if i % text_step == 0 {
+                        div {
+                            class: "al-tick",
+                            title: "{ch.title}",
+                            style: "left: {ch.percent}%",
+                        }
+                    }
+                }
+                if let Some(f) = reading_frac {
                     div {
                         class: "al-marker",
                         "data-testid": "alignment-reading-marker",
-                        style: "left: {pct}%",
+                        style: "left: {f * 100.0}%",
+                    }
+                }
+            }
+            // The connector field: faint threads join matched anchors; the
+            // accent dashed thread is the reading position landing in the
+            // audio — the thing the user judges before confirming.
+            div { class: "al-connector", "aria-hidden": "true",
+                svg {
+                    view_box: "0 0 1000 44",
+                    preserve_aspect_ratio: "none",
+                    for (t, a) in view.anchor_pairs.iter() {
+                        line {
+                            x1: "{t * 1000.0}",
+                            y1: "0",
+                            x2: "{a * 1000.0}",
+                            y2: "44",
+                            class: "al-thread",
+                        }
+                    }
+                    if let (Some(f), Some(m)) = (reading_frac, mapped_frac) {
+                        line {
+                            x1: "{f * 1000.0}",
+                            y1: "0",
+                            x2: "{m * 1000.0}",
+                            y2: "44",
+                            class: "al-thread-mapped",
+                        }
+                    }
+                }
+            }
+            div { class: "al-lane al-lane-audio",
+                for f in files.iter() {
+                    div {
+                        class: "al-seg",
+                        style: format!(
+                            "flex-grow: {}",
+                            if total > 0.0 { f.duration_seconds.max(1.0) } else { 1.0 },
+                        ),
+                        span { class: "al-seg-label", title: "{f.label}", "{basename(&f.label)}" }
+                        span { class: "al-seg-dur", "{fmt_hm(f.duration_seconds)}" }
+                    }
+                }
+                div { class: "al-lane-overlay",
+                    if let Some(f) = listen_frac {
+                        div { class: "al-fill", style: "width: {f * 100.0}%" }
+                    }
+                    for (i, t) in audio_ticks.iter().enumerate() {
+                        if i % audio_step == 0 {
+                            div { class: "al-tick", style: "left: {t * 100.0}%" }
+                        }
+                    }
+                    if let Some(f) = listen_frac {
+                        div {
+                            class: "al-marker",
+                            "data-testid": "alignment-listening-marker",
+                            style: "left: {f * 100.0}%",
+                        }
+                    }
+                    if let Some(m) = mapped_frac {
+                        div {
+                            class: "al-marker al-marker-mapped",
+                            "data-testid": "alignment-mapped-marker",
+                            style: "left: {m * 100.0}%",
+                        }
+                    }
+                }
+            }
+            div { class: if stagger { "al-chip-row al-chip-row-tall" } else { "al-chip-row" },
+                if let Some(f) = listen_frac {
+                    span {
+                        class: "al-chip",
+                        style: "left: {f * 100.0}%; transform: translateX({chip_translate(f)});",
+                        "Listening · {fmt_hm(f * total)}"
+                    }
+                }
+                if let Some(m) = mapped_frac {
+                    span {
+                        class: if stagger { "al-chip al-chip-accent al-chip-dashed al-chip-staggered" } else { "al-chip al-chip-accent al-chip-dashed" },
+                        style: "left: {m * 100.0}%; transform: translateX({chip_translate(m)});",
+                        "≈ your reading maps here · {fmt_hm(m * total)}"
                     }
                 }
             }
@@ -314,36 +582,22 @@ fn render_lanes(
                     "{files.len()} files, played end to end · {fmt_hm(total)}"
                 }
             }
-            div { class: "al-lane al-lane-audio",
-                for f in files.iter() {
-                    div {
-                        class: "al-seg",
-                        style: format!(
-                            "flex-grow: {}",
-                            if total > 0.0 { f.duration_seconds.max(1.0) } else { 1.0 },
-                        ),
-                        span { class: "al-seg-label", "{f.label}" }
-                        span { class: "al-seg-dur", "{fmt_hm(f.duration_seconds)}" }
-                    }
+            if no_positions {
+                p { class: "al-mapped-note", "data-testid": "alignment-empty-note",
+                    "Nothing to compare yet — read or listen a little first, and the "
+                    "positions will land on these lanes."
                 }
-                if let Some(pct) = listen_pct {
-                    div {
-                        class: "al-marker",
-                        "data-testid": "alignment-listening-marker",
-                        style: "left: {pct}%",
-                    }
-                }
-                if let Some(pct) = reading_pct {
-                    div {
-                        class: "al-marker al-marker-mapped",
-                        "data-testid": "alignment-mapped-marker",
-                        style: "left: {pct}%",
-                    }
-                }
-            }
-            if let (Some(pct), true) = (reading_pct, total > 0.0) {
+            } else if let Some(d) = delta {
                 p { class: "al-mapped-note",
-                    "≈ your reading maps to {fmt_hm(total * pct as f64 / 100.0)}"
+                    if d >= 0.0 {
+                        "Your reading spot sits ≈ {fmt_hm(d.abs())} past the listening position."
+                    } else {
+                        "The listening position is ≈ {fmt_hm(d.abs())} past your reading spot."
+                    }
+                }
+            } else if let (Some(m), true) = (mapped_frac, total > 0.0) {
+                p { class: "al-mapped-note",
+                    "≈ your reading maps to {fmt_hm(m * total)}"
                 }
             }
         }
@@ -360,9 +614,17 @@ fn radio_class(picked: bool) -> &'static str {
     }
 }
 
+fn file_row_class(dimmed: bool) -> &'static str {
+    if dimmed {
+        "al-file-row al-file-row-dim"
+    } else {
+        "al-file-row"
+    }
+}
+
 /// The required declaration when several audio files exist: sequence vs
 /// narrations, the ▲▼ re-order controls (sequence), and the primary
-/// picker (narrations).
+/// picker (narrations, non-primary rows dimmed).
 fn render_choice(
     files: Vec<AlignmentAudioFile>,
     mut mode: Signal<CrossFormatLinkMode>,
@@ -394,7 +656,7 @@ fn render_choice(
             div { class: "al-file-rows",
                 for (i, id) in order().iter().copied().enumerate() {
                     if let Some(f) = files.iter().find(|f| f.book_file_id == id) {
-                        div { class: "al-file-row",
+                        div { class: file_row_class(!seq && primary() != Some(id)),
                             if seq {
                                 span { class: "al-file-ord", "{i + 1}" }
                                 button {
@@ -434,10 +696,19 @@ fn render_choice(
                                     onclick: move |_| primary.set(Some(id)),
                                 }
                             }
-                            span { class: "al-file-name", "{f.label}" }
+                            span { class: "al-file-name", title: "{f.label}", "{basename(&f.label)}" }
+                            if !seq && primary() == Some(id) {
+                                span { class: "al-primary-pill", "primary — aligned with the ebook" }
+                            }
                             span { class: "al-seg-dur", "{fmt_hm(f.duration_seconds)}" }
                         }
                     }
+                }
+            }
+            if !seq {
+                p { class: "al-narr-note",
+                    "The other narration stays available from the Listen menu — it just "
+                    "isn't the one Omnibus keeps in step."
                 }
             }
         }
@@ -446,7 +717,7 @@ fn render_choice(
 
 #[cfg(test)]
 mod tests {
-    use super::fmt_hm;
+    use super::{basename, fmt_hm, interpolate_pairs, tick_step};
 
     #[test]
     fn fmt_hm_floors_and_renders_hours_and_bare_minutes() {
@@ -456,5 +727,30 @@ mod tests {
         assert_eq!(fmt_hm(-5.0), "0m");
         // 59:59 must not over-report as an hour.
         assert_eq!(fmt_hm(3_599.0), "59m");
+    }
+
+    #[test]
+    fn interpolate_pairs_bends_through_anchors_and_defaults_linear() {
+        let pairs = [(0.5, 0.7)];
+        assert!((interpolate_pairs(&pairs, 0.25) - 0.35).abs() < 1e-9);
+        assert!((interpolate_pairs(&pairs, 0.5) - 0.7).abs() < 1e-9);
+        assert!((interpolate_pairs(&pairs, 0.75) - 0.85).abs() < 1e-9);
+        assert!((interpolate_pairs(&[], 0.42) - 0.42).abs() < 1e-9);
+    }
+
+    #[test]
+    fn basename_keeps_the_distinguishing_tail() {
+        assert_eq!(
+            basename("Brandon Sanderson/Wind and Truth/WaT (1 of 5).m4b"),
+            "WaT (1 of 5).m4b"
+        );
+        assert_eq!(basename("plain.m4b"), "plain.m4b");
+    }
+
+    #[test]
+    fn tick_step_thins_dense_lanes_and_keeps_sparse_ones() {
+        assert_eq!(tick_step(31), 1);
+        assert_eq!(tick_step(196), 5);
+        assert_eq!(tick_step(0), 1);
     }
 }

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -28,30 +28,21 @@ pub(crate) fn fmt_hm(seconds: f64) -> String {
 }
 
 /// Coarse recency for sync copy ("yesterday"), from a client event clock.
-/// Empty off-web (these surfaces render post-mount only, so SSR never
-/// sees it — rule 07 holds).
+/// These surfaces render post-mount only, so SSR never sees the value
+/// (rule 07 holds) and `crate::time::now_unix` serves every target.
 #[cfg_attr(feature = "mobile", allow(dead_code))]
 pub(crate) fn recency(clock_epoch_secs: i64) -> String {
-    #[cfg(feature = "web")]
-    {
-        let now = (web_sys::js_sys::Date::now() / 1000.0) as i64;
-        let d = (now - clock_epoch_secs).max(0);
-        if d < 90 {
-            "just now".into()
-        } else if d < 3_600 {
-            format!("{}m ago", d / 60)
-        } else if d < 86_400 {
-            format!("{}h ago", d / 3_600)
-        } else if d < 172_800 {
-            "yesterday".into()
-        } else {
-            format!("{}d ago", d / 86_400)
-        }
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        let _ = clock_epoch_secs;
-        String::new()
+    let d = (crate::time::now_unix() - clock_epoch_secs).max(0);
+    if d < 90 {
+        "just now".into()
+    } else if d < 3_600 {
+        format!("{}m ago", d / 60)
+    } else if d < 86_400 {
+        format!("{}h ago", d / 3_600)
+    } else if d < 172_800 {
+        "yesterday".into()
+    } else {
+        format!("{}d ago", d / 86_400)
     }
 }
 

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -95,6 +95,7 @@ pub mod author_photo_edit;
 // a title/body/action-row body for the common single-confirm case.
 pub mod alignment_modal;
 pub mod confirm_modal;
+pub mod sync_glyph;
 pub use confirm_modal::{confirm_modal_body, ConfirmModal, ConfirmModalAction, ConfirmModalTone};
 
 // Shareable quote-card editor (preview + presets + PNG export), shared by

--- a/frontend/src/components/sync_glyph.rs
+++ b/frontend/src/components/sync_glyph.rs
@@ -1,0 +1,27 @@
+//! The cross-format sync mark: the paired-arrows glyph every sync surface
+//! wears (entry row, modal, prompts, hero), ported from the Format Sync
+//! design so the surfaces read as one feature.
+
+use dioxus::prelude::*;
+
+/// The bidirectional-arrows glyph. `size` is the square edge in px.
+#[component]
+pub fn SyncGlyph(#[props(default = 14)] size: u32) -> Element {
+    rsx! {
+        svg {
+            width: "{size}",
+            height: "{size}",
+            view_box: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            "stroke-width": "1.8",
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+            "aria-hidden": "true",
+            path { d: "M4 9h13.5" }
+            path { d: "M13.5 5.5 17.5 9l-4 3.5" }
+            path { d: "M20 15H6.5" }
+            path { d: "M10.5 18.5 6.5 15l4-3.5" }
+        }
+    }
+}

--- a/frontend/src/pages/book_detail/sync_link.rs
+++ b/frontend/src/pages/book_detail/sync_link.rs
@@ -76,6 +76,9 @@ pub(super) fn BdSyncPanel(
                 None => rsx! {},
                 Some(None) => rsx! {
                     div { class: "al-entry al-entry-unlinked",
+                        span { class: "al-entry-glyph",
+                            crate::components::sync_glyph::SyncGlyph { size: 14 }
+                        }
                         span { class: "al-entry-copy",
                             "Positions aren't synced — each format keeps its own spot."
                         }
@@ -101,13 +104,21 @@ pub(super) fn BdSyncPanel(
                         }
                     }
                 },
-                Some(Some(_)) => rsx! {
+                Some(Some(l)) => rsx! {
                     button {
                         class: "al-entry al-entry-linked",
                         "data-testid": "sync-link-manage",
                         onclick: move |_| open_modal.set(true),
-                        span { class: "al-entry-copy", "Positions synced" }
-                        span { class: "al-entry-meta", "ebook \u{2194} audiobook" }
+                        span { class: "al-entry-glyph",
+                            crate::components::sync_glyph::SyncGlyph { size: 14 }
+                        }
+                        span { class: "al-entry-copy",
+                            if l.follow { "Positions synced — following" } else { "Positions synced" }
+                        }
+                        span { class: "al-entry-meta",
+                            "ebook \u{2194} audiobook \u{b7} confirmed "
+                            {crate::components::alignment_modal::recency(l.confirmed_at)}
+                        }
                         span { class: "al-entry-chevron", "\u{203a}" }
                     }
                 },

--- a/frontend/src/pages/landing/hero.rs
+++ b/frontend/src/pages/landing/hero.rs
@@ -141,12 +141,42 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
         .map(|c| c.name.clone())
         .unwrap_or_default();
     let is_audio = point.record.format == ProgressFormat::Audio;
-    let (eyebrow, cta_label) = match (is_audio, point.linked) {
-        (true, true) => ("Continue \u{00b7} synced", "Play"),
-        (false, true) => ("Continue \u{00b7} synced", "Read"),
-        (true, false) => ("Continue listening", "Play"),
-        (false, false) => ("Continue reading", "Read"),
+    let eyebrow = match (is_audio, point.linked) {
+        (_, true) => "Continue \u{00b7} synced",
+        (true, false) => "Continue listening",
+        (false, false) => "Continue reading",
     };
+    // Linked cards carry the position on the primary CTA ("Play · 16h 05m")
+    // per the design; unlinked keep the bare verb.
+    let cta_label = {
+        let verb = if is_audio { "Play" } else { "Read" };
+        let position = if point.linked {
+            if is_audio {
+                point
+                    .record
+                    .audio_position_seconds
+                    .map(crate::components::alignment_modal::fmt_hm)
+            } else {
+                point.record.progress_percent.map(|p| format!("{p}%"))
+            }
+        } else {
+            None
+        };
+        match position {
+            Some(p) => format!("{verb} \u{00b7} {p}"),
+            None => verb.to_string(),
+        }
+    };
+    // Dual-format but unlinked: the hero carries the link invitation the
+    // design draws under the two-card state.
+    let dual_unlinked = !point.linked
+        && book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"))
+        && book.formats.iter().any(|f| {
+            matches!(
+                f.to_ascii_lowercase().as_str(),
+                "m4b" | "m4a" | "mp3" | "aac" | "flac" | "ogg" | "opus" | "wav"
+            )
+        });
     // Linked books carry the mapped "resume in the other format" candidate;
     // the CTA routes to that surface, whose own prompt offers the precise
     // jump once loaded.
@@ -196,7 +226,14 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
                 }
             }
             div { class: "ch-body",
-                span { class: "ch-eyebrow", "{eyebrow}" }
+                span { class: "ch-eyebrow",
+                    "{eyebrow}"
+                    if point.linked {
+                        span { class: "ch-eyebrow-glyph",
+                            crate::components::sync_glyph::SyncGlyph { size: 11 }
+                        }
+                    }
+                }
                 Link {
                     to: Route::BookDetail { uuid: uuid.clone() },
                     class: "ch-title-link",
@@ -208,8 +245,23 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
                 if let Some(pct) = pct {
                     span { class: "ch-bar", i { style: "width:{pct}%" } }
                 }
+                if dual_unlinked {
+                    Link {
+                        to: Route::BookDetail { uuid: uuid.clone() },
+                        class: "ch-link-invite",
+                        "data-testid": "hero-link-invite-{uuid}",
+                        crate::components::sync_glyph::SyncGlyph { size: 12 }
+                        span { "Same book, two spots — link the formats to carry one position." }
+                    }
+                }
                 div { class: "ch-foot",
-                    span { class: "mono ch-meta", "{meta}" }
+                    span { class: "mono ch-meta",
+                        if point.linked { "newest spot: " }
+                        if point.linked {
+                            if is_audio { "audiobook \u{00b7} " } else { "ebook \u{00b7} " }
+                        }
+                        "{meta}"
+                    }
                     if let Some((route, label)) = counterpart {
                         Link {
                             to: route,

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -144,8 +144,24 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
         format!("You read further in the ebook — jump to \u{2248} {label}?")
     };
 
+    let kicker_dismiss_uuid = uuid.clone();
     rsx! {
         div { class: "lp-sync-prompt card", role: "status", "data-testid": "sync-prompt",
+            div { class: "lp-sync-kicker",
+                crate::components::sync_glyph::SyncGlyph { size: 12 }
+                "Cross-format sync"
+                span { class: "lp-sync-kicker-spacer" }
+                button {
+                    class: "btn ghost sm",
+                    "data-testid": "sync-prompt-close",
+                    aria_label: "Dismiss",
+                    onclick: move |_| {
+                        store_dismissed_clock(&kicker_dismiss_uuid, "audio", source_clock);
+                        hidden.set(true);
+                    },
+                    "\u{2715}"
+                }
+            }
             span { class: "lp-sync-copy", "{copy}" }
             button {
                 class: "btn sm",

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -73,12 +73,30 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     let jump_uuid = uuid.clone();
     let dismiss_uuid = uuid.clone();
 
-    // A backward offer must not claim "past this page".
+    // A backward offer must not claim "past this page". The listening
+    // position + recency come along per the design ("≈ 16h 05m, yesterday").
     let behind = c.source_ahead == Some(false);
+    let listened = c
+        .source_position_seconds
+        .map(|s| {
+            let when = crate::components::alignment_modal::recency(c.source_client_updated_at);
+            if when.is_empty() {
+                format!(
+                    " (\u{2248} {})",
+                    crate::components::alignment_modal::fmt_hm(s)
+                )
+            } else {
+                format!(
+                    " (\u{2248} {}, {when})",
+                    crate::components::alignment_modal::fmt_hm(s)
+                )
+            }
+        })
+        .unwrap_or_default();
     let copy = if behind {
-        format!("Your audiobook sits earlier — jump back to \u{2248} {pct}%?")
+        format!("Your audiobook sits earlier{listened} — jump back to \u{2248} {pct}%?")
     } else {
-        format!("You listened past this page — jump to \u{2248} {pct}%?")
+        format!("You listened past this page{listened} — jump to \u{2248} {pct}%?")
     };
     let jump_label = if behind { "Jump back" } else { "Jump" };
 
@@ -108,6 +126,12 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
                     hidden.set(true);
                 },
                 "Stay here"
+            }
+            dioxus_router::Link {
+                to: crate::routes::Route::BookDetail { uuid: uuid.clone() },
+                class: "lp-sync-alignment",
+                "data-testid": "sync-banner-alignment",
+                "View alignment \u{2192}"
             }
         }
     }

--- a/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/AlignmentSheet.swift
@@ -36,6 +36,7 @@ struct AlignmentSheet: View {
 
                     if let view {
                         lanes(view)
+                        legend(view)
                         if view.audioFiles.count > 1 { choice(view) }
                         matchNote(view)
                         actions(view)
@@ -91,9 +92,28 @@ struct AlignmentSheet: View {
             lane(
                 ticks: audioTicks(view),
                 marker: listeningFraction(view),
-                mapped: view.reading?.percent.map { Double($0) / 100 }
+                mapped: mappedFraction(view)
             )
         }
+    }
+
+    /// Reading fraction mapped through the served anchor pairs — the same
+    /// interpolation the jump runs, so the preview cannot disagree.
+    private func mappedFraction(_ view: AlignmentView) -> Double? {
+        guard let pct = view.reading?.percent else { return nil }
+        var frac = Double(pct) / 100
+        var prev = (0.0, 0.0)
+        for pair in view.anchorPairs + [[1.0, 1.0]] where pair.count == 2 {
+            let (t, a) = (pair[0], pair[1])
+            if frac <= t {
+                if t - prev.0 < .ulpOfOne { return prev.1 }
+                let k = (frac - prev.0) / (t - prev.0)
+                frac = min(max(prev.1 + k * (a - prev.1), 0), 1)
+                return frac
+            }
+            prev = (t, a)
+        }
+        return frac
     }
 
     private func laneLabel(_ text: String) -> some View {
@@ -255,17 +275,69 @@ struct AlignmentSheet: View {
         }
     }
 
+    /// The al-mobile artboard's legend: each marker named with its value,
+    /// so the lanes read without decoding line styles.
+    @ViewBuilder
+    private func legend(_ view: AlignmentView) -> some View {
+        VStack(spacing: 0) {
+            if let reading = view.reading, let pct = reading.percent {
+                legendRow(dashed: false, label: "You're reading", value: "\(pct)%")
+            }
+            if let mapped = mappedFraction(view) {
+                let total = timelineFiles(view).reduce(0.0) { $0 + $1.durationSeconds }
+                if total > 0 {
+                    legendRow(
+                        dashed: true,
+                        label: "Maps to the audio",
+                        value: "\u{2248} " + Format.duration(mapped * total)
+                    )
+                }
+            }
+            if let listened = listeningFraction(view) {
+                let total = timelineFiles(view).reduce(0.0) { $0 + $1.durationSeconds }
+                if total > 0 {
+                    legendRow(
+                        dashed: false,
+                        label: "Last listened",
+                        value: Format.duration(listened * total)
+                    )
+                }
+            }
+        }
+        .padding(.top, Spacing.xs)
+    }
+
+    private func legendRow(dashed: Bool, label: String, value: String) -> some View {
+        HStack(spacing: Spacing.sm) {
+            Rectangle()
+                .fill(palette.accentColor.opacity(dashed ? 0.7 : 1))
+                .frame(width: 2, height: 13)
+            Text(label)
+                .font(.ui(12))
+                .foregroundStyle(palette.ink2Color)
+            Spacer()
+            Text(value)
+                .font(.ui(12, weight: .medium))
+                .foregroundStyle(palette.ink1Color)
+        }
+        .padding(.vertical, 5)
+    }
+
     private func actions(_ view: AlignmentView) -> some View {
         VStack(spacing: Spacing.sm) {
             Button {
                 confirm()
             } label: {
-                Text(busy ? "Saving…" : "Looks right — turn on sync")
+                Text(busy ? "Saving…" : "Looks right — sync positions")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(FilledButtonStyle())
             .disabled(busy || !connectivity.isOnline)
             .accessibilityIdentifier("alignment-confirm")
+
+            Button("Not now") { dismiss() }
+                .disabled(busy)
+                .accessibilityIdentifier("alignment-not-now")
 
             if view.link != nil {
                 Button("Unlink", role: .destructive) { unlink() }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1605,6 +1605,9 @@ struct AlignmentView: Codable, Hashable, Sendable {
     /// Usable audio chapter marks: with no anchor match, zero means "no
     /// marks" and nonzero means "marks exist but couldn't be aligned".
     var audioChapterMarks: Int64?
+    /// Matched anchor pairs (text_frac, audio_frac) — the mapped-preview
+    /// interpolation, identical to the pairs the jump uses.
+    var anchorPairs: [[Double]] = []
 
     enum CodingKeys: String, CodingKey {
         case link
@@ -1614,6 +1617,7 @@ struct AlignmentView: Codable, Hashable, Sendable {
         case reading
         case listening
         case audioChapterMarks = "audio_chapter_marks"
+        case anchorPairs = "anchor_pairs"
     }
 }
 

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -101,6 +101,11 @@ pub struct CrossFormatCandidate {
     /// precision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fraction: Option<f64>,
+    /// The source listening row's own position as global timeline seconds
+    /// — the reader banner's "you listened to ≈ 16h 05m" copy. Epub
+    /// targets only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_position_seconds: Option<f64>,
     /// Whether the mapped source position sits ahead of the target's own
     /// current position — `Some(false)` marks a backward offer (the source
     /// regressed), so prompt copy must not claim "further". `None` when
@@ -129,6 +134,12 @@ pub struct AlignmentView {
     pub reading: Option<AlignmentPosition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub listening: Option<AlignmentAudioPosition>,
+    /// Matched anchor pairs `(text_frac, audio_frac)` in `0.0..=1.0`, in
+    /// text order — the modal's connector threads and its anchored
+    /// mapped-preview interpolation (the same pairs the jump uses, so the
+    /// preview cannot lie). Empty when anchoring is off.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub anchor_pairs: Vec<(f64, f64)>,
     /// Usable (titled, non-synthetic) audio chapter marks on the preview
     /// timeline. With `anchor_match` absent on a *non-stale* view, zero
     /// means "no marks in the audio" and nonzero means "marks exist but


### PR DESCRIPTION
## Summary
- Alignment modal rebuilt to the ★ artboard: book identity row (it opens from merge too), connector field with anchor threads + the accent dashed reading→mapped judgement thread, labeled position chips with collision stagger, lane fills, audio chapter ticks, tick thinning for 196-chapter navs, basename-tail segment labels, the delta sentence, an explicit empty-progress state, warn callouts, and state-dependent confirm labels ("Turn on sync anyway" / "Save order & turn on sync").
- The mapped preview now interpolates through `AlignmentView.anchor_pairs` — the same merged (user + chapter) pairs the jump uses, so the preview cannot disagree with it (web + iOS).
- Entry row contained to the design's compact card (max-width, in the progress cluster) with per-state `SyncGlyph`s, follow status, and confirmed recency; player prompt gains its kicker row + ✕; reader banner carries the listening position + recency (`source_position_seconds`) and the "View alignment →" escape hatch; hero gains the glyph, "newest spot:" meta, position-bearing CTA, and the dashed link invitation on unlinked dual-format cards.
- iOS sheet: legend rows per the al-mobile artboard, anchored mapped marker, and the artboard's confirm/dismiss copy.

Closes #1893

## Test plan
- [x] `just test` full matrix green (2087 / 823 / 738 / 672 / 298), incl. new interpolate/basename/tick-step units
- [x] E2E 13/13 (cross-format specs + landing) against a live dev server
- [x] `just lint` + `just lint-css` clean; `just ios-build` + `just ios-test` green (264)

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release**