### PR TITLE
[OMNI-1896] Render Reader First Page Fast and Keep the Footer Honest

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -69,6 +69,11 @@
   var book = null;
   var rendition = null;
   var relocateTimer = null;
+  // Whether epub.js "locations" (the whole-book pagination map) are usable
+  // for the current book — loaded from cache or generated. Until then the
+  // relocate payload carries a coarse spine-derived percent flagged
+  // `pctApprox` instead of epub.js's frozen 0 (issue #1896).
+  var locationsReady = false;
   // False while an initial CFI restore is still settling — mutes emitRelocate
   // so the first-pass landing (a page or two off until fonts/theme reflow) is
   // never persisted as reading progress.
@@ -128,6 +133,7 @@
     endSectionTurn();
     endSettleFade();
     tocFlat = [];
+    locationsReady = false;
     if (rendition) {
       try {
         rendition.destroy();
@@ -166,9 +172,57 @@
     return null;
   }
 
+  // Coarse whole-book percent from spine position alone — the honest stand-in
+  // while the locations map is still being generated (issue #1896). Spine
+  // index plus the visual page fraction within the current section, over the
+  // spine count. Clamped below 100 so an approximation can never claim the
+  // book is finished.
+  function spineApproxPct(start) {
+    try {
+      var spine = book && book.spine;
+      var count = spine
+        ? (spine.spineItems || spine.items || []).length || spine.length || 0
+        : 0;
+      if (!count) return 0;
+      var idx = typeof start.index === "number" ? start.index : 0;
+      var frac = 0;
+      var d = start.displayed;
+      if (d && d.total > 0 && d.page > 0) frac = (d.page - 1) / d.total;
+      var pct = Math.round(((idx + frac) / count) * 100);
+      return Math.max(0, Math.min(99, pct));
+    } catch (e) {
+      return 0;
+    }
+  }
+
   function buildRelocateData(location) {
     var cfi = location && location.start ? location.start.cfi : undefined;
-    var pct = location && location.start ? Math.round((location.start.percentage || 0) * 100) : 0;
+    // Whole-book percent needs the locations map; until it resolves,
+    // epub.js reports `percentage` as a flat 0 for the entire session.
+    // Substitute the spine-derived approximation and say so (`pctApprox`)
+    // rather than rendering a frozen 0% (issue #1896).
+    var pct = 0;
+    var pctApprox = false;
+    if (location && location.start) {
+      if (locationsReady) {
+        // `start.percentage` is a snapshot taken when the relocate fired;
+        // the post-generation re-emit reuses a location minted *before* the
+        // map existed, whose snapshot is a frozen 0 — recompute from the
+        // CFI in that case rather than reporting a mid-book position as 0%.
+        var p = location.start.percentage || 0;
+        if (!p && cfi && book && book.locations) {
+          try {
+            p = book.locations.percentageFromCfi(cfi) || 0;
+          } catch (e) {
+            p = 0;
+          }
+        }
+        pct = Math.round(p * 100);
+      } else {
+        pct = spineApproxPct(location.start);
+        pctApprox = true;
+      }
+    }
     // `displayed` is the visual column epub.js just rendered in the current
     // paginated flow — 1-indexed, and always exactly one away from the
     // previous relocate's page after a next()/prev() turn. This replaced a
@@ -188,6 +242,7 @@
       page: page,
       totalPages: totalPages,
       pct: pct,
+      pctApprox: pctApprox,
       // epub.js sets `atEnd` when the displayed range reaches the last page
       // of the last spine item — `pct` alone tops out below 100 because it
       // tracks the *start* of the visible range.
@@ -307,6 +362,19 @@
       }
     }
 
+    // Resolved when this init's first page is on screen (the same moment
+    // the host's loading overlay drops) — the gate that keeps the
+    // locations pass out of the open path. `painted` is the synchronous
+    // mirror the error handler below reads.
+    var painted = false;
+    var paintResolve = null;
+    var firstPaint = new Promise(function (res) {
+      paintResolve = function () {
+        painted = true;
+        res();
+      };
+    });
+
     // The whole-book `pct` figure comes from epub.js "locations" — a
     // whole-book pagination pass that takes seconds on desktop and much
     // longer in the mobile WebView (the visual page/section total in
