### PR TITLE
fix: batch Kobo annotation downsync UPDATEs into one transaction (#1960)

### DIFF
--- a/db/src/annotations/downsync.rs
+++ b/db/src/annotations/downsync.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use crate::kobo_position::annotation_locations;
 use crate::worker::{Task, Worker};
@@ -105,28 +105,69 @@ pub async fn downsync_book_annotations(
     let locations =
         tokio::task::spawn_blocking(move || annotation_locations(&kepub, &source, &cfis)).await??;
 
-    for ((id, snapshot_cfi), location) in rows.iter().zip(locations) {
-        let Some(location) = location else { continue };
-        // Guarded against a concurrent write: if the row gained an anchor
-        // (a device PATCH adopting the same client_id) or its CFI moved
-        // since the snapshot, this derivation is stale and must not land.
-        let result = sqlx::query(
-            "UPDATE annotations
-                SET kobo_location = ?, client_id = COALESCE(client_id, ?)
-              WHERE id = ? AND kobo_location IS NULL AND epub_cfi_range = ?",
-        )
-        .bind(&location)
-        .bind(uuid::Uuid::new_v4().hyphenated().to_string())
-        .bind(id)
-        .bind(snapshot_cfi)
-        .execute(pool)
-        .await?;
-        if result.rows_affected() > 0 {
-            stats.derived += 1;
-            stats.unresolved -= 1;
-        }
+    let candidates: Vec<(i64, String, String)> = rows
+        .into_iter()
+        .zip(locations)
+        .filter_map(|((id, snapshot_cfi), location)| location.map(|loc| (id, snapshot_cfi, loc)))
+        .collect();
+    if candidates.is_empty() {
+        return Ok(stats);
     }
+
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let derived = apply_derived_locations(&mut tx, &candidates).await?;
+    tx.commit().await?;
+    stats.derived += derived;
+    stats.unresolved -= derived;
     Ok(stats)
+}
+
+/// Rows per chunk for [`apply_derived_locations`]'s batched UPDATE: 4 binds
+/// per row (id, location, minted client_id, snapshot cfi) keeps each
+/// statement comfortably under SQLite's 999 bound-parameter cap.
+const APPLY_CHUNK_SIZE: usize = 200;
+
+/// Persist every derived `(id, snapshot_cfi, location)` in one chunked
+/// `UPDATE ... FROM (VALUES ...)` per chunk, in place of one round-trip per
+/// row. Returns the count of rows actually written.
+///
+/// Each row keeps the same optimistic-concurrency guard the old per-row loop
+/// used — `kobo_location IS NULL AND epub_cfi_range = <snapshot>` — so a row
+/// that gained an anchor (a device PATCH adopting the same client_id) or
+/// whose CFI moved since the snapshot is left untouched rather than
+/// overwritten with a stale derivation. `RETURNING id` is what makes the
+/// count exact: a batch statement's `rows_affected` alone can't say *which*
+/// of several rows in the same chunk passed the guard.
+async fn apply_derived_locations(
+    tx: &mut Transaction<'_, Sqlite>,
+    candidates: &[(i64, String, String)],
+) -> anyhow::Result<usize> {
+    let mut derived = 0;
+    for chunk in candidates.chunks(APPLY_CHUNK_SIZE) {
+        let rows = std::iter::repeat_n("(?, ?, ?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE annotations
+                SET kobo_location = v.column2,
+                    client_id = COALESCE(annotations.client_id, v.column3)
+               FROM (VALUES {rows}) AS v
+              WHERE annotations.id = v.column1
+                AND annotations.kobo_location IS NULL
+                AND annotations.epub_cfi_range = v.column4
+              RETURNING annotations.id"
+        );
+        let mut q = sqlx::query_scalar::<_, i64>(&sql);
+        for (id, snapshot_cfi, location) in chunk {
+            q = q
+                .bind(id)
+                .bind(location)
+                .bind(uuid::Uuid::new_v4().hyphenated().to_string())
+                .bind(snapshot_cfi);
+        }
+        derived += q.fetch_all(&mut **tx).await?.len();
+    }
+    Ok(derived)
 }
 
 /// Boot-time pass: materialize every pending (user, book) pair — the retry

--- a/db/src/annotations/downsync/tests.rs
+++ b/db/src/annotations/downsync/tests.rs
@@ -448,6 +448,72 @@ async fn downsync_all_kobo_annotations_continues_past_a_failing_book_and_reports
 }
 
 #[tokio::test]
+async fn apply_derived_locations_applies_only_rows_that_pass_the_concurrency_guard_in_one_batch() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "carol").await;
+
+    // Three rows in one batch: one already claimed by a concurrent writer
+    // (kobo_location already set), one whose CFI drifted since the snapshot
+    // was taken, and one genuinely open. A single `apply_derived_locations`
+    // call must land only the third.
+    let insert_row = |cfi: &'static str, kobo_location: Option<&'static str>| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query_scalar::<_, i64>(
+                "INSERT INTO annotations (user_id, book_uuid, epub_cfi_range, kobo_location)
+                 VALUES (?, 'book-uuid', ?, ?) RETURNING id",
+            )
+            .bind(user)
+            .bind(cfi)
+            .bind(kobo_location)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+        }
+    };
+    let taken_id = insert_row("cfi-taken", Some("already-claimed")).await;
+    let stale_id = insert_row("cfi-drifted", None).await;
+    let ok_id = insert_row("cfi-ok", None).await;
+
+    // The stale row's snapshot CFI ("cfi-snapshot") no longer matches what's
+    // stored ("cfi-drifted"), so the guard must reject it.
+    let candidates = vec![
+        (taken_id, "cfi-taken".to_string(), "loc-taken".to_string()),
+        (
+            stale_id,
+            "cfi-snapshot".to_string(),
+            "loc-stale".to_string(),
+        ),
+        (ok_id, "cfi-ok".to_string(), "loc-ok".to_string()),
+    ];
+
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await.unwrap();
+    let derived = apply_derived_locations(&mut tx, &candidates).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(derived, 1, "only the open row should have been applied");
+
+    let rows: Vec<(i64, Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT id, kobo_location, client_id FROM annotations WHERE id IN (?, ?, ?)",
+    )
+    .bind(taken_id)
+    .bind(stale_id)
+    .bind(ok_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let find = |id: i64| rows.iter().find(|r| r.0 == id).unwrap();
+
+    // Already-claimed: untouched, not overwritten with the batch's derivation.
+    assert_eq!(find(taken_id).1.as_deref(), Some("already-claimed"));
+    // Stale CFI: guard rejected it, so it stays unresolved.
+    assert_eq!(find(stale_id).1, None);
+    // Open row: applied, and a client_id was minted for it.
+    assert_eq!(find(ok_id).1.as_deref(), Some("loc-ok"));
+    assert!(find(ok_id).2.is_some());
+}
+
+#[tokio::test]
 async fn downsync_book_annotations_propagates_db_error_when_pool_is_closed() {
     let (pool, user, _book_id, uuid, _dir) = fixture("dberr").await;
     pool.close().await;


### PR DESCRIPTION
## Summary
- Closes #1960
- `downsync_book_annotations` (`db/src/annotations/downsync.rs`) derived a Kobo anchor for every pending web-origin annotation on a book and persisted each one with its own sequential, awaited `UPDATE ... WHERE id = ?` inside a `for` loop — no batching, no transaction. This is awaited synchronously on two live Kobo device HTTP request paths (`record_download_state` in `server/src/backend/kobo/resources.rs`, `resolve_adopted_served` in `server/src/backend/kobo/reading_services.rs`), so a book with many pending highlights turned one device request into N sequential round-trip writes on the response critical path.
- Replaced the loop with a single chunked `UPDATE ... FROM (VALUES ...)` per chunk (200 rows/chunk, 4 binds/row, well under SQLite's 999 bound-parameter cap), wrapped in one `BEGIN IMMEDIATE` transaction — matching the shape already used by `upsert_kobo_annotations` (#1837) and `normalize::normalize_norm_columns`.
- The per-row optimistic-concurrency guard (`kobo_location IS NULL AND epub_cfi_range = <snapshot>`) is preserved exactly, expressed per-row via the `VALUES` join instead of per-statement `WHERE`. `RETURNING annotations.id` gives exact per-row-affected accounting, since a batch statement's aggregate `rows_affected` can't say *which* rows in a chunk passed the guard — needed to keep `DownsyncStats.{derived,unresolved}` bookkeeping equivalent to the old per-row loop.
- `downsync_all_kobo_annotations` and `downsync_book_id_annotations` needed no changes — both call `downsync_book_annotations` in their own outer loops, so fixing the inner function fixes all three call sites.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (clean, no warnings)
- [x] `cargo test -p omnibus-db` — PASS (2072 passed, 1 unrelated pre-existing failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` fails because the `test_data/audiobooks/public_domain/` fixture isn't present in this sandbox — it's a `just fixtures`-downloaded release asset, and `just`/nix aren't available in this environment. Unrelated to this change.)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (clean, no warnings)
- [x] `cargo test -p omnibus` — PASS (811 passed, 2 unrelated pre-existing failures: `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` fail because these tests `chmod 0o555` a directory to simulate a read-only library and this sandbox runs the test process as `root`, which bypasses Unix permission checks — same root-cause class as the `inspect_allows_non_admin_with_can_upload` flake called out in the task. Unrelated to this change.)
- [x] New test `apply_derived_locations_applies_only_rows_that_pass_the_concurrency_guard_in_one_batch` (in `db/src/annotations/downsync/tests.rs`) exercises a single batch call with three rows — one already claimed by a concurrent writer, one with a drifted CFI, one open — and asserts only the open row lands, matching the acceptance criteria's "mixed already-taken / stale-CFI / successful rows in one call" requirement.
- [x] Existing `db/src/annotations/downsync/tests.rs` and `db/tests/kobo_downsync_cold_cache.rs` coverage passes unmodified.

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- Precedent followed: `db/src/shelves/write.rs::insert_books` (chunked `INSERT`), `db/src/normalize.rs::normalize_norm_columns` (chunked `UPDATE ... FROM (VALUES ...)`), and `db/src/annotations/mod.rs::upsert_kobo_annotations` (#1837, chunked multi-row `INSERT ... ON CONFLICT`) for the batching shape and `BEGIN IMMEDIATE` convention (`db/src/auth/users.rs`, `db/src/progress.rs`, etc.) for the transaction.
- Pure refactor — no behavior change intended or observed; all pre-existing downsync tests pass unmodified.


---
_Generated by [Claude Code](https://claude.ai/code/session_012DyPEce3qX2Lanco6EZoBr)_