### PR TITLE
refactor: use BEGIN IMMEDIATE in delete_author to close TOCTOU race

### DIFF
--- a/db/src/author_photos_data.rs
+++ b/db/src/author_photos_data.rs
@@ -236,7 +236,8 @@ pub async fn delete_author(
     pool: &SqlitePool,
     author_id: i64,
 ) -> Result<u64, AuthorPhotosDataError> {
-    let mut tx = pool.begin().await?;
+    // BEGIN IMMEDIATE avoids a stale-snapshot 517 on concurrent writes (#1862).
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
     let Some(name): Option<String> = sqlx::query_scalar("SELECT name FROM authors WHERE id = ?")
         .bind(author_id)

--- a/db/src/author_photos_data/tests.rs
+++ b/db/src/author_photos_data/tests.rs
@@ -398,3 +398,60 @@ async fn delete_author_photos_bulk_propagates_db_error_when_pool_is_closed() {
     let err = delete_author_photos_bulk(&pool, &[1, 2]).await.unwrap_err();
     assert!(matches!(err, AuthorPhotosDataError::Db(_)));
 }
+
+// Regression test for the BEGIN IMMEDIATE stale-snapshot 517 fix (#1862),
+// mirroring `upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool`
+// in `db/src/progress/tests.rs`.
+const CONCURRENT_ROUNDS: usize = 5;
+const CONCURRENT_WRITERS_PER_ROUND: usize = 5;
+
+#[tokio::test]
+async fn delete_author_succeeds_for_many_concurrent_writers_on_one_pool() {
+    let _covers = CoversTempDir::new("delete_author_concurrent");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    // One junk author per (round, writer) slot, each also linked to a
+    // shared "Keep Me" author, so every round's concurrent deletes race for
+    // the same `books_authors_link`, `authors`, and `ignored_authors` table
+    // pages instead of each touching disjoint rows.
+    let mut books = Vec::new();
+    let mut names_by_round: Vec<Vec<String>> = Vec::new();
+    for round in 0..CONCURRENT_ROUNDS {
+        let mut names = Vec::new();
+        for i in 0..CONCURRENT_WRITERS_PER_ROUND {
+            let name = format!("Round {round} Junk Author {i}");
+            books.push(indexed(
+                &format!("r{round}-{i}.epub"),
+                Some(&format!("Round {round} Book {i}")),
+                &[name.as_str(), "Keep Me"],
+                &[],
+                None,
+                None,
+            ));
+            names.push(name);
+        }
+        names_by_round.push(names);
+    }
+    replace_books(&pool, "/lib", books).await.unwrap();
+
+    for names in names_by_round {
+        let mut handles = Vec::new();
+        for name in names {
+            let pool = pool.clone();
+            handles.push(tokio::spawn(async move {
+                let author_id: i64 = sqlx::query_scalar("SELECT id FROM authors WHERE name = ?")
+                    .bind(&name)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+                delete_author(&pool, author_id).await
+            }));
+        }
+        for handle in handles {
+            handle
+                .await
+                .expect("writer task panicked")
+                .expect("concurrent delete_author must not surface a database error");
+        }
+    }
+}

--- a/db/src/author_photos_data/tests.rs
+++ b/db/src/author_photos_data/tests.rs
@@ -399,9 +399,7 @@ async fn delete_author_photos_bulk_propagates_db_error_when_pool_is_closed() {
     assert!(matches!(err, AuthorPhotosDataError::Db(_)));
 }
 
-// Regression test for the BEGIN IMMEDIATE stale-snapshot 517 fix (#1862),
-// mirroring `upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool`
-// in `db/src/progress/tests.rs`.
+// Regression test for the BEGIN IMMEDIATE stale-snapshot 517 fix (#1862), mirroring `upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool` in `db/src/progress/tests.rs`.
 const CONCURRENT_ROUNDS: usize = 5;
 const CONCURRENT_WRITERS_PER_ROUND: usize = 5;
 
@@ -410,10 +408,7 @@ async fn delete_author_succeeds_for_many_concurrent_writers_on_one_pool() {
     let _covers = CoversTempDir::new("delete_author_concurrent");
     let pool = init_db("sqlite::memory:").await.unwrap();
 
-    // One junk author per (round, writer) slot, each also linked to a
-    // shared "Keep Me" author, so every round's concurrent deletes race for
-    // the same `books_authors_link`, `authors`, and `ignored_authors` table
-    // pages instead of each touching disjoint rows.
+    // One junk author per (round, writer) slot, all linked to a shared "Keep Me" author, so concurrent deletes race for the same rows instead of disjoint ones.
     let mut books = Vec::new();
     let mut names_by_round: Vec<Vec<String>> = Vec::new();
     for round in 0..CONCURRENT_ROUNDS {


### PR DESCRIPTION
## Summary
- Closes #1882
- `delete_author` in `db/src/author_photos_data.rs` reads (author name, affected book uuids) before writing (unlink, delete, blocklist insert) inside a plain `pool.begin()` (DEFERRED) transaction — the same stale-snapshot read-then-write race that PR #1877 (closing #1862) already fixed across `progress.rs`, `read_status/mod.rs`, `rpc/progress.rs`, and `kobo/state.rs`. That PR explicitly deferred this exact site.
- Switch the transaction open to `pool.begin_with("BEGIN IMMEDIATE")`, mirroring `progress::upsert_progress` and `deletion::run_deletion_tx`, so the write lock is taken up front instead of racing other writers on a stale snapshot.
- Add a concurrent-writers regression test (`delete_author_succeeds_for_many_concurrent_writers_on_one_pool`) in `db/src/author_photos_data/tests.rs`, modeled on `upsert_progress_succeeds_for_many_concurrent_writers_on_one_pool` in `db/src/progress/tests.rs`: several rounds of concurrent `delete_author` calls against distinct authors that all share a linked book, asserting none surface a database error (i.e. no `SQLITE_BUSY_SNAPSHOT`).

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1882 cargo fmt -p omnibus-db` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1882 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1882 cargo test -p omnibus-db` — PASS (18/18 in `author_photos_data::tests`, including the new concurrency regression test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoXwEowehoJgiLF5dbh6gn)_