@@ -317,7 +385,15 @@
     // entries just fall back to regeneration. Caveat: replacing a book's
     // file under the same uuid can leave a slightly stale pct until the
     // entry is cleared.
+    //
+    // Generation (cache miss only) is gated on `firstPaint`: it walks and
+    // parses every spine section on the main thread, so starting it at
+    // book.ready lets it race the initial section render and starve the
+    // relocate timers — the "Loading…"-for-the-whole-book-parse and
+    // frozen-footer symptoms of issue #1896. Until it resolves, relocates
+    // carry the spine-approximate `pct` (see buildRelocateData).
     var locationsCacheKey = opts.locationsKey ? "omn.locs::" + opts.locationsKey : null;
+    var locBook = book;
     book.ready
       .then(function () {
         tocFlat = [];
@@ -334,27 +410,40 @@
         if (cached) {
           try {
             book.locations.load(cached);
+            locationsReady = true;
             return null;
           } catch (e) { /* corrupt cache — regenerate below */ }
         }
-        return book.locations.generate(1024).then(function () {
-          if (locationsCacheKey) {
-            try {
-              window.localStorage.setItem(locationsCacheKey, book.locations.save());
-            } catch (e) { /* quota/unavailable — regenerate next open */ }
-          }
+        return firstPaint.then(function () {
+          // A teardown+init for another book may have superseded this one
+          // while the gate was pending — never generate against it.
+          if (book !== locBook) return null;
+          return locBook.locations.generate(1024).then(function () {
+            if (book !== locBook) return null;
+            locationsReady = true;
+            if (locationsCacheKey) {
+              try {
+                window.localStorage.setItem(locationsCacheKey, locBook.locations.save());
+              } catch (e) { /* quota/unavailable — regenerate next open */ }
+            }
+            return null;
+          });
         });
       })
       .then(function () {
         // Re-emit current location now that locations are resolved so the
         // Rust side gets a real whole-book `pct` on first load (page/total
         // are already live off the current render — see buildRelocateData).
-        if (rendition && rendition.location) {
+        if (book === locBook && rendition && rendition.location) {
           emitRelocate(rendition.location);
         }
       })
       .catch(function () {
-        emitStatus("error");
+        // Before the first paint this is a failed open and the host must
+        // show its error state. After it, the reader is already usable —
+        // a background locations failure only degrades the percent, so
+        // don't replace a working page with the failure overlay.
+        if (!painted) emitStatus("error");
       });
 
     // Restoring a saved position must go through the same settle-then-
@@ -373,6 +462,7 @@
       function () {
         if (!initialCfi) {
           emitStatus("ready");
+          paintResolve();
           return;
         }
         var r = rendition;
@@ -382,6 +472,7 @@
           if (rendition !== r || restoreSettled) return;
           restoreSettled = true;
           emitStatus("ready");
+          paintResolve();
           // A relocate already in flight (debounce pending) carries the
           // freshest measured landing and will emit now that the mute is
           // lifted — don't shadow it with a snapshot. Otherwise emit the

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -442,8 +442,10 @@
         // Before the first paint this is a failed open and the host must
         // show its error state. After it, the reader is already usable —
         // a background locations failure only degrades the percent, so
-        // don't replace a working page with the failure overlay.
-        if (!painted) emitStatus("error");
+        // don't replace a working page with the failure overlay. A chain
+        // whose init has been superseded (book swapped) reports nothing:
+        // its failure describes a book no longer on screen.
+        if (!painted && book === locBook) emitStatus("error");
       });
 
     // Restoring a saved position must go through the same settle-then-

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -95,6 +95,7 @@ pub(crate) fn install_reader_web_interop(uuid: String, prefs: ReaderPrefs, sigs:
             deep_link_cfi,
             bootstrap,
             highlights,
+            sigs.loc,
         ));
     }));
 
