### PR TITLE
fix: label ISBN-shaped identifiers correctly in file details (#1910)

### DIFF
--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -422,12 +422,7 @@ fn bd_identifier_key(ident: &Identifier) -> String {
     format!("{:?}\u{1f}{:?}", ident.scheme, ident.value)
 }
 
-/// Label for a file-details identifier row. A known scheme (`ISBN`, `DOI`,
-/// …) renders as-is; a missing scheme, or the sync layer's `unknown`
-/// placeholder for an EPUB `dc:identifier` with no `opf:scheme` attribute
-/// (`insert_identifier_links` in `db/src/sync/books/shared.rs`), is never
-/// shown to the reader literally — the value's shape decides between `ISBN`
-/// and the generic `Identifier` (#1910).
+/// Label for a file-details identifier row: a known scheme renders as-is; a missing or `unknown` scheme is inferred from the value's shape as `ISBN` or `Identifier`.
 fn bd_identifier_label(ident: &Identifier) -> String {
     match ident.scheme.as_deref() {
         Some(scheme) if !scheme.eq_ignore_ascii_case("unknown") => scheme.to_string(),
@@ -436,23 +431,23 @@ fn bd_identifier_label(ident: &Identifier) -> String {
     }
 }
 
-/// True when `value`, with hyphens and whitespace stripped, is the right
-/// length for an ISBN-10 or ISBN-13 (10 or 13 characters) and every
-/// character is a digit — except the last, which an ISBN-10 check digit
-/// allows to be `X`.
+/// True when `value`, with hyphens and whitespace stripped, is the right length for an ISBN-10 or ISBN-13, digits-only except a trailing ISBN-10 `X` check digit.
 fn bd_looks_like_isbn(value: &str) -> bool {
     let cleaned: Vec<char> = value
         .chars()
         .filter(|c| !c.is_whitespace() && *c != '-')
         .collect();
-    if !matches!(cleaned.len(), 10 | 13) {
-        return false;
+    match cleaned.len() {
+        10 => {
+            let last = cleaned.len() - 1;
+            cleaned
+                .iter()
+                .enumerate()
+                .all(|(i, c)| c.is_ascii_digit() || (i == last && c.eq_ignore_ascii_case(&'x')))
+        }
+        13 => cleaned.iter().all(|c| c.is_ascii_digit()),
+        _ => false,
     }
-    let last = cleaned.len() - 1;
-    cleaned
-        .iter()
-        .enumerate()
-        .all(|(i, c)| c.is_ascii_digit() || (i == last && c.eq_ignore_ascii_case(&'x')))
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -339,7 +339,7 @@ pub(super) fn BdRailSection(
                         for ident in b.identifiers.iter() {
                             BdMetaRow {
                                 key: "{bd_identifier_key(ident)}",
-                                k: ident.scheme.clone().unwrap_or_else(|| "ID".into()),
+                                k: bd_identifier_label(ident),
                                 v: ident.value.clone(),
                             }
                         }
@@ -420,6 +420,39 @@ pub(super) fn BdRailSection(
 /// key.
 fn bd_identifier_key(ident: &Identifier) -> String {
     format!("{:?}\u{1f}{:?}", ident.scheme, ident.value)
+}
+
+/// Label for a file-details identifier row. A known scheme (`ISBN`, `DOI`,
+/// …) renders as-is; a missing scheme, or the sync layer's `unknown`
+/// placeholder for an EPUB `dc:identifier` with no `opf:scheme` attribute
+/// (`insert_identifier_links` in `db/src/sync/books/shared.rs`), is never
+/// shown to the reader literally — the value's shape decides between `ISBN`
+/// and the generic `Identifier` (#1910).
+fn bd_identifier_label(ident: &Identifier) -> String {
+    match ident.scheme.as_deref() {
+        Some(scheme) if !scheme.eq_ignore_ascii_case("unknown") => scheme.to_string(),
+        _ if bd_looks_like_isbn(&ident.value) => "ISBN".to_string(),
+        _ => "Identifier".to_string(),
+    }
+}
+
+/// True when `value`, with hyphens and whitespace stripped, is the right
+/// length for an ISBN-10 or ISBN-13 (10 or 13 characters) and every
+/// character is a digit — except the last, which an ISBN-10 check digit
+/// allows to be `X`.
+fn bd_looks_like_isbn(value: &str) -> bool {
+    let cleaned: Vec<char> = value
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .collect();
+    if !matches!(cleaned.len(), 10 | 13) {
+        return false;
+    }
+    let last = cleaned.len() - 1;
+    cleaned
+        .iter()
+        .enumerate()
+        .all(|(i, c)| c.is_ascii_digit() || (i == last && c.eq_ignore_ascii_case(&'x')))
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/book_detail/body/tests.rs
+++ b/frontend/src/pages/book_detail/body/tests.rs
@@ -49,3 +49,66 @@ fn bd_identifier_key_does_not_collide_when_data_contains_the_delimiter() {
         bd_identifier_key(&split_value)
     );
 }
+
+#[test]
+fn bd_identifier_label_maps_unknown_scheme_isbn10_shape_to_isbn() {
+    // #1910 repro: the sync layer's "unknown" scheme placeholder on an
+    // ISBN-10-shaped value must never surface as the literal word "unknown".
+    let ident = Identifier {
+        value: "0-306-40615-2".into(),
+        scheme: Some("unknown".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "ISBN");
+}
+
+#[test]
+fn bd_identifier_label_maps_unknown_scheme_isbn13_shape_to_isbn() {
+    // The Feywild Job repro from the issue: a hyphenated ISBN-13 under the
+    // "unknown" scheme.
+    let ident = Identifier {
+        value: "978-0-593-59980-8".into(),
+        scheme: Some("unknown".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "ISBN");
+}
+
+#[test]
+fn bd_identifier_label_maps_unknown_scheme_isbn10_checkdigit_x_to_isbn() {
+    let ident = Identifier {
+        value: "080442957X".into(),
+        scheme: Some("unknown".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "ISBN");
+}
+
+#[test]
+fn bd_identifier_label_maps_non_isbn_unknown_scheme_to_generic_identifier() {
+    let ident = Identifier {
+        value: "urn:uuid:c0e51a66-085f-4805-b116-a0d451d281bd".into(),
+        scheme: Some("unknown".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "Identifier");
+}
+
+#[test]
+fn bd_identifier_label_maps_missing_scheme_by_value_shape() {
+    let isbn = Identifier {
+        value: "9780593599808".into(),
+        scheme: None,
+    };
+    let other = Identifier {
+        value: "some-other-id".into(),
+        scheme: None,
+    };
+    assert_eq!(bd_identifier_label(&isbn), "ISBN");
+    assert_eq!(bd_identifier_label(&other), "Identifier");
+}
+
+#[test]
+fn bd_identifier_label_keeps_known_scheme_as_is() {
+    let ident = Identifier {
+        value: "https://example.com/book".into(),
+        scheme: Some("URL".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "URL");
+}

--- a/frontend/src/pages/book_detail/body/tests.rs
+++ b/frontend/src/pages/book_detail/body/tests.rs
@@ -82,6 +82,17 @@ fn bd_identifier_label_maps_unknown_scheme_isbn10_checkdigit_x_to_isbn() {
 }
 
 #[test]
+fn bd_identifier_label_rejects_13char_value_with_trailing_x() {
+    // A trailing check-digit X is only valid for ISBN-10; a 13-char value
+    // ending in X is not a real ISBN-13 and must fall through to generic.
+    let ident = Identifier {
+        value: "978030640615X".into(),
+        scheme: Some("unknown".into()),
+    };
+    assert_eq!(bd_identifier_label(&ident), "Identifier");
+}
+
+#[test]
 fn bd_identifier_label_maps_non_isbn_unknown_scheme_to_generic_identifier() {
     let ident = Identifier {
         value: "urn:uuid:c0e51a66-085f-4805-b116-a0d451d281bd".into(),


### PR DESCRIPTION
## Summary
- Closes #1910
- The book-detail File Details sidebar rendered an identifier's raw `scheme` string as its row label, including the sync layer's `unknown` placeholder (`insert_identifier_links` in `db/src/sync/books/shared.rs`) for an EPUB `dc:identifier` with no `opf:scheme` attribute — so an ISBN would show under a literal `unknown` label.
- Added `bd_identifier_label` in `frontend/src/pages/book_detail/body.rs`: a known scheme renders as-is; a missing or `unknown` scheme is now inferred from the value's shape via `bd_looks_like_isbn` (10 or 13 chars after stripping hyphens/whitespace, with a trailing `X` check-digit allowed for ISBN-10) — `"ISBN"` when it matches, `"Identifier"` otherwise. The raw word `unknown` is never shown.
- Wired the file-details identifier row (`BdRailSection`) to use the new label instead of `ident.scheme.clone().unwrap_or_else(|| "ID".into())`.

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1910 cargo fmt -p omnibus-frontend` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1910 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (no warnings)
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-1910 cargo test -p omnibus-frontend --features server` — PASS (752 passed; 0 failed), including 6 new tests in `pages::book_detail::body::tests` covering ISBN-10 shape, ISBN-13 shape (hyphenated, matching the issue's Feywild Job repro), ISBN-10 with trailing `X` check digit, a non-ISBN `unknown`-scheme identifier (generic label), missing-scheme value-shape inference, and a known scheme rendering as-is.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoXwEowehoJgiLF5dbh6gn)_