### PR TITLE
fix: surface LinkRequired from Synced here as a link prompt, not a 500

### DIFF
--- a/frontend/src/data/cross_format.rs
+++ b/frontend/src/data/cross_format.rs
@@ -61,15 +61,39 @@ pub async fn unlink_cross_format(_server_url: &str, _uuid: &str) -> Result<bool,
     ))
 }
 
+/// Why a "synced here" declaration failed, split so the surfaces can
+/// route "link first" to the link affordance instead of a dead-end
+/// generic failure.
+#[derive(Debug)]
+pub enum SyncPointError {
+    /// No link yet and the book can't auto-link (several audio files) —
+    /// the fix is confirming the alignment, not retrying.
+    LinkRequired,
+    /// Genuine failure: offline, server error, anything else.
+    Other(DataError),
+}
+
+/// The `LinkRequired` refusal travels as its `thiserror` message — the
+/// same de-facto contract `rpc_set_follow_mode` already relies on.
+#[cfg(not(feature = "mobile"))]
+fn classify_sync_point_err(e: DataError) -> SyncPointError {
+    match &e {
+        DataError::Other(msg) if msg.starts_with("confirm the alignment first") => {
+            SyncPointError::LinkRequired
+        }
+        _ => SyncPointError::Other(e),
+    }
+}
+
 /// Declare a "synced here" sync point from the reader or player.
 #[cfg(not(feature = "mobile"))]
 pub async fn declare_sync_point(
     _server_url: &str,
     decl: omnibus_shared::cross_format::DeclareSyncPoint,
-) -> Result<(), DataError> {
+) -> Result<(), SyncPointError> {
     crate::rpc::rpc_declare_sync_point(decl)
         .await
-        .map_err(note_server_fn_err)
+        .map_err(|e| classify_sync_point_err(note_server_fn_err(e)))
 }
 
 /// Flip follow mode on an existing link.
@@ -91,10 +115,10 @@ pub async fn set_follow_mode(
 pub async fn declare_sync_point(
     _server_url: &str,
     _decl: omnibus_shared::cross_format::DeclareSyncPoint,
-) -> Result<(), DataError> {
-    Err(DataError::Other(
+) -> Result<(), SyncPointError> {
+    Err(SyncPointError::Other(DataError::Other(
         "alignment is not available in the mobile shell".into(),
-    ))
+    )))
 }
 
 #[cfg(feature = "mobile")]
@@ -106,4 +130,29 @@ pub async fn set_follow_mode(
     Err(DataError::Other(
         "alignment is not available in the mobile shell".into(),
     ))
+}
+
+#[cfg(all(test, not(feature = "mobile")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_sync_point_err_maps_link_refusal_to_link_required() {
+        let e = DataError::Other(
+            "confirm the alignment first — this book has several audio files".into(),
+        );
+        assert!(matches!(
+            classify_sync_point_err(e),
+            SyncPointError::LinkRequired
+        ));
+    }
+
+    #[test]
+    fn classify_sync_point_err_passes_other_failures_through() {
+        let e = DataError::Other("connection reset".into());
+        assert!(matches!(
+            classify_sync_point_err(e),
+            SyncPointError::Other(_)
+        ));
+    }
 }

--- a/frontend/src/data/cross_format.rs
+++ b/frontend/src/data/cross_format.rs
@@ -73,12 +73,18 @@ pub enum SyncPointError {
     Other(DataError),
 }
 
-/// The `LinkRequired` refusal travels as its `thiserror` message — the
-/// same de-facto contract `rpc_set_follow_mode` already relies on.
+/// Prefix of `CrossFormatError::LinkRequired`'s `#[error]` message
+/// (`db/src/cross_format.rs`) — the refusal's de-facto wire contract, the
+/// same one `rpc_set_follow_mode` relies on. The frontend can't import the
+/// db crate on web/mobile builds, so the string is mirrored here.
+#[cfg(not(feature = "mobile"))]
+const LINK_REQUIRED_PREFIX: &str = "confirm the alignment first";
+
+/// The `LinkRequired` refusal travels as its `thiserror` message.
 #[cfg(not(feature = "mobile"))]
 fn classify_sync_point_err(e: DataError) -> SyncPointError {
     match &e {
-        DataError::Other(msg) if msg.starts_with("confirm the alignment first") => {
+        DataError::Other(msg) if msg.starts_with(LINK_REQUIRED_PREFIX) => {
             SyncPointError::LinkRequired
         }
         _ => SyncPointError::Other(e),

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -239,6 +239,9 @@ pub(super) fn SyncHereButton() -> Element {
                     label.set("Syncing\u{2026}");
                     match crate::data::declare_sync_point("", decl).await {
                         Ok(()) => label.set("Synced \u{2713}"),
+                        Err(crate::data::SyncPointError::LinkRequired) => {
+                            label.set("Link formats first")
+                        }
                         Err(_) => label.set("Sync failed"),
                     }
                 });

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -170,6 +170,9 @@ pub(super) fn SyncHerePill(uuid: String, loc: Signal<super::signals::RelocateDat
                     };
                     match crate::data::declare_sync_point("", decl).await {
                         Ok(()) => label.set("Synced \u{2713}"),
+                        Err(crate::data::SyncPointError::LinkRequired) => {
+                            label.set("Link formats first")
+                        }
                         Err(_) => label.set("Sync failed"),
                     }
                 });


### PR DESCRIPTION
## Summary
- Classify sync-point declaration failures in the data layer: a new `SyncPointError` splits the `LinkRequired` refusal (which travels as its `thiserror` message, the same de-facto contract `rpc_set_follow_mode` uses) from genuine failures.
- "Synced here" on the reader pill and the player cell now shows "Link formats first" for an unlinked multi-file book instead of the dead-end "Sync failed".
- No E2E addition: the reserved dual fixture auto-links (single audio file), so the refusal path is covered by the classifier unit tests; genuine-failure labels are unchanged.

Closes #1936

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 2 new classifier tests pass
- [x] `cargo fmt --check` + clippy (`server`, `web`/wasm32) clean