### PR TITLE
feat: CFI-precision cross-format mapping, follow-only resolution

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -128,15 +128,19 @@ pub async fn upsert_link(
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
     let snapshot = snapshot_json(&audio_files(pool, book_id).await?);
-    // Re-confirmation keeps the follow opt-in; user anchors survive only
+    // Confirming the alignment IS turning sync on — the modal's confirm
+    // button says exactly that, and a linked book that still prompts on
+    // every surface switch reads as broken (live QA on #1944). The follow
+    // toggle can still switch it off afterward; user anchors survive only
     // when the audio set is unchanged — a new set is a new timeline, and
     // the stored global seconds no longer mean anything on it.
     sqlx::query(
         "INSERT INTO cross_format_links
-            (user_id, book_uuid, mode, primary_book_file_id, audio_snapshot, confirmed_at)
-         VALUES (?, ?, ?, ?, ?, CAST(strftime('%s','now') AS INTEGER))
+            (user_id, book_uuid, mode, primary_book_file_id, audio_snapshot, confirmed_at, follow)
+         VALUES (?, ?, ?, ?, ?, CAST(strftime('%s','now') AS INTEGER), 1)
          ON CONFLICT(user_id, book_uuid) DO UPDATE SET
             mode = excluded.mode,
+            follow = 1,
             primary_book_file_id = excluded.primary_book_file_id,
             user_anchors = CASE
                 WHEN cross_format_links.audio_snapshot = excluded.audio_snapshot

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -256,9 +256,15 @@ pub async fn declare_sync_point(
 
     let (text_frac, audio_global) = match decl.format {
         ProgressFormat::Epub => {
-            let frac = decl
-                .ebook_fraction
-                .filter(|f| (0.0..=1.0).contains(f))
+            // The declared CFI names the spot on the server's own ruler —
+            // prefer it over the client fraction, which the web reader
+            // measures on epub.js's different locations scale.
+            let cfi_frac = match decl.epub_cfi.clone() {
+                Some(cfi) => fraction_for_cfi(pool, book_id, cfi).await,
+                None => None,
+            };
+            let frac = cfi_frac
+                .or_else(|| decl.ebook_fraction.filter(|f| (0.0..=1.0).contains(f)))
                 .ok_or(CrossFormatError::CounterpartMissing)?;
             let row = progress::get_progress(pool, user_id, &book_uuid, ProgressFormat::Audio)
                 .await?
@@ -544,26 +550,52 @@ async fn epub_source_fraction(
     let Some(cfi) = source.epub_cfi.clone() else {
         return fallback;
     };
-    let precise = async {
-        let (file_id, epub_path) = crate::book_file_with_id(pool, book_id, "EPUB")
-            .await
-            .ok()??;
-        let stats = crate::epub_structure::get_spine_stats(pool, file_id)
-            .await
-            .ok()?;
-        if stats.is_empty() {
-            return None;
-        }
-        let (spine_index, offset) = tokio::task::spawn_blocking(move || {
-            crate::kobo_position::cfi_spine_offset(&epub_path, &cfi)
-        })
+    fraction_for_cfi(pool, book_id, cfi).await.or(fallback)
+}
+
+/// Full-precision whole-book fraction of one CFI via spine stats — the
+/// single ruler every cross-format exchange resolves on. `None` on any
+/// missing input (no stats yet, unreadable file, unanchorable CFI).
+async fn fraction_for_cfi(pool: &SqlitePool, book_id: i64, cfi: String) -> Option<f64> {
+    let (file_id, epub_path) = crate::book_file_with_id(pool, book_id, "EPUB")
         .await
-        .ok()?
         .ok()??;
-        crate::epub_structure::fraction_at(&stats, spine_index as i64, offset)
+    let stats = crate::epub_structure::get_spine_stats(pool, file_id)
+        .await
+        .ok()?;
+    if stats.is_empty() {
+        return None;
     }
-    .await;
-    precise.or(fallback)
+    let (spine_index, offset) = tokio::task::spawn_blocking(move || {
+        crate::kobo_position::cfi_spine_offset(&epub_path, &cfi)
+    })
+    .await
+    .ok()?
+    .ok()??;
+    crate::epub_structure::fraction_at(&stats, spine_index as i64, offset)
+}
+
+/// Derive the point CFI at a whole-book fraction — the jump target the web
+/// reader consumes directly, so the fraction is never reinterpreted on
+/// epub.js's different locations scale. Response-only and on request (the
+/// resume endpoint's `?derive=cfi`); `None` degrades to the fraction path.
+pub async fn derive_candidate_cfi(pool: &SqlitePool, book_uuid: &str, frac: f64) -> Option<String> {
+    let book_uuid = resolve_canonical_book_uuid(pool, book_uuid).await.ok()??;
+    let book_id = resolve_book_id_by_uuid(pool, &book_uuid).await.ok()??;
+    let (file_id, epub_path) = crate::book_file_with_id(pool, book_id, "EPUB")
+        .await
+        .ok()??;
+    let stats = crate::epub_structure::get_spine_stats(pool, file_id)
+        .await
+        .ok()?;
+    let (spine_index, offset) = crate::epub_structure::position_at_fraction(&stats, frac)?;
+    tokio::task::spawn_blocking(move || {
+        crate::kobo_position::cfi_at_spine_offset(&epub_path, spine_index as usize, offset)
+    })
+    .await
+    .ok()?
+    .ok()
+    .flatten()
 }
 
 /// Compose the answer for `GET /api/books/{uuid}/cross-format-resume`:
@@ -692,6 +724,7 @@ pub async fn resume_candidate(
                             total_duration_seconds: Some(timeline.total_seconds),
                             percent: None,
                             fraction: None,
+                            epub_cfi: None,
                             source_position_seconds: None,
                             source_ahead: current_global.map(|cur| mapped_global > cur),
                         };
@@ -733,6 +766,10 @@ pub async fn resume_candidate(
                         total_duration_seconds: None,
                         percent: Some(pct),
                         fraction: Some(frac.clamp(0.0, 1.0)),
+                        // Derived on request by the resume endpoint
+                        // (`derive_candidate_cfi`), never here — every
+                        // hero card calls this fn and must stay I/O-free.
+                        epub_cfi: None,
                         source_position_seconds: Some(raw_frac * timeline.total_seconds),
                         source_ahead: current.map(|cur| frac > cur),
                     };

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -973,6 +973,152 @@ async fn resume_candidate_audio_target_derives_the_fraction_from_the_stored_cfi(
     );
 }
 
+/// Seed a dual book whose EPUB really exists on disk (two identical
+/// chapters, stats extracted) plus a 1000s single-file audiobook — the
+/// scaffolding the CFI-precision tests share.
+async fn seed_cfi_book(pool: &SqlitePool, tag: &str, uuid: &str) -> i64 {
+    let dir = crate::test_support::make_test_dir(tag);
+    std::fs::create_dir_all(dir.join("sub")).unwrap();
+    std::fs::write(
+        dir.join("sub").join("book.epub"),
+        crate::test_support::build_test_epub(&[
+            ("c1.xhtml", FRACTION_CHAPTER),
+            ("c2.xhtml", FRACTION_CHAPTER),
+        ]),
+    )
+    .unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, ?)")
+        .bind(dir.to_str().unwrap())
+        .bind(tag)
+        .execute(pool)
+        .await
+        .unwrap();
+    let library_id: i64 = sqlx::query_scalar("SELECT id FROM scan_roots WHERE display_name = ?")
+        .bind(tag)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    let book_id: i64 = sqlx::query_scalar(
+        "INSERT INTO books (uuid, scan_key, library_id, path, title, sort)
+         VALUES (?, 'sub/book.epub', ?, 'sub', 'Precise', 'precise') RETURNING id",
+    )
+    .bind(uuid)
+    .bind(library_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, scan_key)
+         VALUES (?, 'EPUB', 'book', 10, 10, 'sub/book.epub')",
+    )
+    .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    let audio_id: i64 = sqlx::query_scalar(
+        "INSERT INTO book_files
+            (book_id, format, filename, size_bytes, mtime_epoch, scan_key, ordinal)
+         VALUES (?, 'M4B', 'part0', 100, 1000, 'a0.m4b', 0) RETURNING id",
+    )
+    .bind(book_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO book_file_parts
+            (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds)
+         VALUES (?, 0, 'a0.m4b', 100, 1000, 1000.0)",
+    )
+    .bind(audio_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    crate::indexer::backfill_epub_structure(pool, dir.to_str().unwrap(), |_, _, _| {})
+        .await
+        .unwrap();
+    book_id
+}
+
+#[tokio::test]
+async fn derive_candidate_cfi_lands_on_the_same_ruler_as_the_walk() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_cfi_book(&pool, "cfi_derive_ruler", "cfi-uuid-2").await;
+    let (epub_file_id, epub_path) = crate::book_file_with_id(&pool, book_id, "EPUB")
+        .await
+        .unwrap()
+        .unwrap();
+    let stats = crate::epub_structure::get_spine_stats(&pool, epub_file_id)
+        .await
+        .unwrap();
+    // The fraction of a known mid-chapter-2 CFI, via the same walk.
+    let (si, off) = crate::kobo_position::cfi_spine_offset(&epub_path, "epubcfi(/6/4!/4/2/1:5)")
+        .unwrap()
+        .unwrap();
+    let frac = crate::epub_structure::fraction_at(&stats, si as i64, off).unwrap();
+
+    let derived = derive_candidate_cfi(&pool, "cfi-uuid-2", frac)
+        .await
+        .expect("derivation should succeed with stats and a readable file");
+    // Round trip: the derived CFI must resolve back to the same fraction —
+    // one ruler, no locations-scale reinterpretation anywhere.
+    let (si2, off2) = crate::kobo_position::cfi_spine_offset(&epub_path, &derived)
+        .unwrap()
+        .unwrap();
+    let frac2 = crate::epub_structure::fraction_at(&stats, si2 as i64, off2).unwrap();
+    assert!(
+        (frac2 - frac).abs() < 1e-9,
+        "derived CFI {derived} resolves to {frac2}, expected {frac}"
+    );
+}
+
+#[tokio::test]
+async fn declare_sync_point_prefers_the_declared_cfi_over_the_client_fraction() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let book_id = seed_cfi_book(&pool, "cfi_declare_pref", "cfi-uuid-3").await;
+    // The Epub declaration needs a stored audio counterpart to pair with.
+    progress::upsert_progress(&pool, user, &audio_update("cfi-uuid-3", 400.0, None, 1_000))
+        .await
+        .unwrap();
+
+    let link = declare_sync_point(
+        &pool,
+        user,
+        &DeclareSyncPoint {
+            book_uuid: "cfi-uuid-3".to_string(),
+            format: ProgressFormat::Epub,
+            // Deliberately wrong locations-scale fraction: the CFI must win.
+            ebook_fraction: Some(0.9),
+            epub_cfi: Some("epubcfi(/6/4!/4/2/1:5)".to_string()),
+            audio_book_file_id: None,
+            audio_seconds: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let (_, epub_path) = crate::book_file_with_id(&pool, book_id, "EPUB")
+        .await
+        .unwrap()
+        .unwrap();
+    let (epub_file_id, _) = crate::book_file_with_id(&pool, book_id, "EPUB")
+        .await
+        .unwrap()
+        .unwrap();
+    let stats = crate::epub_structure::get_spine_stats(&pool, epub_file_id)
+        .await
+        .unwrap();
+    let (si, off) = crate::kobo_position::cfi_spine_offset(&epub_path, "epubcfi(/6/4!/4/2/1:5)")
+        .unwrap()
+        .unwrap();
+    let expected = crate::epub_structure::fraction_at(&stats, si as i64, off).unwrap();
+    let (text_frac, _) = link.user_anchors[0];
+    assert!(
+        (text_frac - expected).abs() < 1e-9,
+        "anchor {text_frac} must come from the CFI ({expected}), not the 0.9 client fraction"
+    );
+}
+
 #[tokio::test]
 async fn resume_candidate_aligns_when_the_target_already_sits_at_the_mapped_spot() {
     // The live We Are Legion case: reader at 19%, listener at the mapped
@@ -1314,6 +1460,7 @@ fn declare_audio(uuid: &str, file_id: Option<i64>, seconds: f64) -> DeclareSyncP
         book_uuid: uuid.to_string(),
         format: ProgressFormat::Audio,
         ebook_fraction: None,
+        epub_cfi: None,
         audio_book_file_id: file_id,
         audio_seconds: Some(seconds),
     }
@@ -1540,6 +1687,7 @@ async fn alignment_view_serves_the_anchor_pairs_the_jump_uses() {
             book_uuid: uuid.clone(),
             format: ProgressFormat::Epub,
             ebook_fraction: Some(0.5),
+            epub_cfi: None,
             audio_book_file_id: None,
             audio_seconds: None,
         },

--- a/db/src/kobo_position/mod.rs
+++ b/db/src/kobo_position/mod.rs
@@ -311,6 +311,33 @@ pub fn span_at_spine_offset(
     derive_span_half(kepub, &href, &anchor)
 }
 
+/// Derive a point CFI at a visible-character offset inside one spine item
+/// of the source EPUB — the cross-format jump-target derivation. No kepub
+/// half: the web reader consumes the CFI directly, so there is nothing to
+/// prove alignment against; an out-of-range offset clamps to the item's
+/// last character rather than failing.
+pub fn cfi_at_spine_offset(
+    source_epub: &Path,
+    spine_index: usize,
+    offset_in_file: u64,
+) -> anyhow::Result<Option<String>> {
+    let mut sdoc = book::open_doc(source_epub)?;
+    if spine_index >= sdoc.spine.len() {
+        return Ok(None);
+    }
+    let s_bytes = book::read_spine_entry(&mut sdoc, spine_index)?;
+    let s_index = walk::index_file(&s_bytes)?;
+    let count = s_index.visible_char_count();
+    if count == 0 {
+        return Ok(None);
+    }
+    let norm_offset = offset_in_file.min(count - 1);
+    let Some((tail, _)) = s_index.tail_at(norm_offset) else {
+        return Ok(None);
+    };
+    Ok(Some(cfi::format_cfi(spine_index, &tail)))
+}
+
 /// The kepub half of [`cfi_to_span`]: find the span covering the source
 /// anchor and prove alignment by snippet at the same offset.
 fn derive_span_half(

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -9139,17 +9139,48 @@ html {
   width: min(720px, 92vw);
   max-height: 84vh;
   overflow-y: auto;
-  padding: 22px 26px;
+  padding: 26px 32px 22px;
 }
-.al-head h3 { margin: 4px 0 6px; }
+/* Book-accent cascade + the frame's tinted wash (Format Sync design:
+   the modal sits in a radial glow of the book's accent). */
+.al-body { position: relative; }
+.al-body::before {
+  content: "";
+  position: absolute;
+  inset: -26px -32px auto;
+  height: 180px;
+  border-radius: 20px 20px 0 0;
+  background: radial-gradient(
+    70% 130% at 30% 0%,
+    color-mix(in oklch, var(--accent, #6a8bd7) 14%, transparent),
+    transparent 65%
+  );
+  pointer-events: none;
+}
+.al-body > * { position: relative; }
+.al-head h3 {
+  margin: 4px 0 6px;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 38px;
+  line-height: 1;
+}
 .al-kicker {
   font-size: 11px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  opacity: 0.7;
+  color: var(--accent, #6a8bd7);
   margin: 0;
 }
-.al-sub { font-size: 13px; opacity: 0.75; margin: 0 0 14px; max-width: 60ch; }
+.al-sub {
+  font-size: 13.5px;
+  color: var(--ink-2, inherit);
+  opacity: 0.9;
+  margin: 12px 0 14px;
+  max-width: 660px;
+  line-height: 1.55;
+}
 .al-lanes { margin: 10px 0 4px; }
 .al-lane-label { font-size: 11.5px; opacity: 0.7; margin: 12px 0 5px; }
 .al-lane {
@@ -9160,7 +9191,7 @@ html {
   overflow: visible;
   background: rgba(127, 127, 127, 0.08);
 }
-.al-lane-audio { display: flex; gap: 3px; background: none; border: 0; }
+.al-lane-audio { display: flex; gap: 3px; background: none; border: 0; height: 46px; }
 .al-seg {
   position: relative;
   min-width: 0;
@@ -9182,15 +9213,15 @@ html {
 .al-seg-dur { font-size: 10px; opacity: 0.6; white-space: nowrap; }
 .al-tick {
   position: absolute;
-  top: 22%;
-  bottom: 22%;
+  top: 24%;
+  bottom: 24%;
   width: 1px;
-  background: rgba(127, 127, 127, 0.45);
+  background: var(--line-2, rgba(127, 127, 127, 0.45));
 }
 .al-marker {
   position: absolute;
-  top: -4px;
-  bottom: -4px;
+  top: -3px;
+  bottom: -3px;
   width: 2px;
   background: var(--accent, #6a8bd7);
   border-radius: 1px;
@@ -9251,9 +9282,9 @@ html {
 .al-foot {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 18px;
-  padding-top: 12px;
+  gap: 10px;
+  margin-top: 22px;
+  padding-top: 16px;
   border-top: 1px solid var(--line, rgba(127, 127, 127, 0.25));
 }
 .al-foot-spacer { flex: 1; }
@@ -9360,38 +9391,41 @@ html {
   border: 1px solid rgba(214, 158, 46, 0.5);
   background: rgba(214, 158, 46, 0.08);
   border-radius: 10px;
-  padding: 11px 13px;
-  margin: 14px 0 0;
+  padding: 12px 14px;
+  margin: 20px 0 0;
 }
-.al-chip-row { position: relative; height: 26px; }
-.al-chip-row-tall { height: 54px; }
+.al-chip-row { position: relative; height: 27px; }
+.al-chip-row-tall { height: 60px; }
 .al-chip {
   position: absolute;
   top: 0;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 9px;
+  padding: 3px 9px;
   border-radius: 999px;
   white-space: nowrap;
-  font-size: 10.5px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.02em;
   border: 1px solid var(--line, rgba(127, 127, 127, 0.35));
   background: var(--bg-1, rgba(127, 127, 127, 0.1));
   z-index: 3;
 }
 .al-chip-accent {
+  color: var(--ink-0, inherit);
   border-color: color-mix(in oklch, var(--accent, #6a8bd7) 55%, transparent);
-  background: color-mix(in oklch, var(--accent, #6a8bd7) 18%, var(--bg-1, transparent));
+  background: color-mix(in oklch, var(--accent, #6a8bd7) 20%, var(--bg-1, transparent));
 }
 .al-chip-dashed { border-style: dashed; }
-.al-chip-staggered { top: 28px; }
+.al-chip-staggered { top: 31px; }
 .al-fill {
   position: absolute;
   inset: 0 auto 0 0;
   background: color-mix(in oklch, var(--accent, #6a8bd7) 13%, transparent);
   pointer-events: none;
 }
-.al-connector { height: 44px; margin: 2px 0; }
+.al-connector { height: 50px; margin: 0; }
 .al-connector svg { display: block; width: 100%; height: 100%; }
 .al-thread {
   stroke: var(--line, rgba(127, 127, 127, 0.4));

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -111,6 +111,11 @@
   // pendingAnnotations, NOT cleared in teardown() — init() tears down
   // first and must still honor a jump that raced it; destroy() clears it.
   var pendingJumpPct = null;
+  // CFI twin of pendingJumpPct: a displayCfi that raced init. Applied
+  // from the same locations hook (a CFI jump needs only the rendition,
+  // but one known safe point keeps the two paths in step); at most one
+  // of the two slots is ever set.
+  var pendingJumpCfi = null;
 
   function emitStatus(state) {
     if (typeof window.__omnibusOnStatus === "function") {
@@ -376,9 +381,17 @@
         if (rendition && rendition.location) {
           emitRelocate(rendition.location, true);
         }
-        // A follow-mode auto-jump that raced this pass now has a locations
-        // map to resolve against — apply it unless navigation cancelled it.
-        if (pendingJumpPct !== null && book && book.locations) {
+        // A follow-mode auto-jump that raced this pass now has a rendition
+        // (and locations) to resolve against — apply it unless navigation
+        // cancelled it. The CFI slot wins: it is the server-derived precise
+        // target, the percentage its locations-scale fallback.
+        if (pendingJumpCfi !== null) {
+          var jumpCfi = pendingJumpCfi;
+          pendingJumpCfi = null;
+          pendingJumpPct = null;
+          restoreEchoPending = false;
+          displaySettled(jumpCfi);
+        } else if (pendingJumpPct !== null && book && book.locations) {
           var pct = pendingJumpPct;
           pendingJumpPct = null;
           restoreEchoPending = false;
@@ -543,6 +556,7 @@
   function next() {
     if (!rendition) return;
     pendingJumpPct = null;
+    pendingJumpCfi = null;
     restoreEchoPending = false;
     displayToken++;
     return rendition.next();
@@ -551,6 +565,7 @@
   function prev() {
     if (!rendition) return;
     pendingJumpPct = null;
+    pendingJumpCfi = null;
     restoreEchoPending = false;
     displayToken++;
     return rendition.prev();
@@ -1454,6 +1469,7 @@
   function destroy() {
     if (!rendition) return;
     pendingJumpPct = null;
+    pendingJumpCfi = null;
     teardown();
   }
 
@@ -1654,6 +1670,7 @@
   function display(target) {
     if (!rendition || !target) return;
     pendingJumpPct = null;
+    pendingJumpCfi = null;
     restoreEchoPending = false;
     var t = String(target);
     var hash = t.indexOf("#");
@@ -1792,11 +1809,28 @@
     // its landing (even one emitted by the restore-settle unmute) must
     // persist, so it clears the pending echo tag.
     restoreEchoPending = false;
+    pendingJumpCfi = null;
     if (!book || !book.locations || !book.locations.length()) {
       pendingJumpPct = pct;
       return;
     }
     applyPercentage(pct);
+  }
+
+  // Jump straight to a server-derived point CFI — the cross-format sync
+  // surfaces' precise entry point (displayPercentage is their fallback).
+  // Parked until init builds the rendition, like a pre-locations
+  // percentage jump.
+  function displayCfi(cfi) {
+    if (!cfi) return;
+    restoreEchoPending = false;
+    pendingJumpPct = null;
+    if (!rendition) {
+      pendingJumpCfi = cfi;
+      return;
+    }
+    pendingJumpCfi = null;
+    displaySettled(cfi);
   }
 
   window.OmnibusReader = {
@@ -1816,6 +1850,7 @@
     requestToc: requestToc,
     display: display,
     displayPercentage: displayPercentage,
+    displayCfi: displayCfi,
     copyText: copyText,
     shareText: shareText,
     search: search,

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -215,6 +215,14 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
         "Sync stays off until you confirm. You can unlink any time."
     };
 
+    // The design themes the whole modal off the BOOK's accent — fills,
+    // chips, markers, and the header wash all derive from it. Absent an
+    // extracted accent the app default cascades through unchanged.
+    let accent_style = book()
+        .as_ref()
+        .and_then(|b| b.accent.clone())
+        .map(|a| format!("--accent: {a};"))
+        .unwrap_or_default();
     rsx! {
         ConfirmModal {
             testid: "alignment-modal",
@@ -222,6 +230,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
             dialog_class: "al-modal card",
             busy: busy(),
             on_dismiss: move |_| open.set(false),
+            div { class: "al-body", style: "{accent_style}",
             div { class: "al-head",
                 p { class: "al-kicker",
                     span { class: "al-kicker-glyph", SyncGlyph { size: 13 } }
@@ -363,6 +372,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                     },
                     "{confirm_label}"
                 }
+            }
             }
         }
     }

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -90,6 +90,7 @@ fn transport_controls_js() -> &'static str {
       // `el.src` if it differs from the current part, preserving the
       // play/pause state across the swap.
       seek: function(absSeconds){
+        this._seeded = true;
         var s = Math.max(0, absSeconds || 0);
         // Push the target time to the transport display immediately —
         // don't wait for the element's own `timeupdate`, which some
@@ -190,17 +191,29 @@ fn listeners_js() -> &'static str {
         window.__omnibusOnAudioDuration(d);
       }
     });
+    // The seed gate: until the boot's initial position has actually been
+    // applied to the element (or the user seeks/plays for real), the
+    // element sits at 0 — and a pause fired by a load()/src swap in that
+    // window would flush a hard 0.0 over the stored position with a fresh
+    // clock, which the cross-format follow then propagates into the other
+    // format. No emission may persist an unseeded element's position.
     el.addEventListener('timeupdate', function(){
+      var oa = window.OmnibusAudio;
+      if (oa && !oa._seeded) return;
       if (window.__omnibusOnAudioTime) {
         window.__omnibusOnAudioTime(absTime());
       }
     });
     el.addEventListener('play', function(){
+      var oa = window.OmnibusAudio;
+      if (oa) oa._seeded = true;
       if (window.__omnibusOnAudioPlay) {
         window.__omnibusOnAudioPlay(absTime());
       }
     });
     el.addEventListener('pause', function(){
+      var oa = window.OmnibusAudio;
+      if (oa && !oa._seeded) return;
       if (window.__omnibusOnAudioPause) {
         window.__omnibusOnAudioPause(absTime());
       }
@@ -237,6 +250,7 @@ fn direct_play_init_js() -> &'static str {
       // is the absolute resume position in seconds.
       initDirect: function(parts, initialPositionAbs){
         this._mode = 'direct';
+        this._seeded = false;
         this._parts = parts;
         var acc = 0;
         this._cumOffsets = [];
@@ -256,9 +270,11 @@ fn direct_play_init_js() -> &'static str {
         while (idx < this._cumOffsets.length - 1 && s >= this._cumOffsets[idx + 1]) idx++;
         this._index = idx;
         var local = s - this._cumOffsets[idx];
+        var oa = this;
         var onMeta = function(){
           el.removeEventListener('loadedmetadata', onMeta);
           try { el.currentTime = local; } catch(_) {}
+          oa._seeded = true;
         };
         el.addEventListener('loadedmetadata', onMeta);
         el.src = parts[idx].url;
@@ -276,6 +292,7 @@ fn hls_init_js() -> &'static str {
       // `null` to skip the seek.
       initHls: function(url, initialPositionAbs){
         this._mode = 'hls';
+        this._seeded = false;
         if (typeof Hls !== 'undefined' && Hls.isSupported()) {
           var hls = new Hls();
           hls.loadSource(url);
@@ -292,10 +309,16 @@ fn hls_init_js() -> &'static str {
         } else {
           console.warn('OmnibusAudio: no HLS support in this browser');
         }
+        if (typeof initialPositionAbs !== 'number' || initialPositionAbs <= 0) {
+          // No stored position to apply: the element's 0 IS the position.
+          this._seeded = true;
+        }
         if (typeof initialPositionAbs === 'number' && initialPositionAbs > 0) {
+          var hoa = this;
           var onMeta = function(){
             el.removeEventListener('loadedmetadata', onMeta);
             try { el.currentTime = Math.max(0, initialPositionAbs); } catch(_) {}
+            hoa._seeded = true;
           };
           el.addEventListener('loadedmetadata', onMeta);
         }

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -197,23 +197,28 @@ fn listeners_js() -> &'static str {
     // window would flush a hard 0.0 over the stored position with a fresh
     // clock, which the cross-format follow then propagates into the other
     // format. No emission may persist an unseeded element's position.
+    // Fail CLOSED when the shim is null (dom_reset_js clears it during
+    // SPA-nav): a stale element's listeners can still fire in that window,
+    // and an unowned element is exactly the unseeded-position source this
+    // gate exists to silence.
     el.addEventListener('timeupdate', function(){
       var oa = window.OmnibusAudio;
-      if (oa && !oa._seeded) return;
+      if (!oa || !oa._seeded) return;
       if (window.__omnibusOnAudioTime) {
         window.__omnibusOnAudioTime(absTime());
       }
     });
     el.addEventListener('play', function(){
       var oa = window.OmnibusAudio;
-      if (oa) oa._seeded = true;
+      if (!oa) return;
+      oa._seeded = true;
       if (window.__omnibusOnAudioPlay) {
         window.__omnibusOnAudioPlay(absTime());
       }
     });
     el.addEventListener('pause', function(){
       var oa = window.OmnibusAudio;
-      if (oa && !oa._seeded) return;
+      if (!oa || !oa._seeded) return;
       if (window.__omnibusOnAudioPause) {
         window.__omnibusOnAudioPause(absTime());
       }

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -480,7 +480,7 @@ async fn run_manifest_init(
     // `initDirect`'s one-shot restore seek and lose. Skipped entirely for an
     // explicit picker `?file_id=` (see `resolve_follow_boot`).
     let follow_resume = if file_id.is_none() {
-        super::sync_prompt::fetch_resume(&uuid_for_fetch, "audio").await
+        super::sync_prompt::fetch_resume_with(&uuid_for_fetch, "audio", false).await
     } else {
         None
     };

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -497,6 +497,7 @@ mod boot_resume_tests {
                 total_duration_seconds: Some(35_760.0),
                 percent: None,
                 fraction: None,
+                epub_cfi: None,
                 source_position_seconds: None,
                 source_ahead: Some(true),
             }),

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -209,7 +209,6 @@ pub(super) fn ReadyPlayer(
                 },
             }
 
-            {sync_prompt_slot(&uuid)}
 
             PlayerOverlays {
                 panes,
@@ -535,9 +534,7 @@ pub(super) fn PlayerOverlays(
 /// shell renders nothing here (native iOS owns its own prompt).
 #[cfg(not(feature = "mobile"))]
 fn sync_prompt_slot(uuid: &str) -> Element {
-    rsx! {
-        super::sync_prompt::SyncJumpPrompt { uuid: uuid.to_string() }
-    }
+    rsx! {}
 }
 
 #[cfg(feature = "mobile")]

--- a/frontend/src/pages/listen/ready_player.rs
+++ b/frontend/src/pages/listen/ready_player.rs
@@ -529,15 +529,3 @@ pub(super) fn PlayerOverlays(
         }
     }
 }
-
-/// Web-only slot for the cross-format jump prompt; the hybrid mobile
-/// shell renders nothing here (native iOS owns its own prompt).
-#[cfg(not(feature = "mobile"))]
-fn sync_prompt_slot(uuid: &str) -> Element {
-    rsx! {}
-}
-
-#[cfg(feature = "mobile")]
-fn sync_prompt_slot(_uuid: &str) -> Element {
-    rsx! {}
-}

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -1,64 +1,15 @@
-//! Cross-format resume prompt on the web player: when the linked book's
-//! reading position is newer, a floating dismissable card offers the
-//! mapped jump. Declining stores the source's event clock locally so the
-//! prompt re-arms only after the reading position advances — never a
-//! progress write. Web-only surface, like the mini dock.
+//! Cross-format transport for the web player: the resume fetch shared by
+//! the reader's follow resolver and the listen bootstrap, plus the
+//! "Synced here" toolbar control. Follow-only — the old "jump ahead?"
+//! card is gone (linking IS turning sync on), and follow resolution at
+//! boot owns the mapped position. Web-only surface, like the mini dock.
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
-use dioxus_router::Link;
-use omnibus_shared::cross_format::{CrossFormatCandidate, CrossFormatResumeState};
-
-use crate::components::alignment_modal::fmt_hm;
-use crate::routes::Route;
-
-/// Dismissal memory: the newest source clock the user has declined, per
-/// `(book, target)`. Stored in localStorage on web; no-ops elsewhere.
-pub(crate) fn dismissed_clock(uuid: &str, target: &str) -> Option<i64> {
-    #[cfg(feature = "web")]
-    {
-        let storage = web_sys::window()?.local_storage().ok()??;
-        storage
-            .get_item(&format!("omn.syncprompt::{uuid}::{target}"))
-            .ok()?
-            .and_then(|v| v.parse().ok())
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        let _ = (uuid, target);
-        None
-    }
-}
-
-/// Persist a declined candidate's source clock (see [`dismissed_clock`]).
-pub(crate) fn store_dismissed_clock(uuid: &str, target: &str, clock: i64) {
-    #[cfg(feature = "web")]
-    {
-        if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-            let _ = storage.set_item(
-                &format!("omn.syncprompt::{uuid}::{target}"),
-                &clock.to_string(),
-            );
-        }
-    }
-    #[cfg(not(feature = "web"))]
-    {
-        let _ = (uuid, target, clock);
-    }
-}
 
 /// Fetch the full cross-format resume for `(uuid, target)` — raw REST
-/// over the same-origin cookie session (the `fetch_manifest` pattern).
-/// `None` on any transport failure: the surfaces this feeds are
-/// best-effort chrome, never an error surface.
-pub(crate) async fn fetch_resume(
-    uuid: &str,
-    target: &str,
-) -> Option<omnibus_shared::cross_format::CrossFormatResume> {
-    fetch_resume_with(uuid, target, false).await
-}
-
-/// [`fetch_resume`] with the server-side CFI derivation opt-in — only the
+/// over the same-origin cookie session. `derive_cfi` asks the server to
+/// attach the mapped point CFI (`?derive=cfi`) — only the
 /// reader surfaces ask (`derive=cfi` opens the EPUB server-side), so the
 /// audio/boot callers stay on the plain fetch.
 pub(crate) async fn fetch_resume_with(
@@ -80,131 +31,6 @@ pub(crate) async fn fetch_resume_with(
     {
         let _ = (uuid, target, derive_cfi);
         None
-    }
-}
-
-/// The floating prompt card. Renders nothing until the post-mount fetch
-/// finds an undismissed candidate (SSR and first WASM paint agree).
-#[component]
-pub(super) fn SyncJumpPrompt(uuid: String) -> Element {
-    let mut candidate = use_signal(|| None::<CrossFormatCandidate>);
-    let mut hidden = use_signal(|| false);
-    let playback = crate::use_playback();
-
-    let fetch_uuid = uuid.clone();
-    use_effect(move || {
-        let uuid = fetch_uuid.clone();
-        spawn(async move {
-            let Some(resume) = fetch_resume(&uuid, "audio").await else {
-                return;
-            };
-            if resume.state != CrossFormatResumeState::Candidate {
-                return;
-            }
-            let Some(c) = resume.candidate else {
-                return;
-            };
-            if resume.follow {
-                // Follow mode: resolve-at-open is the boot's job
-                // (`resolve_follow_boot` seeds the mapped file + position
-                // before the first play). A second actor here raced the
-                // boot's one-shot restore seek — and, deciding against a
-                // not-yet-loaded player, could re-navigate into an
-                // explicit-file boot that skipped follow entirely. No
-                // card, no seek: stay quiet.
-                return;
-            }
-            // Re-arm rule: an already-declined source position stays quiet
-            // until the reading position advances past it.
-            if dismissed_clock(&uuid, "audio")
-                .is_some_and(|seen| c.source_client_updated_at <= seen)
-            {
-                return;
-            }
-            candidate.set(Some(c));
-        });
-    });
-
-    let Some(c) = candidate() else {
-        return rsx! {};
-    };
-    if hidden() {
-        return rsx! {};
-    }
-    let seconds = c.audio_position_seconds.unwrap_or(0.0);
-    let label = fmt_hm(seconds);
-    let dismiss_uuid = uuid.clone();
-    let accept_uuid = uuid.clone();
-    let source_clock = c.source_client_updated_at;
-    let target_file = c.book_file_id;
-    let total = c.total_duration_seconds.unwrap_or(0.0);
-
-    // A backward offer must not claim "further".
-    let copy = if c.source_ahead == Some(false) {
-        format!("You're re-reading earlier in the ebook — jump back to \u{2248} {label}?")
-    } else {
-        format!("You read further in the ebook — jump to \u{2248} {label}?")
-    };
-
-    let kicker_dismiss_uuid = uuid.clone();
-    rsx! {
-        div { class: "lp-sync-prompt card", role: "status", "data-testid": "sync-prompt",
-            div { class: "lp-sync-kicker",
-                crate::components::sync_glyph::SyncGlyph { size: 12 }
-                "Cross-format sync"
-                span { class: "lp-sync-kicker-spacer" }
-                button {
-                    class: "btn ghost sm",
-                    "data-testid": "sync-prompt-close",
-                    aria_label: "Dismiss",
-                    onclick: move |_| {
-                        store_dismissed_clock(&kicker_dismiss_uuid, "audio", source_clock);
-                        hidden.set(true);
-                    },
-                    "\u{2715}"
-                }
-            }
-            span { class: "lp-sync-copy", "{copy}" }
-            button {
-                class: "btn sm",
-                "data-testid": "sync-prompt-accept",
-                onclick: move |_| {
-                    hidden.set(true);
-                    store_dismissed_clock(&accept_uuid, "audio", source_clock);
-                    // Seek only when the mapped file is the one the player
-                    // loaded (explicitly, or implicitly for a single-file
-                    // timeline); otherwise navigate so the right file
-                    // loads and this prompt re-offers the precise seek.
-                    let loaded = (playback.file_id)();
-                    let same_file = loaded == target_file
-                        || (loaded.is_none() && ((playback.duration)() - total).abs() < 1.0);
-                    if same_file {
-                        super::helpers::seek_to(seconds);
-                    } else {
-                        dioxus_router::navigator().push(Route::BookListen {
-                            uuid: accept_uuid.clone(),
-                            file_id: target_file,
-                        });
-                    }
-                },
-                "Jump"
-            }
-            button {
-                class: "btn ghost sm",
-                "data-testid": "sync-prompt-dismiss",
-                onclick: move |_| {
-                    store_dismissed_clock(&dismiss_uuid, "audio", source_clock);
-                    hidden.set(true);
-                },
-                "Keep my spot"
-            }
-            Link {
-                to: Route::BookDetail { uuid: uuid.clone() },
-                class: "lp-sync-alignment",
-                "data-testid": "sync-prompt-alignment",
-                "View alignment \u{2192}"
-            }
-        }
     }
 }
 

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -55,9 +55,21 @@ pub(crate) async fn fetch_resume(
     uuid: &str,
     target: &str,
 ) -> Option<omnibus_shared::cross_format::CrossFormatResume> {
+    fetch_resume_with(uuid, target, false).await
+}
+
+/// [`fetch_resume`] with the server-side CFI derivation opt-in — only the
+/// reader surfaces ask (`derive=cfi` opens the EPUB server-side), so the
+/// audio/boot callers stay on the plain fetch.
+pub(crate) async fn fetch_resume_with(
+    uuid: &str,
+    target: &str,
+    derive_cfi: bool,
+) -> Option<omnibus_shared::cross_format::CrossFormatResume> {
     #[cfg(feature = "web")]
     {
-        let url = format!("/api/books/{uuid}/cross-format-resume?target={target}");
+        let derive = if derive_cfi { "&derive=cfi" } else { "" };
+        let url = format!("/api/books/{uuid}/cross-format-resume?target={target}{derive}");
         let resp = gloo_net::http::Request::get(&url).send().await.ok()?;
         if resp.status() != 200 {
             return None;
@@ -66,7 +78,7 @@ pub(crate) async fn fetch_resume(
     }
     #[cfg(not(feature = "web"))]
     {
-        let _ = (uuid, target);
+        let _ = (uuid, target, derive_cfi);
         None
     }
 }
@@ -222,6 +234,7 @@ pub(super) fn SyncHereButton() -> Element {
                     book_uuid: uuid,
                     format: omnibus_shared::ProgressFormat::Audio,
                     ebook_fraction: None,
+                    epub_cfi: None,
                     audio_book_file_id: (playback.file_id)(),
                     audio_seconds: Some((playback.elapsed)()),
                 };

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -21,7 +21,8 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
     use_effect(move || {
         let uuid = fetch_uuid.clone();
         spawn(async move {
-            let Some(resume) = crate::pages::listen::sync_prompt::fetch_resume(&uuid, "epub").await
+            let Some(resume) =
+                crate::pages::listen::sync_prompt::fetch_resume_with(&uuid, "epub", true).await
             else {
                 return;
             };
@@ -33,14 +34,18 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
             };
             if resume.follow {
                 // Follow mode: resolve-at-open — move the text to the
-                // mapped spot silently, full precision, no banner.
+                // mapped spot silently, no banner. The server-derived CFI
+                // is the precise target (one ruler end to end); the
+                // locations-scale percentage is only the fallback.
                 #[cfg(feature = "web")]
                 {
-                    let jump = c
+                    if let Some(cfi) = c.epub_cfi.as_deref() {
+                        super::reader_call_json("displayCfi", cfi);
+                    } else if let Some(pct) = c
                         .fraction
                         .map(|f| (f * 100.0).clamp(0.0, 100.0))
-                        .or(c.percent.map(|p| p as f64));
-                    if let Some(pct) = jump {
+                        .or(c.percent.map(|p| p as f64))
+                    {
                         super::reader_call("displayPercentage", &pct.to_string());
                     }
                 }
@@ -69,6 +74,7 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
         .fraction
         .map(|f| (f * 100.0).clamp(0.0, 100.0))
         .unwrap_or(pct as f64);
+    let jump_cfi = c.epub_cfi.clone();
     let source_clock = c.source_client_updated_at;
     let jump_uuid = uuid.clone();
     let dismiss_uuid = uuid.clone();
@@ -112,9 +118,12 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
                     // The glue only exists on interactive targets; SSR
                     // compiles this handler but never runs it.
                     #[cfg(feature = "web")]
-                    super::reader_call("displayPercentage", &jump_pct.to_string());
+                    match jump_cfi.as_deref() {
+                        Some(cfi) => super::reader_call_json("displayCfi", cfi),
+                        None => super::reader_call("displayPercentage", &jump_pct.to_string()),
+                    }
                     #[cfg(not(feature = "web"))]
-                    let _ = jump_pct;
+                    let _ = (jump_pct, &jump_cfi);
                 },
                 "{jump_label}"
             }
@@ -159,12 +168,16 @@ pub(super) fn SyncHerePill(uuid: String, loc: Signal<super::signals::RelocateDat
                 }
                 let uuid = uuid.clone();
                 let frac = loc.peek().frac;
+                // The CFI names this spot on the server's own ruler; the
+                // locations-scale fraction rides along as the fallback.
+                let cfi = loc.peek().cfi.clone();
                 spawn(async move {
                     label.set("Syncing\u{2026}");
                     let decl = omnibus_shared::cross_format::DeclareSyncPoint {
                         book_uuid: uuid,
                         format: omnibus_shared::ProgressFormat::Epub,
                         ebook_fraction: Some(frac.clamp(0.0, 1.0)),
+                        epub_cfi: cfi,
                         audio_book_file_id: None,
                         audio_seconds: None,
                     };

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -1,22 +1,18 @@
-//! Cross-format resume banner on the web reader: when the linked book's
-//! listening position is newer, a slim banner under the top bar offers the
-//! mapped percent jump (via the glue's `displayPercentage`). Declining
-//! stores the source clock locally so the banner re-arms only after the
-//! listening position advances. Web-only surface.
+//! Cross-format follow resolution on the web reader, plus the "Synced
+//! here" footer pill. Follow-only: opening a linked book whose listening
+//! position is newer silently moves the text to the mapped spot (the
+//! server-derived CFI when available). The old "jump ahead?" banner is
+//! gone — linking IS turning sync on, and a linked book that still
+//! prompts on every surface switch reads as broken. Web-only surface.
 #![cfg(not(feature = "mobile"))]
 
 use dioxus::prelude::*;
-use omnibus_shared::cross_format::CrossFormatCandidate;
 
-use crate::pages::listen::sync_prompt::{dismissed_clock, store_dismissed_clock};
-
-/// The banner. Renders nothing until the post-mount fetch finds an
-/// undismissed candidate, so SSR and the first WASM paint agree.
+/// Invisible resolver: fetches the resume candidate once per mount and,
+/// in follow mode, applies the mapped position through the glue. Renders
+/// nothing on every target, so SSR and the first WASM paint agree.
 #[component]
 pub(super) fn SyncJumpBanner(uuid: String) -> Element {
-    let mut candidate = use_signal(|| None::<CrossFormatCandidate>);
-    let mut hidden = use_signal(|| false);
-
     let fetch_uuid = uuid.clone();
     use_effect(move || {
         let uuid = fetch_uuid.clone();
@@ -32,118 +28,31 @@ pub(super) fn SyncJumpBanner(uuid: String) -> Element {
             let Some(c) = resume.candidate else {
                 return;
             };
-            if resume.follow {
-                // Follow mode: resolve-at-open — move the text to the
-                // mapped spot silently, no banner. The server-derived CFI
-                // is the precise target (one ruler end to end); the
-                // locations-scale percentage is only the fallback.
-                #[cfg(feature = "web")]
-                {
-                    if let Some(cfi) = c.epub_cfi.as_deref() {
-                        super::reader_call_json("displayCfi", cfi);
-                    } else if let Some(pct) = c
-                        .fraction
-                        .map(|f| (f * 100.0).clamp(0.0, 100.0))
-                        .or(c.percent.map(|p| p as f64))
-                    {
-                        super::reader_call("displayPercentage", &pct.to_string());
-                    }
-                }
+            if !resume.follow {
                 return;
             }
-            if dismissed_clock(&uuid, "epub").is_some_and(|seen| c.source_client_updated_at <= seen)
+            // Only the web target has a glue to drive; SSR compiles the
+            // candidate binding but never consumes it.
+            #[cfg(not(feature = "web"))]
+            let _ = c;
+            // Resolve-at-open — move the text to the mapped spot silently.
+            // The server-derived CFI is the precise target (one ruler end
+            // to end); the locations-scale percentage is only the fallback.
+            #[cfg(feature = "web")]
             {
-                return;
+                if let Some(cfi) = c.epub_cfi.as_deref() {
+                    super::reader_call_json("displayCfi", cfi);
+                } else if let Some(pct) = c
+                    .fraction
+                    .map(|f| (f * 100.0).clamp(0.0, 100.0))
+                    .or(c.percent.map(|p| p as f64))
+                {
+                    super::reader_call("displayPercentage", &pct.to_string());
+                }
             }
-            candidate.set(Some(c));
         });
     });
-
-    let Some(c) = candidate() else {
-        return rsx! {};
-    };
-    if hidden() {
-        return rsx! {};
-    }
-    let Some(pct) = c.percent else {
-        return rsx! {};
-    };
-    // Jump at full precision (the floored `pct` is display copy only) —
-    // integer percent alone lands up to a page early on a long book.
-    let jump_pct = c
-        .fraction
-        .map(|f| (f * 100.0).clamp(0.0, 100.0))
-        .unwrap_or(pct as f64);
-    let jump_cfi = c.epub_cfi.clone();
-    let source_clock = c.source_client_updated_at;
-    let jump_uuid = uuid.clone();
-    let dismiss_uuid = uuid.clone();
-
-    // A backward offer must not claim "past this page". The listening
-    // position + recency come along per the design ("≈ 16h 05m, yesterday").
-    let behind = c.source_ahead == Some(false);
-    let listened = c
-        .source_position_seconds
-        .map(|s| {
-            let when = crate::components::alignment_modal::recency(c.source_client_updated_at);
-            if when.is_empty() {
-                format!(
-                    " (\u{2248} {})",
-                    crate::components::alignment_modal::fmt_hm(s)
-                )
-            } else {
-                format!(
-                    " (\u{2248} {}, {when})",
-                    crate::components::alignment_modal::fmt_hm(s)
-                )
-            }
-        })
-        .unwrap_or_default();
-    let copy = if behind {
-        format!("Your audiobook sits earlier{listened} — jump back to \u{2248} {pct}%?")
-    } else {
-        format!("You listened past this page{listened} — jump to \u{2248} {pct}%?")
-    };
-    let jump_label = if behind { "Jump back" } else { "Jump" };
-
-    rsx! {
-        div { class: "rd-sync-banner card", role: "status", "data-testid": "sync-banner",
-            span { class: "rd-sync-copy", "{copy}" }
-            button {
-                class: "btn sm",
-                "data-testid": "sync-banner-jump",
-                onclick: move |_| {
-                    store_dismissed_clock(&jump_uuid, "epub", source_clock);
-                    hidden.set(true);
-                    // The glue only exists on interactive targets; SSR
-                    // compiles this handler but never runs it.
-                    #[cfg(feature = "web")]
-                    match jump_cfi.as_deref() {
-                        Some(cfi) => super::reader_call_json("displayCfi", cfi),
-                        None => super::reader_call("displayPercentage", &jump_pct.to_string()),
-                    }
-                    #[cfg(not(feature = "web"))]
-                    let _ = (jump_pct, &jump_cfi);
-                },
-                "{jump_label}"
-            }
-            button {
-                class: "btn ghost sm",
-                "data-testid": "sync-banner-dismiss",
-                onclick: move |_| {
-                    store_dismissed_clock(&dismiss_uuid, "epub", source_clock);
-                    hidden.set(true);
-                },
-                "Stay here"
-            }
-            dioxus_router::Link {
-                to: crate::routes::Route::BookDetail { uuid: uuid.clone() },
-                class: "lp-sync-alignment",
-                "data-testid": "sync-banner-alignment",
-                "View alignment \u{2192}"
-            }
-        }
-    }
+    rsx! {}
 }
 
 /// "Synced here" footer pill: declares the current reading position (full

--- a/server/src/backend/cross_format.rs
+++ b/server/src/backend/cross_format.rs
@@ -21,6 +21,12 @@ pub(super) struct ResumeQuery {
     /// The format the client wants to resume in; the other format's
     /// position is the mapping source.
     target: ProgressFormat,
+    /// `cfi` asks the server to derive the mapped point CFI for an
+    /// epub-target candidate (`CrossFormatCandidate::epub_cfi`) — opt-in
+    /// because it opens the EPUB, and the hero/list callers must stay
+    /// I/O-free. Anything else (or absent) skips derivation.
+    #[serde(default)]
+    derive: Option<String>,
 }
 
 /// One error mapping for every handler in this module: 404 for an unknown
@@ -48,7 +54,23 @@ pub(super) async fn get_cross_format_resume(
     Query(q): Query<ResumeQuery>,
 ) -> Response {
     match db::cross_format::resume_candidate(&state.pool, user.id, &uuid, q.target).await {
-        Ok(resume) => Json(resume).into_response(),
+        Ok(mut resume) => {
+            // Response-only derivation, mirroring the Kobo follow lane: the
+            // stored rows are never touched, and a derivation failure just
+            // leaves the fraction fallback in place.
+            if q.derive.as_deref() == Some("cfi") {
+                if let Some(c) = resume.candidate.as_mut() {
+                    if c.target == ProgressFormat::Epub && c.epub_cfi.is_none() {
+                        if let Some(frac) = c.fraction {
+                            c.epub_cfi =
+                                db::cross_format::derive_candidate_cfi(&state.pool, &uuid, frac)
+                                    .await;
+                        }
+                    }
+                }
+            }
+            Json(resume).into_response()
+        }
         Err(e) => error_response("cross_format_resume", e),
     }
 }

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -101,6 +101,13 @@ pub struct CrossFormatCandidate {
     /// precision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fraction: Option<f64>,
+    /// Server-derived point CFI at the mapped fraction, present only when
+    /// the caller asked (`?derive=cfi`): the web reader displays it
+    /// directly, so the fraction is never reinterpreted on epub.js's
+    /// different locations scale. Absent on audio targets and on
+    /// derivation failure — `fraction` remains the fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epub_cfi: Option<String>,
     /// The source listening row's own position as global timeline seconds
     /// — the reader banner's "you listened to ≈ 16h 05m" copy. Epub
     /// targets only.
@@ -245,6 +252,12 @@ pub struct DeclareSyncPoint {
     /// Reading surface: whole-book fraction (`0.0..=1.0`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ebook_fraction: Option<f64>,
+    /// Reading surface, optional precision upgrade: the reader's current
+    /// CFI. When present the server derives the anchor fraction from it on
+    /// its own spine-stats ruler, overriding `ebook_fraction` (which the
+    /// web reader measures on epub.js's different locations scale).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epub_cfi: Option<String>,
     /// Listening surface: the playing file and seconds within it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio_book_file_id: Option<i64>,

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -45,13 +45,6 @@ test.beforeAll(async ({ request }) => {
     data: { update: { book_uuid: uuid, mode: "sequence" } },
   });
   expect(link.status(), "link confirm failed").toBe(200);
-  // Confirming a link now turns follow on (auto-apply, no prompts). The
-  // prompt tests below cover the follow-OFF surfaces, so switch it off
-  // explicitly; the sync-point test re-enables it via its declaration.
-  const followOff = await request.post("/api/rpc/cross-format/follow", {
-    data: { uuid, body: { enabled: false } },
-  });
-  expect(followOff.status(), "disable follow for prompt tests").toBe(200);
 });
 
 test.afterAll(async ({ request }) => {
@@ -128,63 +121,28 @@ async function writeAudioSeconds(
   expect(resp.status(), "audio progress write failed").toBe(200);
 }
 
-test("the player offers the mapped jump when reading is ahead", async ({
+test("a linked book resolves silently on the player — no prompt, mapped seek", async ({
   page,
   request,
 }) => {
-  // Audio parked at the start: on the 2-second fixture MP3, any later
-  // position would sit at/past the mapped reading spot and read as a
-  // backward offer under the equivalence gate's direction flag.
+  // Linking turns follow on, and follow-only is the whole surface now:
+  // the old "jump ahead?" card is gone, the boot itself seeds the mapped
+  // position (resolve_follow_boot). Reading ahead at 50% of the text maps
+  // to ~1s of the 2-second fixture — the seek slider must boot past 0
+  // with no prompt card anywhere.
   await writeAudioSeconds(request, 0);
   await writeEpubPercent(request, 50);
 
   await gotoReady(page, `/listen/${uuid}`);
-  const prompt = page.getByTestId("sync-prompt");
-  await expect(prompt).toBeVisible();
-  await expect(prompt).toContainText("jump to");
-
-  await page.getByTestId("sync-prompt-accept").click();
-  await expect(prompt).toHaveCount(0);
-});
-
-test("declining stores the spot and re-arms only when reading advances", async ({
-  page,
-  request,
-}) => {
-  await writeEpubPercent(request, 60);
-  await gotoReady(page, `/listen/${uuid}`);
-  await expect(page.getByTestId("sync-prompt")).toBeVisible();
-
-  await page.getByTestId("sync-prompt-dismiss").click();
-  await expect(page.getByTestId("sync-prompt")).toHaveCount(0);
-
-  // Same position after a fresh navigation: still quiet. Wait for the
-  // network to settle so the candidate fetch has definitely resolved
-  // before asserting absence.
-  await gotoReady(page, `/listen/${uuid}`);
   await page.waitForLoadState("networkidle");
   await expect(page.getByTestId("sync-prompt")).toHaveCount(0);
-
-  // The reading position advances: the prompt re-arms.
-  await writeEpubPercent(request, 70);
-  await gotoReady(page, `/listen/${uuid}`);
-  await expect(page.getByTestId("sync-prompt")).toBeVisible();
-  await page.getByTestId("sync-prompt-dismiss").click();
-});
-
-test("the reader offers the inverse jump when listening is ahead", async ({
-  page,
-  request,
-}) => {
-  await writeAudioSeconds(request, 55);
-
-  await gotoReady(page, `/read/${uuid}`);
-  const banner = page.getByTestId("sync-banner");
-  await expect(banner).toBeVisible();
-  await expect(banner).toContainText("%");
-
-  await page.getByTestId("sync-banner-dismiss").click();
-  await expect(banner).toHaveCount(0);
+  const seek = page.getByRole("slider", { name: "Seek" });
+  await expect
+    .poll(async () => Number(await seek.inputValue()), {
+      timeout: 15_000,
+      message: "the boot should seed the mapped (non-zero) position",
+    })
+    .toBeGreaterThan(0);
 });
 
 test("the hero shows one synced card with the counterpart affordance", async ({
@@ -292,7 +250,6 @@ test("declaring a sync point turns on follow and the reader auto-applies", async
   await writeAudioSeconds(request, 2);
   await gotoReady(page, `/read/${uuid}`);
   await page.waitForLoadState("networkidle");
-  await expect(page.getByTestId("sync-banner")).toHaveCount(0);
   // The footer's whole-book percent proves the view actually moved to the
   // mapped spot (audio at end → epub ≈ 100%), not merely that no banner
   // showed — a silently-dropped jump also shows no banner.

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -45,6 +45,13 @@ test.beforeAll(async ({ request }) => {
     data: { update: { book_uuid: uuid, mode: "sequence" } },
   });
   expect(link.status(), "link confirm failed").toBe(200);
+  // Confirming a link now turns follow on (auto-apply, no prompts). The
+  // prompt tests below cover the follow-OFF surfaces, so switch it off
+  // explicitly; the sync-point test re-enables it via its declaration.
+  const followOff = await request.post("/api/rpc/cross-format/follow", {
+    data: { uuid, body: { enabled: false } },
+  });
+  expect(followOff.status(), "disable follow for prompt tests").toBe(200);
 });
 
 test.afterAll(async ({ request }) => {


### PR DESCRIPTION
## Summary
- Map through CFIs on one ruler end to end: jumps consume a server-derived point CFI (`cfi_at_spine_offset`, attached on request via the resume endpoint's `?derive=cfi`) and "Synced here" declares by the reader's CFI (`fraction_for_cfi`), eliminating the spine-stats-vs-epub.js-locations scale skew that landed jumps minutes off.
- Gate audio transport persistence behind a seed flag: no `pause`/`timeupdate` emission can persist until the element has applied its boot position, killing the hard-0.0 flushes that wiped positions on every surface hop (evidenced by four `old→0.0` backward-write log entries live).
- Confirming a link now turns follow on — the modal's confirm button already says "turn on sync", and a linked book that still prompts on every switch reads as broken.
- Remove the "jump ahead?" prompt surfaces entirely (player card, reader banner, dismissal bookkeeping): follow-only resolution, with the reader's resolver reduced to an invisible effect and the boot owning the player side.
- Bring the alignment modal to the Format Sync design spec: book-accent theming cascaded through fills/chips/markers plus the header wash, 38px italic serif heading, design lane geometry (46px audio strip, 50px connector, 27/29/60 chip rows), mono chips, and design paddings.

Closes #1944

## Test plan
- [x] db: 44 cross-format tests incl. CFI round-trip and CFI-beats-fraction declaration; frontend: 804 tests incl. `resolve_follow_boot`
- [x] clippy (`server`, `mobile`, `web`/wasm32) + fmt + `just lint-css` + `just lint-ts` clean
- [x] `cross_format_prompts` (rewritten follow-only) + `reader` E2E — 19/19 on a fresh dev DB
- [x] Validated live on omnibus-test through `omni-1944-rc1..rc3`