### PR TITLE
fix: let follow jumps supersede the mount restore on reader and player

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -73,6 +73,13 @@
   // so the first-pass landing (a page or two off until fonts/theme reflow) is
   // never persisted as reading progress.
   var restoreSettled = true;
+  // Monotonic navigation generation: bumped by every explicit display
+  // (jumps, TOC/link nav, page turns). The restore settle chain and each
+  // displaySettled capture the value at start and skip their corrective
+  // redisplay when a later navigation has superseded them — without this
+  // the restore's re-display(initialCfi) yanks the view back off a
+  // follow-mode jump that landed while it was settling.
+  var displayToken = 0;
   // True from a CFI restore until its first post-settle emission — that
   // emission re-states the restored position and is tagged `echo` so the
   // host renders it without persisting it (see emitRelocate).
@@ -395,6 +402,12 @@
     var initialCfi = opts.cfi || null;
     restoreSettled = !initialCfi;
     restoreEchoPending = !!initialCfi;
+    // A jump or turn during the settle supersedes the restore — its
+    // corrective redisplay must not pull the view back (see displayToken).
+    var restoreToken = displayToken;
+    var restoreCurrent = function () {
+      return displayToken === restoreToken;
+    };
     rendition.display(initialCfi || undefined).then(
       function () {
         if (!initialCfi) {
@@ -427,8 +440,9 @@
             emitRelocate(rendition.location);
           }
         };
-        redisplayWhenSettled(initialCfi)
+        redisplayWhenSettled(initialCfi, restoreCurrent)
           .then(function () {
+            if (!restoreCurrent()) return;
             return nudgeToTarget(initialCfi);
           })
           .catch(function () {
@@ -530,6 +544,7 @@
     if (!rendition) return;
     pendingJumpPct = null;
     restoreEchoPending = false;
+    displayToken++;
     return rendition.next();
   }
 
@@ -537,6 +552,7 @@
     if (!rendition) return;
     pendingJumpPct = null;
     restoreEchoPending = false;
+    displayToken++;
     return rendition.prev();
   }
 
@@ -1509,7 +1525,7 @@
   // Wait for the active section's webfonts to settle, then re-display
   // `target` against the final layout. Returns a promise resolving once the
   // corrective redisplay completes, so callers can sequence on it.
-  function redisplayWhenSettled(target) {
+  function redisplayWhenSettled(target, stillCurrent) {
     var doc = null;
     try {
       var contents = rendition.getContents();
@@ -1539,6 +1555,7 @@
         });
       })
       .then(function () {
+        if (stillCurrent && !stillCurrent()) return;
         if (rendition) return rendition.display(target);
       });
   }
