### PR TITLE
refactor: dedupe now_unix in progress.rs against auth.rs (#1933)

### DIFF
--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -66,18 +66,6 @@ fn parse_format(raw: &str) -> ProgressFormat {
 /// this; the 2026-08-11 chapter-19-to-13 revert was hours.
 const AUDIO_BACKWARD_JUMP_THRESHOLD_SECONDS: f64 = 600.0;
 
-/// Current unix time in seconds. Mirrors the `strftime('%s','now')` clamp
-/// [`upsert_progress_tx`]'s SQL applies, used only to predict — for
-/// logging — whether a write is about to lose to the timestamp guard; the
-/// SQL `WHERE` clause remains the sole source of truth for the real
-/// decision.
-fn now_unix() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
 /// Upsert a position row for `(user, book, format)` and return the
 /// **surviving** server-authoritative record. Resolves the request uuid to
 /// the **canonical** `books.uuid` (keeping the `BookNotFound` guard — you
@@ -273,7 +261,7 @@ fn warn_if_rejected_by_timestamp_guard(
     let Some(stored_ts) = stored_client_updated_at else {
         return;
     };
-    let now = now_unix();
+    let now = crate::auth::now_unix();
     let offered = client_updated_at.unwrap_or(now).min(now);
     if offered < stored_ts {
         tracing::warn!(

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -7,7 +7,7 @@
 use omnibus_shared::EbookMetadata;
 
 use super::*;
-use crate::{init_db, replace_books};
+use crate::{auth::now_unix, init_db, replace_books};
 
 /// Map a merged/auto-attached `uuid` onto an existing `book_id` the way the
 /// merge transaction does (`db/src/merge/transaction.rs`), so the session path
@@ -532,15 +532,6 @@ async fn upsert_is_last_write_wins() {
     };
     let saved = upsert_progress(&pool, user, &second).await.unwrap();
     assert_eq!(saved.epub_cfi.as_deref(), Some("epubcfi(/6/12!/4/8/3:7)"));
-}
-
-/// Current unix seconds, for asserting a stored `client_updated_at` landed
-/// near "now" without pinning an exact value the test doesn't control.
-fn now_unix() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `db/src/progress.rs` defined a private `now_unix() -> i64` that was byte-for-byte identical to the existing `pub(crate) fn now_unix()` in `db/src/auth.rs`. Removed it and updated its one call site (`warn_if_rejected_by_timestamp_guard`) to call `crate::auth::now_unix()`.
- `db/src/progress/tests.rs` had a third, also-identical copy used as a test helper. Removed it too, importing `crate::auth::now_unix` instead (it's `pub(crate)`, reachable from the test module in the same crate).
- Closes #1933

## Test plan
- [x] `cargo fmt -p omnibus-db` — no changes
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 2042 passed, 1 pre-existing failure unrelated to this change (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` — missing audio fixture, `just fixtures` was not run in this environment)
- [x] `cargo test -p omnibus-db progress::` — 82 passed, 0 failed

## Notes
- No behavior change; mechanical dedup only, per the issue's acceptance criteria.
- Per the issue notes, the test-scoped duplicate was also removed (rather than left as-is) since `crate::auth::now_unix` is reachable from `progress/tests.rs` in the same crate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AwHYFpQZpSAkKFhoyNFPSA)_