### PR TITLE
fix: show seek target immediately in the audio transport while paused

### DIFF
--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -96,7 +96,7 @@ fn transport_controls_js() -> &'static str {
         // browsers fire unreliably (or not at all) for a seek issued while
         // paused, leaving the readout and scrub position stuck at the old
         // value until playback starts (#1897).
-        if (window.__omnibusOnAudioTime) { window.__omnibusOnAudioTime(s); }
+        if (typeof window.__omnibusOnAudioTime === 'function') { window.__omnibusOnAudioTime(s); }
         if (this._mode === 'direct' && this._parts) {
           var i = 0;
           while (i < this._cumOffsets.length - 1 && s >= this._cumOffsets[i + 1]) i++;
@@ -367,7 +367,11 @@ mod tests {
         // A paused seek must push the transport display immediately (#1897)
         // rather than waiting on the element's own `timeupdate`.
         assert!(
-            js.contains("if (window.__omnibusOnAudioTime) { window.__omnibusOnAudioTime(s); }"),
+            js.contains("typeof window.__omnibusOnAudioTime === 'function'"),
+            "seek does not guard the immediate time push with a typeof check"
+        );
+        assert!(
+            js.contains("__omnibusOnAudioTime(s)"),
             "seek does not push the target time immediately"
         );
         // Sanity: no stray `{{` / `}}` escape pairs leaked from a `format!`.

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -47,8 +47,10 @@ pub(super) fn control_surface_js(rate_lit: &str, vol_lit: &str, uuid_lit: &str) 
 
 /// OmnibusAudio object scaffold: mode + direct-mode state plus the
 /// transport-control methods (play/pause/toggle/setRate/stop/seek/skip).
-/// Pure JS with no Rust interpolation, so it lives as a raw `&'static
-/// str` with literal braces.
+/// `seek` pushes the target time to the transport display synchronously
+/// (not just via the element's `timeupdate`), so a paused seek shows
+/// immediate feedback (#1897). Pure JS with no Rust interpolation, so it
+/// lives as a raw `&'static str` with literal braces.
 fn transport_controls_js() -> &'static str {
     r#"      // Playback mode. Set by initDirect / initHls; null before either fires.
       _mode: null,
@@ -89,6 +91,12 @@ fn transport_controls_js() -> &'static str {
       // play/pause state across the swap.
       seek: function(absSeconds){
         var s = Math.max(0, absSeconds || 0);
+        // Push the target time to the transport display immediately —
+        // don't wait for the element's own `timeupdate`, which some
+        // browsers fire unreliably (or not at all) for a seek issued while
+        // paused, leaving the readout and scrub position stuck at the old
+        // value until playback starts (#1897).
+        if (window.__omnibusOnAudioTime) { window.__omnibusOnAudioTime(s); }
         if (this._mode === 'direct' && this._parts) {
           var i = 0;
           while (i < this._cumOffsets.length - 1 && s >= this._cumOffsets[i + 1]) i++;
@@ -356,6 +364,12 @@ mod tests {
             "direct_play_init_js missing"
         );
         assert!(js.contains("initHls: function(url"), "hls_init_js missing");
+        // A paused seek must push the transport display immediately (#1897)
+        // rather than waiting on the element's own `timeupdate`.
+        assert!(
+            js.contains("if (window.__omnibusOnAudioTime) { window.__omnibusOnAudioTime(s); }"),
+            "seek does not push the target time immediately"
+        );
         // Sanity: no stray `{{` / `}}` escape pairs leaked from a `format!`.
         assert!(!js.contains("{{"), "literal {{ leaked into JS");
         assert!(!js.contains("}}"), "literal }} leaked into JS");

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -95,8 +95,11 @@ pub(super) fn on_skip_forward_30() -> impl FnMut(MouseEvent) + 'static {
 }
 
 /// Seek the shared audio element to an absolute position in seconds. Shared
-/// by the full player's scrub/chapter handlers and the mini-dock's chapter
-/// jumps; no-op off web (SSR has no audio element to poke).
+/// by the full player's scrub/chapter/bookmark handlers and the mini-dock's
+/// chapter jumps; no-op off web (SSR has no audio element to poke). The JS
+/// `seek` shim pushes the target time to the transport display immediately
+/// — playing or paused — rather than waiting on the element's own
+/// `timeupdate` (#1897).
 #[cfg(not(feature = "mobile"))]
 pub(super) fn seek_to(secs: f64) {
     #[cfg(feature = "web")]

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -742,6 +742,52 @@ test("opens chapters drawer and shows played/current/upcoming row states", async
 });
 
 // ---------------------------------------------------------------------------
+// 10b. Paused chapter-list seek shows immediate transport feedback (#1897)
+// ---------------------------------------------------------------------------
+
+test("shows the target time immediately after a paused chapter-list seek (#1897)", async ({
+  page,
+  request,
+}) => {
+  // Two parts → two synthetic chapters, so a chapter-row click seeks to a
+  // real, non-zero target (see the "opens chapters drawer" test above).
+  const uuid = await fetchBookUuidByTitle(request, MULTIPART_MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  // The player boots paused — the regression only reproduces on a seek
+  // issued while paused, so pin that precondition before seeking.
+  await expect(
+    page.getByRole("button", { name: "Play", exact: true }),
+  ).toBeVisible();
+
+  const seek = page.getByRole("slider", { name: "Seek" });
+  await expect(seek).toBeVisible();
+  const before = await seek.inputValue();
+
+  await page.getByRole("button", { name: /^chapters/i }).click();
+  await expect(page.getByTestId("chapters-drawer")).toBeVisible();
+  await page.getByTestId("chapter-row-upcoming").first().click();
+
+  // Still paused — a seek must not itself start playback.
+  await expect(
+    page.getByRole("button", { name: "Play", exact: true }),
+  ).toBeVisible();
+
+  // Bug #1897: without pushing the seek target into the transport display
+  // immediately, the scrub slider and elapsed readout stay at `before`
+  // until a `timeupdate` fires — which never happens while paused. Assert
+  // it updates right away, with no play() call anywhere in this test.
+  await expect
+    .poll(() => seek.inputValue(), {
+      message: "seek slider should reflect the chapter jump while paused",
+    })
+    .not.toBe(before);
+  const target = Number(await seek.inputValue());
+  expect(target).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- A programmatic seek issued while the audio player is paused (chapter-list jump, bookmark open, scrub-release, cross-format resume prompt) only moved `el.currentTime`; the transport readout and scrub position waited on the `<audio>` element's `timeupdate` event, which browsers don't reliably fire for a seek issued while paused — so the display stayed at the old position until playback resumed.
- `OmnibusAudio.seek` (`frontend/src/pages/listen/bootstrap/js.rs`) now pushes the target time to `window.__omnibusOnAudioTime` immediately, before touching the element/part swap. Every paused-seek caller funnels through `helpers::seek_to` → this one JS function, so chapter jumps, bookmark opens, and the scrubber all get the fix for free.
- Updated the doc comments on `seek_to` and the JS transport-controls scaffold to record the new immediate-feedback behavior, and added a unit-test assertion pinning the new line in `control_surface_js`.

Closes #1897

## Test plan
- [x] `cargo fmt -p omnibus-frontend` — no changes needed
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS (763 passed; 0 failed)
- [ ] `cargo clippy -p omnibus-frontend --target wasm32-unknown-unknown --no-default-features --features web -- -D warnings` — not run; the `wasm32-unknown-unknown` target isn't installed in this environment (`rustup target list --installed` doesn't list it)
- [x] Added `ui_tests/playwright/tests/flows/listen.spec.ts` test "shows the target time immediately after a paused chapter-list seek (#1897)" per rule 04 (AC3) — asserts the seek slider updates to the chapter-jump target while the player stays paused, with no playback tick involved. Not run locally (no browser/server available in this environment); CI will run it via the `run_ui_tests` label on this PR.

## Notes
- 


---
_Generated by [Claude Code](https://claude.ai/code/session_016Emok4ndtiZhu6YFYa1Gdy)_