@@ -1595,11 +1612,16 @@
 
   function displaySettled(target) {
     if (!rendition) return;
+    displayToken++;
+    var myToken = displayToken;
+    var current = function () {
+      return displayToken === myToken;
+    };
     var reveal = beginSettleFade();
     rendition
       .display(target)
       .then(function () {
-        return redisplayWhenSettled(target);
+        return redisplayWhenSettled(target, current);
       })
       .then(reveal, function () {
         /* target may be gone after a teardown */

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -474,8 +474,26 @@ async fn run_manifest_init(
         }
     }
 
+    // Resolve follow at boot: when the link follows the counterpart and the
+    // reading position maps newer, seed playback with the mapped spot
+    // instead of the stored row — a post-boot corrective seek would race
+    // `initDirect`'s one-shot restore seek and lose. Skipped entirely for an
+    // explicit picker `?file_id=` (see `resolve_follow_boot`).
+    let follow_resume = if file_id.is_none() {
+        super::sync_prompt::fetch_resume(&uuid_for_fetch, "audio").await
+    } else {
+        None
+    };
+    if !is_current() {
+        return;
+    }
+    let follow_boot = super::helpers::resolve_follow_boot(file_id, follow_resume.as_ref());
+
     let row_file = server_row.as_ref().and_then(|r| r.book_file_id);
-    let boot_file = resolve_boot_file(file_id, row_file);
+    let boot_file = follow_boot
+        .as_ref()
+        .and_then(|(file, _)| *file)
+        .or_else(|| resolve_boot_file(file_id, row_file));
     let mut manifest = fetch_manifest(&uuid_for_fetch, boot_file).await;
     // The row's stored id is a soft reference — a reindex may have replaced
     // the `book_files` row since the position was saved. Fall back to the
@@ -509,14 +527,27 @@ async fn run_manifest_init(
     // way via `audio_file_count == 0`).
     let mut loaded_file_sig = playback.loaded_file_id;
     loaded_file_sig.set((loaded_file > 0).then_some(loaded_file));
-    let resume_pos = resolve_boot_position(
-        server_row
-            .as_ref()
-            .map(|r| (r.book_file_id, r.audio_position_seconds)),
-        initial_position,
-        loaded_file,
-        audio_file_count,
-    );
+    // The mapped position applies only when the manifest actually loaded the
+    // candidate's file (the dead-row fallback above may have swapped it) —
+    // otherwise fall back to the stored-row resolution unchanged.
+    let follow_pos = follow_boot
+        .as_ref()
+        .filter(|(file, _)| match file {
+            Some(fid) => *fid == loaded_file || loaded_file == 0,
+            None => true,
+        })
+        .map(|(_, seconds)| *seconds);
+    let resume_pos = match follow_pos {
+        Some(mapped) => mapped,
+        None => resolve_boot_position(
+            server_row
+                .as_ref()
+                .map(|r| (r.book_file_id, r.audio_position_seconds)),
+            initial_position,
+            loaded_file,
+            audio_file_count,
+        ),
+    };
     let pos_lit = serde_json::to_string(&resume_pos).unwrap_or_else(|_| "0".into());
 
     match manifest {

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -157,6 +157,30 @@ pub(super) fn resolve_boot_position(
     }
 }
 
+/// Follow-at-boot override: with follow on and a mapped Candidate, the
+/// boot seeds the mapped `(file, seconds)` instead of the stored row — a
+/// post-boot corrective seek would race `initDirect`'s one-shot restore
+/// seek and lose. An explicit picker `?file_id=` outranks follow: that is
+/// a deliberate navigation to a specific file, not a resume.
+#[cfg(not(feature = "mobile"))]
+#[cfg_attr(not(feature = "web"), allow(dead_code))]
+pub(super) fn resolve_follow_boot(
+    explicit_file: Option<i64>,
+    resume: Option<&omnibus_shared::cross_format::CrossFormatResume>,
+) -> Option<(Option<i64>, f64)> {
+    if explicit_file.is_some() {
+        return None;
+    }
+    let resume = resume?;
+    if !resume.follow
+        || resume.state != omnibus_shared::cross_format::CrossFormatResumeState::Candidate
+    {
+        return None;
+    }
+    let c = resume.candidate.as_ref()?;
+    Some((c.book_file_id, c.audio_position_seconds?))
+}
+
 /// localStorage key for the persisted session volume preference.
 #[cfg(feature = "web")]
 const VOLUME_KEY: &str = "omnibus.listen.volume";
@@ -451,7 +475,58 @@ mod tests {
 // their only caller), so their tests live in a separately-gated module.
 #[cfg(all(test, not(feature = "mobile")))]
 mod boot_resume_tests {
-    use super::{resolve_boot_file, resolve_boot_position, resolve_resume_pos};
+    use omnibus_shared::cross_format::{
+        CrossFormatCandidate, CrossFormatResume, CrossFormatResumeState, MappingConfidence,
+    };
+    use omnibus_shared::ProgressFormat;
+
+    use super::{
+        resolve_boot_file, resolve_boot_position, resolve_follow_boot, resolve_resume_pos,
+    };
+
+    fn follow_resume(follow: bool, state: CrossFormatResumeState) -> CrossFormatResume {
+        CrossFormatResume {
+            state,
+            candidate: Some(CrossFormatCandidate {
+                target: ProgressFormat::Audio,
+                source_format: ProgressFormat::Epub,
+                source_client_updated_at: 1,
+                confidence: MappingConfidence::UserAnchored,
+                book_file_id: Some(917),
+                audio_position_seconds: Some(21_822.0),
+                total_duration_seconds: Some(35_760.0),
+                percent: None,
+                fraction: None,
+                source_position_seconds: None,
+                source_ahead: Some(true),
+            }),
+            follow,
+        }
+    }
+
+    #[test]
+    fn resolve_follow_boot_seeds_the_mapped_file_and_seconds() {
+        let resume = follow_resume(true, CrossFormatResumeState::Candidate);
+        assert_eq!(
+            resolve_follow_boot(None, Some(&resume)),
+            Some((Some(917), 21_822.0))
+        );
+    }
+
+    #[test]
+    fn resolve_follow_boot_stands_aside_for_an_explicit_picker_file() {
+        let resume = follow_resume(true, CrossFormatResumeState::Candidate);
+        assert_eq!(resolve_follow_boot(Some(919), Some(&resume)), None);
+    }
+
+    #[test]
+    fn resolve_follow_boot_requires_follow_and_a_candidate_state() {
+        let no_follow = follow_resume(false, CrossFormatResumeState::Candidate);
+        assert_eq!(resolve_follow_boot(None, Some(&no_follow)), None);
+        let aligned = follow_resume(true, CrossFormatResumeState::Aligned);
+        assert_eq!(resolve_follow_boot(None, Some(&aligned)), None);
+        assert_eq!(resolve_follow_boot(None, None), None);
+    }
 
     #[test]
     fn resolve_resume_pos_prefers_server_position_when_present() {

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -93,23 +93,13 @@ pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
                 return;
             };
             if resume.follow {
-                // Follow mode: resolve-at-open. Apply the mapped position
-                // silently — same seek-vs-navigate file guard as an
-                // accepted offer, no card, no dismissal bookkeeping.
-                let seconds = c.audio_position_seconds.unwrap_or(0.0);
-                let loaded = (playback.file_id)();
-                let same_file = loaded == c.book_file_id
-                    || (loaded.is_none()
-                        && ((playback.duration)() - c.total_duration_seconds.unwrap_or(0.0)).abs()
-                            < 1.0);
-                if same_file {
-                    super::helpers::seek_to(seconds);
-                } else {
-                    dioxus_router::navigator().push(Route::BookListen {
-                        uuid: uuid.clone(),
-                        file_id: c.book_file_id,
-                    });
-                }
+                // Follow mode: resolve-at-open is the boot's job
+                // (`resolve_follow_boot` seeds the mapped file + position
+                // before the first play). A second actor here raced the
+                // boot's one-shot restore seek — and, deciding against a
+                // not-yet-loaded player, could re-navigate into an
+                // explicit-file boot that skipped follow entirely. No
+                // card, no seek: stay quiet.
                 return;
             }
             // Re-arm rule: an already-declined source position stays quiet

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -217,12 +217,24 @@ test("declaring a sync point turns on follow and the reader auto-applies", async
   page,
   request,
 }) => {
+  // Establish a REAL stored CFI first: the live failure mode was the
+  // restore settle chain yanking the view back off the follow jump, and
+  // that chain only engages when a stored CFI restore is in flight — a
+  // percent-only row skips the restore entirely, which is how the earlier
+  // version of this test missed it.
+  await gotoReady(page, `/read/${uuid}`);
+  await expectMutation(
+    page,
+    { method: "POST", url: /\/api\/rpc\/progress(?:\?|$)/ },
+    async () => page.getByTestId("reader-next").click(),
+  );
+
   // Earlier tests in this serial file leave WALL-clock progress writes
-  // (a reader relocate, a player flush), which outrank this file's
-  // synthetic `now-60+n` clocks at the resume clock gate — the follow
-  // candidate would read as NothingNewer and the auto-apply would never
-  // fire. Re-anchor above the newest stored clock (staying at-or-behind
-  // wall clock, which the server clamps to).
+  // (a reader relocate, a player flush — and the page turn above), which
+  // outrank this file's synthetic `now-60+n` clocks at the resume clock
+  // gate — the follow candidate would read as NothingNewer and the
+  // auto-apply would never fire. Re-anchor above the newest stored clock
+  // (staying at-or-behind wall clock, which the server clamps to).
   let newest = 0;
   for (const format of ["epub", "audio"] as const) {
     const resp = await request.post("/api/rpc/progress/get", {
@@ -246,9 +258,8 @@ test("declaring a sync point turns on follow and the reader auto-applies", async
     .toBeGreaterThan(newest + 3);
   clock = Math.floor(Date.now() / 1000) - 3;
 
-  // Fresh positions: reading behind, listening ahead — then declare from
-  // the player so follow mode engages.
-  await writeEpubPercent(request, 85);
+  // Reading behind (the stored page-turn CFI above), listening ahead —
+  // then declare from the player so follow mode engages.
   await writeAudioSeconds(request, 1);
 
   await gotoReady(page, `/listen/${uuid}`);


### PR DESCRIPTION
## Summary
- Reader glue: a display-generation token — any explicit navigation (jump, page turn, TOC/display) supersedes the in-flight restore, so the settle chain's corrective `redisplay(storedCfi)` can no longer yank the view back off a follow jump (live repro: CTA said the mapped ~30%, the reader snapped back to the stored 3%).
- Player: follow resolves at boot — `resolve_follow_boot` seeds `initDirect` with the mapped file + position instead of the stored row, so no second actor races the one-shot `loadedmetadata` restore seek (the deploy's backward-write log caught the old race writing the mapped 21,822s and then stomping it back to 10,632s). An explicit `?file_id=` pick outranks follow.
- The follow E2E now establishes a real stored CFI (a page turn) before the follow open, so restore-vs-jump is exercised on every run; `resolve_follow_boot` gets three unit tests.

Closes #1941

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` (incl. 3 new `resolve_follow_boot` tests)
- [x] clippy (`server`, `mobile`, `web`/wasm32) + `cargo fmt --check` clean
- [x] `cross_format_prompts` + `reader` E2E green on a fresh dev DB at branch time; validated live on omnibus-test as `omni-1941-rc1`