@@ -257,6 +258,12 @@ struct BootstrapLiterals {
 /// the book-detail saved-passages list), so resuming where this book was last
 /// left off would ignore the whole point of the link. The relocate handler
 /// then persists the new position as usual.
+///
+/// The same progress fetch also seeds `loc` with the server's stored
+/// whole-book percent (flagged approximate) so the footer/ribbon show the
+/// last-known position immediately — not a blank (or a frozen 0%) while
+/// epub.js fetches, parses, and paginates the book (issue #1896, AC2). The
+/// first real relocate overwrites the seed wholesale.
 #[cfg(feature = "web")]
 async fn spawn_bootstrap_and_highlights(
     uuid: String,
@@ -264,6 +271,7 @@ async fn spawn_bootstrap_and_highlights(
     deep_link_cfi: Option<String>,
     lits: BootstrapLiterals,
     mut highlights: Signal<Vec<Highlight>>,
+    mut loc: Signal<super::RelocateData>,
 ) {
     use super::bootstrap::{reader_bootstrap_js, BootstrapArgs};
     use super::reader_call_json2;
@@ -274,13 +282,23 @@ async fn spawn_bootstrap_and_highlights(
     let chosen = match deep_link_cfi {
         Some(cfi) => Some(cfi),
         None => {
-            let server_cfi =
-                crate::data::get_progress("", &uuid, omnibus_shared::ProgressFormat::Epub)
-                    .await
-                    .ok()
-                    .flatten()
-                    .and_then(|r| r.epub_cfi);
-            server_cfi.or(local_saved)
+            let record = crate::data::get_progress("", &uuid, omnibus_shared::ProgressFormat::Epub)
+                .await
+                .ok()
+                .flatten();
+            let stored_pct = record.as_ref().and_then(|r| r.progress_percent);
+            if let Some(pct) = stored_pct.filter(|p| (1..=100).contains(p)) {
+                // Guarded on "no relocate yet" so a fast epub.js mount can
+                // never be clobbered by this slower round trip.
+                if loc.peek().cfi.is_none() {
+                    loc.set(super::RelocateData {
+                        pct: pct as u32,
+                        pct_approx: true,
+                        ..Default::default()
+                    });
+                }
+            }
+            record.and_then(|r| r.epub_cfi).or(local_saved)
         }
     };
     let cfi_arg = json_literal(&chosen);

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -113,12 +113,27 @@ async fn mount_and_drain(
 ) {
     prefs_storage::load_and_apply_reader_prefs(prefs).await;
     let local_saved = crate::reader_progress::load(&uuid);
-    let server_cfi = data::get_progress(&server_url, &uuid, ProgressFormat::Epub)
+    let record = data::get_progress(&server_url, &uuid, ProgressFormat::Epub)
         .await
         .ok()
-        .flatten()
-        .and_then(|r| r.epub_cfi);
-    let cfi = server_cfi.or(local_saved);
+        .flatten();
+    // Seed the footer with the server's stored whole-book percent (flagged
+    // approximate) so the position shows during the WebView's slow
+    // fetch/parse/paginate window instead of a blank or frozen 0% — the
+    // mobile mirror of the web bootstrap's seed (issue #1896, AC2). The
+    // first real relocate overwrites it wholesale.
+    let stored_pct = record.as_ref().and_then(|r| r.progress_percent);
+    if let Some(pct) = stored_pct.filter(|p| (1..=100).contains(p)) {
+        let mut loc = sigs.loc;
+        if loc.peek().cfi.is_none() {
+            loc.set(RelocateData {
+                pct: pct as u32,
+                pct_approx: true,
+                ..Default::default()
+            });
+        }
+    }
+    let cfi = record.and_then(|r| r.epub_cfi).or(local_saved);
 
     // Backstop for the route-level offline bounce (`BookReadPage`'s guard):
     // at cold start the app may still believe it's online, and the progress

--- a/frontend/src/pages/reader/signals.rs
+++ b/frontend/src/pages/reader/signals.rs
@@ -42,6 +42,13 @@ pub(crate) struct RelocateData {
     pub(crate) page: u32,
     pub(crate) total_pages: u32,
     pub(crate) pct: u32,
+    // True while `pct` is the glue's coarse spine-derived approximation —
+    // the whole-book locations map hasn't resolved yet (generation runs in
+    // the background after first paint; issue #1896). The formatters render
+    // an approximate percent as "~N%" so a first session never shows a
+    // frozen, falsely-precise "0%".
+    #[serde(default)]
+    pub(crate) pct_approx: bool,
     // True when the rendered range reaches the book's end (epub.js
     // `location.atEnd`) — the auto `Finished` trigger. `pct` can't stand in:
     // it tracks the start of the visible range, so it tops out below 100.
@@ -52,6 +59,17 @@ pub(crate) struct RelocateData {
     pub(crate) chapter_title: String,
 }
 
+/// The percent readout: "N%" once the whole-book locations map has
+/// resolved, "~N%" while `pct` is still the coarse spine approximation —
+/// honest instead of falsely precise (issue #1896).
+fn pct_label(loc: &RelocateData) -> String {
+    if loc.pct_approx {
+        format!("~{}%", loc.pct)
+    } else {
+        format!("{}%", loc.pct)
+    }
+}
+
 /// Format the bottom-bar `page` and `chapter` strings from a relocate
 /// event. `page`/`total_pages` are scoped to the current chapter (see
 /// [`RelocateData`]). Returns `("", "")` until epub.js has produced a
@@ -59,11 +77,13 @@ pub(crate) struct RelocateData {
 pub(crate) fn format_progress_labels(loc: &RelocateData) -> (String, String) {
     let page = if loc.total_pages > 0 {
         format!(
-            "p.\u{a0}{} of {}\u{a0}\u{b7}\u{a0}{}%",
-            loc.page, loc.total_pages, loc.pct
+            "p.\u{a0}{} of {}\u{a0}\u{b7}\u{a0}{}",
+            loc.page,
+            loc.total_pages,
+            pct_label(loc)
         )
     } else if loc.pct > 0 {
-        format!("{}%", loc.pct)
+        pct_label(loc)
     } else {
         String::new()
     };
@@ -107,7 +127,7 @@ pub(crate) fn format_ambient_page(loc: &RelocateData) -> String {
     if loc.total_pages > 0 {
         loc.page.to_string()
     } else if loc.pct > 0 {
-        format!("{}%", loc.pct)
+        pct_label(loc)
     } else {
         String::new()
     }
@@ -119,9 +139,9 @@ pub(crate) fn format_ambient_page(loc: &RelocateData) -> String {
 /// only the phone breakpoint displays it.
 pub(crate) fn format_title_sub(loc: &RelocateData) -> String {
     if loc.chapter > 0 {
-        format!("Ch.\u{a0}{} \u{b7} {}%", loc.chapter, loc.pct)
+        format!("Ch.\u{a0}{} \u{b7} {}", loc.chapter, pct_label(loc))
     } else if loc.pct > 0 {
-        format!("{}%", loc.pct)
+        pct_label(loc)
     } else {
         String::new()
     }
@@ -131,7 +151,12 @@ pub(crate) fn format_title_sub(loc: &RelocateData) -> String {
 /// epub.js has paginated the book.
 pub(crate) fn format_contents_progress(loc: &RelocateData) -> String {
     if loc.total_pages > 0 {
-        format!("{} / {} \u{b7} {}%", loc.page, loc.total_pages, loc.pct)
+        format!(
+            "{} / {} \u{b7} {}",
+            loc.page,
+            loc.total_pages,
+            pct_label(loc)
+        )
     } else {
         String::new()
     }
@@ -195,6 +220,7 @@ mod tests {
             page: 42,
             total_pages: 300,
             pct: 14,
+            pct_approx: false,
             at_end: false,
             chapter: 3,
             total_chapters: 24,
@@ -287,6 +313,58 @@ mod tests {
         );
     }
 
+    // Issue #1896 (AC2): while the locations map is still resolving, the
+    // percent renders as an explicit approximation ("~N%") rather than a
+    // frozen, falsely-precise figure.
+    #[test]
+    fn format_progress_labels_marks_an_approximate_pct_with_a_tilde() {
+        let data = RelocateData {
+            page: 1,
+            total_pages: 20,
+            pct: 47,
+            pct_approx: true,
+            ..Default::default()
+        };
+        let (page, _) = format_progress_labels(&data);
+        assert_eq!(page, "p.\u{a0}1 of 20\u{a0}\u{b7}\u{a0}~47%");
+    }
+
+    #[test]
+    fn format_title_sub_and_ambient_page_and_contents_mark_approximate_pct() {
+        let data = RelocateData {
+            page: 3,
+            total_pages: 20,
+            pct: 47,
+            pct_approx: true,
+            chapter: 2,
+            total_chapters: 50,
+            ..Default::default()
+        };
+        assert_eq!(format_title_sub(&data), "Ch.\u{a0}2 \u{b7} ~47%");
+        assert_eq!(format_contents_progress(&data), "3 / 20 \u{b7} ~47%");
+        let bare = RelocateData {
+            pct: 47,
+            pct_approx: true,
+            ..Default::default()
+        };
+        assert_eq!(format_ambient_page(&bare), "~47%");
+    }
+
+    // The glue's relocate payload flags the approximation as `pctApprox`;
+    // a payload without it (older glue, tests) must decode as exact.
+    #[test]
+    fn relocate_data_decodes_pct_approx_from_camel_case_and_defaults_false() {
+        let with: RelocateData =
+            serde_json::from_str(r#"{"page":1,"totalPages":2,"pct":40,"pctApprox":true,"chapter":0,"totalChapters":0,"chapterTitle":""}"#)
+                .expect("decode");
+        assert!(with.pct_approx);
+        let without: RelocateData = serde_json::from_str(
+            r#"{"page":1,"totalPages":2,"pct":40,"chapter":0,"totalChapters":0,"chapterTitle":""}"#,
+        )
+        .expect("decode");
+        assert!(!without.pct_approx);
+    }
+
     #[test]
     fn format_progress_labels_falls_back_to_pct_only_when_total_pages_unknown() {
         let data = RelocateData {
@@ -294,6 +372,7 @@ mod tests {
             page: 0,
             total_pages: 0,
             pct: 7,
+            pct_approx: false,
             at_end: false,
             chapter: 0,
             total_chapters: 0,

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -58,9 +58,10 @@ const PROGRESS_POST = {
   expectedStatus: 200,
 };
 
-// The bottom-bar page label ("p. 3 of 12 · 25%") renders only after epub.js
-// has painted AND the whole-book pagination resolved — the strongest signal
-// that relocates are flowing. Note the NBSP after "p." in the label.
+// The bottom-bar page label ("p. 3 of 12 · 25%" — or "· ~25%" while the
+// whole-book pagination still resolves in the background, issue #1896)
+// renders once epub.js has painted and the first relocate landed — the
+// signal that relocates are flowing. Note the NBSP after "p." in the label.
 const PAGE_LABEL = /p\.\u00a0\d+ of \d+/;
 
 async function footerPageLabel(page: Page): Promise<string> {


### PR DESCRIPTION
## Summary
- Measured root cause: the open path waited on epub.js's `locations.generate(1024)` (whole-book pagination on the main thread — 5.8 s for a 150k-word EPUB in the foreground, minutes in a throttled tab), starving first render and freezing the footer at "p. 1 of 2 · 0%"; the network was already fine (warm reopens revalidate the strong ETag and get a 304, ~300 bytes on the wire — no server change needed).
- Glue now gates `locations.generate` on first paint and keeps it fully in the background; while the map resolves, relocates carry a coarse spine-derived percent flagged approximate, and the post-generation re-emit recomputes percent via `percentageFromCfi` instead of a stale pre-map snapshot.
- Web and mobile footers seed from the server's stored `progress_percent` (rendered `~N%`) before epub.js fetches a byte; `RelocateData` gains a serde-default `pct_approx` so old payloads decode unchanged.
- After-fix measurements: cold open with a 48% saved position shows `~48%` at 0.6 s and a full footer at 1.2 s (generation refines to exact 48% at 5.8 s in the background); warm reopen is ready at 0.35 s with an exact footer at 0.8 s.

Closes #1896

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 798 passed (new tests: approximate-label formatting across all four formatters, `pctApprox` decode + default)
- [x] `just lint` (fmt + clippy incl. wasm32/mobile + stylelint) and Biome/tsc for the spec edit — clean
- [x] Playwright `reader.spec.ts` 16/16; before/after measured with an instrumented Chromium against a locally generated 3.5 MB EPUB (not committed)

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The reporter's 15–25 s wall time wasn't reproduced exactly (their hardware/book); the measured mechanism — the locations pass on the open path, worst in throttled tabs — and its removal are what's verified. The mobile WKWebView seed path compiles and mirrors web but wasn't run on-device.