### PR TITLE
[OMNI-1911] Repaint Every Surface in One Frame on Theme Switch

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -174,6 +174,18 @@ body.atrium,
    can't bounce. */
 html, body { overscroll-behavior: none; }
 
+/* A theme switch must repaint every surface in one frame. The hover/focus
+   transitions on buttons, chips, rows, and captions otherwise animate the
+   token flip too — each at its own 0.08–0.25s duration — so controls recolor
+   at visibly different times while the grounds snap. `AtriumRoot` holds this
+   class for the flip frame only (cleared two animation frames later), so
+   hover polish is untouched outside the switch. */
+.atrium.theme-snap *,
+.atrium.theme-snap *::before,
+.atrium.theme-snap *::after {
+  transition: none !important;
+}
+
 .atrium *,
 .atrium *::before,
 .atrium *::after { box-sizing: border-box; }

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -47,6 +47,16 @@ impl Theme {
     }
 }
 
+/// Transient theme-switch flag, provided alongside the theme signal by
+/// [`init_theme`]. While `true`, [`AtriumRoot`] renders a `theme-snap` class
+/// that suppresses CSS transitions (see `.atrium.theme-snap` in
+/// `atrium.css`), so a theme switch repaints every surface in the same frame
+/// instead of each hover transition animating the palette change at its own
+/// duration. Raised by [`apply_theme`], cleared by the root two animation
+/// frames later.
+#[derive(Clone, Copy)]
+pub struct ThemeSnap(pub Signal<bool>);
+
 /// Install the theme signal in the app context. Call once from the root
 /// component.
 ///
