### PR TITLE
feat: route player title and reader back to book detail

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -3026,6 +3026,13 @@ a.idx-letter-on:focus-visible {
   color: var(--accent); font-weight: 500;
 }
 
+/* Title + byline link back to the book-detail page; the text keeps the
+   stage typography rather than anchor styling. */
+.lp-booklink {
+  display: block; color: inherit; text-decoration: none;
+}
+.lp-booklink:hover .lp-title { text-decoration: underline; text-underline-offset: 6px; }
+
 .lp-title {
   font-family: var(--serif); font-style: italic;
   font-size: clamp(36px, 5vw, 64px);
@@ -7697,6 +7704,8 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 
 .m-player-now { text-align: center; padding: 20px 6px 6px; }
 .m-player-eyebrow { color: var(--accent); }
+/* Title + byline tap through to the book-detail page; keep player styling. */
+.m-player-booklink { display: block; color: inherit; text-decoration: none; }
 /* Scoped under `.atrium` so this outranks the design-system `.atrium h1`
    (font-size: 64px). The player title is an <h1>; without the extra class
    the 64px hero size wins on specificity (0,1,1 vs 0,1,0), overflows the

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -240,8 +240,13 @@ fn render_unsupported(
                 }
             }
             div { class: "m-player-now",
-                {player_title(&view.title)}
-                div { class: "m-player-by", "by {view.author}" }
+                Link {
+                    class: "m-player-booklink",
+                    to: Route::BookDetail { uuid: uuid.to_string() },
+                    "aria-label": "Open details for {view.title}",
+                    {player_title(&view.title)}
+                    div { class: "m-player-by", "by {view.author}" }
+                }
             }
             div { class: "m-player-msg",
                 p { class: "subtitle",
@@ -477,8 +482,13 @@ fn render_player_header(
             div { class: "label m-player-eyebrow",
                 "Now playing \u{00b7} Chapter {derived.chapter_no} of {derived.chapter_count}"
             }
-            {player_title(&view.title)}
-            div { class: "m-player-by", "by {view.author}" }
+            Link {
+                class: "m-player-booklink",
+                to: Route::BookDetail { uuid: uuid.to_string() },
+                "aria-label": "Open details for {view.title}",
+                {player_title(&view.title)}
+                div { class: "m-player-by", "by {view.author}" }
+            }
             if derived.has_chapters {
                 div { class: "m-player-chline", "Ch. {derived.chapter_no} \u{00b7} {derived.chapter_title}" }
             }

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -195,7 +195,7 @@ pub(super) fn ReadyPlayer(
             }
 
             PlayerStageBinding {
-                book_meta: BookMeta { book: book.clone(), title, author },
+                book_meta: BookMeta { book: book.clone(), uuid: uuid.clone(), title, author },
                 signals,
                 panes,
                 chapter_state: ChapterSignals {
@@ -234,6 +234,7 @@ pub(super) fn ReadyPlayer(
 #[derive(Clone, PartialEq)]
 pub(super) struct BookMeta {
     pub book: EbookMetadata,
+    pub uuid: String,
     pub title: String,
     pub author: String,
 }
@@ -313,6 +314,7 @@ pub(super) fn PlayerStageBinding(
 ) -> Element {
     let BookMeta {
         book,
+        uuid,
         title,
         author,
     } = book_meta;
@@ -351,6 +353,7 @@ pub(super) fn PlayerStageBinding(
         PlayerStage {
             content: PlayerContent {
                 book: book.clone(),
+                uuid,
                 title,
                 author,
                 chapters: chs.clone(),

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -189,7 +189,7 @@ pub(super) fn PlayerStage(
                 div { class: "lp-kicker", "{kicker}" }
                 Link {
                     class: "lp-booklink",
-                    to: Route::BookDetail { uuid: uuid.clone() },
+                    to: Route::BookDetail { uuid },
                     "aria-label": "Open details for {title}",
                     h1 { class: "lp-title", "{title}" }
                     div { class: "lp-author", "by {author}" }

--- a/frontend/src/pages/listen/stage.rs
+++ b/frontend/src/pages/listen/stage.rs
@@ -6,11 +6,13 @@
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
+use dioxus_router::Link;
 use omnibus_shared::{ChapterInfo, EbookMetadata};
 
 use super::chapter_map::ChapterMap;
 use super::controls::{Toolbar, TransportButtons};
 use crate::components::atrium::Cover;
+use crate::Route;
 
 /// Build the "Now playing" kicker text, including chapter counter when available.
 pub(super) fn kicker_text(ch_count: usize, current_chapter_index: usize) -> String {
@@ -97,10 +99,12 @@ pub(super) struct PlaybackPosition {
     pub current_chapter_index: usize,
 }
 
-/// Static per-book display content: the book itself, title, author, and the full chapter list.
+/// Static per-book display content: the book itself, its route uuid, title,
+/// author, and the full chapter list.
 #[derive(Clone, PartialEq)]
 pub(super) struct PlayerContent {
     pub book: EbookMetadata,
+    pub uuid: String,
     pub title: String,
     pub author: String,
     pub chapters: Vec<ChapterInfo>,
@@ -165,6 +169,7 @@ pub(super) fn PlayerStage(
 ) -> Element {
     let PlayerContent {
         book,
+        uuid,
         title,
         author,
         chapters,
@@ -182,8 +187,13 @@ pub(super) fn PlayerStage(
             }
             div { class: "lp-info-col",
                 div { class: "lp-kicker", "{kicker}" }
-                h1 { class: "lp-title", "{title}" }
-                div { class: "lp-author", "by {author}" }
+                Link {
+                    class: "lp-booklink",
+                    to: Route::BookDetail { uuid: uuid.clone() },
+                    "aria-label": "Open details for {title}",
+                    h1 { class: "lp-title", "{title}" }
+                    div { class: "lp-author", "by {author}" }
+                }
                 if let Some(sub) = chapter_sub {
                     div { class: "lp-chapter-sub", "{sub}" }
                 }

--- a/frontend/src/pages/reader/chrome_handlers.rs
+++ b/frontend/src/pages/reader/chrome_handlers.rs
@@ -47,19 +47,16 @@ pub(super) fn install_chrome_handlers(
     (on_back, on_prev, on_next, on_keydown)
 }
 
-/// Leave the reader: back through history when there is any, else route to
-/// the book's detail page. The native shell has no browser history to lean
-/// on when it cold-starts into `/read/:uuid`, and its `go_back` was a no-op
-/// for years — the explicit detail-page fallback matches the audiobook
-/// player's back affordance.
+/// Leave the reader: always route to the book's detail page. History-walking
+/// (`go_back`) returned to wherever the reader was entered from — the landing
+/// grid, search, the Continue hero — but the reader's back affordance means
+/// "close this book", and its home is the detail page. `replace` keeps the
+/// reader itself out of history so the browser back button doesn't bounce
+/// between the reader and the detail page.
 fn back_to_book(nav: dioxus_router::Navigator, uuid: &str) {
-    if nav.can_go_back() {
-        nav.go_back();
-    } else {
-        let _ = nav.push(crate::Route::BookDetail {
-            uuid: uuid.to_string(),
-        });
-    }
+    let _ = nav.replace(crate::Route::BookDetail {
+        uuid: uuid.to_string(),
+    });
 }
 
 /// Whether a page-turn was triggered backwards or forwards.

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -90,11 +90,15 @@ test("renders the listen page layout for an mp3 audiobook", async ({
   // "Now playing" kicker above the book title.
   await expect(page.getByText("Now playing")).toBeVisible();
 
-  // Book metadata in the player stage.
+  // Book metadata in the player stage — the title/byline block is a link
+  // back to the book's detail page.
   await expect(
     page.getByRole("heading", { name: MP3_BOOK.title }),
   ).toBeVisible();
   await expect(page.getByText(`by ${MP3_BOOK.author}`)).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: `Open details for ${MP3_BOOK.title}` }),
+  ).toBeVisible();
 
   // Transport: chapter map + seek scrubber + skip-back / play / skip-forward / rate / volume.
   await expect(page.getByTestId("chapter-map")).toBeVisible();
@@ -134,6 +138,20 @@ test("renders the listen page layout for an m4b audiobook", async ({
   await expect(page.getByText(`by ${M4B_BOOK.author}`)).toBeVisible();
 
   await waitForPlayerReady(page);
+});
+
+test("clicking the book title opens the book detail page", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  await page
+    .getByRole("link", { name: `Open details for ${MP3_BOOK.title}` })
+    .click();
+  await expect(page).toHaveURL(new RegExp(`/books/${uuid}$`));
 });
 
 test("persists playback speed per audiobook across reloads", async ({

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -118,6 +118,20 @@ test("renders the listen page layout for an mp3 audiobook", async ({
   await expect(page.getByRole("slider", { name: "Volume" })).toBeVisible();
 });
 
+test("clicking the book title opens the book detail page", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
+  await gotoReady(page, `/listen/${uuid}`);
+  await waitForPlayerReady(page);
+
+  await page
+    .getByRole("link", { name: `Open details for ${MP3_BOOK.title}` })
+    .click();
+  await expect(page).toHaveURL(new RegExp(`/books/${uuid}$`));
+});
+
 // ---------------------------------------------------------------------------
 // 2. Layout — M4B audiobook
 // ---------------------------------------------------------------------------
@@ -138,20 +152,6 @@ test("renders the listen page layout for an m4b audiobook", async ({
   await expect(page.getByText(`by ${M4B_BOOK.author}`)).toBeVisible();
 
   await waitForPlayerReady(page);
-});
-
-test("clicking the book title opens the book detail page", async ({
-  page,
-  request,
-}) => {
-  const uuid = await fetchBookUuidByTitle(request, MP3_BOOK.title);
-  await gotoReady(page, `/listen/${uuid}`);
-  await waitForPlayerReady(page);
-
-  await page
-    .getByRole("link", { name: `Open details for ${MP3_BOOK.title}` })
-    .click();
-  await expect(page).toHaveURL(new RegExp(`/books/${uuid}$`));
 });
 
 test("persists playback speed per audiobook across reloads", async ({

--- a/ui_tests/playwright/tests/flows/reader.spec.ts
+++ b/ui_tests/playwright/tests/flows/reader.spec.ts
@@ -103,6 +103,20 @@ test("renders the reader layout", async ({ page, request }) => {
   await expect(page.getByTestId("reader-spread-double")).toBeVisible();
 });
 
+test("the back button leaves the reader for the book detail page", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/read/${uuid}`);
+  await expect(page.getByTestId("reader-back")).toBeVisible();
+
+  // Back always routes to the book's detail page — never to whatever entry
+  // point (landing, search, Continue hero) the reader was opened from.
+  await page.getByTestId("reader-back").click();
+  await expect(page).toHaveURL(new RegExp(`/books/${uuid}$`));
+});
+
 test("black theme overrides a publisher color on the EPUB body", async ({
   page,
   request,
@@ -538,8 +552,8 @@ test("restores the exact reading position when the reader is reopened", async ({
     return body?.epub_cfi ?? "";
   };
 
-  // Leave the reader (explicit navigation — the reader-back button walks
-  // browser history, which in a test context leads to about:blank), then
+  // Leave the reader (explicit navigation — equivalent to the reader-back
+  // button, which routes to the book's detail page), then
   // reopen: it must land on the exact page we left, not a page drifted by
   // the first-pass display's pre-webfont layout. The restore POST is
   // page-load triggered (hydration + epub render + settle + debounce), so


### PR DESCRIPTION
## Summary
- The fullscreen audio player's title + byline (web stage and mobile player, including the HLS-unsupported screen) are now a link to the book's detail page.
- The EPUB reader's back button (and final-Escape) now always routes to the book's detail page via `nav.replace`, instead of walking browser history back to whatever surface opened the reader.

## Test plan
- [x] `just lint` (full matrix incl. wasm32 clippy + stylelint) and `just lint-ts`
- [x] `cargo test -p omnibus-frontend --features server` — 802 passed
- [x] New Playwright coverage: reader back-button navigation test, listen title-link test + layout-test link assertion; all passing against a live dev server

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.