### PR TITLE
feat: log backward position jumps and rejected writes on progress upsert

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -61,6 +61,23 @@ fn parse_format(raw: &str) -> ProgressFormat {
     }
 }
 
+/// Backward jump in an accepted audio position write that's worth a WARN
+/// (~10 minutes). A normal skip-back or chapter re-listen is well under
+/// this; the 2026-08-11 chapter-19-to-13 revert was hours.
+const AUDIO_BACKWARD_JUMP_THRESHOLD_SECONDS: f64 = 600.0;
+
+/// Current unix time in seconds. Mirrors the `strftime('%s','now')` clamp
+/// [`upsert_progress_tx`]'s SQL applies, used only to predict — for
+/// logging — whether a write is about to lose to the timestamp guard; the
+/// SQL `WHERE` clause remains the sole source of truth for the real
+/// decision.
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 /// Upsert a position row for `(user, book, format)` and return the
 /// **surviving** server-authoritative record. Resolves the request uuid to
 /// the **canonical** `books.uuid` (keeping the `BookNotFound` guard — you
@@ -119,6 +136,12 @@ pub async fn upsert_progress_tx(
         .await?
         .ok_or(ProgressError::BookNotFound)?;
     let fmt = format_str(update.format);
+
+    // Snapshot the row this write would land on, purely for the two WARNs
+    // this function logs (#1861) — neither reads back into the upsert itself.
+    let existing = existing_progress_snapshot(tx, user_id, &book_uuid, fmt).await?;
+    warn_if_rejected_by_timestamp_guard(&book_uuid, update.client_updated_at, existing.0);
+
     // `strftime('%s','now')` returns TEXT; SQLite's default storage-class
     // sort order ranks every INTEGER below every TEXT value regardless of
     // magnitude, so `MIN(<int param>, <text now>)` would always pick the
@@ -185,7 +208,7 @@ pub async fn upsert_progress_tx(
     .bind(fmt)
     .fetch_one(&mut **tx)
     .await?;
-    Ok(ProgressRecord {
+    let record = ProgressRecord {
         book_uuid,
         format: update.format,
         epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
@@ -195,7 +218,94 @@ pub async fn upsert_progress_tx(
         book_file_id: row.try_get::<Option<i64>, _>("book_file_id")?,
         updated_at: row.try_get::<i64, _>("updated_at")?,
         client_updated_at: row.try_get::<i64, _>("client_updated_at")?,
-    })
+    };
+
+    // If this write was rejected (by either guard above), the row is
+    // unchanged, so `new` equals the pre-write snapshot and this can't
+    // fire — only a genuinely *accepted* jump ever crosses the threshold.
+    if update.format == ProgressFormat::Audio {
+        warn_if_audio_jumped_backward(&record, existing.1);
+    }
+
+    Ok(record)
+}
+
+/// The `(client_updated_at, audio_position_seconds)` a `(user, book, format)`
+/// row held immediately before an upsert — `None`/`None` when no row exists
+/// yet. Read-only; used solely to detect the two WARN conditions below.
+async fn existing_progress_snapshot(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    book_uuid: &str,
+    fmt: &str,
+) -> Result<(Option<i64>, Option<f64>), ProgressError> {
+    let Some(row) = sqlx::query(
+        "SELECT COALESCE(client_updated_at, updated_at) AS client_updated_at,
+                audio_position_seconds
+         FROM reading_progress
+         WHERE user_id = ? AND book_uuid = ? AND format = ?",
+    )
+    .bind(user_id)
+    .bind(book_uuid)
+    .bind(fmt)
+    .fetch_optional(&mut **tx)
+    .await?
+    else {
+        return Ok((None, None));
+    };
+    Ok((
+        Some(row.try_get::<i64, _>("client_updated_at")?),
+        row.try_get::<Option<f64>, _>("audio_position_seconds")?,
+    ))
+}
+
+/// AC1 (#1861): a write is about to lose to the timestamp guard when the
+/// offered stamp — clamped forward to server-now, same as the SQL — is
+/// older than the stamp already on the row. Predicted here in Rust rather
+/// than read back from the upsert's own `WHERE`, purely for logging; a
+/// prediction that ever disagreed with the SQL would still change nothing,
+/// since the guard itself is unmodified.
+fn warn_if_rejected_by_timestamp_guard(
+    book_uuid: &str,
+    client_updated_at: Option<i64>,
+    stored_client_updated_at: Option<i64>,
+) {
+    let Some(stored_ts) = stored_client_updated_at else {
+        return;
+    };
+    let now = now_unix();
+    let offered = client_updated_at.unwrap_or(now).min(now);
+    if offered < stored_ts {
+        tracing::warn!(
+            book_uuid,
+            stored_client_updated_at = stored_ts,
+            offered_client_updated_at = offered,
+            "progress write rejected by timestamp guard"
+        );
+    }
+}
+
+/// AC2 (#1861): an *accepted* audio write whose new position lands more
+/// than [`AUDIO_BACKWARD_JUMP_THRESHOLD_SECONDS`] behind the old one — a
+/// rejected write leaves `record.audio_position_seconds` equal to the old
+/// value, so this can only fire for a write that actually landed.
+fn warn_if_audio_jumped_backward(
+    record: &ProgressRecord,
+    stored_audio_position_seconds: Option<f64>,
+) {
+    let (Some(old), Some(new)) = (stored_audio_position_seconds, record.audio_position_seconds)
+    else {
+        return;
+    };
+    if old - new > AUDIO_BACKWARD_JUMP_THRESHOLD_SECONDS {
+        tracing::warn!(
+            book_uuid = %record.book_uuid,
+            old_position_seconds = old,
+            new_position_seconds = new,
+            client_updated_at = record.client_updated_at,
+            "accepted audio write moved position backward past threshold"
+        );
+    }
 }
 
 /// Attach a server-derived KoboSpan location (and percent, when the row

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -2644,3 +2644,279 @@ async fn record_session_succeeds_for_many_concurrent_writers_on_one_pool() {
         }
     }
 }
