### PR TITLE
docs: trim three module doc comments to the 5-line cap

### DIFF
--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -1,12 +1,8 @@
 //! Reading-stats aggregation over the `reading_sessions` /
 //! `listening_sessions` tables plus `journal_entries` / `book_read_status`
-//! for completion; no new query-time schema. Every metric is computed in SQL
-//! and cached process-wide per user for 60s. The Pages tile ([`pages`]) sums
-//! the `books.word_count` estimate persisted at index time — see that
-//! module's doc comment for the sourcing model. [`book`] holds the
-//! book-scoped counterpart ([`book::book_insights`]) for the book-detail
-//! page's Insights card. [`compute`] holds the SQL-heavy aggregation body
-//! this module's cache wraps.
+//! for completion; no new query-time schema. See the `book`, `compute`, and
+//! `pages` submodules for the per-scope aggregation bodies this module's
+//! cache wraps.
 
 mod book;
 mod compute;
@@ -64,6 +60,9 @@ impl From<crate::books::BooksError> for StatsError {
 
 type Cache = Mutex<HashMap<(i64, StatsRange), (i64, StatsSummary)>>;
 
+/// Process-wide cache shared by every request for every user — keyed by
+/// `(user_id, range)` so no cached aggregate leaks between users, and read
+/// through by [`user_stats_at`] before any SQL runs.
 fn cache() -> &'static Cache {
     static CACHE: OnceLock<Cache> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))

--- a/frontend/src/format.rs
+++ b/frontend/src/format.rs
@@ -1,8 +1,8 @@
 //! Small display formatters shared across surfaces: file size/label for
 //! `book_files` pickers, [`plural`] for search-result summaries, and the
 //! [`format_date_short`]/[`format_date_month_year`] pair for table and
-//! series-card dates. Pure, dependency-free functions, so they unit-test
-//! without a renderer and compute identically on SSR and WASM (rule 07).
+//! series-card dates. Pure functions with no Dioxus/renderer state, so
+//! they unit-test easily and render identically on SSR and WASM (rule 07).
 
 use omnibus_shared::BookFileInfo;
 

--- a/frontend/src/format.rs
+++ b/frontend/src/format.rs
@@ -1,11 +1,8 @@
-//! Small display formatters shared across surfaces that render `book_files`
-//! — the hero's file picker and the admin delete dialog — [`plural`], a
-//! trivial pluralizer reused by the desktop and mobile search result
-//! summaries, and the [`format_date_short`]/[`format_date_month_year`] pair
-//! that turns a stored date string into a human one for the landing table
-//! and series pages. Pure functions, no Dioxus, so they unit-test without a
-//! renderer, and — per `.claude/rules/07-hydration.md` — compute identically
-//! on SSR and the WASM client since neither reads any target-specific state.
+//! Small display formatters shared across surfaces: file size/label for
+//! `book_files` pickers, [`plural`] for search-result summaries, and the
+//! [`format_date_short`]/[`format_date_month_year`] pair for table and
+//! series-card dates. Pure, dependency-free functions, so they unit-test
+//! without a renderer and compute identically on SSR and WASM (rule 07).
 
 use omnibus_shared::BookFileInfo;
 

--- a/frontend/src/pages/book_detail/dates.rs
+++ b/frontend/src/pages/book_detail/dates.rs
@@ -1,13 +1,7 @@
 //! Date formatting shared by the book-detail sections that stamp a
-//! unix-seconds timestamp (journal entries, saved passages). [`fmt_long_date`]
-//! itself stays dependency-free and deterministic; [`use_local_dates_ready`]
-//! is hoisted once per list (not once per row — a heavily-annotated book runs
-//! to hundreds) and starts `false` so SSR and the first client paint render
-//! the same UTC day (rule 07), flipping to `true` in a post-mount effect on
-//! web. [`local_date_offset`] then resolves each row's *own* offset from its
-//! *own* timestamp via [`crate::time::local_utc_offset_secs`] — never a
-//! single cached "today" value shared across rows, because DST means two
-//! entries on either side of a clock change carry different offsets.
+//! unix-seconds timestamp (journal entries, saved passages). Renders in the
+//! viewer's local calendar day rather than UTC, staying SSR/hydration-safe
+//! per rule 07 — see the function docs below for how.
 
 use dioxus::prelude::*;
 


### PR DESCRIPTION
## Summary
- Closes #1931
- Trims three module `//!` doc comments that had grown past the ~5-line cap in `.claude/rules/05-rust-style.md` § Comments & docs: `frontend/src/pages/book_detail/dates.rs` (10 → 4 lines), `frontend/src/format.rs` (8 → 5 lines), `db/src/stats/mod.rs` (9 → 5 lines).
- No logic or behavior changes — comments only. `dates.rs`'s module doc already duplicated rationale that lives on `use_local_dates_ready`/`local_date_offset`/`fmt_long_date`'s own `///` docs, so trimming there removed the duplication rather than deleting substance. `stats/mod.rs`'s per-submodule detail (Pages tile sourcing, book-scoped counterpart, SQL-heavy aggregation body) was already covered by the `pages`/`book`/`compute` submodules' own doc comments, so the module doc now just points to them; the "process-wide, per-user-keyed" caching detail moved onto a new `///` comment on `cache()`.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo doc --workspace --no-deps` — the literal command fails in this sandbox because `--workspace` includes the `mobile` crate, which needs GTK/WebKitGTK system libs only provisioned by the project's `.#mobile` Nix shell (unavailable here, no `nix` in this environment). Ran the equivalent for every crate touched instead: `cargo doc --no-deps -p omnibus-db -p omnibus-shared -p omnibus-frontend -p omnibus` — PASS (exit 0; only pre-existing, unrelated broken-intra-doc-link warnings in `routes.rs`/`auth/mod.rs`/`logging.rs`/`security_headers.rs`, none in the three touched files).
- [x] `cargo clippy -p omnibus-frontend --all-targets -- -D warnings` — the literal command fails to even compile in this sandbox: `omnibus-frontend` declares `default = []`, so building it standalone with no features hits `#[cfg(feature = "web"/"server")]`-gated items that don't exist without one; this is pre-existing and unrelated to this change (errors are all in `account.rs`/`users/mod.rs`, not the edited files). Ran the repo's actual equivalent instead — `cargo clippy --all-targets -- -D warnings` (workspace default-members: server + shared + frontend, which unifies frontend's `server` feature via `omnibus`'s dependency), matching the first line of the `lint` recipe in `Justfile` — PASS.
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (808 passed; 0 failed)
- [x] `cargo test -p omnibus-db` — 2071 passed; 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing environment gap, not a regression: it panics with `audiobook fixture ... missing — run \`just fixtures\``, and this sandbox has no `just`/network access to fetch the public-domain binary fixtures documented in `.claude/rules/01-dev-environment.md`. Unrelated to the comment-only change in this PR.

## Version
- [x] **No release** — comments-only change, no behavior difference; leaving release labels unmarked per instructions (this PR touches `.rs` files so it isn't automatically release-skip-exempt, but a maintainer can apply `no release` if desired).

## Notes
- Pure doc-comment relocation/trim, mechanical per the issue's suggested approach — no `.rs` logic touched beyond comments.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpJS3vzvqdDWmYJz7EL71S)_