### PR TITLE
fix: correct reader footer chapter/percent and add TOC-jump loading state

### DIFF
--- a/frontend/src/pages/reader/chrome.rs
+++ b/frontend/src/pages/reader/chrome.rs
@@ -143,7 +143,7 @@ fn reader_title_block(book_title: &str, chapter_title: &str, title_sub: &str) ->
             span { class: "rd-title-book", "{book_title}" }
             if !chapter_title.is_empty() {
                 span { class: "rd-title-sep", "\u{b7}" }
-                span { class: "rd-title-ch", "{chapter_title}" }
+                span { class: "rd-title-ch", "data-testid": "reader-header-chapter", "{chapter_title}" }
             }
             // Phone sub-line ("Ch. 14 · 68%") — the breakpoint stacks the
             // title block and swaps the inline chapter for this.

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -9,6 +9,7 @@ use omnibus_shared::Highlight;
 use super::prefs::ReaderPrefs;
 use super::search_panel::SearchResult;
 use super::selection::SelectionData;
+use super::signals::resolve_chapter_position;
 use super::toc_drawer::TocEntry;
 use super::ReaderStatus;
 
@@ -126,17 +127,33 @@ fn register_window_callbacks(
 
     let uuid_for_save = uuid_cb;
     let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
-        if let Ok(data) = serde_json::from_str::<super::RelocateData>(&json) {
+        if let Ok(mut data) = serde_json::from_str::<super::RelocateData>(&json) {
+            // Re-derive chapter/total from the TOC's own order rather than
+            // trusting the glue's numbers verbatim — see
+            // `signals::resolve_chapter_position` (issue #1909, AC1).
+            let toc_snapshot = toc.peek().clone();
+            let previous_chapter = loc.peek().chapter;
+            let (chapter, total_chapters) =
+                resolve_chapter_position(&toc_snapshot, &data, previous_chapter);
+            data.chapter = chapter;
+            data.total_chapters = total_chapters;
+
             if let Some(ref cfi) = data.cfi {
                 crate::reader_progress::save(&uuid_for_save, cfi);
                 let uuid_for_post = uuid_for_save.clone();
                 let cfi_for_post = cfi.clone();
+                // `progress_percent` is the same whole-book figure the
+                // footer/ribbon render (`data.pct`) — sending it keeps the
+                // landing hero's stored percent in step with what the
+                // reader itself is showing (issue #1909, AC2).
+                let percent_for_post = i64::from(data.pct.min(100));
                 wasm_bindgen_futures::spawn_local(async move {
                     let body = serde_json::json!({
                         "update": {
                             "book_uuid": uuid_for_post,
                             "format": "epub",
                             "epub_cfi": cfi_for_post,
+                            "progress_percent": percent_for_post,
                         }
                     });
                     if let Ok(req) = gloo_net::http::Request::post("/api/rpc/progress").json(&body)
@@ -144,6 +161,15 @@ fn register_window_callbacks(
                         let _ = req.send().await;
                     }
                 });
+            }
+            // A relocate always names the (corrected) current position, so
+            // it also signals that an in-flight chapter jump has finished
+            // rendering — flip a TOC-jump-triggered `Loading` back to
+            // `Ready` (issue #1909, AC3). Guarded so a relocate stray after
+            // a load `Failed` can't resurrect the overlay as if nothing
+            // went wrong.
+            if *status.peek() == ReaderStatus::Loading {
+                status.set(ReaderStatus::Ready);
             }
             loc.set(data);
         }

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -16,6 +16,7 @@ use crate::time::now_unix;
 use super::prefs::ReaderPrefs;
 use super::search_panel::SearchResult;
 use super::selection::SelectionData;
+use super::signals::resolve_chapter_position;
 use super::toc_drawer::TocEntry;
 use super::{reader_call_json, reader_call_json2, ReaderStatus, RelocateData};
 
@@ -213,15 +214,33 @@ async fn drain_reader_events(
     let mut last_cfi: Option<String> = None;
     crate::js_interop::drain_events(eval, move |event: ReaderEvent| match event {
         ReaderEvent::Relocate { json } => {
-            if let Ok(data) = serde_json::from_str::<RelocateData>(&json) {
+            if let Ok(mut data) = serde_json::from_str::<RelocateData>(&json) {
+                // Re-derive chapter/total from the TOC's own order rather
+                // than trusting the glue's numbers verbatim — see
+                // `signals::resolve_chapter_position` (issue #1909, AC1).
+                let toc_snapshot = toc.peek().clone();
+                let previous_chapter = loc.peek().chapter;
+                let (chapter, total_chapters) =
+                    resolve_chapter_position(&toc_snapshot, &data, previous_chapter);
+                data.chapter = chapter;
+                data.total_chapters = total_chapters;
+
                 if let Some(cfi) = data.cfi.clone() {
                     crate::reader_progress::save(&uuid, &cfi);
                     // Only POST on an actual position change (the glue
                     // debounces, but re-renders can re-emit the same CFI).
                     if last_cfi.as_deref() != Some(cfi.as_str()) {
                         last_cfi = Some(cfi.clone());
-                        persist_progress(&uuid, &server_url, cfi);
+                        persist_progress(&uuid, &server_url, cfi, data.pct);
                     }
+                }
+                // A relocate names the (corrected) current position, so it
+                // also signals that an in-flight chapter jump has finished
+                // rendering — flip a TOC-jump-triggered `Loading` back to
+                // `Ready` (issue #1909, AC3). Guarded so a stray relocate
+                // after a load `Failed` can't resurrect the overlay.
+                if *status.peek() == ReaderStatus::Loading {
+                    status.set(ReaderStatus::Ready);
                 }
                 loc.set(data);
             }
@@ -281,8 +300,11 @@ async fn drain_reader_events(
 }
 
 /// Persist the latest CFI to the server (fire-and-forget); the local in-memory
-/// save already happened on the calling side.
-fn persist_progress(uuid: &str, server_url: &str, cfi: String) {
+/// save already happened on the calling side. `pct` is the same whole-book
+/// figure the footer/ribbon render — carrying it into `progress_percent`
+/// keeps the landing hero's stored percent in step with what the reader
+/// itself is showing (issue #1909, AC2).
+fn persist_progress(uuid: &str, server_url: &str, cfi: String, pct: u32) {
     let uuid = uuid.to_string();
     let server_url = server_url.to_string();
     spawn(async move {
@@ -291,7 +313,7 @@ fn persist_progress(uuid: &str, server_url: &str, cfi: String) {
             format: ProgressFormat::Epub,
             epub_cfi: Some(cfi),
             audio_position_seconds: None,
-            progress_percent: None,
+            progress_percent: Some(i64::from(pct.min(100))),
             kobo_location: None,
             book_file_id: None,
             client_updated_at: Some(now_unix()),

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -633,37 +633,4 @@ fn ReaderLayout(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    // `Signal::new` needs a Dioxus runtime, so this runs inside a
-    // `VirtualDom` (see `reader::prefs::tests`). Regression for issue #1909
-    // (AC3): a TOC-jump-triggered `Loading` must blank the header's chapter
-    // readout rather than showing the previous chapter alongside the
-    // loading affordance, and must restore it once the jump lands.
-    #[test]
-    fn derive_reader_display_blanks_chapter_title_while_loading_and_restores_it_once_ready() {
-        #[component]
-        fn AssertDisplay() -> Element {
-            let loc = Signal::new(RelocateData {
-                chapter: 5,
-                total_chapters: 94,
-                chapter_title: "Chapter Five".to_string(),
-                pct: 12,
-                ..Default::default()
-            });
-            let book_meta: Signal<Option<omnibus_shared::EbookMetadata>> = Signal::new(None);
-
-            let loading = derive_reader_display(loc, book_meta, ReaderStatus::Loading);
-            assert_eq!(loading.chapter_title, "");
-            assert_eq!(loading.title_sub, "");
-
-            let ready = derive_reader_display(loc, book_meta, ReaderStatus::Ready);
-            assert_eq!(ready.chapter_title, "Chapter Five");
-            assert!(!ready.title_sub.is_empty());
-
-            rsx! {}
-        }
-        VirtualDom::new(AssertDisplay).rebuild_in_place();
-    }
-}
+mod tests;

--- a/frontend/src/pages/reader/mod.rs
+++ b/frontend/src/pages/reader/mod.rs
@@ -136,7 +136,7 @@ pub fn BookReadPage(uuid: String) -> Element {
         book_title,
         book_author,
         book_accent,
-    } = derive_reader_display(loc, book_meta);
+    } = derive_reader_display(loc, book_meta, status());
 
     rsx! {
         ReaderLayout {
@@ -170,6 +170,7 @@ pub fn BookReadPage(uuid: String) -> Element {
                 search_results,
                 show_bookmarks,
                 show_annotations,
+                status,
             },
             nav: ReaderNavHandlers {
                 on_keydown,
@@ -382,18 +383,35 @@ struct ReaderDisplay {
 }
 
 /// Derive page/chapter labels and book title/author/accent from `loc` and `book_meta`.
+///
+/// `status` gates the top-bar chapter readout: while a TOC/bookmark/search
+/// jump is in flight (`ReaderStatus::Loading`), the header blanks the
+/// previous chapter's title/sub-line rather than showing it alongside the
+/// loading affordance — see [`ReaderStatus`] and issue #1909 (AC3). The
+/// footer/ribbon strings are left alone; they settle the moment the new
+/// relocate lands, same as `status` itself.
 fn derive_reader_display(
     loc: Signal<RelocateData>,
     book_meta: Signal<Option<omnibus_shared::EbookMetadata>>,
+    status: ReaderStatus,
 ) -> ReaderDisplay {
     // One read: every derived label comes from the same relocate snapshot.
     let loc_now = loc.read();
     let (page_str, chapter_str) = format_progress_labels(&loc_now);
     let ambient_page = format_ambient_page(&loc_now);
-    let title_sub = format_title_sub(&loc_now);
+    let loading = status == ReaderStatus::Loading;
+    let title_sub = if loading {
+        String::new()
+    } else {
+        format_title_sub(&loc_now)
+    };
     let contents_progress = format_contents_progress(&loc_now);
     let pct = loc_now.pct;
-    let chapter_title = loc_now.chapter_title.clone();
+    let chapter_title = if loading {
+        String::new()
+    } else {
+        loc_now.chapter_title.clone()
+    };
     let current_cfi = loc_now.cfi.clone().unwrap_or_default();
     let book_title = book_meta
         .read()
@@ -469,6 +487,9 @@ pub(super) struct ReaderPanelSignals {
     pub search_results: Signal<Vec<SearchResult>>,
     pub show_bookmarks: Signal<bool>,
     pub show_annotations: Signal<bool>,
+    /// Threaded through so a TOC jump can flip the reader into its loading
+    /// state before asking the glue to navigate (see `overlays::render_toc_overlay`).
+    pub status: Signal<ReaderStatus>,
 }
 
 /// Navigation + keyboard handlers for the top bar, page-turn gutters, and surface keydown.
@@ -608,5 +629,41 @@ fn ReaderLayout(
                 panels,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `Signal::new` needs a Dioxus runtime, so this runs inside a
+    // `VirtualDom` (see `reader::prefs::tests`). Regression for issue #1909
+    // (AC3): a TOC-jump-triggered `Loading` must blank the header's chapter
+    // readout rather than showing the previous chapter alongside the
+    // loading affordance, and must restore it once the jump lands.
+    #[test]
+    fn derive_reader_display_blanks_chapter_title_while_loading_and_restores_it_once_ready() {
+        #[component]
+        fn AssertDisplay() -> Element {
+            let loc = Signal::new(RelocateData {
+                chapter: 5,
+                total_chapters: 94,
+                chapter_title: "Chapter Five".to_string(),
+                pct: 12,
+                ..Default::default()
+            });
+            let book_meta: Signal<Option<omnibus_shared::EbookMetadata>> = Signal::new(None);
+
+            let loading = derive_reader_display(loc, book_meta, ReaderStatus::Loading);
+            assert_eq!(loading.chapter_title, "");
+            assert_eq!(loading.title_sub, "");
+
+            let ready = derive_reader_display(loc, book_meta, ReaderStatus::Ready);
+            assert_eq!(ready.chapter_title, "Chapter Five");
+            assert!(!ready.title_sub.is_empty());
+
+            rsx! {}
+        }
+        VirtualDom::new(AssertDisplay).rebuild_in_place();
     }
 }

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -127,13 +127,9 @@ pub(super) struct OverlayMeta {
 
 /// Contents (table-of-contents) drawer, shown while `show_toc` is set.
 ///
-/// `on_navigate` flips `status` to [`ReaderStatus::Loading`] before asking
-/// the glue to display the target — the same overlay `ReaderViewerStage`
-/// already renders for the initial book load covers the jump too, and the
-/// header blanks the outgoing chapter's title in step (`derive_reader_display`
-/// in `mod.rs`) rather than showing it alongside the new chapter's content.
-/// The relocate that lands once the target has rendered flips `status` back
-/// to `Ready` (`interop`/`mobile`'s relocate handlers) — see issue #1909 (AC3).
+/// `on_navigate` flips `status` to [`ReaderStatus::Loading`] before asking the
+/// glue to display the target, so the header blanks the outgoing chapter
+/// until the relocate that confirms the jump landed flips it back to `Ready`.
 fn render_toc_overlay(
     show_toc: Signal<bool>,
     toc: Signal<Vec<super::toc_drawer::TocEntry>>,

--- a/frontend/src/pages/reader/overlays.rs
+++ b/frontend/src/pages/reader/overlays.rs
@@ -16,7 +16,7 @@ use super::reader_bookmarks::ReaderBookmarksDrawer;
 use super::search_panel::SearchPanel;
 use super::selection::{SelectionActions, SelectionAnchor, SelectionData, SelectionPopover};
 use super::toc_drawer::TocDrawer;
-use super::ReaderPanelSignals;
+use super::{ReaderPanelSignals, ReaderStatus};
 
 /// Selection popover: highlight / note / quote / copy / share actions for the
 /// current text selection. Renders nothing when there is no selection.
@@ -126,11 +126,20 @@ pub(super) struct OverlayMeta {
 }
 
 /// Contents (table-of-contents) drawer, shown while `show_toc` is set.
+///
+/// `on_navigate` flips `status` to [`ReaderStatus::Loading`] before asking
+/// the glue to display the target — the same overlay `ReaderViewerStage`
+/// already renders for the initial book load covers the jump too, and the
+/// header blanks the outgoing chapter's title in step (`derive_reader_display`
+/// in `mod.rs`) rather than showing it alongside the new chapter's content.
+/// The relocate that lands once the target has rendered flips `status` back
+/// to `Ready` (`interop`/`mobile`'s relocate handlers) — see issue #1909 (AC3).
 fn render_toc_overlay(
     show_toc: Signal<bool>,
     toc: Signal<Vec<super::toc_drawer::TocEntry>>,
     chapter_title: String,
     contents_progress: String,
+    status: Signal<ReaderStatus>,
 ) -> Element {
     if !show_toc() {
         return rsx! {};
@@ -141,6 +150,8 @@ fn render_toc_overlay(
             current_title: chapter_title,
             progress_label: contents_progress,
             on_navigate: move |href: String| {
+                let mut status = status;
+                status.set(ReaderStatus::Loading);
                 #[cfg(any(feature = "web", feature = "mobile"))]
                 super::reader_call_json("display", &href);
                 let _ = &href;
@@ -385,11 +396,12 @@ pub(super) fn ReaderOverlays(meta: OverlayMeta, panels: ReaderPanelSignals) -> E
         search_results,
         show_bookmarks,
         show_annotations,
+        status,
         ..
     } = panels;
 
     rsx! {
-        {render_toc_overlay(show_toc, toc, chapter_title.clone(), contents_progress)}
+        {render_toc_overlay(show_toc, toc, chapter_title.clone(), contents_progress, status)}
         {render_highlights_overlay(show_highlights, highlights, quote_target, note_target)}
         {render_search_overlay(show_search, search_results)}
         {render_bookmarks_overlay(show_bookmarks, uuid.clone(), current_cfi.clone(), chapter_title.clone())}

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -75,14 +75,10 @@ pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
     (page, chapter)
 }
 
-/// Resolve the displayed chapter index/total from the flat TOC's own order
-/// rather than trusting the glue's `chapter`/`total_chapters` pair verbatim.
-/// A front-matter spine item with no direct TOC entry arrives with an empty
-/// `chapter_title`, and the glue's own href match falls through to 0 for
-/// it — which reads as the counter going backwards mid-front-matter (issue
-/// #1909, AC1). When the title doesn't resolve, the previous chapter is
-/// carried forward instead of regressing to 0; a title that *does* match
-/// always wins outright, including a legitimate backward jump.
+/// Resolve the displayed chapter index/total from the flat TOC's own array
+/// order rather than the glue's `chapter`/`total_chapters` pair verbatim,
+/// carrying the previous chapter forward instead of regressing to 0 when
+/// the incoming title doesn't match any TOC entry.
 #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 pub(crate) fn resolve_chapter_position(
     toc: &[TocEntry],

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -6,6 +6,7 @@
 use dioxus::prelude::*;
 use omnibus_shared::EbookMetadata;
 
+use super::toc_drawer::TocEntry;
 use crate::contexts::use_server_url;
 use crate::data;
 
@@ -72,6 +73,34 @@ pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
         String::new()
     };
     (page, chapter)
+}
+
+/// Resolve the displayed chapter index/total from the flat TOC's own order
+/// rather than trusting the glue's `chapter`/`total_chapters` pair verbatim.
+/// A front-matter spine item with no direct TOC entry arrives with an empty
+/// `chapter_title`, and the glue's own href match falls through to 0 for
+/// it — which reads as the counter going backwards mid-front-matter (issue
+/// #1909, AC1). When the title doesn't resolve, the previous chapter is
+/// carried forward instead of regressing to 0; a title that *does* match
+/// always wins outright, including a legitimate backward jump.
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
+pub(crate) fn resolve_chapter_position(
+    toc: &[TocEntry],
+    incoming: &RelocateData,
+    previous_chapter: u32,
+) -> (u32, u32) {
+    if toc.is_empty() {
+        return (incoming.chapter, incoming.total_chapters);
+    }
+    let total = toc.len() as u32;
+    let chapter = if incoming.chapter_title.is_empty() {
+        previous_chapter
+    } else {
+        toc.iter()
+            .position(|entry| entry.label == incoming.chapter_title)
+            .map_or(previous_chapter, |idx| idx as u32 + 1)
+    };
+    (chapter, total)
 }
 
 /// Format the phone minimal-chrome footer: just the page number (or the
@@ -277,5 +306,66 @@ mod tests {
         let (page, chapter) = format_progress_labels(&data);
         assert_eq!(page, "7%");
         assert_eq!(chapter, "");
+    }
+
+    fn toc_entry(label: &str) -> TocEntry {
+        TocEntry {
+            label: label.to_string(),
+            href: format!("{label}.xhtml"),
+            level: 0,
+        }
+    }
+
+    fn relocate_with_title(title: &str) -> RelocateData {
+        RelocateData {
+            chapter_title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    // Regression for issue #1909 (AC1): a front-matter spine item with no
+    // direct TOC entry must never read as chapter 0 — the previous chapter
+    // carries forward instead of the counter going backwards.
+    #[test]
+    fn resolve_chapter_position_carries_previous_chapter_forward_when_title_is_unmatched() {
+        let toc = vec![toc_entry("Cover"), toc_entry("Chapter One")];
+        let (chapter, total) = resolve_chapter_position(&toc, &relocate_with_title(""), 1);
+        assert_eq!((chapter, total), (1, 2));
+    }
+
+    #[test]
+    fn resolve_chapter_position_matches_the_toc_array_position_when_the_title_resolves() {
+        let toc = vec![
+            toc_entry("Cover"),
+            toc_entry("Dedication"),
+            toc_entry("Chapter One"),
+        ];
+        let (chapter, total) =
+            resolve_chapter_position(&toc, &relocate_with_title("Chapter One"), 1);
+        assert_eq!((chapter, total), (3, 3));
+    }
+
+    #[test]
+    fn resolve_chapter_position_falls_back_to_incoming_values_before_the_toc_has_loaded() {
+        let incoming = RelocateData {
+            chapter: 4,
+            total_chapters: 12,
+            ..Default::default()
+        };
+        assert_eq!(resolve_chapter_position(&[], &incoming, 3), (4, 12));
+    }
+
+    // A matched title always wins outright, so a deliberate backward jump
+    // (TOC/bookmark navigation to an earlier chapter) is never clamped by
+    // the forward-carry rule above.
+    #[test]
+    fn resolve_chapter_position_allows_a_matched_title_to_move_backward() {
+        let toc = vec![
+            toc_entry("Cover"),
+            toc_entry("Chapter One"),
+            toc_entry("Chapter Two"),
+        ];
+        let (chapter, _) = resolve_chapter_position(&toc, &relocate_with_title("Chapter One"), 3);
+        assert_eq!(chapter, 2);
     }
 }

--- a/frontend/src/pages/reader/tests.rs
+++ b/frontend/src/pages/reader/tests.rs
@@ -1,0 +1,31 @@
+//! Tests for `derive_reader_display`. `Signal::new` needs a Dioxus runtime,
+//! so this runs inside a `VirtualDom` (the pattern in
+//! `frontend/src/pages/reader/prefs/tests.rs`).
+
+use super::*;
+
+#[test]
+fn derive_reader_display_blanks_chapter_title_while_loading_and_restores_it_once_ready() {
+    #[component]
+    fn AssertDisplay() -> Element {
+        let loc = Signal::new(RelocateData {
+            chapter: 5,
+            total_chapters: 94,
+            chapter_title: "Chapter Five".to_string(),
+            pct: 12,
+            ..Default::default()
+        });
+        let book_meta: Signal<Option<omnibus_shared::EbookMetadata>> = Signal::new(None);
+
+        let loading = derive_reader_display(loc, book_meta, ReaderStatus::Loading);
+        assert_eq!(loading.chapter_title, "");
+        assert_eq!(loading.title_sub, "");
+
+        let ready = derive_reader_display(loc, book_meta, ReaderStatus::Ready);
+        assert_eq!(ready.chapter_title, "Chapter Five");
+        assert!(!ready.title_sub.is_empty());
+
+        rsx! {}
+    }
+    VirtualDom::new(AssertDisplay).rebuild_in_place();
+}

--- a/ui_tests/playwright/tests/fixtures/epubs.ts
+++ b/ui_tests/playwright/tests/fixtures/epubs.ts
@@ -508,6 +508,11 @@ export const FIXTURE_BOOKS: readonly ExpectedBook[] = [
   // Public-domain Project Gutenberg / Standard Ebooks EPUBs under
   // `test_data/epubs/public_domain/`. Metadata below is what each file's OPF
   // actually claims — `db/tests/public_domain_epubs.rs` keeps the parser honest.
+  //
+  // `dracula` is reserved for the TOC-jump loading-state regression in
+  // reader.spec.ts (issue #1909): it needs a real multi-chapter book so the
+  // contents drawer lists more than one row to jump between — no other spec
+  // may open it in the reader.
   {
     slug: "dracula",
     filename: "public_domain/dracula.epub",

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -181,10 +181,8 @@ test("shows a loading state during a TOC jump and blanks the outgoing chapter in
 
   // Establish a real baseline chapter in the header before jumping — proves
   // the assertion below is about the readout actually clearing, not just
-  // never having had anything to clear in the first place. No dedicated
-  // testid on this span (`chrome.rs`'s `reader_title_block`), so this is the
-  // one spot in the file that reaches for a class locator.
-  const headerChapter = page.locator(".rd-title-ch");
+  // never having had anything to clear in the first place.
+  const headerChapter = page.getByTestId("reader-header-chapter");
   await expect(headerChapter).toBeVisible({ timeout: 20_000 });
 
   await page.getByTestId("reader-toc").click();
@@ -194,15 +192,24 @@ test("shows a loading state during a TOC jump and blanks the outgoing chapter in
   // A row a few entries in, so the jump actually moves off the current
   // (front-matter) chapter rather than re-displaying it.
   await expect(rows.nth(3)).toBeVisible();
-  await rows.nth(3).click();
 
-  // The drawer closes and the loading affordance appears immediately — this
-  // is synchronous with the click (`overlays::render_toc_overlay`), so it
-  // never races the epub.js render — and the header must not show the
-  // outgoing chapter alongside it.
-  await expect(drawer).toHaveCount(0);
-  await expect(page.getByTestId("reader-loading")).toBeVisible();
-  await expect(headerChapter).toHaveCount(0);
+  // The jump lands via the same relocate that fires the progress-save POST,
+  // so asserting that mutation is also the strongest signal the jump landed.
+  await expectMutation(
+    page,
+    { ...PROGRESS_POST, timeout: 20_000 },
+    async () => {
+      await rows.nth(3).click();
+
+      // The drawer closes and the loading affordance appears immediately —
+      // this is synchronous with the click (`overlays::render_toc_overlay`),
+      // so it never races the epub.js render — and the header must not show
+      // the outgoing chapter alongside it.
+      await expect(drawer).toHaveCount(0);
+      await expect(page.getByTestId("reader-loading")).toBeVisible();
+      await expect(headerChapter).toHaveCount(0);
+    },
+  );
 
   // Once the jump lands, the loading overlay clears and the header shows a
   // chapter again — never stuck blank, never stuck loading.

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -45,6 +45,10 @@ const PROGRESS_ERR_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "great-gatsby")!;
 const DEEP_LINK_BOOK = FIXTURE_BOOKS.find(
   (b) => b.slug === "romeo-and-juliet",
 )!;
+// Reserved for the TOC-jump loading-state regression (see the reservation
+// comment on this fixture in fixtures/epubs.ts) — a real multi-chapter book,
+// so the contents drawer lists more than one row to jump between.
+const TOC_JUMP_BOOK = FIXTURE_BOOKS.find((b) => b.slug === "dracula")!;
 
 // The epub.js progress POST fires on the reader's relocate events; pin the
 // exact pathname so the sibling `/api/rpc/progress/get` reads never match.
@@ -160,6 +164,50 @@ test("opens the contents and highlights drawers from the top chrome", async ({
   // Contents drawer opens from the top chrome.
   await page.getByTestId("reader-toc").click();
   await expect(page.getByTestId("reader-toc-drawer")).toBeVisible();
+});
+
+// Regression for issue #1909 (AC3): a TOC jump must show a loading
+// affordance, and the header must never show the outgoing chapter alongside
+// the target's content. `dracula` (reserved above in fixtures/epubs.ts) is a
+// real multi-chapter book so the contents drawer lists more than one row.
+test("shows a loading state during a TOC jump and blanks the outgoing chapter in the header", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(60_000);
+  const uuid = await fetchBookUuidByTitle(request, TOC_JUMP_BOOK.title);
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-viewer")).toBeVisible();
+
+  // Establish a real baseline chapter in the header before jumping — proves
+  // the assertion below is about the readout actually clearing, not just
+  // never having had anything to clear in the first place. No dedicated
+  // testid on this span (`chrome.rs`'s `reader_title_block`), so this is the
+  // one spot in the file that reaches for a class locator.
+  const headerChapter = page.locator(".rd-title-ch");
+  await expect(headerChapter).toBeVisible({ timeout: 20_000 });
+
+  await page.getByTestId("reader-toc").click();
+  const drawer = page.getByTestId("reader-toc-drawer");
+  await expect(drawer).toBeVisible();
+  const rows = page.getByTestId("reader-toc-row");
+  // A row a few entries in, so the jump actually moves off the current
+  // (front-matter) chapter rather than re-displaying it.
+  await expect(rows.nth(3)).toBeVisible();
+  await rows.nth(3).click();
+
+  // The drawer closes and the loading affordance appears immediately — this
+  // is synchronous with the click (`overlays::render_toc_overlay`), so it
+  // never races the epub.js render — and the header must not show the
+  // outgoing chapter alongside it.
+  await expect(drawer).toHaveCount(0);
+  await expect(page.getByTestId("reader-loading")).toBeVisible();
+  await expect(headerChapter).toHaveCount(0);
+
+  // Once the jump lands, the loading overlay clears and the header shows a
+  // chapter again — never stuck blank, never stuck loading.
+  await expect(page.getByTestId("reader-loading")).toHaveCount(0);
+  await expect(headerChapter).toBeVisible({ timeout: 20_000 });
 });
 
 test("seeds a highlight and deletes it from the highlights drawer", async ({

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -174,24 +174,33 @@ test("shows a loading state during a TOC jump and blanks the outgoing chapter in
   page,
   request,
 }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(90_000);
   const uuid = await fetchBookUuidByTitle(request, TOC_JUMP_BOOK.title);
   await gotoReady(page, `/read/${uuid}`);
   await expect(page.getByTestId("reader-viewer")).toBeVisible();
 
-  // Establish a real baseline chapter in the header before jumping — proves
-  // the assertion below is about the readout actually clearing, not just
-  // never having had anything to clear in the first place.
   const headerChapter = page.getByTestId("reader-header-chapter");
+  const drawer = page.getByTestId("reader-toc-drawer");
+  const rows = page.getByTestId("reader-toc-row");
+
+  // The book opens on its cover — a spine item with no direct TOC entry, so
+  // the header renders nothing there. Jump to a real TOC row first to
+  // establish a genuine baseline chapter in the header, so the assertion
+  // below is about the readout actually clearing, not just never having had
+  // anything to clear in the first place.
+  await page.getByTestId("reader-toc").click();
+  await expect(drawer).toBeVisible();
+  await expect(rows.nth(3)).toBeVisible();
+  await expectMutation(page, { ...PROGRESS_POST, timeout: 20_000 }, async () =>
+    rows.nth(3).click(),
+  );
+  await expect(drawer).toHaveCount(0);
   await expect(headerChapter).toBeVisible({ timeout: 20_000 });
 
+  // Jump again, further into the book — this is the transition under test.
   await page.getByTestId("reader-toc").click();
-  const drawer = page.getByTestId("reader-toc-drawer");
   await expect(drawer).toBeVisible();
-  const rows = page.getByTestId("reader-toc-row");
-  // A row a few entries in, so the jump actually moves off the current
-  // (front-matter) chapter rather than re-displaying it.
-  await expect(rows.nth(3)).toBeVisible();
+  await expect(rows.nth(6)).toBeVisible();
 
   // The jump lands via the same relocate that fires the progress-save POST,
   // so asserting that mutation is also the strongest signal the jump landed.
@@ -199,7 +208,7 @@ test("shows a loading state during a TOC jump and blanks the outgoing chapter in
     page,
     { ...PROGRESS_POST, timeout: 20_000 },
     async () => {
-      await rows.nth(3).click();
+      await rows.nth(6).click();
 
       // The drawer closes and the loading affordance appears immediately —
       // this is synchronous with the click (`overlays::render_toc_overlay`),


### PR DESCRIPTION
## Summary
- Closes #1909
- **AC1** — front-matter spine items with no direct TOC entry were reporting `chapter: 0` (the JS glue's `findChapter` href-match falls through for them), which read as the counter going backwards mid-front-matter. Added `signals::resolve_chapter_position`, called from both the web (`interop.rs`) and mobile (`mobile.rs`) relocate handlers: it re-derives chapter/total from the flat TOC's own array order, and carries the previous chapter forward instead of regressing to 0 when the incoming title doesn't match a TOC entry. A title that *does* match always wins outright, so a deliberate backward jump (TOC/bookmark navigation) still works.
- **AC2** — the reader computed a whole-book `pct` (epub.js's `location.start.percentage`) for the footer/ribbon but never sent it back to the server, so `reading_progress.progress_percent` — the field the landing hero's `resume_meta` reads — stayed unset for a book read purely through the reader. Both relocate handlers now include `progress_percent` in the `ProgressUpdate`/POST body they already send, so the footer and the landing hero derive from the same figure.
- **AC3** — a TOC jump called straight into the epub.js glue with no loading state, so the header kept showing the outgoing chapter for the whole settle-then-redisplay window. `render_toc_overlay`'s `on_navigate` now flips `status` to `ReaderStatus::Loading` before asking the glue to navigate (reusing the existing `reader-loading` overlay on `ReaderViewerStage`); `derive_reader_display` blanks the header's chapter title/sub-line while `status == Loading`; the relocate that lands once the target has rendered flips `status` back to `Ready`.

## Test plan
- [x] `cargo fmt -p omnibus-frontend -- --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (768 passed, 0 failed), including new `signals::tests::resolve_chapter_position_*` and `reader::tests::derive_reader_display_blanks_chapter_title_while_loading_and_restores_it_once_ready`
- [ ] Playwright: added a new spec case in `reader.spec.ts` (`shows a loading state during a TOC jump and blanks the outgoing chapter in the header`), using a newly-reserved `dracula` fixture for a real multi-chapter TOC. **Unverified locally** — no browser/server in this environment; the `run_ui_tests` label lets CI run it.

## Notes
- Scope: `frontend/src/pages/reader/{signals,mod,overlays,interop,mobile}.rs` plus the matching Playwright spec/fixture. The vendored `frontend/assets/vendor/epub-reader-glue.js` was deliberately left untouched — all three fixes are implemented on the Rust side of the bridge.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Emok4ndtiZhu6YFYa1Gdy)_