### PR TITLE
fix: resolve boot file from progress row in Android hybrid player

### DIFF
--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -108,16 +108,14 @@ pub(super) fn seek_to(secs: f64) {
     let _ = secs;
 }
 
-// The resume-decision trio below is only *called* from the web bootstrap
-// (`bootstrap::run_manifest_init`), but lives here un-gated-on-web so its
-// tests run under the crate's test matrix (`server` feature) — the
-// bootstrap module itself is `#![cfg(feature = "web")]` and its tests
-// never execute there.
+// The resume-decision trio below is called from both the web bootstrap
+// (`bootstrap::run_manifest_init`) and the mobile host driver
+// (`mobile::host::load_manifest`/`init_direct_and_drain`) — un-gated on
+// either target so it can't drift between the two (#1888, #1923).
 
 /// Select the resume position: prefer the server-authoritative value when
 /// available, fall back to the locally cached initial position.
-#[cfg(not(feature = "mobile"))]
-#[cfg_attr(not(feature = "web"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 fn resolve_resume_pos(server_pos: Option<f64>, local_pos: f64) -> f64 {
     server_pos.unwrap_or(local_pos)
 }
@@ -126,8 +124,7 @@ fn resolve_resume_pos(server_pos: Option<f64>, local_pos: f64) -> f64 {
 /// otherwise the progress row's stored `book_file_id`, so resume lands in
 /// the file the seconds were recorded in (#1888); `None` (the server's
 /// lowest-ordinal default) only when neither names one.
-#[cfg(not(feature = "mobile"))]
-#[cfg_attr(not(feature = "web"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 pub(super) fn resolve_boot_file(requested: Option<i64>, row_file: Option<i64>) -> Option<i64> {
     requested.or(row_file)
 }
@@ -140,8 +137,7 @@ pub(super) fn resolve_boot_file(requested: Option<i64>, row_file: Option<i64>) -
 /// seconds recorded in another file, or in no named file at all (the local
 /// cache never names one), start playback at zero rather than splicing one
 /// file's offset into another (#1888).
-#[cfg(not(feature = "mobile"))]
-#[cfg_attr(not(feature = "web"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "web", feature = "mobile")), allow(dead_code))]
 pub(super) fn resolve_boot_position(
     row: Option<(Option<i64>, Option<f64>)>,
     local_pos: f64,
@@ -447,9 +443,9 @@ mod tests {
     }
 }
 
