### PR TITLE
fix: format dates in table view and series pages (#1905)

### DIFF
--- a/frontend/src/format.rs
+++ b/frontend/src/format.rs
@@ -91,12 +91,19 @@ struct ParsedDate {
 /// `T` or space onward (time-of-day, offset) is dropped — every caller here
 /// renders a calendar date, never a clock time. Returns `None` when the
 /// leading segment isn't a parseable year.
+///
+/// A day outside 1–31 (`YYYY-MM-00`, a stray admin override, …) is treated
+/// the same as an absent day rather than parsed literally — narrowing to
+/// month/year is the graceful failure, not `"Month 0, YYYY"`.
 fn parse_date_prefix(raw: &str) -> Option<ParsedDate> {
     let date_part = raw.trim().split(['T', ' ']).next()?;
     let mut segments = date_part.split('-');
     let year = segments.next()?.parse().ok()?;
     let month = segments.next().and_then(|m| m.parse().ok());
-    let day = segments.next().and_then(|d| d.parse().ok());
+    let day = segments
+        .next()
+        .and_then(|d| d.parse().ok())
+        .filter(|d| (1..=31).contains(d));
     Some(ParsedDate { year, month, day })
 }
 

--- a/frontend/src/format.rs
+++ b/frontend/src/format.rs
@@ -1,8 +1,11 @@
 //! Small display formatters shared across surfaces that render `book_files`
-//! — the hero's file picker and the admin delete dialog — plus [`plural`], a
+//! — the hero's file picker and the admin delete dialog — [`plural`], a
 //! trivial pluralizer reused by the desktop and mobile search result
-//! summaries. Pure functions, no Dioxus, so they unit-test without a
-//! renderer.
+//! summaries, and the [`format_date_short`]/[`format_date_month_year`] pair
+//! that turns a stored date string into a human one for the landing table
+//! and series pages. Pure functions, no Dioxus, so they unit-test without a
+//! renderer, and — per `.claude/rules/07-hydration.md` — compute identically
+//! on SSR and the WASM client since neither reads any target-specific state.
 
 use omnibus_shared::BookFileInfo;
 
@@ -47,55 +50,96 @@ pub fn plural(n: u32) -> &'static str {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Em dash used for a date with nothing displayable — absent, unparsable, or
+/// a sentinel value (see [`SENTINEL_YEAR_MAX`]).
+const EM_DASH: &str = "\u{2014}";
 
-    fn file(format: &str, ordinal: i64, label: Option<&str>) -> BookFileInfo {
-        BookFileInfo {
-            id: 1,
-            format: format.to_string(),
-            filename: "f".into(),
-            ordinal,
-            label: label.map(str::to_string),
-            size_bytes: 0,
-            path: None,
-            etag: None,
-        }
-    }
+/// Calibre's "no publish date" placeholder — `UNDEFINED_DATE =
+/// datetime(101, 1, 1, tzinfo=utc)`, serialized into OPF as
+/// `0101-01-01T00:00:00+00:00` — and anything at or before it in year. No
+/// book in a real library has a genuine publication date that old, so any
+/// parsed year in this range means "date unknown," not "ancient."
+const SENTINEL_YEAR_MAX: i32 = 101;
 
-    #[test]
-    fn file_size_scales_the_unit_to_the_byte_count() {
-        assert_eq!(file_size(512), Some("512 B".into()));
-        assert_eq!(file_size(3_100), Some("3.1 KB".into()));
-        assert_eq!(file_size(3_100_000), Some("3.1 MB".into()));
-        assert_eq!(file_size(2_500_000_000), Some("2.5 GB".into()));
-    }
+const MONTH_NAMES: [&str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
 
-    #[test]
-    fn file_size_is_absent_for_an_unstated_size() {
-        assert_eq!(file_size(0), None);
-        assert_eq!(file_size(-1), None);
-    }
+/// A calendar date pulled from a stored date string's leading `YYYY`,
+/// `YYYY-MM`, or `YYYY-MM-DD` prefix.
+struct ParsedDate {
+    year: i32,
+    month: Option<u32>,
+    day: Option<u32>,
+}
 
-    #[test]
-    fn file_label_prefers_the_stored_label_over_the_ordinal() {
-        assert_eq!(
-            file_label(&file("epub", 0, Some("10th anniversary"))),
-            "EPUB · 10th anniversary"
-        );
-    }
+/// Parse the leading date out of a stored date string. Handles a full ISO
+/// 8601 timestamp (`2016-05-02T21:00:00+00:00`, `2026-07-31T00:01:35Z`), the
+/// SQLite `datetime()` shape `added_at` uses (`2024-01-02 03:04:05`), a bare
+/// `YYYY-MM-DD`, or a year-only / year-month OPF `dc:date`. Everything from a
+/// `T` or space onward (time-of-day, offset) is dropped — every caller here
+/// renders a calendar date, never a clock time. Returns `None` when the
+/// leading segment isn't a parseable year.
+fn parse_date_prefix(raw: &str) -> Option<ParsedDate> {
+    let date_part = raw.trim().split(['T', ' ']).next()?;
+    let mut segments = date_part.split('-');
+    let year = segments.next()?.parse().ok()?;
+    let month = segments.next().and_then(|m| m.parse().ok());
+    let day = segments.next().and_then(|d| d.parse().ok());
+    Some(ParsedDate { year, month, day })
+}
 
-    #[test]
-    fn file_label_falls_back_to_a_one_based_part_number() {
-        assert_eq!(file_label(&file("mp3", 1, None)), "MP3 · Part 2");
-        assert_eq!(file_label(&file("mp3", 1, Some("  "))), "MP3 · Part 2");
-    }
+/// Full month name for a 1-based month number, or `None` when it's out of
+/// range (a malformed source value) — callers fall back to a bare year.
+fn month_name(month: u32) -> Option<&'static str> {
+    month
+        .checked_sub(1)
+        .and_then(|i| MONTH_NAMES.get(i as usize))
+        .copied()
+}
 
-    #[test]
-    fn plural_matches_count() {
-        assert_eq!(plural(0), "s");
-        assert_eq!(plural(1), "");
-        assert_eq!(plural(2), "s");
+/// Shared absent/sentinel gate for the two public formatters below: parses
+/// `raw`, renders it with `render` when it names a real year, and falls back
+/// to an em dash otherwise.
+fn render_date(raw: &str, render: impl FnOnce(&ParsedDate) -> String) -> String {
+    match parse_date_prefix(raw) {
+        Some(d) if d.year > SENTINEL_YEAR_MAX => render(&d),
+        _ => EM_DASH.to_string(),
     }
 }
+
+/// Format a stored date string as a short human date for a table cell —
+/// `"May 2, 2016"`, falling back to `"May 2016"` or `"2016"` as the source
+/// narrows. Absent, unparsable, and sentinel dates (see
+/// [`SENTINEL_YEAR_MAX`]) render as an em dash.
+pub fn format_date_short(raw: &str) -> String {
+    render_date(raw, |d| match (d.month.and_then(month_name), d.day) {
+        (Some(month), Some(day)) => format!("{month} {day}, {}", d.year),
+        (Some(month), None) => format!("{month} {}", d.year),
+        (None, _) => d.year.to_string(),
+    })
+}
+
+/// Format a stored date string as `"May 2016"` for a series card — coarser
+/// than [`format_date_short`] since a card only has room for month + year.
+/// Same absent/sentinel handling.
+pub fn format_date_month_year(raw: &str) -> String {
+    render_date(raw, |d| match d.month.and_then(month_name) {
+        Some(month) => format!("{month} {}", d.year),
+        None => d.year.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/frontend/src/format/tests.rs
+++ b/frontend/src/format/tests.rs
@@ -84,6 +84,12 @@ fn format_date_short_falls_back_to_the_bare_year_with_no_month() {
 }
 
 #[test]
+fn format_date_short_narrows_to_month_and_year_when_the_day_is_out_of_range() {
+    assert_eq!(format_date_short("2016-05-00"), "May 2016");
+    assert_eq!(format_date_short("2016-05-32"), "May 2016");
+}
+
+#[test]
 fn format_date_short_renders_an_em_dash_for_an_empty_string() {
     assert_eq!(format_date_short(""), "\u{2014}");
 }

--- a/frontend/src/format/tests.rs
+++ b/frontend/src/format/tests.rs
@@ -1,0 +1,136 @@
+//! Tests for the small display formatters in [`super`].
+
+use super::*;
+
+fn file(format: &str, ordinal: i64, label: Option<&str>) -> BookFileInfo {
+    BookFileInfo {
+        id: 1,
+        format: format.to_string(),
+        filename: "f".into(),
+        ordinal,
+        label: label.map(str::to_string),
+        size_bytes: 0,
+        path: None,
+        etag: None,
+    }
+}
+
+#[test]
+fn file_size_scales_the_unit_to_the_byte_count() {
+    assert_eq!(file_size(512), Some("512 B".into()));
+    assert_eq!(file_size(3_100), Some("3.1 KB".into()));
+    assert_eq!(file_size(3_100_000), Some("3.1 MB".into()));
+    assert_eq!(file_size(2_500_000_000), Some("2.5 GB".into()));
+}
+
+#[test]
+fn file_size_is_absent_for_an_unstated_size() {
+    assert_eq!(file_size(0), None);
+    assert_eq!(file_size(-1), None);
+}
+
+#[test]
+fn file_label_prefers_the_stored_label_over_the_ordinal() {
+    assert_eq!(
+        file_label(&file("epub", 0, Some("10th anniversary"))),
+        "EPUB · 10th anniversary"
+    );
+}
+
+#[test]
+fn file_label_falls_back_to_a_one_based_part_number() {
+    assert_eq!(file_label(&file("mp3", 1, None)), "MP3 · Part 2");
+    assert_eq!(file_label(&file("mp3", 1, Some("  "))), "MP3 · Part 2");
+}
+
+#[test]
+fn plural_matches_count() {
+    assert_eq!(plural(0), "s");
+    assert_eq!(plural(1), "");
+    assert_eq!(plural(2), "s");
+}
+
+#[test]
+fn format_date_short_renders_a_full_iso_timestamp_with_offset() {
+    assert_eq!(
+        format_date_short("2016-05-02T21:00:00+00:00"),
+        "May 2, 2016"
+    );
+}
+
+#[test]
+fn format_date_short_renders_a_full_iso_timestamp_with_z_suffix() {
+    assert_eq!(format_date_short("2026-07-31T00:01:35Z"), "July 31, 2026");
+}
+
+#[test]
+fn format_date_short_renders_the_sqlite_datetime_shape_added_at_uses() {
+    assert_eq!(format_date_short("2024-01-02 03:04:05"), "January 2, 2024");
+}
+
+#[test]
+fn format_date_short_renders_a_bare_calendar_date() {
+    assert_eq!(format_date_short("1843-10-01"), "October 1, 1843");
+}
+
+#[test]
+fn format_date_short_falls_back_to_month_and_year_with_no_day() {
+    assert_eq!(format_date_short("2016-05"), "May 2016");
+}
+
+#[test]
+fn format_date_short_falls_back_to_the_bare_year_with_no_month() {
+    assert_eq!(format_date_short("2016"), "2016");
+}
+
+#[test]
+fn format_date_short_renders_an_em_dash_for_an_empty_string() {
+    assert_eq!(format_date_short(""), "\u{2014}");
+}
+
+#[test]
+fn format_date_short_renders_an_em_dash_for_unparsable_text() {
+    assert_eq!(format_date_short("circa 1850"), "\u{2014}");
+}
+
+#[test]
+fn format_date_short_renders_an_em_dash_for_the_calibre_undefined_date_sentinel() {
+    assert_eq!(format_date_short("0101-01-01T00:00:00+00:00"), "\u{2014}");
+}
+
+#[test]
+fn format_date_short_renders_an_em_dash_for_year_at_or_below_the_sentinel() {
+    assert_eq!(format_date_short("0001-01-01"), "\u{2014}");
+    assert_eq!(format_date_short("0101-06-15"), "\u{2014}");
+}
+
+#[test]
+fn format_date_short_renders_a_real_year_just_above_the_sentinel() {
+    assert_eq!(format_date_short("0102-01-01"), "January 1, 102");
+}
+
+#[test]
+fn format_date_month_year_renders_month_and_year() {
+    assert_eq!(
+        format_date_month_year("2016-05-02T21:00:00+00:00"),
+        "May 2016"
+    );
+}
+
+#[test]
+fn format_date_month_year_falls_back_to_the_bare_year_with_no_month() {
+    assert_eq!(format_date_month_year("2016"), "2016");
+}
+
+#[test]
+fn format_date_month_year_renders_an_em_dash_for_the_sentinel() {
+    assert_eq!(
+        format_date_month_year("0101-01-01T00:00:00+00:00"),
+        "\u{2014}"
+    );
+}
+
+#[test]
+fn format_date_month_year_renders_an_em_dash_for_an_empty_string() {
+    assert_eq!(format_date_month_year(""), "\u{2014}");
+}

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -247,11 +247,16 @@ pub(super) fn RowSeriesCell(series_line: String, series_text: String, ctx: CellE
 }
 
 /// Grouped display fields (column class, testid, value, placeholder) for a [`RowScalarCell`].
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Default)]
 pub(super) struct RowScalarCellDisplay {
     pub col_class: String,
     pub cell_testid: String,
     pub value: String,
+    /// Raw value to seed the input with when edit mode opens, when it
+    /// differs from the rendered `value` — e.g. Published shows a formatted
+    /// date (see [`crate::format::format_date_short`]) but must still edit
+    /// the underlying stored string. Defaults to `value`.
+    pub edit_value: Option<String>,
     pub placeholder: String,
 }
 
@@ -268,6 +273,7 @@ pub(super) fn RowScalarCell(
         col_class,
         cell_testid,
         value,
+        edit_value,
         placeholder,
     } = display;
     let CellEditCtx {
@@ -281,8 +287,8 @@ pub(super) fn RowScalarCell(
                 col_class,
                 cell_testid,
                 display_value: value,
+                edit_value,
                 placeholder,
-                ..Default::default()
             },
             field,
             is_admin,

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -163,7 +163,10 @@ struct RowDisplay {
     added: String,
     tags_text: String,
     genres_text: String,
+    /// Raw stored value — seeds the edit input so opening the cell shows the
+    /// editable source string, not the formatted display text.
     published: String,
+    published_display: String,
     language: String,
 }
 
@@ -204,10 +207,13 @@ fn derive_row_display(
         series_line,
         series_text: book.series.clone().unwrap_or_default(),
         authors_text: contributor_names(&book.creators),
-        updated: book.modified.as_deref().unwrap_or("").to_string(),
-        added: book.added_at.as_deref().unwrap_or("").to_string(),
+        updated: crate::format::format_date_short(book.modified.as_deref().unwrap_or("")),
+        added: crate::format::format_date_short(book.added_at.as_deref().unwrap_or("")),
         tags_text: book.subjects.join(", "),
         genres_text: book.genres.join(", "),
+        published_display: crate::format::format_date_short(
+            book.published.as_deref().unwrap_or(""),
+        ),
         published: book.published.clone().unwrap_or_default(),
         language: book.language.clone().unwrap_or_default(),
         book: book.clone(),
@@ -314,6 +320,7 @@ fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
         tags_text,
         genres_text,
         published,
+        published_display,
         language,
     } = display;
     let cover_alt = title.clone();
@@ -373,7 +380,8 @@ fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
             display: RowScalarCellDisplay {
                 col_class: "ebook-col-published".to_string(),
                 cell_testid: "ebook-cell-published".to_string(),
-                value: published,
+                value: published_display,
+                edit_value: Some(published),
                 placeholder: "YYYY-MM-DD".to_string(),
             },
             field: EditField::Published,
@@ -388,6 +396,7 @@ fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
                 cell_testid: "ebook-cell-language".to_string(),
                 value: language,
                 placeholder: "en".to_string(),
+                ..Default::default()
             },
             field: EditField::Language,
             ctx: cell_ctx,

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -123,8 +123,8 @@ fn series_book_row(book: &EbookMetadata) -> Element {
                     if let Some(ref idx) = book.series_index {
                         "Book #{idx}"
                     }
-                    if let Some(ref year) = book.published {
-                        " · {year}"
+                    if let Some(ref published) = book.published {
+                        " · {crate::format::format_date_month_year(published)}"
                     }
                 }
                 h3 { class: "series-card-title",

--- a/ui_tests/playwright/tests/fixtures/epubs.ts
+++ b/ui_tests/playwright/tests/fixtures/epubs.ts
@@ -35,7 +35,11 @@ export interface ExpectedBook {
    * fixtures pin `[]`.
    */
   tags?: string[];
-  /** Verbatim text rendered in the published cell. */
+  /**
+   * Raw stored `dc:date` value (e.g. `"1843-10-01"`). The published cell
+   * renders a formatted human date derived from this, not the raw string —
+   * see `expectedPublishedText` in `utils/ebooks.ts`.
+   */
   published?: string;
   /** Verbatim text rendered in the language cell (BCP-47). */
   language: string;

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -125,7 +125,11 @@ function expectedPublishedText(raw: string): string {
     return "—";
   }
   const month = monthStr ? Number(monthStr) : undefined;
-  const day = dayStr ? Number(dayStr) : undefined;
+  const dayNum = dayStr ? Number(dayStr) : undefined;
+  // Explicit range check, not JS truthiness — `0` is a valid `Number` but an
+  // invalid day, and falsy-zero would silently disagree with the Rust side's
+  // `(1..=31).contains(d)` filter in `parse_date_prefix`.
+  const day = dayNum !== undefined && dayNum >= 1 && dayNum <= 31 ? dayNum : undefined;
   const monthName =
     month && month >= 1 && month <= 12 ? MONTH_NAMES[month - 1] : undefined;
   if (monthName && day) return `${monthName} ${day}, ${year}`;

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -90,6 +90,49 @@ function expectedSeriesText(book: ExpectedBook): string {
   return "";
 }
 
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+// Calibre's "no publish date" placeholder (`UNDEFINED_DATE =
+// datetime(101, 1, 1, tzinfo=utc)`) and anything at or before it in year —
+// mirrors `SENTINEL_YEAR_MAX` in `frontend/src/format.rs`.
+const SENTINEL_YEAR_MAX = 101;
+
+/**
+ * Expected text for the published cell, mirroring
+ * `frontend::format::format_date_short` (#1905): a stored `YYYY[-MM[-DD]]`
+ * date renders as `"Month D, YYYY"`, narrowing to `"Month YYYY"` or `"YYYY"`
+ * as the source narrows; an absent, unparsable, or sentinel date renders as
+ * an em dash. Keep the two formatters in lockstep.
+ */
+function expectedPublishedText(raw: string): string {
+  const datePart = raw.trim().split(/[T ]/)[0] ?? "";
+  const [yearStr, monthStr, dayStr] = datePart.split("-");
+  const year = Number(yearStr);
+  if (!yearStr || !Number.isFinite(year) || year <= SENTINEL_YEAR_MAX) {
+    return "—";
+  }
+  const month = monthStr ? Number(monthStr) : undefined;
+  const day = dayStr ? Number(dayStr) : undefined;
+  const monthName =
+    month && month >= 1 && month <= 12 ? MONTH_NAMES[month - 1] : undefined;
+  if (monthName && day) return `${monthName} ${day}, ${year}`;
+  if (monthName) return `${monthName} ${year}`;
+  return `${year}`;
+}
+
 /**
  * Assert every visible cell in a fixture's row matches the expected metadata.
  * Each per-cell testid (`ebook-cell-title`, `-author`, `-series`,
@@ -123,7 +166,7 @@ export async function expectRowMatches(
     );
   }
   await expect(row.getByTestId("ebook-cell-published")).toHaveText(
-    expected.published ?? "",
+    expectedPublishedText(expected.published ?? ""),
   );
   await expect(row.getByTestId("ebook-cell-language")).toHaveText(
     expected.language,

--- a/ui_tests/playwright/tests/utils/ebooks.ts
+++ b/ui_tests/playwright/tests/utils/ebooks.ts
@@ -129,7 +129,8 @@ function expectedPublishedText(raw: string): string {
   // Explicit range check, not JS truthiness — `0` is a valid `Number` but an
   // invalid day, and falsy-zero would silently disagree with the Rust side's
   // `(1..=31).contains(d)` filter in `parse_date_prefix`.
-  const day = dayNum !== undefined && dayNum >= 1 && dayNum <= 31 ? dayNum : undefined;
+  const day =
+    dayNum !== undefined && dayNum >= 1 && dayNum <= 31 ? dayNum : undefined;
   const monthName =
     month && month >= 1 && month <= 12 ? MONTH_NAMES[month - 1] : undefined;
   if (monthName && day) return `${monthName} ${day}, ${year}`;


### PR DESCRIPTION
## Summary
- Closes #1905
- Landing table view's Published / Last updated / Added columns rendered raw
  ISO timestamps (`2016-05-02T21:00:00+00:00`, `2026-07-31T00:01:35Z`); the
  series detail page did the same for each book's publication date.
- Added `format_date_short`/`format_date_month_year` to `frontend/src/format.rs`
  — pure, target-agnostic string formatters (no new date-library dependency)
  that turn a stored `YYYY[-MM[-DD]]`-prefixed date into a short human date
  (`"May 2, 2016"`) or a month/year one (`"May 2016"`), narrowing gracefully
  when the source has less precision.
- Both formatters treat Calibre's "no publish date" placeholder
  (`0101-01-01T00:00:00+00:00`, `UNDEFINED_DATE = datetime(101, 1, 1)`) and
  any date at or before it in year as absent, rendering an em dash instead of
  leaking the sentinel digits.
- The table's Published cell keeps editing the raw stored string (only its
  *display* text is formatted) so admin overrides aren't corrupted by the
  formatted text round-tripping through the edit input.
- Updated the Playwright fixture-comparison helper
  (`ui_tests/playwright/tests/utils/ebooks.ts`) to assert the same formatted
  text the table now renders, mirroring the Rust formatter the same way the
  existing series-cell helper already does.

## Test plan
- `cargo fmt` — PASS
- `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- `cargo test -p omnibus-frontend --features server` — PASS (778 passed)

## Notes
- Playwright itself was not run locally (no nix in this environment); the
  `run_ui_tests` label is applied so CI exercises the updated
  `landing.spec.ts` assertions.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Emok4ndtiZhu6YFYa1Gdy)_