### PR TITLE
fix: tag restore-settle relocates as echoes and never persist them

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -73,6 +73,10 @@
   // so the first-pass landing (a page or two off until fonts/theme reflow) is
   // never persisted as reading progress.
   var restoreSettled = true;
+  // True from a CFI restore until its first post-settle emission — that
+  // emission re-states the restored position and is tagged `echo` so the
+  // host renders it without persisting it (see emitRelocate).
+  var restoreEchoPending = false;
   var tocFlat = [];
   var currentTheme = "dark";
   // Whether the section iframe runs scripts. Only then can we await the
@@ -361,14 +365,16 @@
         // Re-emit current location now that locations are resolved so the
         // Rust side gets a real whole-book `pct` on first load (page/total
         // are already live off the current render — see buildRelocateData).
+        // An echo: it re-states the position, it doesn't report movement.
         if (rendition && rendition.location) {
-          emitRelocate(rendition.location);
+          emitRelocate(rendition.location, true);
         }
         // A follow-mode auto-jump that raced this pass now has a locations
         // map to resolve against — apply it unless navigation cancelled it.
         if (pendingJumpPct !== null && book && book.locations) {
           var pct = pendingJumpPct;
           pendingJumpPct = null;
+          restoreEchoPending = false;
           applyPercentage(pct);
         }
       })
@@ -388,6 +394,7 @@
     // saved progress paint (and report ready) immediately.
     var initialCfi = opts.cfi || null;
     restoreSettled = !initialCfi;
+    restoreEchoPending = !!initialCfi;
     rendition.display(initialCfi || undefined).then(
       function () {
         if (!initialCfi) {
@@ -497,9 +504,23 @@
     });
   }
 