@@ -61,11 +71,25 @@ impl Theme {
 /// `frontend/src/pages/landing.rs`.
 pub fn init_theme() {
     let mut theme = use_context_provider(|| Signal::new(Theme::Dark));
+    use_context_provider(|| ThemeSnap(Signal::new(false)));
     use_effect(move || {
         if let Some(persisted) = read_persisted_theme() {
             theme.set(persisted);
         }
     });
+}
+
+/// Switch the app theme. Raises the [`ThemeSnap`] flag in the same batch as
+/// the theme write, so the render that flips `data-theme` also carries the
+/// transition-suppressing `theme-snap` class — without it, every control
+/// with a hover `transition` (buttons, chips, rows, captions) animates the
+/// palette change at its own 0.08–0.25s duration while untransitioned
+/// surfaces snap, and the switch visibly repaints in pieces.
+pub fn apply_theme(mut theme: Signal<Theme>, snap: ThemeSnap, t: Theme) {
+    let mut flag = snap.0;
+    flag.set(true);
+    theme.set(t);
+    persist_theme(t);
 }
 
 /// Wrap the app body in the Atrium themed container. The `data-theme`
@@ -74,10 +98,30 @@ pub fn init_theme() {
 #[component]
 pub fn AtriumRoot(children: Element) -> Element {
     let theme = use_context::<Signal<Theme>>();
+    let snap = use_context::<ThemeSnap>().0;
+    let mut snap_writer = snap;
     let attr = theme.read().as_attr();
+    // Clear the snap class only after the flip frame: whether a CSS
+    // transition starts is decided from the *after-change* style, so removing
+    // `transition: none` in the same frame as the palette change would let
+    // the transitions animate anyway. Two rAFs guarantee at least one style
+    // pass with the class applied. Effects never run during SSR, and the flag
+    // starts `false` on every target, so SSR and first client paint both
+    // render the bare `atrium` class (rule 07).
+    use_effect(move || {
+        if snap() {
+            spawn(async move {
+                let mut eval = dioxus::document::eval(
+                    "requestAnimationFrame(() => requestAnimationFrame(() => dioxus.send(true)));",
+                );
+                let _ = eval.recv::<bool>().await;
+                snap_writer.set(false);
+            });
+        }
+    });
     rsx! {
         div {
-            class: "atrium",
+            class: if snap() { "atrium theme-snap" } else { "atrium" },
             "data-theme": "{attr}",
             {children}
         }
@@ -281,6 +325,76 @@ mod tests {
     #[test]
     fn fallback_title_uses_filename_for_whitespace_only_title() {
         assert_eq!(fallback_title(Some("   "), "dune.epub"), "dune.epub");
+    }
+}
+
+// Rendered-markup coverage for the theme root: the default (SSR / first
+// client paint) class must stay the bare `atrium` for hydration parity, the
+// raised snap flag must add `theme-snap`, and `apply_theme` must move both
+// signals in one batch.
+#[cfg(all(test, feature = "server"))]
+mod render_tests {
+    use dioxus::prelude::*;
+
+    use crate::test_support::render_in_vdom;
+
+    use super::*;
+
+    fn default_root() -> Element {
+        init_theme();
+        rsx! {
+            AtriumRoot {
+                div { "content" }
+            }
+        }
+    }
+
+    fn snapped_root() -> Element {
+        use_context_provider(|| Signal::new(Theme::Dark));
+        use_context_provider(|| ThemeSnap(Signal::new(true)));
+        rsx! {
+            AtriumRoot {
+                div { "content" }
+            }
+        }
+    }
+
+    fn applied_root() -> Element {
+        let theme = use_context_provider(|| Signal::new(Theme::Dark));
+        let snap = use_context_provider(|| ThemeSnap(Signal::new(false)));
+        use_hook(move || apply_theme(theme, snap, Theme::Sepia));
+        rsx! {
+            AtriumRoot {
+                div { "content" }
+            }
+        }
+    }
+
+    #[test]
+    fn atrium_root_renders_bare_class_and_dark_theme_by_default() {
+        let html = render_in_vdom(default_root);
+        assert!(html.contains(r#"class="atrium""#), "html: {html}");
+        assert!(!html.contains("theme-snap"), "html: {html}");
+        assert!(html.contains(r#"data-theme="dark""#), "html: {html}");
+    }
+
+    #[test]
+    fn atrium_root_adds_theme_snap_class_while_flag_is_raised() {
+        let html = render_in_vdom(snapped_root);
+        assert!(
+            html.contains(r#"class="atrium theme-snap""#),
+            "html: {html}"
+        );
+    }
+
+    #[test]
+    fn apply_theme_flips_data_theme_and_raises_snap_in_one_render() {
+        let html = render_in_vdom(applied_root);
+        assert!(html.contains(r#"data-theme="sepia""#), "html: {html}");
+        assert!(
+            html.contains(r#"class="atrium theme-snap""#),
+            "html: {html}"
+        );
     }
 }
 

--- a/frontend/src/components/atrium.rs
+++ b/frontend/src/components/atrium.rs
@@ -55,7 +55,7 @@ impl Theme {
 /// duration. Raised by [`apply_theme`], cleared by the root two animation
 /// frames later.
 #[derive(Clone, Copy)]
-pub struct ThemeSnap(pub Signal<bool>);
+pub(crate) struct ThemeSnap(pub(crate) Signal<bool>);
 
 /// Install the theme signal in the app context. Call once from the root
 /// component.
@@ -85,7 +85,7 @@ pub fn init_theme() {
 /// with a hover `transition` (buttons, chips, rows, captions) animates the
 /// palette change at its own 0.08–0.25s duration while untransitioned
 /// surfaces snap, and the switch visibly repaints in pieces.
-pub fn apply_theme(mut theme: Signal<Theme>, snap: ThemeSnap, t: Theme) {
+pub(crate) fn apply_theme(mut theme: Signal<Theme>, snap: ThemeSnap, t: Theme) {
     let mut flag = snap.0;
     flag.set(true);
     theme.set(t);
@@ -111,8 +111,15 @@ pub fn AtriumRoot(children: Element) -> Element {
     use_effect(move || {
         if snap() {
             spawn(async move {
+                // The setTimeout race bounds the wait: rAF never fires in a
+                // throttled/hidden tab, and a stuck flag would leave hover
+                // transitions off for the whole session. An eval that fails
+                // outright errors `recv`, which clears the flag the same way.
                 let mut eval = dioxus::document::eval(
-                    "requestAnimationFrame(() => requestAnimationFrame(() => dioxus.send(true)));",
+                    "let done = false;
+                     const fin = () => { if (!done) { done = true; dioxus.send(true); } };
+                     requestAnimationFrame(() => requestAnimationFrame(fin));
+                     setTimeout(fin, 250);",
                 );
                 let _ = eval.recv::<bool>().await;
                 snap_writer.set(false);

--- a/frontend/src/components/user_menu.rs
+++ b/frontend/src/components/user_menu.rs
@@ -9,7 +9,7 @@ use dioxus::prelude::*;
 use dioxus_router::{use_navigator, Link};
 use omnibus_shared::{ProgressFormat, ResumePoint, UserSummary};
 
-use crate::components::atrium::{persist_theme, Cover, Theme};
+use crate::components::atrium::{Cover, Theme};
 use crate::components::glyphs::{book_glyph, play_glyph};
 use crate::components::user_avatar::UserAvatar;
 use crate::focus_after_paint::focus_after_paint;
@@ -438,7 +438,7 @@ fn UmStat(label: String, detail: String, to: Option<Route>, open: Signal<bool>) 
 #[cfg(any(feature = "web", feature = "server"))]
 #[component]
 fn UmThemeSeg(theme: Signal<Theme>) -> Element {
-    let mut theme = theme;
+    let snap = use_context::<crate::components::atrium::ThemeSnap>();
     let current = *theme.read();
     let dark_on = matches!(current, Theme::Dark);
     let black_on = matches!(current, Theme::Black);
@@ -452,40 +452,44 @@ fn UmThemeSeg(theme: Signal<Theme>) -> Element {
                     class: if dark_on { "um-theme-btn on" } else { "um-theme-btn" },
                     r#type: "button",
                     "data-testid": "theme-dark",
-                    onclick: move |_| {
-                        theme.set(Theme::Dark);
-                        persist_theme(Theme::Dark);
-                    },
+                    onclick: move |_| crate::components::atrium::apply_theme(
+                        theme,
+                        snap,
+                        Theme::Dark,
+                    ),
                     "Dark"
                 }
                 button {
                     class: if black_on { "um-theme-btn on" } else { "um-theme-btn" },
                     r#type: "button",
                     "data-testid": "theme-black",
-                    onclick: move |_| {
-                        theme.set(Theme::Black);
-                        persist_theme(Theme::Black);
-                    },
+                    onclick: move |_| crate::components::atrium::apply_theme(
+                        theme,
+                        snap,
+                        Theme::Black,
+                    ),
                     "Black"
                 }
                 button {
                     class: if light_on { "um-theme-btn on" } else { "um-theme-btn" },
                     r#type: "button",
                     "data-testid": "theme-light",
-                    onclick: move |_| {
-                        theme.set(Theme::Light);
-                        persist_theme(Theme::Light);
-                    },
+                    onclick: move |_| crate::components::atrium::apply_theme(
+                        theme,
+                        snap,
+                        Theme::Light,
+                    ),
                     "Light"
                 }
                 button {
                     class: if sepia_on { "um-theme-btn on" } else { "um-theme-btn" },
                     r#type: "button",
                     "data-testid": "theme-sepia",
-                    onclick: move |_| {
-                        theme.set(Theme::Sepia);
-                        persist_theme(Theme::Sepia);
-                    },
+                    onclick: move |_| crate::components::atrium::apply_theme(
+                        theme,
+                        snap,
+                        Theme::Sepia,
+                    ),
                     "Sepia"
                 }
             }

--- a/frontend/src/pages/account.rs
+++ b/frontend/src/pages/account.rs
@@ -719,7 +719,8 @@ fn AccountLinkRow(to: Route, label: String) -> Element {
 #[cfg(feature = "mobile")]
 #[component]
 fn ThemeControl() -> Element {
-    let mut theme = use_context::<Signal<Theme>>();
+    let theme = use_context::<Signal<Theme>>();
+    let snap = use_context::<crate::components::atrium::ThemeSnap>();
     let current = theme.read().as_attr();
     rsx! {
         div { class: "m-account-theme",
@@ -731,10 +732,11 @@ fn ThemeControl() -> Element {
                         r#type: "button",
                         class: if kind.as_attr() == current { "m-account-seg-btn on" } else { "m-account-seg-btn" },
                         "aria-pressed": if kind.as_attr() == current { "true" } else { "false" },
-                        onclick: move |_| {
-                            theme.set(kind.to_theme());
-                            crate::components::atrium::persist_theme(kind.to_theme());
-                        },
+                        onclick: move |_| crate::components::atrium::apply_theme(
+                            theme,
+                            snap,
+                            kind.to_theme(),
+                        ),
                         "{name}"
                     }
                 }

--- a/frontend/src/pages/reader/prefs.rs
+++ b/frontend/src/pages/reader/prefs.rs
@@ -6,7 +6,7 @@
 
 use dioxus::prelude::*;
 
-use crate::components::atrium::{persist_theme, Theme};
+use crate::components::atrium::{apply_theme, Theme, ThemeSnap};
 
 #[cfg(feature = "mobile")]
 use super::mobile::prefs_storage::save_reader_pref_mobile;
@@ -30,6 +30,7 @@ pub(crate) const FONT_SIZE_MAX: i32 = 32;
 #[derive(Copy, Clone)]
 pub(crate) struct ReaderPrefs {
     pub theme: Signal<Theme>,
+    pub snap: ThemeSnap,
     pub font_size: Signal<i32>,
     pub typeface: Signal<Typeface>,
     pub line_spacing: Signal<LineSpacing>,
@@ -39,12 +40,11 @@ pub(crate) struct ReaderPrefs {
 }
 
 impl ReaderPrefs {
-    /// Apply `t` and persist it via the atrium theme writer. Themes are
-    /// app-wide (not just reader-scoped) so persistence is shared.
+    /// Apply `t` via the atrium theme writer (raises the transition-snap
+    /// flag and persists). Themes are app-wide (not just reader-scoped) so
+    /// persistence is shared.
     pub(crate) fn set_theme(self, t: Theme) {
-        let mut theme = self.theme;
-        theme.set(t);
-        persist_theme(t);
+        apply_theme(self.theme, self.snap, t);
     }
 
     /// Step the font size down one px (clamped to `FONT_SIZE_MIN`), push
@@ -168,6 +168,7 @@ impl ReaderPrefs {
 /// app-wide atrium signal so changes here flip both reader and the
 /// surrounding chrome.
 pub(crate) fn init_reader_prefs(theme: Signal<Theme>) -> ReaderPrefs {
+    let snap = use_context::<ThemeSnap>();
     let mut font_size = use_signal(default_font_size);
     let mut typeface = use_signal(default_typeface);
     let mut line_spacing = use_signal(default_line_spacing);
@@ -203,6 +204,7 @@ pub(crate) fn init_reader_prefs(theme: Signal<Theme>) -> ReaderPrefs {
 
     ReaderPrefs {
         theme,
+        snap,
         font_size,
         typeface,
         line_spacing,

--- a/frontend/src/pages/reader/prefs/tests.rs
+++ b/frontend/src/pages/reader/prefs/tests.rs
@@ -43,6 +43,7 @@ fn font_pct_maps_font_size_bounds_and_midpoint_to_expected_percentage() {
     fn AssertFontPct() -> Element {
         let prefs = ReaderPrefs {
             theme: Signal::new(Theme::Dark),
+            snap: crate::components::atrium::ThemeSnap(Signal::new(false)),
             font_size: Signal::new(FONT_SIZE_MIN),
             typeface: Signal::new(Typeface::Editorial),
             line_spacing: Signal::new(LineSpacing::Cozy),

--- a/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
+++ b/ui_tests/playwright/tests/flows/theme_toggle.spec.ts
@@ -41,6 +41,12 @@ test("toggles dark to light, persists across reload", async ({ page }) => {
   await page.getByTestId("theme-light").click();
   await expect(root).toHaveAttribute("data-theme", "light");
 
+  // The switch briefly holds a `theme-snap` class on the root that disables
+  // CSS transitions so every surface repaints in the same frame. It must
+  // clear again (two animation frames later) or hover transitions would stay
+  // dead for the whole session — poll for the settled class.
+  await expect.poll(async () => root.getAttribute("class")).toBe("atrium");
+
   const stored = await page.evaluate(() =>
     window.localStorage.getItem("omn.theme"),
   );


### PR DESCRIPTION
## Summary
- Reproduced with instrumentation: theme state is coherent (one signal, one `data-theme` attribute, all colors via tokens), but ~60 hover-affordance `transition: background/color` rules animate the token flip too, each at its own 0.08–0.25 s duration — so buttons and list rows visibly lag surfaces that snap, which is the partial-repaint QA sighting.
- New `ThemeSnap` context + `apply_theme()` raise a `theme-snap` class on the Atrium root in the same batch as the theme write; `.atrium.theme-snap * { transition: none !important }` makes the flip atomic, and the class clears after two rAFs so hover transitions come right back.
- All three theme writers (user menu, mobile You tab, reader Aa panel) route through `apply_theme`; SSR/first paint always renders the bare `atrium` class, preserving hydration parity (rule 07).

Closes #1911

## Test plan
- [x] 3 new render tests in `atrium.rs` (hydration-guard default, snap-while-raised, one-render flip); `theme_toggle.spec.ts` polls that the class self-clears
- [x] `cargo test -p omnibus-frontend --features server` 798 passed; `just lint` + `just lint-ts` clean
- [x] Verified in-browser both directions: all sampled surfaces at target colors in the same t=0 style pass, persistence intact, no console errors

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The two non-defect contributors observed during QA are called out in #1911: cover-art shelf tiles are dark in both themes by design, and a large full-page style recalc can raster promoted scroll layers a frame late.