### PR TITLE
[OMNI-1880] Rate-Adjust Continue Hero Time-Left Labels

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -613,10 +613,22 @@ pub async fn resume_points(
         };
         // Only rows that will render a listening card need the preference —
         // it feeds the rate-adjusted "left" readout on the resume surfaces.
+        // Direct lookup, not `get_playback_rate`: `record.book_uuid` was
+        // canonicalized by `upsert_progress_tx` at write time, so re-resolving
+        // per row would double this endpoint's query count for a no-op. A row
+        // predating a later merge can miss the preference and fall back to 1x
+        // until its next write re-canonicalizes it — cosmetic, and accepted.
         let playback_rate = match total_duration_seconds {
-            Some(_) => get_playback_rate(pool, user_id, &record.book_uuid)
-                .await?
-                .map(|r| r.playback_rate),
+            Some(_) => sqlx::query(
+                "SELECT playback_rate FROM audiobook_playback_preferences
+                 WHERE user_id = ? AND book_uuid = ?",
+            )
+            .bind(user_id)
+            .bind(&record.book_uuid)
+            .fetch_optional(pool)
+            .await?
+            .map(|row| row.try_get::<f64, _>("playback_rate"))
+            .transpose()?,
             None => None,
         };
         points.push(ResumePoint {

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -611,12 +611,21 @@ pub async fn resume_points(
                 (None, None, None)
             }
         };
+        // Only rows that will render a listening card need the preference —
+        // it feeds the rate-adjusted "left" readout on the resume surfaces.
+        let playback_rate = match total_duration_seconds {
+            Some(_) => get_playback_rate(pool, user_id, &record.book_uuid)
+                .await?
+                .map(|r| r.playback_rate),
+            None => None,
+        };
         points.push(ResumePoint {
             record,
             book,
             total_duration_seconds,
             chapter_number,
             chapter_count,
+            playback_rate,
         });
     }
     Ok(points)

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -1607,6 +1607,44 @@ async fn resume_points_enrich_audio_rows_with_duration_and_chapter() {
     assert_eq!(p.total_duration_seconds, Some(1200.0));
     assert_eq!(p.chapter_number, Some(2));
     assert_eq!(p.chapter_count, Some(3));
+    // No saved preference: the resume surfaces treat this as 1x.
+    assert_eq!(p.playback_rate, None);
+}
+
+#[tokio::test]
+async fn resume_points_carry_the_saved_playback_rate_for_audio_rows() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    seed_audiobook(&pool, uuid).await;
+    upsert_progress(
+        &pool,
+        user,
+        &ProgressUpdate {
+            book_uuid: uuid.into(),
+            format: ProgressFormat::Audio,
+            epub_cfi: None,
+            audio_position_seconds: Some(450.0),
+            progress_percent: None,
+            kobo_location: None,
+            book_file_id: None,
+            client_updated_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    set_playback_rate(
+        &pool,
+        user,
+        uuid,
+        &omnibus_shared::AudiobookPlaybackRateUpdate { playback_rate: 2.0 },
+    )
+    .await
+    .unwrap();
+
+    let points = resume_points(&pool, user, 5).await.unwrap();
+    assert_eq!(points.len(), 1);
+    assert_eq!(points[0].playback_rate, Some(2.0));
 }
 
 /// Attach a second audiobook file to `book_id` — a different narration of

--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -10,7 +10,7 @@ use crate::components::atrium::Cover;
 use crate::components::{BookActionMeta, FormatSwitcher};
 use crate::{data, Route};
 
-use super::dates::fmt_long_date;
+use super::dates::{fmt_long_date, local_date_offset, use_local_dates_ready};
 use super::discovery::{
     cover_src, list_count_label, same_hand_author_label, same_hand_title, same_hand_year,
     suggestion_cover_book, SuggestionsSpinner,
@@ -416,7 +416,8 @@ fn BdInsightsCard(uuid: String) -> Element {
             }
         });
     }));