-  function emitRelocate(location) {
+  // `isEcho` marks an emission that re-states a position the host already
+  // knows (the restore settle, the locations-resolved re-emit) rather than
+  // reporting movement. The host renders echoes but must not persist them:
+  // an echo write stamps a fresh clock on an unmoved position, which
+  // out-orders a newer counterpart-format position at the cross-format
+  // clock gate. The first emission after a CFI restore is an echo even
+  // when it arrives through the debounced relocated handler, so the flag
+  // is consumed here rather than trusted to the call sites.
+  function emitRelocate(location, isEcho) {
     if (!restoreSettled) return;
+    var echo = !!isEcho;
+    if (restoreEchoPending) {
+      restoreEchoPending = false;
+      echo = true;
+    }
     var data = buildRelocateData(location);
+    data.echo = echo;
     if (data.cfi && typeof window.__omnibusOnRelocate === "function") {
       window.__omnibusOnRelocate(JSON.stringify(data));
     }
@@ -508,12 +529,14 @@
   function next() {
     if (!rendition) return;
     pendingJumpPct = null;
+    restoreEchoPending = false;
     return rendition.next();
   }
 
   function prev() {
     if (!rendition) return;
     pendingJumpPct = null;
+    restoreEchoPending = false;
     return rendition.prev();
   }
 
@@ -1609,6 +1632,7 @@
   function display(target) {
     if (!rendition || !target) return;
     pendingJumpPct = null;
+    restoreEchoPending = false;
     var t = String(target);
     var hash = t.indexOf("#");
     // CFIs and bare hrefs pass straight through. Fragment hrefs resolve to
@@ -1742,6 +1766,10 @@
   // mode auto-jump fires right after mount) is parked and applied by the
   // locations .then in init() rather than silently dropped.
   function displayPercentage(pct) {
+    // A percentage jump — user-accepted or follow-mode — is real movement:
+    // its landing (even one emitted by the restore-settle unmute) must
+    // persist, so it clears the pending echo tag.
+    restoreEchoPending = false;
     if (!book || !book.locations || !book.locations.length()) {
       pendingJumpPct = pct;
       return;

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -127,10 +127,14 @@ fn register_window_callbacks(
     let uuid_for_save = uuid_cb;
     let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
         if let Ok(data) = serde_json::from_str::<super::RelocateData>(&json) {
-            if let Some(ref cfi) = data.cfi {
-                crate::reader_progress::save(&uuid_for_save, cfi);
+            // Echo emissions re-state a position the server already holds —
+            // persisting one would stamp a fresh clock on an unmoved
+            // position and shadow a newer audiobook spot at the
+            // cross-format clock gate. Render, don't write.
+            if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo) {
+                crate::reader_progress::save(&uuid_for_save, &cfi);
                 let uuid_for_post = uuid_for_save.clone();
-                let cfi_for_post = cfi.clone();
+                let cfi_for_post = cfi;
                 wasm_bindgen_futures::spawn_local(async move {
                     // `client_updated_at` is the event time the server's
                     // conditional upsert arbitrates on; without it a write

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -218,13 +218,15 @@ async fn drain_reader_events(
                 // a position the server already holds — persisting one stamps
                 // a fresh clock on an unmoved position and shadows a newer
                 // audiobook spot at the cross-format clock gate. Same rule as
-                // the web interop; render, don't write.
-                if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo) {
-                    crate::reader_progress::save(&uuid, &cfi);
-                    // Only POST on an actual position change (the glue
-                    // debounces, but re-renders can re-emit the same CFI).
-                    if last_cfi.as_deref() != Some(cfi.as_str()) {
-                        last_cfi = Some(cfi.clone());
+                // the web interop; render, don't write. `last_cfi` tracks the
+                // last SEEN position (echoes included), so a later non-echo
+                // re-emit of the same CFI (a re-render) stays deduped rather
+                // than re-posting the unmoved position.
+                if let Some(cfi) = data.cfi.clone() {
+                    let moved = last_cfi.as_deref() != Some(cfi.as_str());
+                    last_cfi = Some(cfi.clone());
+                    if !data.echo && moved {
+                        crate::reader_progress::save(&uuid, &cfi);
                         persist_progress(&uuid, &server_url, cfi);
                     }
                 }

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -214,7 +214,12 @@ async fn drain_reader_events(
     crate::js_interop::drain_events(eval, move |event: ReaderEvent| match event {
         ReaderEvent::Relocate { json } => {
             if let Ok(data) = serde_json::from_str::<RelocateData>(&json) {
-                if let Some(cfi) = data.cfi.clone() {
+                // Echo emissions (restore settle, locations re-emit) re-state
+                // a position the server already holds — persisting one stamps
+                // a fresh clock on an unmoved position and shadows a newer
+                // audiobook spot at the cross-format clock gate. Same rule as
+                // the web interop; render, don't write.
+                if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo) {
                     crate::reader_progress::save(&uuid, &cfi);
                     // Only POST on an actual position change (the glue
                     // debounces, but re-renders can re-emit the same CFI).

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -189,6 +189,7 @@ mod tests {
             chapter: 3,
             total_chapters: 24,
             chapter_title: String::new(),
+            echo: false,
         };
         let (page, chapter) = format_progress_labels(&data);
         assert!(page.contains("p."));
@@ -289,6 +290,7 @@ mod tests {
             chapter: 0,
             total_chapters: 0,
             chapter_title: String::new(),
+            echo: false,
         };
         let (page, chapter) = format_progress_labels(&data);
         assert_eq!(page, "7%");

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -55,6 +55,14 @@ pub(crate) struct RelocateData {
     pub(crate) chapter: u32,
     pub(crate) total_chapters: u32,
     pub(crate) chapter_title: String,
+    /// True when the glue re-states a position the host already knows (the
+    /// restore settle, the locations-resolved re-emit) rather than reporting
+    /// movement. Rendered like any relocate, but never persisted: an echo
+    /// write stamps a fresh clock on an unmoved position, which out-orders a
+    /// newer counterpart-format position at the cross-format clock gate.
+    #[serde(default)]
+    #[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
+    pub(crate) echo: bool,
 }
 
 /// Format the bottom-bar `page` and `chapter` strings from a relocate

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -476,28 +476,45 @@ test("restores the exact reading position when the reader is reopened", async ({
   // Leave the reader (explicit navigation — the reader-back button walks
   // browser history, which in a test context leads to about:blank), then
   // reopen: it must land on the exact page we left, not a page drifted by
-  // the first-pass display's pre-webfont layout. The restore POST is
-  // page-load triggered (hydration + epub render + settle + debounce), so
-  // give the mutation waiter more room than a click gets.
+  // the first-pass display's pre-webfont layout. The restore settle is an
+  // ECHO — it re-states a position the server already holds — so the
+  // reopen must issue NO progress write at all: an echo write stamps a
+  // fresh clock on an unmoved position, which shadows a newer audiobook
+  // position at the cross-format clock gate.
+  const progressPosts: string[] = [];
+  page.on("request", (req) => {
+    if (
+      req.method() === "POST" &&
+      /\/api\/rpc\/progress(?:\?|$)/.test(req.url())
+    ) {
+      progressPosts.push(req.postData() ?? "");
+    }
+  });
   await gotoReady(page, `/books/${uuid}`);
-  await expectMutation(page, { ...PROGRESS_POST, timeout: 20_000 }, async () =>
-    gotoReady(page, `/read/${uuid}`),
-  );
-  await expect.poll(storedCfi, { timeout: 10_000 }).toBe(leftCfi);
+  await gotoReady(page, `/read/${uuid}`);
   await expect
     .poll(async () => footerPageLabel(page), { timeout: 20_000 })
     .toBe(leftAt);
+  expect(progressPosts, "a reopen must not write progress").toEqual([]);
+  await expect.poll(storedCfi, { timeout: 10_000 }).toBe(leftCfi);
 
-  // And again: the first reopen must not have rewritten the stored position,
-  // so a second reopen still lands on the same page (no cumulative drift).
-  await gotoReady(page, `/books/${uuid}`);
-  await expectMutation(page, { ...PROGRESS_POST, timeout: 20_000 }, async () =>
-    gotoReady(page, `/read/${uuid}`),
+  // A real page turn after the restore still persists — the echo skip
+  // must not mute genuine movement.
+  const turned = await expectMutation(page, PROGRESS_POST, async () =>
+    page.getByTestId("reader-next").click(),
   );
-  await expect.poll(storedCfi, { timeout: 10_000 }).toBe(leftCfi);
+  const turnedCfi = turned.request.postDataJSON().update.epub_cfi as string;
+  const turnedAt = await footerPageLabel(page);
+  progressPosts.length = 0;
+
+  // And again: the reopen lands on the turned page, still without writing.
+  await gotoReady(page, `/books/${uuid}`);
+  await gotoReady(page, `/read/${uuid}`);
   await expect
     .poll(async () => footerPageLabel(page), { timeout: 20_000 })
-    .toBe(leftAt);
+    .toBe(turnedAt);
+  expect(progressPosts, "a reopen must not write progress").toEqual([]);
+  await expect.poll(storedCfi, { timeout: 10_000 }).toBe(turnedCfi);
 });
 
 test("a ?cfi= deep link opens the reader at that passage, not the resume point", async ({

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -495,8 +495,11 @@ test("restores the exact reading position when the reader is reopened", async ({
   await expect
     .poll(async () => footerPageLabel(page), { timeout: 20_000 })
     .toBe(leftAt);
-  expect(progressPosts, "a reopen must not write progress").toEqual([]);
   await expect.poll(storedCfi, { timeout: 10_000 }).toBe(leftCfi);
+  // Asserted last in the phase: the slower polls above outlast the glue's
+  // relocate debounce + async POST spawn, so a straggler echo write would
+  // have landed in the collector by now.
+  expect(progressPosts, "a reopen must not write progress").toEqual([]);
 
   // A real page turn after the restore still persists — the echo skip
   // must not mute genuine movement.
@@ -513,8 +516,8 @@ test("restores the exact reading position when the reader is reopened", async ({
   await expect
     .poll(async () => footerPageLabel(page), { timeout: 20_000 })
     .toBe(turnedAt);
-  expect(progressPosts, "a reopen must not write progress").toEqual([]);
   await expect.poll(storedCfi, { timeout: 10_000 }).toBe(turnedCfi);
+  expect(progressPosts, "a reopen must not write progress").toEqual([]);
 });
 
 test("a ?cfi= deep link opens the reader at that passage, not the resume point", async ({


### PR DESCRIPTION
## Summary
- The glue now tags emissions that re-state a known position (`echo: true` on the restore settle and the locations-resolved re-emit); the first emission after a CFI restore is tagged even when it arrives through the debounced relocated handler.
- Web and mobile interops render echo relocates but skip the local save and the progress POST — an echo write stamps a fresh clock on an unmoved position, which out-orders a newer audiobook position at the cross-format clock gate (the Heaven's River failure).
- Any explicit navigation (page turn, TOC/display jump, percentage jump incl. the follow auto-apply) clears the pending echo tag, so a jump landing emitted by the restore-settle unmute still persists.
- The progress-restore spec now asserts the new contract: a reopen renders the stored position with zero progress POSTs, a real turn still persists, and a second reopen lands on the turned page.
- Behavior note: merely opening a book no longer bumps it on the Continue rail — any real page turn still does. A `?cfi=` deep-link glance no longer moves the resume point until the reader actually turns a page.

Closes #1935

## Test plan
- [x] `reader.spec.ts` + `cross_format_prompts.spec.ts` — 20/20 on a fresh dev DB
- [x] `cargo fmt --check` + clippy (`server`, `mobile`, `web`/wasm32) clean, `just lint-ts`