+
+// --- #1861: WARN logging on rejected writes and backward audio jumps ---
+
+/// Captures every WARN-or-louder `tracing` event's message plus fields as
+/// one formatted line, while installed as the default subscriber —
+/// `set_default` scopes it to the current thread, so `#[tokio::test]`'s
+/// single-threaded current-thread runtime keeps a test's capture isolated
+/// from any other test running in the process. Mirrors the `QueryCounter`
+/// pattern in `db/src/epub_rewrite/tests.rs`; every `Subscriber` method
+/// besides `event` is a no-op since this only needs to tally/record events,
+/// never spans.
+struct WarnCapture(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+struct FieldLine(String);
+
+impl tracing::field::Visit for FieldLine {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write as _;
+        let _ = write!(self.0, " {}={:?}", field.name(), value);
+    }
+}
+
+impl tracing::Subscriber for WarnCapture {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.level() <= &tracing::Level::WARN
+    }
+    fn new_span(&self, _attrs: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        if event.metadata().level() > &tracing::Level::WARN {
+            return;
+        }
+        let mut line = FieldLine(String::new());
+        event.record(&mut line);
+        self.0.lock().unwrap().push(line.0);
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_warn_when_write_rejected_by_timestamp_guard() {
+    // AC1 (#1861): a rejected write must emit one WARN naming the book and
+    // both timestamps, so a revert like the 2026-08-11 chapter-19-to-13 one
+    // leaves a trace even though the response silently carries the winner.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Book A").await;
+    upsert_progress(
+        &pool,
+        user,
+        &ProgressUpdate {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Epub,
+            epub_cfi: Some("epubcfi(newer)".into()),
+            audio_position_seconds: None,
+            progress_percent: None,
+            kobo_location: None,
+            book_file_id: None,
+            client_updated_at: Some(2000),
+        },
+    )
+    .await
+    .unwrap();
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    upsert_progress(
+        &pool,
+        user,
+        &ProgressUpdate {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Epub,
+            epub_cfi: Some("epubcfi(stale-offline-replay)".into()),
+            audio_position_seconds: None,
+            progress_percent: None,
+            kobo_location: None,
+            book_file_id: None,
+            client_updated_at: Some(1000),
+        },
+    )
+    .await
+    .unwrap();
+    drop(guard);
+
+    let captured = events.lock().unwrap();
+    assert_eq!(captured.len(), 1, "exactly one WARN, got {captured:?}");
+    let line = &captured[0];
+    assert!(
+        line.contains(&format!("book_uuid={uuid:?}")),
+        "missing book uuid: {line}"
+    );
+    assert!(
+        line.contains("stored_client_updated_at=2000"),
+        "missing stored stamp: {line}"
+    );
+    assert!(
+        line.contains("offered_client_updated_at=1000"),
+        "missing offered stamp: {line}"
+    );
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_warn_when_accepted_audio_write_jumps_backward_past_threshold() {
+    // AC2 (#1861): an accepted write that moves the audio position backward
+    // by more than the ~10-minute threshold must emit one WARN with both
+    // positions.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 1).await;
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 20_000.0, Some(files[0]), 100),
+    )
+    .await
+    .unwrap();
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    let saved = upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 100.0, Some(files[0]), 200),
+    )
+    .await
+    .unwrap();
+    drop(guard);
+
+    assert_eq!(saved.audio_position_seconds, Some(100.0), "write must land");
+    let captured = events.lock().unwrap();
+    assert_eq!(captured.len(), 1, "exactly one WARN, got {captured:?}");
+    let line = &captured[0];
+    // Unlike the timestamp-guard WARN above, this call site formats
+    // `book_uuid` with `%` (Display), so the captured field carries no
+    // Debug-quoting — see `warn_if_audio_jumped_backward` in progress.rs.
+    assert!(
+        line.contains(&format!("book_uuid={uuid}")),
+        "missing book uuid: {line}"
+    );
+    assert!(
+        line.contains("old_position_seconds=20000.0"),
+        "missing old position: {line}"
+    );
+    assert!(
+        line.contains("new_position_seconds=100.0"),
+        "missing new position: {line}"
+    );
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_nothing_for_a_normal_forward_write() {
+    // AC3 (#1861): a plain forward write — newer timestamp, position moving
+    // ahead — must not emit either WARN.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 1).await;
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 100.0, Some(files[0]), 100),
+    )
+    .await
+    .unwrap();
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 400.0, Some(files[0]), 200),
+    )
+    .await
+    .unwrap();
+    drop(guard);
+
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "a forward write must not log a new WARN"
+    );
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_nothing_for_a_small_backward_audio_seek() {
+    // A normal skip-back / chapter re-listen (well under the ~10-minute
+    // threshold) is ordinary playback, not a revert — must stay silent.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 1).await;
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 1_000.0, Some(files[0]), 100),
+    )
+    .await
+    .unwrap();
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 970.0, Some(files[0]), 200),
+    )
+    .await
+    .unwrap();
+    drop(guard);
+
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "a 30s skip-back must not cross the ~10-minute threshold"
+    );
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_nothing_for_the_first_write_to_a_book() {
+    // No prior row means no "old" position to compare against — the very
+    // first write for a `(user, book, format)` must never look like a jump.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 1).await;
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    upsert_progress(&pool, user, &audio_update(&uuid, 5.0, Some(files[0]), 100))
+        .await
+        .unwrap();
+    drop(guard);
+
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "the first write for a book must not log a WARN"
+    );
+}
+
+#[tokio::test]
+async fn upsert_progress_tx_logs_nothing_when_a_write_is_rejected_by_the_audio_file_guard() {
+    // The multi-file-audio-guard rejection (#1888) is a different rejection
+    // reason than the timestamp guard, and out of this issue's scope — it
+    // must not be misreported as a timestamp-guard rejection.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (book_id, uuid) = seed(&pool, "/lib", "Book A").await;
+    let files = seed_audio_files(&pool, book_id, 2).await;
+    upsert_progress(
+        &pool,
+        user,
+        &audio_update(&uuid, 23_718.0, Some(files[1]), 100),
+    )
+    .await
+    .unwrap();
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let guard = tracing::subscriber::set_default(WarnCapture(events.clone()));
+    let survived = upsert_progress(&pool, user, &audio_update(&uuid, 60.0, None, 200))
+        .await
+        .unwrap();
+    drop(guard);
+
+    assert_eq!(
+        survived.audio_position_seconds,
+        Some(23_718.0),
+        "the audio-file guard must still reject the write"
+    );
+    assert!(
+        events.lock().unwrap().is_empty(),
+        "the audio-file-guard rejection is out of #1861's scope"
+    );
+}

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -2649,9 +2649,14 @@ async fn record_session_succeeds_for_many_concurrent_writers_on_one_pool() {
 
 /// Captures every WARN-or-louder `tracing` event's message plus fields as
 /// one formatted line, while installed as the default subscriber —
-/// `set_default` scopes it to the current thread, so `#[tokio::test]`'s
-/// single-threaded current-thread runtime keeps a test's capture isolated
-/// from any other test running in the process. Mirrors the `QueryCounter`
+/// `set_default` scopes it to the current thread, so a single-threaded
+/// runtime keeps a test's capture isolated from any other test running in
+/// the process. Every test using this pattern pins
+/// `#[tokio::test(flavor = "current_thread")]` explicitly rather than
+/// relying on the tokio-macros default (`current_thread` for `#[tokio::test]`
+/// regardless of the `rt-multi-thread` feature — that feature only makes
+/// `flavor = "multi_thread"` available as an opt-in) so the reliance stays
+/// true even if that default ever changed. Mirrors the `QueryCounter`
 /// pattern in `db/src/epub_rewrite/tests.rs`; every `Subscriber` method
 /// besides `event` is a no-op since this only needs to tally/record events,
 /// never spans.
@@ -2687,7 +2692,7 @@ impl tracing::Subscriber for WarnCapture {
     fn exit(&self, _span: &tracing::span::Id) {}
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_warn_when_write_rejected_by_timestamp_guard() {
     // AC1 (#1861): a rejected write must emit one WARN naming the book and
     // both timestamps, so a revert like the 2026-08-11 chapter-19-to-13 one
@@ -2749,7 +2754,7 @@ async fn upsert_progress_tx_logs_warn_when_write_rejected_by_timestamp_guard() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_warn_when_accepted_audio_write_jumps_backward_past_threshold() {
     // AC2 (#1861): an accepted write that moves the audio position backward
     // by more than the ~10-minute threshold must emit one WARN with both
@@ -2798,7 +2803,7 @@ async fn upsert_progress_tx_logs_warn_when_accepted_audio_write_jumps_backward_p
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_nothing_for_a_normal_forward_write() {
     // AC3 (#1861): a plain forward write — newer timestamp, position moving
     // ahead — must not emit either WARN.
@@ -2831,7 +2836,7 @@ async fn upsert_progress_tx_logs_nothing_for_a_normal_forward_write() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_nothing_for_a_small_backward_audio_seek() {
     // A normal skip-back / chapter re-listen (well under the ~10-minute
     // threshold) is ordinary playback, not a revert — must stay silent.
@@ -2864,7 +2869,7 @@ async fn upsert_progress_tx_logs_nothing_for_a_small_backward_audio_seek() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_nothing_for_the_first_write_to_a_book() {
     // No prior row means no "old" position to compare against — the very
     // first write for a `(user, book, format)` must never look like a jump.
@@ -2886,7 +2891,7 @@ async fn upsert_progress_tx_logs_nothing_for_the_first_write_to_a_book() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn upsert_progress_tx_logs_nothing_when_a_write_is_rejected_by_the_audio_file_guard() {
     // The multi-file-audio-guard rejection (#1888) is a different rejection
     // reason than the timestamp guard, and out of this issue's scope — it


### PR DESCRIPTION
## Summary
- `upsert_progress_tx` (`db/src/progress.rs`) resolved conflicts purely on `client_updated_at` and never inspected the position itself — both a rejected write and an accepted audio write jumping backward by hours were silent, which is why the 2026-08-11 chapter-19-to-13 revert couldn't be diagnosed from server logs.
- Snapshot the pre-write `(client_updated_at, audio_position_seconds)` for the `(user, book, format)` row, purely for logging, and emit one `tracing::warn!` for each of two cases: a write rejected by the timestamp guard (book uuid + stored/offered stamps), and an accepted audio write whose position lands more than ~10 minutes behind the old one (book uuid + old/new positions + stamp).
- Observability only — the SQL `WHERE` clause remains the sole source of truth for conflict resolution; nothing about which write wins changes.

## Test plan
- [x] `cargo test -p omnibus-db` — 2036 passed, 0 failed (includes 3 new tests covering AC1/AC2/AC3)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check`

Closes #1861

## Version
- [x] Patch — default, left unlabeled

## Notes
- No behavior change to conflict resolution; this is logging-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Emok4ndtiZhu6YFYa1Gdy


---
_Generated by [Claude Code](https://claude.ai/code/session_016Emok4ndtiZhu6YFYa1Gdy)_