-// The resume-decision helpers don't exist on mobile (the web bootstrap is
-// their only caller), so their tests live in a separately-gated module.
-#[cfg(all(test, not(feature = "mobile")))]
+// The resume-decision helpers are shared by both the web bootstrap and the
+// mobile host driver, so their tests run under every feature combination.
+#[cfg(test)]
 mod boot_resume_tests {
     use super::{resolve_boot_file, resolve_boot_position, resolve_resume_pos};
 

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -149,23 +149,11 @@ struct PlayerProps {
     on_nav_back: EventHandler<MouseEvent>,
 }
 
-/// Reconcile the resume position: server-authoritative value wins, else the
-/// locally cached position, else 0.
-async fn resolve_resume(server_url: &str, uuid: &str) -> f64 {
-    let server_pos = data::get_progress(server_url, uuid, ProgressFormat::Audio)
-        .await
-        .ok()
-        .flatten()
-        .and_then(|r| r.audio_position_seconds);
-    server_pos
-        .or_else(|| crate::audiobook_progress::load(uuid))
-        .unwrap_or(0.0)
-}
-
 /// Persist the latest position both locally and to the server
-/// (fire-and-forget). `file_id` is the `?file_id=` the player was entered
-/// with, so a book carrying several audiobooks resumes in the one being
-/// listened to; `None` keeps the server's first-file default.
+/// (fire-and-forget). `file_id` is the `book_files` row the manifest
+/// actually loaded — not the raw `?file_id=` the player was entered with —
+/// so a book carrying several audiobooks resumes in the one being listened
+/// to (#1888, #1923); `None` only when the server predates file identity.
 fn persist_position(uuid: &str, file_id: Option<i64>, server_url: &str, seconds: f64) {
     crate::audiobook_progress::save(uuid, seconds);
     let uuid = uuid.to_string();

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -6,12 +6,13 @@
 
 use dioxus::dioxus_core::Task;
 use dioxus::prelude::*;
-use omnibus_shared::AudiobookManifest;
+use omnibus_shared::{AudiobookManifest, ProgressFormat, ProgressRecord};
 
 use super::state::{use_mobile_playback, MobilePlayback, SleepState};
 use super::view::PlayerView;
-use super::{interop, persist_position, resolve_resume};
+use super::{interop, persist_position};
 use crate::data;
+use crate::pages::listen::helpers::{resolve_boot_file, resolve_boot_position};
 
 /// `book_files.id` of the first audio file, lowest ordinal wins, or `None`.
 ///
@@ -24,10 +25,35 @@ fn first_audio_file_id(files: &[omnibus_shared::BookFileInfo]) -> Option<i64> {
     crate::offline::downloads::default_audio_file_id(files)
 }
 
-/// What a load run is playing: the book, plus the `?file_id=` it was entered
-/// with. `None` means "whatever the server serves by default" — carried
-/// through to every position write so a book with several audiobooks resumes
-/// in the one being listened to.
+/// The `book_files` id a manifest's `file_identity()` names, or `None` for
+/// a server predating file-identity fields (`file_identity() == (0, 0)`).
+/// Position writes must carry this — the file the manifest actually
+/// resolved — rather than the raw requested id (#1888, #1923).
+fn resolved_file_id(loaded_file: i64) -> Option<i64> {
+    (loaded_file > 0).then_some(loaded_file)
+}
+
+/// Whether a manifest fetch that failed against the resolved boot file
+/// should retry once against the client-computed default: only when the
+/// picker made no explicit choice (a dead `?file_id=` must fail loudly,
+/// never silently substitute another file) and the resolved file actually
+/// differs from the default (nothing to gain retrying the same request).
+/// Covers a stale progress-row `book_file_id` a reindex has since replaced.
+fn should_retry_manifest_with_default(
+    selected_file_id: Option<i64>,
+    boot_file: Option<i64>,
+    default_file: Option<i64>,
+) -> bool {
+    selected_file_id.is_none() && boot_file != default_file
+}
+
+/// What a load run is playing: the book, plus the `book_files` id every
+/// position write should carry — the file the manifest actually resolved
+/// (an explicit picker selection, else the progress row's stored
+/// `book_file_id`, else the server's lowest-ordinal default), not the raw
+/// `?file_id=` the route was entered with. Mirrors web's
+/// `PlaybackState::loaded_file_id` (#1888, #1923). `None` only when the
+/// server predates file-identity fields (`audio_file_count == 0`).
 struct LoadTarget {
     uuid: String,
     file_id: Option<i64>,
@@ -181,9 +207,22 @@ async fn load_book_metadata(
     }
 }
 
-/// Resolve the target file (picker choice, else the first audio file) and
-/// fetch its manifest, surfacing transport errors on `error`/`loading`.
-/// Returns `None` on failure — the failure is already reported.
+/// Resolve the boot file the same way the web bootstrap's
+/// `resolve_boot_file` does — an explicit picker selection wins, otherwise
+/// the progress row's stored `book_file_id`, so resume lands in the file
+/// the seconds were recorded in (#1888) — then fetch its manifest,
+/// surfacing transport errors on `error`/`loading`. If neither names one,
+/// falls back to the first audio file (mirrors the server's own
+/// lowest-ordinal default).
+///
+/// The row's `book_file_id` is a soft reference: a reindex may have
+/// replaced the `book_files` row since the position was saved. A failed
+/// fetch against it retries once against the client-computed default
+/// rather than failing an otherwise-healthy book — never when the picker
+/// made an explicit choice, since a dead `?file_id=` should fail loudly.
+/// Returns the manifest and the progress row consulted (reused by
+/// `init_direct_and_drain` for the resume position, avoiding a second
+/// fetch). `None` on failure — the failure is already reported.
 async fn load_manifest(
     server_url: &str,
     uuid: &str,
@@ -191,12 +230,26 @@ async fn load_manifest(
     book: &omnibus_shared::EbookMetadata,
     mut error: Signal<Option<String>>,
     mut loading: Signal<bool>,
-) -> Option<(AudiobookManifest, Option<i64>)> {
-    // Honor the picker's explicit choice; otherwise default to the first audio
-    // file (a bare `/listen/:uuid` with no `?file_id=`).
-    let file_id = selected_file_id.or_else(|| first_audio_file_id(&book.book_files));
-    match data::get_manifest(server_url, uuid, file_id).await {
-        Ok(m) => Some((m, file_id)),
+) -> Option<(AudiobookManifest, Option<ProgressRecord>)> {
+    let row = data::get_progress(server_url, uuid, ProgressFormat::Audio)
+        .await
+        .ok()
+        .flatten();
+    let row_file = row.as_ref().and_then(|r| r.book_file_id);
+    let default_file = first_audio_file_id(&book.book_files);
+    let boot_file = resolve_boot_file(selected_file_id, row_file).or(default_file);
+    match data::get_manifest(server_url, uuid, boot_file).await {
+        Ok(m) => Some((m, row)),
+        Err(_) if should_retry_manifest_with_default(selected_file_id, boot_file, default_file) => {
+            match data::get_manifest(server_url, uuid, default_file).await {
+                Ok(m) => Some((m, row)),
+                Err(e) => {
+                    error.set(Some(e.to_string()));
+                    loading.set(false);
+                    None
+                }
+            }
+        }
         Err(e) => {
             error.set(Some(e.to_string()));
             loading.set(false);
@@ -237,11 +290,17 @@ async fn load_and_drain(
     let Some(book) = load_book_metadata(&server_url, &uuid, error, loading).await else {
         return;
     };
-    let Some((manifest, _file_id)) =
+    let Some((manifest, row)) =
         load_manifest(&server_url, &uuid, selected_file_id, &book, error, loading).await
     else {
         return;
     };
+
+    // The file the manifest actually resolved — `0`/`0` means a server
+    // predating file-identity fields; keep posting no file id rather than
+    // inventing one (mirrors web's `run_manifest_init`).
+    let (loaded_file, audio_file_count) = manifest.file_identity();
+    let loaded_file_id = resolved_file_id(loaded_file);
 
     match manifest {
         AudiobookManifest::Direct {
@@ -265,8 +324,11 @@ async fn load_and_drain(
                 &book,
                 LoadTarget {
                     uuid,
-                    file_id: selected_file_id,
+                    file_id: loaded_file_id,
                 },
+                row,
+                loaded_file,
+                audio_file_count,
                 server_url,
                 parts,
                 total_duration_seconds,
@@ -335,10 +397,14 @@ async fn resolve_playback_rate(ctx: MobilePlayback, server_url: &str, uuid: &str
 /// Direct-play arm of [`load_and_drain`]: resolve resume + rate, seed the
 /// view/duration signals, install the JS control surface, then drain audio
 /// events until superseded.
+#[allow(clippy::too_many_arguments)] // orthogonal resume/manifest inputs; a bundling struct would just rename them
 async fn init_direct_and_drain(
     ctx: MobilePlayback,
     book: &omnibus_shared::EbookMetadata,
     target: LoadTarget,
+    row: Option<ProgressRecord>,
+    loaded_file: i64,
+    audio_file_count: i64,
     server_url: String,
     parts: Vec<omnibus_shared::ManifestPart>,
     total_duration_seconds: f64,
@@ -350,7 +416,16 @@ async fn init_direct_and_drain(
     let mut elapsed = ctx.elapsed;
     let LoadTarget { uuid, file_id } = target;
 
-    let resume = resolve_resume(&server_url, &uuid).await;
+    // Mirrors web's `resolve_boot_position`: on a multi-file book, seconds
+    // apply only when the row names the file that was actually loaded —
+    // otherwise they'd splice one file's offset into another (#1888).
+    let local_pos = crate::audiobook_progress::load(&uuid).unwrap_or(0.0);
+    let resume = resolve_boot_position(
+        row.map(|r| (r.book_file_id, r.audio_position_seconds)),
+        local_pos,
+        loaded_file,
+        audio_file_count,
+    );
     let playback_rate = resolve_playback_rate(ctx, &server_url, &uuid).await;
     let pv = PlayerView::from_direct(book, chapters, total_duration_seconds, parts.clone());
     // Cover artwork for the lock screen: the same tokened thumbnail the
@@ -453,7 +528,10 @@ fn mark_read_status(uuid: &str, server_url: &str, at_end: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::{audio_blocked_offline, first_audio_file_id, playing_out_of_sync};
+    use super::{
+        audio_blocked_offline, first_audio_file_id, playing_out_of_sync, resolved_file_id,
+        should_retry_manifest_with_default,
+    };
     use omnibus_shared::BookFileInfo;
 
     #[test]
@@ -512,6 +590,52 @@ mod tests {
     fn first_audio_file_id_is_none_without_an_audio_file() {
         let files = vec![bf(1, "EPUB", 0), bf(2, "PDF", 0)];
         assert_eq!(first_audio_file_id(&files), None);
+    }
+
+    #[test]
+    fn resolved_file_id_names_a_positive_loaded_file() {
+        assert_eq!(resolved_file_id(917), Some(917));
+    }
+
+    #[test]
+    fn resolved_file_id_is_none_for_a_legacy_server_without_identity() {
+        // `file_identity()` decodes a pre-#1888 payload as (0, 0); posting a
+        // fabricated id would be worse than posting none at all.
+        assert_eq!(resolved_file_id(0), None);
+    }
+
+    #[test]
+    fn should_retry_manifest_with_default_only_on_an_unattributed_fallback() {
+        // No explicit selection, and the row's (stale) file differs from
+        // the client-computed default — worth one retry.
+        assert!(should_retry_manifest_with_default(
+            None,
+            Some(919),
+            Some(917)
+        ));
+    }
+
+    #[test]
+    fn should_retry_manifest_with_default_never_overrides_an_explicit_pick() {
+        // A picker selection failing must fail loudly, not silently swap
+        // in a different file the listener didn't ask for.
+        assert!(!should_retry_manifest_with_default(
+            Some(919),
+            Some(919),
+            Some(917)
+        ));
+    }
+
+    #[test]
+    fn should_retry_manifest_with_default_skips_when_already_the_default() {
+        // The failed request already *was* the default — retrying it would
+        // just repeat the same failing call.
+        assert!(!should_retry_manifest_with_default(
+            None,
+            Some(917),
+            Some(917)
+        ));
+        assert!(!should_retry_manifest_with_default(None, None, None));
     }
 
     use super::needs_reload;


### PR DESCRIPTION
## Summary
- Closes #1923
- The Android hybrid player's `mobile::host` driver (`frontend/src/pages/listen/mobile/host.rs`) always defaulted a multi-file audiobook's boot file to the first audio file, ignoring the progress row's stored `book_file_id`, and posted the raw requested (often absent) file id back through `persist_position` — the same bug class #1888 fixed on the web listen/Immersive Read player, deferred without a tracking issue until now.
- Mirrors the web fix's `resolve_boot_file`/`resolve_boot_position` helpers (`frontend/src/pages/listen/helpers.rs`, now shared rather than web-only) inside `load_manifest` / `load_and_drain` / `init_direct_and_drain`:
  - Boot file resolution: explicit picker selection > progress row's stored `book_file_id` > server's default file (with a one-time retry against the client-computed default if the row's id is a stale soft reference a reindex has since replaced — never for an explicit `?file_id=`, which fails loudly instead).
  - The **resolved** file id (from the manifest's own `file_identity()`), not the raw requested one, now threads through `LoadTarget` into every `persist_position` call.
  - The stored resume position is only applied when it's attributable to the file actually loaded (`resolve_boot_position`'s guard) — zeroed rather than spliced across files on a multi-file book.
- Added unit coverage for the new resolution logic: the shared `helpers::boot_resume_tests` module now runs under the `mobile` feature too (previously web-only), plus new host-local tests for `resolved_file_id` and `should_retry_manifest_with_default`.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-frontend --features mobile --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-frontend --features mobile` — PASS (704 passed, 2 pre-existing unrelated failures in `offline::media::tests` reproduced identically on unmodified `main`, confirmed via `git stash`; not touched by this change)
- [ ] On-device Android verification — not possible in this environment (no Android SDK/emulator); static/unit-test verification only.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Removed `mobile.rs`'s now-redundant `resolve_resume` (its logic is superseded by `resolve_boot_position`, called from `init_direct_and_drain` with the progress row already fetched in `load_manifest`, avoiding a duplicate fetch).
- The web bootstrap (`bootstrap::run_manifest_init`) was left untouched — only its helper functions' `cfg` gates were relaxed so mobile can call them too, per the issue's suggested approach.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpJS3vzvqdDWmYJz7EL71S)_