-    let [started, time_read, sessions, pace] = bd_insight_values(insights());
+    let dates_ready = use_local_dates_ready();
+    let [started, time_read, sessions, pace] = bd_insight_values(insights(), dates_ready());
 
     rsx! {
         div { class: "card", "data-testid": "insights-card",
@@ -448,11 +449,13 @@ fn BdInsightsCard(uuid: String) -> Element {
 /// `None` (no sessions yet, whether because the fetch hasn't resolved or the
 /// book truly has none) renders all four as em-dashes — the SSR seed and the
 /// AC2 empty state are the same value, so there is no flash-then-revert.
-fn bd_insight_values(insights: Option<BookInsights>) -> [String; 4] {
+/// `dates_ready` gates the Started date's local-day offset (rule 07; see
+/// [`use_local_dates_ready`]).
+fn bd_insight_values(insights: Option<BookInsights>, dates_ready: bool) -> [String; 4] {
     let dash = || "\u{2014}".to_string();
     match insights {
         Some(i) if i.sessions > 0 => [
-            fmt_long_date(i.started_at),
+            fmt_long_date(i.started_at, local_date_offset(dates_ready, i.started_at)),
             bd_duration_label(i.seconds_total),
             i.sessions.to_string(),
             format!(

--- a/frontend/src/pages/book_detail/body/tests.rs
+++ b/frontend/src/pages/book_detail/body/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 #[test]
 fn bd_insight_values_shows_em_dashes_when_insights_is_none() {
     assert_eq!(
-        bd_insight_values(None),
+        bd_insight_values(None, false),
         ["\u{2014}", "\u{2014}", "\u{2014}", "\u{2014}"]
     );
 }
@@ -23,7 +23,9 @@ fn bd_insight_values_formats_started_time_read_sessions_and_pace() {
         seconds_total: 5400,       // 1h 30m across 3 sessions
         sessions: 3,
     };
-    let [started, time_read, sessions, pace] = bd_insight_values(Some(insights));
+    // `dates_ready: false` pins the deterministic UTC day (offset 0), same
+    // as SSR and the first client paint.
+    let [started, time_read, sessions, pace] = bd_insight_values(Some(insights), false);
     assert_eq!(started, "November 14, 2023");
     assert_eq!(time_read, "1h 30m");
     assert_eq!(sessions, "3");
@@ -41,7 +43,7 @@ fn bd_insight_values_guards_against_a_zero_session_count() {
         sessions: 0,
     };
     assert_eq!(
-        bd_insight_values(Some(insights)),
+        bd_insight_values(Some(insights), false),
         ["\u{2014}", "\u{2014}", "\u{2014}", "\u{2014}"]
     );
 }

--- a/frontend/src/pages/landing/resume_meta.rs
+++ b/frontend/src/pages/landing/resume_meta.rs
@@ -4,7 +4,7 @@
 
 use omnibus_shared::{ProgressFormat, ResumePoint};
 
-use crate::pages::listen::helpers::remaining_at_rate;
+use crate::pages::listen::remaining_at_rate;
 
 /// Meta line + progress percentage for a resume point. Audio rows with known
 /// totals get "Ch. N · 42% · 7h 50m left" — the "left" span rate-adjusted by

--- a/frontend/src/pages/landing/resume_meta.rs
+++ b/frontend/src/pages/landing/resume_meta.rs
@@ -4,9 +4,13 @@
 
 use omnibus_shared::{ProgressFormat, ResumePoint};
 
+use crate::pages::listen::helpers::remaining_at_rate;
+
 /// Meta line + progress percentage for a resume point. Audio rows with known
-/// totals get "Ch. N · 42% · 7h 50m left"; audio without totals falls back to
-/// the raw position; epub rows read as a plain continue affordance.
+/// totals get "Ch. N · 42% · 7h 50m left" — the "left" span rate-adjusted by
+/// the saved playback rate, matching the player's readouts; audio without
+/// totals falls back to the raw position; epub rows read as a plain continue
+/// affordance.
 pub(super) fn resume_meta(point: &ResumePoint) -> (String, Option<i64>) {
     if point.record.format == ProgressFormat::Epub {
         // A stored whole-book percent (a Kobo's write, or the comic pager's
@@ -22,7 +26,10 @@ pub(super) fn resume_meta(point: &ResumePoint) -> (String, Option<i64>) {
             // Clamped to 0..=100 above, so the cast is in-range (NaN → 0).
             #[allow(clippy::cast_possible_truncation)]
             let pct = ((pos / total).clamp(0.0, 1.0) * 100.0).round() as i64;
-            let left = format_hm_left((total - pos).max(0.0));
+            let left = format_hm_left(remaining_at_rate(
+                (total - pos).max(0.0),
+                point.playback_rate.unwrap_or(1.0),
+            ));
             let ch = point
                 .chapter_number
                 .map(|n| format!("Ch. {n} \u{00b7} "))
@@ -89,6 +96,7 @@ mod tests {
             total_duration_seconds: total,
             chapter_number: Some(3),
             chapter_count: Some(10),
+            playback_rate: None,
         }
     }
 
@@ -97,6 +105,16 @@ mod tests {
         let (meta, pct) = resume_meta(&point(ProgressFormat::Audio, Some(3600.0), Some(7200.0)));
         assert_eq!(pct, Some(50));
         assert_eq!(meta, "Ch. 3 \u{00b7} 50% \u{00b7} 1h 00m left");
+    }
+
+    #[test]
+    fn resume_meta_scales_time_left_by_the_saved_playback_rate() {
+        let mut p = point(ProgressFormat::Audio, Some(3600.0), Some(7200.0));
+        p.playback_rate = Some(2.0);
+        let (meta, pct) = resume_meta(&p);
+        // Percent stays in book time; only the wall-clock wait scales.
+        assert_eq!(pct, Some(50));
+        assert_eq!(meta, "Ch. 3 \u{00b7} 50% \u{00b7} 30m left");
     }
 
     #[test]

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -25,7 +25,7 @@ mod chapter_nav;
 mod chapters_drawer;
 #[cfg(not(feature = "mobile"))]
 mod controls;
-pub(crate) mod helpers;
+mod helpers;
 #[cfg(not(feature = "mobile"))]
 mod mini_dock;
 #[cfg(feature = "mobile")]
@@ -47,6 +47,10 @@ mod stage;
 
 #[cfg(not(feature = "mobile"))]
 use ready_player::{PlaybackSignals, ReadyPlayer};
+
+// The one helper the landing resume surfaces share with the players, so
+// every remaining-time readout scales identically; `helpers` stays private.
+pub(crate) use helpers::remaining_at_rate;
 
 // App-root re-exports: the audio element + dock are mounted by `App` /
 // `ScreenLayout`, and the playback driver is called once from `App`.

--- a/frontend/src/pages/listen.rs
+++ b/frontend/src/pages/listen.rs
@@ -25,7 +25,7 @@ mod chapter_nav;
 mod chapters_drawer;
 #[cfg(not(feature = "mobile"))]
 mod controls;
-mod helpers;
+pub(crate) mod helpers;
 #[cfg(not(feature = "mobile"))]
 mod mini_dock;
 #[cfg(feature = "mobile")]

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -290,9 +290,9 @@ pub(super) fn format_hms(seconds: f64) -> String {
 
 /// Rate-adjusted "time left" for a real (1x) `remaining` duration; falls back
 /// to `remaining` unscaled when `rate` is non-finite or non-positive. Shared
-/// by the web and mobile players so every remaining-time readout scales the
-/// same way.
-pub(super) fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
+/// by the web and mobile players and the landing resume hero so every
+/// remaining-time readout scales the same way.
+pub(crate) fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
     if !rate.is_finite() || rate <= 0.0 {
         return remaining;
     }

--- a/frontend/src/routes.rs
+++ b/frontend/src/routes.rs
@@ -484,6 +484,7 @@ mod tests {
             total_duration_seconds: None,
             chapter_number: None,
             chapter_count: None,
+            playback_rate: None,
         }
     }
 

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -267,8 +267,10 @@ private struct HeroCard: View {
             if let total = point.totalDurationSeconds,
                let position = point.record.audioPositionSeconds {
                 // Rate-adjusted: the wall-clock wait at the saved speed,
-                // matching the player's own "left" readout.
-                let left = Format.atRate(total - position, rate: point.playbackRate ?? 1.0)
+                // matching the player's own "left" readout. Clamped first —
+                // a saved position past the reported total (stale metadata)
+                // must read as 0 left, not a negative span.
+                let left = Format.atRate(max(0, total - position), rate: point.playbackRate ?? 1.0)
                 return Format.humanDuration(Int64(left)) + " left"
             }
             return "In progress"

--- a/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
+++ b/omnibus-ios/omnibus/Features/Library/ContinueHero.swift
@@ -266,7 +266,10 @@ private struct HeroCard: View {
             }
             if let total = point.totalDurationSeconds,
                let position = point.record.audioPositionSeconds {
-                return Format.humanDuration(Int64(total - position)) + " left"
+                // Rate-adjusted: the wall-clock wait at the saved speed,
+                // matching the player's own "left" readout.
+                let left = Format.atRate(total - position, rate: point.playbackRate ?? 1.0)
+                return Format.humanDuration(Int64(left)) + " left"
             }
             return "In progress"
         }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -516,6 +516,10 @@ struct ResumePoint: Codable, Sendable, Identifiable {
     var totalDurationSeconds: Double?
     var chapterNumber: Int64?
     var chapterCount: Int64?
+    /// The saved playback rate for this book's audio, so the hero's "left"
+    /// readout can show the wall-clock wait. `nil` for epub rows, when no
+    /// preference is saved (1x), and against older servers.
+    var playbackRate: Double?
 
     /// Scoped by format as well as book, mirroring `CacheKey.progress`.
     ///
@@ -539,6 +543,7 @@ struct ResumePoint: Codable, Sendable, Identifiable {
         case totalDurationSeconds = "total_duration_seconds"
         case chapterNumber = "chapter_number"
         case chapterCount = "chapter_count"
+        case playbackRate = "playback_rate"
     }
 
     /// Fraction complete for the progress bar, when the format supports one.

--- a/omnibus-ios/omnibusTests/ContinueRailTests.swift
+++ b/omnibus-ios/omnibusTests/ContinueRailTests.swift
@@ -177,3 +177,27 @@ struct ResumeSpliceTests {
         #expect(spliced?.contains { $0.id == "book-5:epub" } == false)
     }
 }
+
+// MARK: - Wire decode
+
+@Suite("Resume point playback rate")
+struct ResumePointPlaybackRateTests {
+    @Test("carries the saved rate under the wire key the server writes")
+    func rateRoundTripsUnderTheWireKey() throws {
+        var p = point(record(format: .audio, at: 450), duration: 1_200)
+        p.playbackRate = 2.0
+        let data = try JSONEncoder().encode(p)
+        // Pin the snake_case wire name, not just a same-struct round-trip.
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(object?["playback_rate"] as? Double == 2.0)
+        #expect(try JSONDecoder().decode(ResumePoint.self, from: data).playbackRate == 2.0)
+    }
+
+    @Test("a payload without a saved rate decodes to nil, read as 1x")
+    func missingRateDecodesToNil() throws {
+        let data = try JSONEncoder().encode(point(record(format: .audio, at: 450), duration: 1_200))
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(object?.keys.contains("playback_rate") == false)
+        #expect(try JSONDecoder().decode(ResumePoint.self, from: data).playbackRate == nil)
+    }
+}

--- a/shared/src/progress.rs
+++ b/shared/src/progress.rs
@@ -216,6 +216,11 @@ pub struct ResumePoint {
     /// Total chapter count, for a "Ch. 3 of 12" readout. `None` for epub rows.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chapter_count: Option<i64>,
+    /// The user's saved playback rate for this book, so resume surfaces can
+    /// rate-adjust their "left" readouts. `None` for epub rows and when no
+    /// preference has been saved (treat as 1x).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub playback_rate: Option<f64>,
 }
 
 /// Batched session row (reader / audio open-to-close span). Mobile


### PR DESCRIPTION
## Summary
- Rate-adjust the "time left" label on the web landing Continue hero and the iOS ContinueHero using the saved per-book playback rate — the two readouts #1902 deferred; percent stays in content time, matching the players.
- Thread `playback_rate` through `ResumePoint` (shared → db → `/api/progress/recent` / `rpc_recent_progress`) with `#[serde(default, skip_serializing_if)]` so old servers and clients stay wire-compatible.
- Repair `main`'s frontend compile break: the Insights card's "Started" date now passes the local-day offset (#1927 landed a one-arg `fmt_long_date` call after #1928 changed its signature).

Closes #1880

## Test plan
- [x] iOS: `omnibusTests` suite TEST SUCCEEDED (incl. new `ResumePointPlaybackRateTests`); build green
- [x] Rust: db 116 passed, frontend `--features server` 796 passed, fmt + clippy `-D warnings` clean across shared/db/frontend (server, mobile, wasm32 web)
- [x] Frontend `--features mobile`: only pre-existing `offline::media` failures, which also fail on clean `main`

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Most of #1880 was already fixed by #1902; the tester's build 65 predates that merge, so the next TestFlight build picks up the player readout fixes regardless — this PR covers the two hero labels #1902 left behind.