### PR TITLE
fix: wire user-menu Shelves tile, de-fang the rest (#1913)

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -2892,7 +2892,8 @@ a.idx-letter-on:focus-visible {
   .um-nr-play:hover { opacity: 0.9; }
 }
 
-/* Stat grid (stubs) */
+/* Stat grid: Shelves links out (#1913); the rest are non-interactive
+   stats (`.um-stat-static`) until they have an aggregate web page. */
 .um-stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 .um-stat {
   display: flex; flex-direction: column; gap: 4px;
@@ -2900,7 +2901,10 @@ a.idx-letter-on:focus-visible {
   background: var(--bg-2); border: 1px solid var(--line-2);
   text-decoration: none; color: inherit;
 }
-.um-stat[aria-disabled="true"] { opacity: .85; cursor: not-allowed; }
+@media (hover: hover) {
+  a.um-stat:hover { border-color: var(--line-1); }
+}
+.um-stat-static { cursor: default; opacity: .85; }
 .um-stat-label { color: var(--ink-0); font-size: 12px; font-weight: 500; }
 .um-stat-detail { color: var(--ink-3); font-family: var(--mono); font-size: 10px; }
 

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -381,18 +381,17 @@ fn UmAccountRows(open: Signal<bool>, is_admin: bool) -> Element {
 }
 
 /// Session-scoped linear rows: the stubbed "Switch user" row and the
-/// real Sign-out button.
+/// real Sign-out button. "Switch user" has no destination yet (there is
+/// no multi-account switcher on web), so it renders as a plain,
+/// non-interactive `div` rather than a link that swallows the click
+/// (#1913) — same non-anchor stub pattern as the Journal/Highlights/Goals
+/// tiles in [`UmStat`].
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 fn UmSessionRows(on_signout: EventHandler<()>) -> Element {
     rsx! {
         div { class: "um-rows",
-            a {
-                class: "um-row",
-                href: "#",
-                "aria-disabled": "true",
-                tabindex: "-1",
-                onclick: move |evt| evt.prevent_default(),
+            div { class: "um-row", "aria-disabled": "true",
                 span { class: "um-row-icon", "⇄" }
                 span { class: "um-row-label", "Switch user" }
             }

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -1,6 +1,8 @@
 //! User-menu dropdown mounted in the top nav. Real wiring: recent progress,
-//! Settings, Sign out, Dark/Light theme, and app version. Other account
-//! surfaces remain stubbed. See [`UserMenu`] for the SSR/hydration handling
+//! Settings, Sign out, Dark/Light theme, app version, and (#1913) the
+//! Shelves stat tile. Journal/Highlights/Goals have no aggregate web page
+//! yet, so their tiles render as non-interactive stats rather than dead
+//! links — see [`UmStat`]. See [`UserMenu`] for the SSR/hydration handling
 //! of the pre-auth trigger state.
 
 use dioxus::prelude::*;
@@ -81,6 +83,9 @@ pub fn UserMenu() -> Element {
     rsx! {}
 }
 
+#[cfg(all(test, feature = "server"))]
+mod tests;
+
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 fn UserMenuTrigger(user: Option<UserSummary>, open: Signal<bool>) -> Element {
@@ -159,10 +164,15 @@ fn UserMenuPanel(user: UserSummary, open: Signal<bool>) -> Element {
             UmNowReading {}
 
             div { class: "um-stat-grid",
-                UmStat { label: "Journal", detail: "24 entries" }
-                UmStat { label: "Highlights", detail: "412 quotes" }
-                UmStat { label: "Shelves", detail: "3 shared" }
-                UmStat { label: "Goals", detail: "12 / 24 books" }
+                UmStat { label: "Journal", detail: "24 entries", to: None, open }
+                UmStat { label: "Highlights", detail: "412 quotes", to: None, open }
+                UmStat {
+                    label: "Shelves",
+                    detail: "3 shared",
+                    to: Some(Route::Shelves {}),
+                    open,
+                }
+                UmStat { label: "Goals", detail: "12 / 24 books", to: None, open }
             }
 
             UmAccountRows { open, is_admin }
@@ -398,19 +408,31 @@ fn UmSessionRows(on_signout: EventHandler<()>) -> Element {
     }
 }
 
+/// One tile in the stat grid. `to: Some(route)` renders a real navigable
+/// link that closes the menu on click (#1913); `to: None` renders a plain,
+/// non-interactive `div` for a stat whose destination page doesn't exist on
+/// web yet — never a link that swallows the click (`href="#"` + `onclick:
+/// prevent_default`), which is what this replaced.
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
-fn UmStat(label: String, detail: String) -> Element {
-    rsx! {
-        a {
-            class: "um-stat",
-            href: "#",
-            "aria-disabled": "true",
-            tabindex: "-1",
-            onclick: move |evt| evt.prevent_default(),
-            div { class: "um-stat-label", "{label}" }
-            div { class: "um-stat-detail", "{detail}" }
-        }
+fn UmStat(label: String, detail: String, to: Option<Route>, open: Signal<bool>) -> Element {
+    let mut open = open;
+    match to {
+        Some(route) => rsx! {
+            Link {
+                class: "um-stat",
+                to: route,
+                onclick: move |_| open.set(false),
+                div { class: "um-stat-label", "{label}" }
+                div { class: "um-stat-detail", "{detail}" }
+            }
+        },
+        None => rsx! {
+            div { class: "um-stat um-stat-static", "aria-disabled": "true",
+                div { class: "um-stat-label", "{label}" }
+                div { class: "um-stat-detail", "{detail}" }
+            }
+        },
     }
 }
 

--- a/frontend/src/components/user_menu/tests.rs
+++ b/frontend/src/components/user_menu/tests.rs
@@ -1,0 +1,43 @@
+//! Render-smoke coverage for [`UmStat`] (#1913): a `to: None` tile must
+//! render as a plain, non-interactive `div` with no `href` at all, and no
+//! tile — linked or not — may ever emit `href="#"`. The `to: Some(route)`
+//! tile's `Link` needs a live `RouterContext`, which (like `shelves_rail`'s
+//! "All books" row, see its `tests.rs`) this harness doesn't mount; Dioxus
+//! catches that per-component, so the surrounding grid still renders and the
+//! `href="#"` regression check still holds across both tiles.
+
+use super::*;
+use crate::test_support::render_in_vdom;
+
+fn stat_grid_harness() -> Element {
+    let open = use_signal(|| false);
+    rsx! {
+        div { class: "um-stat-grid",
+            UmStat { label: "Journal", detail: "24 entries", to: None, open }
+            UmStat {
+                label: "Shelves",
+                detail: "3 shared",
+                to: Some(Route::Shelves {}),
+                open,
+            }
+        }
+    }
+}
+
+#[test]
+fn um_stat_renders_a_non_interactive_div_when_no_destination_exists() {
+    let html = render_in_vdom(stat_grid_harness);
+    assert!(html.contains("um-stat-static"));
+    assert!(html.contains("Journal"));
+    assert!(html.contains("24 entries"));
+    assert!(html.contains("aria-disabled=\"true\""));
+}
+
+#[test]
+fn um_stat_never_emits_an_href_hash_placeholder() {
+    let html = render_in_vdom(stat_grid_harness);
+    assert!(
+        !html.contains("href=\"#\""),
+        "a stat tile must never render a dead href=\"#\" link (#1913), got: {html}"
+    );
+}

--- a/frontend/src/components/user_menu/tests.rs
+++ b/frontend/src/components/user_menu/tests.rs
@@ -1,10 +1,11 @@
-//! Render-smoke coverage for [`UmStat`] (#1913): a `to: None` tile must
-//! render as a plain, non-interactive `div` with no `href` at all, and no
-//! tile — linked or not — may ever emit `href="#"`. The `to: Some(route)`
-//! tile's `Link` needs a live `RouterContext`, which (like `shelves_rail`'s
-//! "All books" row, see its `tests.rs`) this harness doesn't mount; Dioxus
-//! catches that per-component, so the surrounding grid still renders and the
-//! `href="#"` regression check still holds across both tiles.
+//! Render-smoke coverage for [`UmStat`] and [`UmSessionRows`] (#1913): a
+//! stubbed row/tile must render as a plain, non-interactive element with no
+//! `href` at all, and no row — linked or not — may ever emit `href="#"`.
+//! The `to: Some(route)` tile's `Link` needs a live `RouterContext`, which
+//! (like `shelves_rail`'s "All books" row, see its `tests.rs`) this harness
+//! doesn't mount; Dioxus catches that per-component, so the surrounding
+//! grid still renders and the `href="#"` regression check still holds
+//! across every tile/row.
 
 use super::*;
 use crate::test_support::render_in_vdom;
@@ -24,13 +25,26 @@ fn stat_grid_harness() -> Element {
     }
 }
 
+/// Isolates the `to: None` tile alone (no sibling `Link`) so the
+/// href-absence assertion below is unambiguous about which node it covers.
+fn static_stat_harness() -> Element {
+    let open = use_signal(|| false);
+    rsx! {
+        UmStat { label: "Journal", detail: "24 entries", to: None, open }
+    }
+}
+
 #[test]
 fn um_stat_renders_a_non_interactive_div_when_no_destination_exists() {
-    let html = render_in_vdom(stat_grid_harness);
+    let html = render_in_vdom(static_stat_harness);
     assert!(html.contains("um-stat-static"));
     assert!(html.contains("Journal"));
     assert!(html.contains("24 entries"));
     assert!(html.contains("aria-disabled=\"true\""));
+    assert!(
+        !html.contains("href"),
+        "a non-interactive stat tile must not be an anchor at all, got: {html}"
+    );
 }
 
 #[test]
@@ -39,5 +53,22 @@ fn um_stat_never_emits_an_href_hash_placeholder() {
     assert!(
         !html.contains("href=\"#\""),
         "a stat tile must never render a dead href=\"#\" link (#1913), got: {html}"
+    );
+}
+
+fn session_rows_harness() -> Element {
+    rsx! {
+        UmSessionRows { on_signout: EventHandler::new(|()| {}) }
+    }
+}
+
+#[test]
+fn um_session_rows_renders_switch_user_as_a_non_interactive_row() {
+    let html = render_in_vdom(session_rows_harness);
+    assert!(html.contains("Switch user"));
+    assert!(html.contains("aria-disabled=\"true\""));
+    assert!(
+        !html.contains("href"),
+        "the stubbed Switch-user row must not be an anchor at all (#1913), got: {html}"
     );
 }


### PR DESCRIPTION
## Summary
- Closes #1913
- The four stat tiles in the user menu (Journal / Highlights / Shelves / Goals) were `<a href="#">` elements with an `onclick: prevent_default` — dead links that swallowed the click.
- `frontend/src/components/user_menu.rs`: `UmStat` now takes `to: Option<Route>`. Shelves is wired to the real `Route::Shelves` (`/shelves`, which already renders a plain shelf list on web) and closes the menu on click, matching the other real nav rows in the panel. Journal, Highlights, and Goals have no aggregate cross-book page on web yet (`rpc::journals`/`rpc::highlights` only list entries *per book*), so they now render as plain, non-interactive `div`s — no `href`, no anchor at all — rather than a link that swallows the click. This mirrors the same stub pattern already used for these three tiles in the mobile account page's quick-links grid (`QuickGrid` in `frontend/src/pages/account.rs`).
- `frontend/assets/atrium.css`: added a hover affordance for the now-real link tile and a `.um-stat-static` modifier for the non-interactive tiles (replacing the old `[aria-disabled="true"]` styling, which no longer applies since the static tiles aren't anchors).
- No hydration concern (rule 07): the `Some`/`None` branch on `to` is fixed per call site, identical on SSR and the first client render.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1913 cargo fmt -p omnibus-frontend` — PASS (no diff)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1913 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1913 cargo test -p omnibus-frontend --features server` — PASS (748 passed, 0 failed), including two new render-smoke tests in `frontend/src/components/user_menu/tests.rs` asserting the non-interactive tile has no `href` and that no tile ever emits `href="#"`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoXwEowehoJgiLF5dbh6gn)_