### PR TITLE
docs: trim convert module docs to the 5-line cap, drop F5.9 tags in cleanup.rs

### DIFF
--- a/db/src/cleanup.rs
+++ b/db/src/cleanup.rs
@@ -25,9 +25,9 @@ pub enum CleanupError {
     Pattern(#[from] regex::Error),
 }
 
-/// Confidence tier of a detected suggestion, per F5.9's technical design:
-/// Tier 0 is a high-confidence normalized-key or regex match; Tier 1 is a
-/// fuzzy match, always surfaced (never gated behind an opt-in toggle).
+/// Confidence tier of a detected suggestion: Tier 0 is a high-confidence
+/// normalized-key or regex match; Tier 1 is a fuzzy match, always surfaced
+/// (never gated behind an opt-in toggle).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Tier {
@@ -353,7 +353,7 @@ fn fuzzy_merge_suggestions(
     suggestions
 }
 
-/// Fuzzy-match threshold: token-set Jaccard >= 0.85 (F5.9 technical design).
+/// Fuzzy-match threshold: token-set Jaccard >= 0.85.
 const FUZZY_JACCARD_THRESHOLD: f64 = 0.85;
 
 fn token_set(key: &str) -> HashSet<&str> {

--- a/db/src/convert/execute.rs
+++ b/db/src/convert/execute.rs
@@ -2,9 +2,7 @@
 //! book's `source_format` file to `target_format`, writing the result into
 //! the conversion cache ([`super::fs::convert_path`]) via an atomic
 //! temp-then-rename, mirroring `crate::kepub::convert::convert_book`. Driven
-//! by the worker's `Task::ConvertFormat` (`crate::worker`), which gates
-//! calls behind a concurrency semaphore and a per-`(book_id, source_format,
-//! target_format)` keyed mutex.
+//! by `Task::ConvertFormat` (`crate::worker`).
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -60,6 +58,10 @@ pub enum ConvertError {
 /// binary isn't runnable, the source file is missing, the job exceeds
 /// `OMNIBUS_CONVERT_TIMEOUT_SECS` (default [`DEFAULT_TIMEOUT_SECS`]), or
 /// `ebook-convert` exits non-zero.
+///
+/// Callers run this behind the worker's convert-concurrency semaphore and a
+/// per-`(book_id, source_format, target_format)` keyed mutex — see
+/// `Task::ConvertFormat` in `crate::worker`.
 pub async fn convert_book(
     pool: &SqlitePool,
     book_id: i64,

--- a/db/src/convert/fs.rs
+++ b/db/src/convert/fs.rs
@@ -2,8 +2,7 @@
 //! directory and the per-`(book_id, target_format)` output path. Mirrors
 //! `crate::kepub::fs`. [`convert_path`] is the **only** place a
 //! caller-supplied format token becomes a path component — every other
-//! site that needs the cache path derives it from `convert_path`'s own
-//! output rather than reformatting the token a second time.
+//! site derives the cache path from its output instead.
 
 use std::path::PathBuf;
 

--- a/db/src/convert/mod.rs
+++ b/db/src/convert/mod.rs
@@ -1,11 +1,8 @@
-//! Calibre `ebook-convert` integration: binary detection (where it lives —
-//! `$OMNIBUS_EBOOK_CONVERT_PATH`, else `$PATH` — and whether it is runnable),
-//! plus the shell-out that actually converts a book
-//! ([`execute::convert_book`], driven by `Task::ConvertFormat` in
-//! `crate::worker`). Calibre is strictly optional — an unresolved binary
-//! logs one startup warning and leaves conversion disabled. The
-//! admin-overridable `ebook_convert_path` setting lives in
-//! `crate::settings::ebook_convert`.
+//! Calibre `ebook-convert` integration: binary detection ([`detect`]) plus
+//! the shell-out that converts a book ([`execute::convert_book`], driven by
+//! `Task::ConvertFormat` in `crate::worker`). Calibre is strictly
+//! optional — an unresolved binary logs one startup warning and leaves
+//! conversion disabled.
 
 mod detect;
 mod execute;


### PR DESCRIPTION
## Summary
- `db/src/convert/execute.rs`, `fs.rs`, and `mod.rs` carried module `//!` blocks over the ~5-line cap in [.claude/rules/05-rust-style.md](.claude/rules/05-rust-style.md) — trimmed to 5 lines each. `execute.rs`'s semaphore/keyed-mutex detail was moved to a function-level `///` on `convert_book` (that detail is also already documented on `Task::ConvertFormat` in `crate::worker`) rather than dropped; `mod.rs`'s dropped detail (the `$OMNIBUS_EBOOK_CONVERT_PATH`/`$PATH` resolution order, the settings-override location) already lives in `detect.rs`'s and `settings::ebook_convert`'s own module docs.
- `db/src/cleanup.rs` carried a roadmap-phase reference ("per F5.9's technical design") inside a `pub` doc comment on `Tier`, plus a second one on `FUZZY_JACCARD_THRESHOLD` found during the same pass — both removed, prose kept intact.
- Closes #1853

## Test plan
- [x] `cargo fmt -p omnibus-db` — PASS (no diff beyond the doc edits)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (clean)
- [x] `cargo test -p omnibus-db` — 2042 passed, 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is the known missing-fixtures case documented in `.claude/rules/01-dev-environment.md` (`test_data/audiobooks` isn't checked into git; needs `just fixtures`, unavailable in this cloud session) — unrelated to this doc-only change.
- [x] `cargo doc -p omnibus-db --no-deps` — PASS, builds cleanly (exit 0). Pre-existing unrelated rustdoc lint warnings elsewhere in the crate (private intra-doc links, a redundant link target) are untouched by this change; none originate from the four files this PR edits.
- [x] Verified module `//!` blocks are now ≤5 lines in all three `convert/` files, and the "F5.9" tag no longer appears in `cleanup.rs`.

Mechanical doc-comment-only change; no logic touched.

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
-

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DPtZ3DUpjpSdPSEZZaHiYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPtZ3DUpjpSdPSEZZaHiYE)_