### PR TITLE
feat: scope OPDS feeds to shelves visible to the viewer (#932)

### DIFF
--- a/db/src/shelves.rs
+++ b/db/src/shelves.rs
@@ -19,7 +19,7 @@ mod tests;
 pub use provision::{provision_wishlist_shelf, provision_wishlist_shelves};
 pub use read::{
     get_shelf, kobo_synced_book_uuids, list_visible_shelves, manual_shelves_containing,
-    preview_rule, shelf_page, LIST_SHELVES_LIMIT,
+    preview_rule, shelf_exclusive_hidden_uuids, shelf_page, LIST_SHELVES_LIMIT,
 };
 pub use write::{add_books, create_shelf, delete_shelf, remove_book, update_shelf};
 

--- a/db/src/shelves/read/detail.rs
+++ b/db/src/shelves/read/detail.rs
@@ -2,6 +2,8 @@
 //! rule preview, per-book "which shelves" membership, and the Kobo sync
 //! membership union. The multi-shelf rail lives in [`super::summary`].
 
+use std::collections::HashSet;
+
 use omnibus_shared::{
     EbookMetadata, MatchMode, RulePreview, Shelf, ShelfKind, ShelfPage, ShelfRule, SortDir, SortKey,
 };
@@ -56,6 +58,53 @@ pub async fn manual_shelves_containing(
     rows.into_iter()
         .map(|r| r.try_get::<i64, _>("id").map_err(ShelfError::from))
         .collect()
+}
+
+/// Book uuids in `candidates` that are confined to a manual shelf `viewer_id`
+/// cannot see: on at least one manual shelf, and every one of those shelves
+/// is private and owned by someone else. A book on no shelf at all, or on
+/// any shelf the viewer owns, that's public, or `is_admin` covers, is never
+/// in the result — so this only ever *narrows* an already-visible set.
+///
+/// This is the predicate the OPDS catalogs layer on top of their normal
+/// library reads (#932): a book that's reachable only by hand-picking it
+/// onto a private shelf must not surface in a browse/search/new/nav feed —
+/// or a direct cover/file link — for a viewer who can't see that shelf,
+/// even though the file itself is otherwise an ordinary, generally-served
+/// library book. Chunked like [`manual_shelves_containing`]'s siblings so a
+/// large candidate page stays under SQLite's bound-parameter cap.
+pub async fn shelf_exclusive_hidden_uuids(
+    pool: &SqlitePool,
+    viewer_id: i64,
+    is_admin: bool,
+    candidates: &[String],
+) -> Result<HashSet<String>, ShelfError> {
+    const CHUNK_SIZE: usize = 200;
+    let mut hidden = HashSet::new();
+    for chunk in candidates.chunks(CHUNK_SIZE) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT sb.book_uuid AS uuid,
+                    MAX(CASE WHEN s.owner_user_id = ? OR s.visibility = 'public' OR ?
+                             THEN 1 ELSE 0 END) AS any_visible
+               FROM shelf_books sb
+               JOIN shelves s ON s.id = sb.shelf_id
+              WHERE sb.book_uuid IN ({placeholders})
+              GROUP BY sb.book_uuid"
+        );
+        let mut q = sqlx::query(&sql).bind(viewer_id).bind(is_admin);
+        for uuid in chunk {
+            q = q.bind(uuid);
+        }
+        let rows = q.fetch_all(pool).await?;
+        for r in &rows {
+            let any_visible: i64 = r.try_get("any_visible")?;
+            if any_visible == 0 {
+                hidden.insert(r.try_get::<String, _>("uuid")?);
+            }
+        }
+    }
+    Ok(hidden)
 }
 
 /// Full shelf detail (including its rules), or `None` if the id is unknown.

--- a/db/src/shelves/read/detail.rs
+++ b/db/src/shelves/read/detail.rs
@@ -90,6 +90,7 @@ pub async fn shelf_exclusive_hidden_uuids(
                FROM shelf_books sb
                JOIN shelves s ON s.id = sb.shelf_id
               WHERE sb.book_uuid IN ({placeholders})
+                AND s.kind = 'manual'
               GROUP BY sb.book_uuid"
         );
         let mut q = sqlx::query(&sql).bind(viewer_id).bind(is_admin);

--- a/db/src/shelves/read/mod.rs
+++ b/db/src/shelves/read/mod.rs
@@ -17,7 +17,8 @@ mod detail;
 mod summary;
 
 pub use detail::{
-    get_shelf, kobo_synced_book_uuids, manual_shelves_containing, preview_rule, shelf_page,
+    get_shelf, kobo_synced_book_uuids, manual_shelves_containing, preview_rule,
+    shelf_exclusive_hidden_uuids, shelf_page,
 };
 pub use summary::list_visible_shelves;
 

--- a/db/src/shelves/tests.rs
+++ b/db/src/shelves/tests.rs
@@ -1697,3 +1697,135 @@ async fn shelf_owner_attribution_uses_the_display_name_when_one_is_set() {
     let row = listed.iter().find(|s| s.id == id).unwrap();
     assert_eq!(row.owner_username, "Seamus");
 }
+
+// --- shelf_exclusive_hidden_uuids (#932) ------------------------------------
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_hides_a_book_confined_to_a_private_shelf_from_a_non_owner() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let alice = make_user(&pool, "alice", false).await;
+    let bob = make_user(&pool, "bob", false).await;
+    create_shelf(
+        &pool,
+        alice,
+        &manual_req("Secret Stack", vec!["uuid-1".into()]),
+    )
+    .await
+    .unwrap();
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, bob, false, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.contains("uuid-1"), "non-owner must not see it");
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, alice, false, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.is_empty(), "the owner must still see their own book");
+}
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_does_not_hide_a_book_on_a_public_shelf() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let alice = make_user(&pool, "alice", false).await;
+    let bob = make_user(&pool, "bob", false).await;
+    let mut req = manual_req("Front Window", vec!["uuid-1".into()]);
+    req.visibility = Visibility::Public;
+    create_shelf(&pool, alice, &req).await.unwrap();
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, bob, false, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.is_empty(), "a public shelf's books stay visible");
+}
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_does_not_hide_a_book_with_no_shelf_membership() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let alice = make_user(&pool, "alice", false).await;
+    let bob = make_user(&pool, "bob", false).await;
+    create_shelf(
+        &pool,
+        alice,
+        &manual_req("Secret Stack", vec!["uuid-1".into()]),
+    )
+    .await
+    .unwrap();
+
+    // uuid-2 is on no shelf at all — never affected regardless of viewer.
+    let hidden = shelf_exclusive_hidden_uuids(&pool, bob, false, &["uuid-2".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.is_empty());
+}
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_treats_an_admin_as_able_to_see_every_shelf() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let alice = make_user(&pool, "alice", false).await;
+    let admin = make_user(&pool, "admin", true).await;
+    create_shelf(
+        &pool,
+        alice,
+        &manual_req("Secret Stack", vec!["uuid-1".into()]),
+    )
+    .await
+    .unwrap();
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, admin, true, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.is_empty());
+}
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_stays_visible_when_any_one_of_several_shelves_is_visible() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let alice = make_user(&pool, "alice", false).await;
+    let bob = make_user(&pool, "bob", false).await;
+    let carol = make_user(&pool, "carol", false).await;
+    // Both private, owned by different users — the book is on two shelves
+    // Carol can't see, but Bob's own private shelf still covers it.
+    create_shelf(
+        &pool,
+        alice,
+        &manual_req("Alice's private", vec!["uuid-1".into()]),
+    )
+    .await
+    .unwrap();
+    create_shelf(
+        &pool,
+        bob,
+        &manual_req("Bob's private", vec!["uuid-1".into()]),
+    )
+    .await
+    .unwrap();
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, bob, false, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(hidden.is_empty(), "Bob owns one of the two shelves");
+
+    let hidden = shelf_exclusive_hidden_uuids(&pool, carol, false, &["uuid-1".to_string()])
+        .await
+        .unwrap();
+    assert!(
+        hidden.contains("uuid-1"),
+        "Carol can see neither shelf the book is confined to"
+    );
+}
+
+#[tokio::test]
+async fn shelf_exclusive_hidden_uuids_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = shelf_exclusive_hidden_uuids(&pool, 1, false, &["uuid-1".to_string()])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ShelfError::Sqlx(_)));
+}

--- a/server/src/backend/opds/all.rs
+++ b/server/src/backend/opds/all.rs
@@ -44,10 +44,12 @@ pub(super) fn bad_cursor_response() -> Response {
 }
 
 /// Fetch one page of the ebook-scoped library for the All Books feeds:
-/// title order, e-reader formats only. `pub(super)` — the single read both
-/// catalogs' All Books pages come from.
+/// title order, e-reader formats only, narrowed to books `user` may see
+/// (#932 — drops a book confined to a manual shelf `user` cannot see).
+/// `pub(super)` — the single read both catalogs' All Books pages come from.
 pub(super) async fn load_page(
     state: &AppState,
+    user: &OpdsAuthUser,
     cursor: Option<&PageCursor>,
 ) -> Result<db::BookPage, Response> {
     let settings = db::get_settings(&state.pool)
@@ -73,11 +75,12 @@ pub(super) async fn load_page(
     .await
     .map_err(|e| internal("list all books", e))?;
     retain_ereader_books(&mut page.books);
+    super::retain_shelf_visible(state, user, &mut page.books).await?;
     Ok(page)
 }
 
 pub(super) async fn all_books(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Query(query): Query<AllQuery>,
 ) -> Response {
@@ -85,7 +88,7 @@ pub(super) async fn all_books(
         Ok(c) => c,
         Err(_) => return bad_cursor_response(),
     };
-    let page = match load_page(&state, cursor.as_ref()).await {
+    let page = match load_page(&state, &user, cursor.as_ref()).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };

--- a/server/src/backend/opds/authors.rs
+++ b/server/src/backend/opds/authors.rs
@@ -139,11 +139,11 @@ pub(super) async fn by_letter(
 
 /// `GET /opds/author/{id}` — acquisition feed of one author's books.
 pub(super) async fn acquisition_feed(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Response {
-    let author = match load_author(&state, id).await {
+    let author = match load_author(&state, &user, id).await {
         Ok(Some(a)) => a,
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
         Err(resp) => return resp,
@@ -165,24 +165,28 @@ pub(super) async fn acquisition_feed(
 /// serve: the configured ebook library only (see the `opds` module doc),
 /// then to the formats an acquisition link can point at — an audiobook-only
 /// or physical-only row would otherwise surface as an entry with no
-/// download. `Ok(None)` is an unknown author id; `Err` is a ready-to-return
-/// failure response. `pub(super)` — reused by `opds::json_authors` so both
-/// catalogs' author feeds carry the same entries.
+/// download — and finally to books `user` may see (#932). `Ok(None)` is an
+/// unknown author id; `Err` is a ready-to-return failure response.
+/// `pub(super)` — reused by `opds::json_authors` so both catalogs' author
+/// feeds carry the same entries.
 pub(super) async fn load_author(
     state: &AppState,
+    user: &OpdsAuthUser,
     author_id: i64,
 ) -> Result<Option<AuthorDetail>, Response> {
     let settings = db::get_settings(&state.pool)
         .await
         .map_err(|e| internal("read settings", e))?;
     let paths = db::collect_paths(settings.ebook_library_path.as_deref(), None);
-    let author = db::get_author_for_paths(&state.pool, author_id, &paths)
+    let Some(mut author) = db::get_author_for_paths(&state.pool, author_id, &paths)
         .await
-        .map_err(|e| internal("read author", e))?;
-    Ok(author.map(|mut author| {
-        retain_ereader_books(&mut author.books);
-        author
-    }))
+        .map_err(|e| internal("read author", e))?
+    else {
+        return Ok(None);
+    };
+    retain_ereader_books(&mut author.books);
+    super::retain_shelf_visible(state, user, &mut author.books).await?;
+    Ok(Some(author))
 }
 
 /// Load every author across the configured ebook library (see the `opds`

--- a/server/src/backend/opds/delegate.rs
+++ b/server/src/backend/opds/delegate.rs
@@ -6,17 +6,23 @@
 //! resolved user. Query strings and the raw request (range/conditional
 //! headers) pass through untouched, so resume and 304 behaviour is
 //! identical to the `/api` originals.
+//!
+//! Each route also re-checks [`super::is_shelf_hidden`] (#932) before
+//! delegating: a book that's confined to a manual shelf this viewer can't
+//! see must not be fetchable by a client that already knows (or guesses)
+//! its uuid, even though it never surfaced in a feed. Answered as a 404,
+//! matching `shelves::load_visible_shelf`'s no-existence-leak rule.
 
 use axum::{
     extract::{Path, Query, Request, State},
-    http::HeaderMap,
-    response::Response,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
 };
 
 use crate::auth::{MediaAuthUser, OpdsAuthUser};
 
 use super::super::{audiobooks, covers, deny_without_download, ebooks};
-use super::AppState;
+use super::{is_shelf_hidden, AppState};
 
 /// `GET /opds/covers/{uuid}` → [`covers::get_cover`].
 pub(super) async fn cover(
@@ -25,6 +31,11 @@ pub(super) async fn cover(
     path: Path<String>,
     headers: HeaderMap,
 ) -> Response {
+    match is_shelf_hidden(&state.0, &user, &path.0).await {
+        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(false) => {}
+        Err(resp) => return resp,
+    }
     covers::get_cover(MediaAuthUser(user.0), state, path, headers).await
 }
 
@@ -35,6 +46,11 @@ pub(super) async fn thumb(
     path: Path<(String, String)>,
     headers: HeaderMap,
 ) -> Response {
+    match is_shelf_hidden(&state.0, &user, &path.0 .0).await {
+        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(false) => {}
+        Err(resp) => return resp,
+    }
     covers::get_thumb(MediaAuthUser(user.0), state, path, headers).await
 }
 
@@ -49,6 +65,11 @@ pub(super) async fn ebook_file(
 ) -> Response {
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
+    }
+    match is_shelf_hidden(&state.0, &user, &path.0).await {
+        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(false) => {}
+        Err(resp) => return resp,
     }
     ebooks::get_ebook_file(MediaAuthUser(user.0), state, path, query, req).await
 }
@@ -65,6 +86,11 @@ pub(super) async fn ebook_download(
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
     }
+    match is_shelf_hidden(&state.0, &user, &path.0).await {
+        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(false) => {}
+        Err(resp) => return resp,
+    }
     ebooks::get_ebook_download(user.0, state, path, query, req).await
 }
 
@@ -78,6 +104,11 @@ pub(super) async fn audiobook_download(
 ) -> Response {
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
+    }
+    match is_shelf_hidden(&state.0, &user, &path.0).await {
+        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(false) => {}
+        Err(resp) => return resp,
     }
     audiobooks::get_audiobook_download(user.0, state, path, query, req).await
 }

--- a/server/src/backend/opds/delegate.rs
+++ b/server/src/backend/opds/delegate.rs
@@ -46,7 +46,8 @@ pub(super) async fn thumb(
     path: Path<(String, String)>,
     headers: HeaderMap,
 ) -> Response {
-    match is_shelf_hidden(&state.0, &user, &path.0 .0).await {
+    let (uuid, _size) = &path.0;
+    match is_shelf_hidden(&state.0, &user, uuid).await {
         Ok(true) => return StatusCode::NOT_FOUND.into_response(),
         Ok(false) => {}
         Err(resp) => return resp,

--- a/server/src/backend/opds/json_all.rs
+++ b/server/src/backend/opds/json_all.rs
@@ -16,7 +16,7 @@ use super::json_entries::book_publication;
 use super::json_response;
 
 pub(super) async fn all_books(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Query(query): Query<AllQuery>,
 ) -> Response {
@@ -24,7 +24,7 @@ pub(super) async fn all_books(
         Ok(c) => c,
         Err(_) => return bad_cursor_response(),
     };
-    let page = match load_page(&state, cursor.as_ref()).await {
+    let page = match load_page(&state, &user, cursor.as_ref()).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };

--- a/server/src/backend/opds/json_authors.rs
+++ b/server/src/backend/opds/json_authors.rs
@@ -108,11 +108,11 @@ pub(super) async fn by_letter(
 
 /// `GET /opds/v2/author/{id}` — publication feed of one author's books.
 pub(super) async fn acquisition_feed(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Response {
-    let author = match load_author(&state, id).await {
+    let author = match load_author(&state, &user, id).await {
         Ok(Some(a)) => a,
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
         Err(resp) => return resp,

--- a/server/src/backend/opds/json_new.rs
+++ b/server/src/backend/opds/json_new.rs
@@ -4,44 +4,19 @@
 //! always agree.
 
 use axum::{extract::State, response::Response};
-use omnibus_db as db;
 use omnibus_shared::opds::{Feed, FeedMetadata, Link, MEDIA_TYPE};
-use omnibus_shared::{SortDir, SortKey, ViewFilters};
 
-use super::entries::retain_ereader_books;
 use super::json_entries::book_publication;
-use super::new::NEW_LIMIT;
-use super::{internal, json_response};
+use super::json_response;
+use super::new::load_new_arrivals;
 use crate::auth::OpdsAuthUser;
 use crate::backend::AppState;
 
-pub(super) async fn new_arrivals(_user: OpdsAuthUser, State(state): State<AppState>) -> Response {
-    let settings = match db::get_settings(&state.pool).await {
-        Ok(s) => s,
-        Err(e) => return internal("read settings", e),
+pub(super) async fn new_arrivals(user: OpdsAuthUser, State(state): State<AppState>) -> Response {
+    let books = match load_new_arrivals(&state, &user).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
     };
-    // OPDS scope is the ebook library only — see the `opds` module doc.
-    let paths = db::collect_paths(settings.ebook_library_path.as_deref(), None);
-    let mut books = if paths.is_empty() {
-        Vec::new()
-    } else {
-        match db::list_books_page(
-            &state.pool,
-            &paths,
-            SortKey::NewestAdded,
-            SortDir::Desc,
-            &ViewFilters::default(),
-            &[],
-            None,
-            NEW_LIMIT,
-        )
-        .await
-        {
-            Ok(page) => page.books,
-            Err(e) => return internal("list recently added books", e),
-        }
-    };
-    retain_ereader_books(&mut books);
     let feed = Feed {
         metadata: FeedMetadata {
             title: "Recently Added".to_string(),

--- a/server/src/backend/opds/json_search.rs
+++ b/server/src/backend/opds/json_search.rs
@@ -8,41 +8,24 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use omnibus_db as db;
 use omnibus_shared::opds::{Feed, FeedMetadata, Link, MEDIA_TYPE};
-use omnibus_shared::search_query_too_long;
 
-use super::entries::retain_ereader_books;
 use super::json_entries::book_publication;
-use super::search::SearchQuery;
-use super::{internal, json_response};
+use super::json_response;
+use super::search::{load_matches, SearchQuery};
 use crate::auth::OpdsAuthUser;
 use crate::backend::AppState;
 
 pub(super) async fn search(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Query(params): Query<SearchQuery>,
 ) -> Response {
-    if search_query_too_long(&params.q) {
-        return (StatusCode::BAD_REQUEST, "query too long").into_response();
-    }
-    let settings = match db::get_settings(&state.pool).await {
-        Ok(s) => s,
-        Err(e) => return internal("read settings", e),
+    let books = match load_matches(&state, &user, &params.q).await {
+        Ok(Some(b)) => b,
+        Ok(None) => return (StatusCode::BAD_REQUEST, "query too long").into_response(),
+        Err(resp) => return resp,
     };
-    // OPDS scope is the ebook library only (see `opds` module doc) — an
-    // audiobook-only match would carry no working acquisition link.
-    let paths = db::collect_paths(settings.ebook_library_path.as_deref(), None);
-    let mut books = if paths.is_empty() || params.q.trim().is_empty() {
-        Vec::new()
-    } else {
-        match db::search_books_for_paths(&state.pool, &paths, &params.q).await {
-            Ok(b) => b,
-            Err(e) => return internal("search books", e),
-        }
-    };
-    retain_ereader_books(&mut books);
     let self_href = format!("/opds/v2/search?q={}", urlencoding::encode(&params.q));
     let feed = Feed {
         metadata: FeedMetadata {

--- a/server/src/backend/opds/json_series.rs
+++ b/server/src/backend/opds/json_series.rs
@@ -13,8 +13,8 @@ use axum::{
 use omnibus_db as db;
 use omnibus_shared::opds::{Feed, FeedMetadata, Link, MEDIA_TYPE};
 
-use super::entries::retain_ereader_books;
 use super::json_entries::book_publication;
+use super::series::load_series;
 use super::{internal, json_nav_link, json_response};
 use crate::auth::OpdsAuthUser;
 use crate::backend::AppState;
@@ -62,37 +62,32 @@ pub(super) async fn index(_user: OpdsAuthUser, State(state): State<AppState>) ->
 /// `GET /opds/v2/series/{id}` — publication feed of one series' books, in
 /// series-index order (`db::get_series`'s ordering).
 pub(super) async fn acquisition_feed(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Response {
-    match db::get_series(&state.pool, id).await {
-        Ok(Some(mut series)) => {
-            // Ebook-scoped like the author acquisition feed — an
-            // audiobook/physical-only book in the same series would carry
-            // no working acquisition link here.
-            retain_ereader_books(&mut series.books);
-            let publications: Vec<_> = series.books.iter().map(book_publication).collect();
-            let feed = Feed {
-                metadata: FeedMetadata {
-                    title: series.name.clone(),
-                    number_of_items: Some(publications.len() as i64),
-                    ..Default::default()
-                },
-                links: vec![
-                    Link::new(format!("/opds/v2/series/{id}"))
-                        .with_rel("self")
-                        .with_type(MEDIA_TYPE),
-                    Link::new("/opds/v2")
-                        .with_rel("start")
-                        .with_type(MEDIA_TYPE),
-                ],
-                navigation: Vec::new(),
-                publications,
-            };
-            json_response(&feed)
-        }
-        Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => internal("read series", e),
-    }
+    let series = match load_series(&state, &user, id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(resp) => return resp,
+    };
+    let publications: Vec<_> = series.books.iter().map(book_publication).collect();
+    let feed = Feed {
+        metadata: FeedMetadata {
+            title: series.name.clone(),
+            number_of_items: Some(publications.len() as i64),
+            ..Default::default()
+        },
+        links: vec![
+            Link::new(format!("/opds/v2/series/{id}"))
+                .with_rel("self")
+                .with_type(MEDIA_TYPE),
+            Link::new("/opds/v2")
+                .with_rel("start")
+                .with_type(MEDIA_TYPE),
+        ],
+        navigation: Vec::new(),
+        publications,
+    };
+    json_response(&feed)
 }

--- a/server/src/backend/opds/mod.rs
+++ b/server/src/backend/opds/mod.rs
@@ -21,15 +21,20 @@
 //! catalogs cannot silently drift on what a book, author, or search result
 //! actually is.
 //!
-//! Every browse/search/new/nav/author/series read also narrows to books
-//! the caller may see (#932, [`retain_shelf_visible`]): a book confined to
-//! a manual shelf the viewer cannot see (a private shelf owned by someone
-//! else) is dropped, even though the file itself is otherwise an ordinary,
-//! generally-served library book. A book with no shelf membership, or with
-//! at least one shelf visible to the viewer, is unaffected. The
-//! byte-serving [`delegate`] routes apply the single-uuid form
-//! ([`is_shelf_hidden`]) so a known uuid can't be fetched directly around
-//! the feeds either.
+//! Every browse/search/new/nav/author/series **acquisition** read also
+//! narrows to books the caller may see (#932, [`retain_shelf_visible`]): a
+//! book confined to a manual shelf the viewer cannot see (a private shelf
+//! owned by someone else) is dropped, even though the file itself is
+//! otherwise an ordinary, generally-served library book. A book with no
+//! shelf membership, or with at least one shelf visible to the viewer, is
+//! unaffected. The byte-serving [`delegate`] routes apply the single-uuid
+//! form ([`is_shelf_hidden`]) so a known uuid can't be fetched directly
+//! around the feeds either. **Known gap:** the per-author/per-series
+//! *navigation*-level `book_count` shown in `/opds/authors/{letter}` and
+//! `/opds/series` (sourced from `db::list_authors`/`list_series`, informational
+//! summary text only) is **not** narrowed by this filter — only the actual
+//! acquisition-feed entries are. A shelf-exclusive book can still nudge
+//! that count without ever appearing as an entry.
 
 use axum::{
     http::header,
@@ -236,12 +241,29 @@ async fn retain_shelf_visible(
 /// rather than paging through a fetched list. `true` means `user` must not
 /// be shown this book — the delegate routes 404 rather than 403, matching
 /// [`shelves::load_visible_shelf`]'s no-existence-leak rule.
+///
+/// Canonicalizes `uuid` through [`db::resolve_canonical_book_uuid`] first
+/// (#932 follow-up): the media handlers this gate sits in front of resolve
+/// a path uuid via `resolve_book_id_by_uuid`, which falls back to
+/// `merged_uuids` — a book merged away from an old uuid still serves under
+/// it. `shelf_books` only ever names the *canonical* uuid, so checking the
+/// raw path segment let an old/merged uuid walk straight past a shelf that
+/// hides the surviving book. An unresolvable uuid (unknown to both `books`
+/// and `merged_uuids`) is never "shelf-hidden" by this rule — the handler's
+/// own lookup 404s it as not-found, which is the correct answer for that
+/// case.
 async fn is_shelf_hidden(
     state: &AppState,
     user: &OpdsAuthUser,
     uuid: &str,
 ) -> Result<bool, Response> {
-    let candidates = [uuid.to_string()];
+    let Some(canonical) = db::resolve_canonical_book_uuid(&state.pool, uuid)
+        .await
+        .map_err(|e| internal("resolve canonical book uuid", e))?
+    else {
+        return Ok(false);
+    };
+    let candidates = [canonical.clone()];
     let hidden = db::shelves::shelf_exclusive_hidden_uuids(
         &state.pool,
         user.0.id,
@@ -250,5 +272,5 @@ async fn is_shelf_hidden(
     )
     .await
     .map_err(|e| internal("check shelf-exclusive visibility", e))?;
-    Ok(hidden.contains(uuid))
+    Ok(hidden.contains(&canonical))
 }

--- a/server/src/backend/opds/mod.rs
+++ b/server/src/backend/opds/mod.rs
@@ -20,6 +20,16 @@
 //! reuse their DB reads and format-selection helpers directly, so the two
 //! catalogs cannot silently drift on what a book, author, or search result
 //! actually is.
+//!
+//! Every browse/search/new/nav/author/series read also narrows to books
+//! the caller may see (#932, [`retain_shelf_visible`]): a book confined to
+//! a manual shelf the viewer cannot see (a private shelf owned by someone
+//! else) is dropped, even though the file itself is otherwise an ordinary,
+//! generally-served library book. A book with no shelf membership, or with
+//! at least one shelf visible to the viewer, is unaffected. The
+//! byte-serving [`delegate`] routes apply the single-uuid form
+//! ([`is_shelf_hidden`]) so a known uuid can't be fetched directly around
+//! the feeds either.
 
 use axum::{
     http::header,
@@ -27,8 +37,11 @@ use axum::{
     routing::get,
     Extension, Router,
 };
+use omnibus_db as db;
 use omnibus_shared::opds as opds2;
+use omnibus_shared::EbookMetadata;
 
+use crate::auth::OpdsAuthUser;
 use crate::http_errors::internal;
 
 use super::AppState;
@@ -179,4 +192,63 @@ fn json_nav_link(title: &str, href: &str) -> opds2::Link {
         .with_rel("subsection")
         .with_type(opds2::MEDIA_TYPE)
         .with_title(title)
+}
+
+/// Drop every book in `books` that's confined to a manual shelf `user`
+/// cannot see (#932): on at least one manual shelf, and every one of those
+/// shelves is private and owned by someone else. A book on no shelf at
+/// all, or on any shelf visible to `user`, is untouched — so this only
+/// ever narrows a page the caller already fetched through the normal
+/// (shelf-unaware) library read. Every browse/search/new/nav handler in
+/// both catalogs runs its page through this after the e-reader-format
+/// filter, so the two catalogs can't drift on the rule.
+async fn retain_shelf_visible(
+    state: &AppState,
+    user: &OpdsAuthUser,
+    books: &mut Vec<EbookMetadata>,
+) -> Result<(), Response> {
+    let candidates: Vec<String> = books
+        .iter()
+        .filter_map(|b| b.unique_identifier.clone())
+        .collect();
+    if candidates.is_empty() {
+        return Ok(());
+    }
+    let hidden = db::shelves::shelf_exclusive_hidden_uuids(
+        &state.pool,
+        user.0.id,
+        user.0.is_admin,
+        &candidates,
+    )
+    .await
+    .map_err(|e| internal("filter shelf-exclusive books", e))?;
+    if !hidden.is_empty() {
+        books.retain(|b| match &b.unique_identifier {
+            Some(uuid) => !hidden.contains(uuid),
+            None => true,
+        });
+    }
+    Ok(())
+}
+
+/// Single-uuid form of [`retain_shelf_visible`] for the byte-serving
+/// [`delegate`] routes, which resolve a `{uuid}` path segment directly
+/// rather than paging through a fetched list. `true` means `user` must not
+/// be shown this book — the delegate routes 404 rather than 403, matching
+/// [`shelves::load_visible_shelf`]'s no-existence-leak rule.
+async fn is_shelf_hidden(
+    state: &AppState,
+    user: &OpdsAuthUser,
+    uuid: &str,
+) -> Result<bool, Response> {
+    let candidates = [uuid.to_string()];
+    let hidden = db::shelves::shelf_exclusive_hidden_uuids(
+        &state.pool,
+        user.0.id,
+        user.0.is_admin,
+        &candidates,
+    )
+    .await
+    .map_err(|e| internal("check shelf-exclusive visibility", e))?;
+    Ok(hidden.contains(uuid))
 }

--- a/server/src/backend/opds/new.rs
+++ b/server/src/backend/opds/new.rs
@@ -2,7 +2,7 @@
 
 use axum::{extract::State, response::Response};
 use omnibus_db as db;
-use omnibus_shared::{SortDir, SortKey, ViewFilters};
+use omnibus_shared::{EbookMetadata, SortDir, SortKey, ViewFilters};
 
 use super::atom::{Feed, Link, ACQUISITION_TYPE, NAVIGATION_TYPE};
 use super::entries::{book_entry, retain_ereader_books};
@@ -17,17 +17,22 @@ use crate::backend::AppState;
 /// "recently added" feeds can't drift apart in size.
 pub(super) const NEW_LIMIT: i64 = 50;
 
-pub(super) async fn new_arrivals(_user: OpdsAuthUser, State(state): State<AppState>) -> Response {
-    let settings = match db::get_settings(&state.pool).await {
-        Ok(s) => s,
-        Err(e) => return internal("read settings", e),
-    };
+/// Fetch the recently-added page: e-reader formats only, narrowed to books
+/// `user` may see (#932). `pub(super)` — the single read both catalogs'
+/// Recently Added feeds come from.
+pub(super) async fn load_new_arrivals(
+    state: &AppState,
+    user: &OpdsAuthUser,
+) -> Result<Vec<EbookMetadata>, Response> {
+    let settings = db::get_settings(&state.pool)
+        .await
+        .map_err(|e| internal("read settings", e))?;
     // OPDS scope is the ebook library only — see the `opds` module doc.
     let paths = db::collect_paths(settings.ebook_library_path.as_deref(), None);
     let mut books = if paths.is_empty() {
         Vec::new()
     } else {
-        match db::list_books_page(
+        db::list_books_page(
             &state.pool,
             &paths,
             SortKey::NewestAdded,
@@ -38,12 +43,19 @@ pub(super) async fn new_arrivals(_user: OpdsAuthUser, State(state): State<AppSta
             NEW_LIMIT,
         )
         .await
-        {
-            Ok(page) => page.books,
-            Err(e) => return internal("list recently added books", e),
-        }
+        .map_err(|e| internal("list recently added books", e))?
+        .books
     };
     retain_ereader_books(&mut books);
+    super::retain_shelf_visible(state, user, &mut books).await?;
+    Ok(books)
+}
+
+pub(super) async fn new_arrivals(user: OpdsAuthUser, State(state): State<AppState>) -> Response {
+    let books = match load_new_arrivals(&state, &user).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
     let feed = Feed {
         id: "urn:omnibus:opds:new".to_string(),
         title: "Recently Added".to_string(),

--- a/server/src/backend/opds/search.rs
+++ b/server/src/backend/opds/search.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use omnibus_db as db;
-use omnibus_shared::search_query_too_long;
+use omnibus_shared::{search_query_too_long, EbookMetadata};
 use serde::Deserialize;
 
 use super::atom::{Feed, Link, ACQUISITION_TYPE, NAVIGATION_TYPE};
@@ -24,30 +24,46 @@ pub(super) struct SearchQuery {
     pub(super) q: String,
 }
 
-pub(super) async fn search(
-    _user: OpdsAuthUser,
-    State(state): State<AppState>,
-    Query(params): Query<SearchQuery>,
-) -> Response {
-    if search_query_too_long(&params.q) {
-        return (StatusCode::BAD_REQUEST, "query too long").into_response();
+/// Run the FTS match: e-reader formats only, narrowed to books `user` may
+/// see (#932). `pub(super)` — the single read both catalogs' search feeds
+/// come from. `Ok(None)` means the query itself was rejected (too long);
+/// callers map it to the 400 both catalogs share.
+pub(super) async fn load_matches(
+    state: &AppState,
+    user: &OpdsAuthUser,
+    q: &str,
+) -> Result<Option<Vec<EbookMetadata>>, Response> {
+    if search_query_too_long(q) {
+        return Ok(None);
     }
-    let settings = match db::get_settings(&state.pool).await {
-        Ok(s) => s,
-        Err(e) => return internal("read settings", e),
-    };
+    let settings = db::get_settings(&state.pool)
+        .await
+        .map_err(|e| internal("read settings", e))?;
     // OPDS scope is the ebook library only (see `opds` module doc) — an
     // audiobook-only match would carry no working acquisition link.
     let paths = db::collect_paths(settings.ebook_library_path.as_deref(), None);
-    let mut books = if paths.is_empty() || params.q.trim().is_empty() {
+    let mut books = if paths.is_empty() || q.trim().is_empty() {
         Vec::new()
     } else {
-        match db::search_books_for_paths(&state.pool, &paths, &params.q).await {
-            Ok(b) => b,
-            Err(e) => return internal("search books", e),
-        }
+        db::search_books_for_paths(&state.pool, &paths, q)
+            .await
+            .map_err(|e| internal("search books", e))?
     };
     retain_ereader_books(&mut books);
+    super::retain_shelf_visible(state, user, &mut books).await?;
+    Ok(Some(books))
+}
+
+pub(super) async fn search(
+    user: OpdsAuthUser,
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Response {
+    let books = match load_matches(&state, &user, &params.q).await {
+        Ok(Some(b)) => b,
+        Ok(None) => return (StatusCode::BAD_REQUEST, "query too long").into_response(),
+        Err(resp) => return resp,
+    };
     let self_href = format!("/opds/search?q={}", urlencoding::encode(&params.q));
     let feed = Feed {
         id: "urn:omnibus:opds:search".to_string(),

--- a/server/src/backend/opds/series.rs
+++ b/server/src/backend/opds/series.rs
@@ -10,6 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use omnibus_db as db;
+use omnibus_shared::SeriesDetail;
 
 use crate::auth::OpdsAuthUser;
 use crate::backend::AppState;
@@ -65,27 +66,48 @@ pub(super) async fn index(_user: OpdsAuthUser, State(state): State<AppState>) ->
 /// `GET /opds/series/{id}` — acquisition feed of one series' books, in
 /// series-index order (`db::get_series`'s ordering).
 pub(super) async fn acquisition_feed(
-    _user: OpdsAuthUser,
+    user: OpdsAuthUser,
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Response {
-    match db::get_series(&state.pool, id).await {
-        Ok(Some(mut series)) => {
-            retain_ereader_books(&mut series.books);
-            let feed = Feed {
-                id: format!("urn:omnibus:opds:series:{id}"),
-                title: series.name.clone(),
-                updated: now_rfc3339(),
-                links: vec![
-                    Link::new("self", format!("/opds/series/{id}"), ACQUISITION_TYPE),
-                    Link::new("up", "/opds/series", NAVIGATION_TYPE),
-                    Link::new("start", "/opds", NAVIGATION_TYPE),
-                ],
-                entries: series.books.iter().map(book_entry).collect(),
-            };
-            xml_response(ACQUISITION_TYPE, feed.to_xml())
-        }
-        Ok(None) => StatusCode::NOT_FOUND.into_response(),
-        Err(e) => internal("read series", e),
-    }
+    let series = match load_series(&state, &user, id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(resp) => return resp,
+    };
+    let feed = Feed {
+        id: format!("urn:omnibus:opds:series:{id}"),
+        title: series.name.clone(),
+        updated: now_rfc3339(),
+        links: vec![
+            Link::new("self", format!("/opds/series/{id}"), ACQUISITION_TYPE),
+            Link::new("up", "/opds/series", NAVIGATION_TYPE),
+            Link::new("start", "/opds", NAVIGATION_TYPE),
+        ],
+        entries: series.books.iter().map(book_entry).collect(),
+    };
+    xml_response(ACQUISITION_TYPE, feed.to_xml())
+}
+
+/// Load one series with its books narrowed to e-reader formats and to
+/// books `user` may see (#932) — an audiobook/physical-only book, or one
+/// confined to a manual shelf `user` cannot see, would otherwise surface
+/// as an entry with no working acquisition link. `Ok(None)` is an unknown
+/// series id; `Err` is a ready-to-return failure response. `pub(super)` —
+/// reused by `opds::json_series` so both catalogs' series feeds carry the
+/// same entries.
+pub(super) async fn load_series(
+    state: &AppState,
+    user: &OpdsAuthUser,
+    series_id: i64,
+) -> Result<Option<SeriesDetail>, Response> {
+    let Some(mut series) = db::get_series(&state.pool, series_id)
+        .await
+        .map_err(|e| internal("read series", e))?
+    else {
+        return Ok(None);
+    };
+    retain_ereader_books(&mut series.books);
+    super::retain_shelf_visible(state, user, &mut series.books).await?;
+    Ok(Some(series))
 }

--- a/server/src/backend/opds/shelves.rs
+++ b/server/src/backend/opds/shelves.rs
@@ -1,8 +1,11 @@
 //! Shelves browse: `/opds/shelves` (navigation feed of the viewer's
 //! visible shelves) and `/opds/shelves/{id}` (one shelf's acquisition
-//! feed, title order). The one OPDS surface that reads the caller's
-//! identity: listing via `db::list_visible_shelves`, per-shelf access
-//! re-checked with `db::can_view` — a non-visible shelf 404s, never 403s.
+//! feed, title order): listing via `db::list_visible_shelves`, per-shelf
+//! access re-checked with `db::can_view` — a non-visible shelf 404s, never
+//! 403s. Every other OPDS handler now reads the caller's identity too
+//! (#932), via `super::retain_shelf_visible`/`super::is_shelf_hidden` —
+//! this module is just the one surface where the *shelf itself* (rather
+//! than a book confined to one) is the thing being gated.
 
 use axum::{
     extract::{Path, State},

--- a/server/src/backend/opds/tests/mod.rs
+++ b/server/src/backend/opds/tests/mod.rs
@@ -1,12 +1,13 @@
 //! HTTP-layer contract tests for `/opds/*`, driving `opds_router` directly
 //! (like `kobo/tests.rs`) via `oneshot` against an in-memory DB. Shared
 //! fixtures live here, alongside the Atom v1 catalog and timestamp-parsing
-//! tests; the JSON catalog, HTTP Basic auth, and All Books/Series/Shelves
-//! tests are split into the sibling modules below.
+//! tests; the JSON catalog, HTTP Basic auth, All Books/Series/Shelves, and
+//! shelf-scoped visibility tests are split into the sibling modules below.
 
 mod all_series_shelves;
 mod basic_auth;
 mod json_catalog;
+mod shelf_scoped_visibility;
 
 use axum::{
     body::to_bytes,

--- a/server/src/backend/opds/tests/shelf_scoped_visibility.rs
+++ b/server/src/backend/opds/tests/shelf_scoped_visibility.rs
@@ -14,6 +14,45 @@ use super::{
     author_id_by_name, body_string, fixture, seed_synced_ebook_with_series, series_id_by_name,
 };
 
+/// Seed one book with a *real* on-disk EPUB file — unlike `seed_synced_ebook`,
+/// which writes DB rows only — so a 200-vs-404 split in a delegate-route test
+/// proves the shelf gate rather than a missing-file 404 either way. Returns
+/// the `tempfile::TempDir` guard; keep it alive for the file's lifetime.
+async fn seed_downloadable_book(
+    pool: &sqlx::SqlitePool,
+    uuid: &str,
+    title: &str,
+) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("alpha.epub"), b"PK\x03\x04 fake-epub").unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(tmp.path().to_str().unwrap())
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id =
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, ?)")
+            .bind(uuid)
+            .bind(lib_id)
+            .bind(tmp.path().to_str().unwrap())
+            .bind(title)
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'alpha', 0)",
+    )
+    .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    tmp
+}
+
 async fn seed_private_manual_shelf(
     pool: &sqlx::SqlitePool,
     owner_id: i64,
@@ -249,47 +288,13 @@ async fn series_acquisition_feed_excludes_a_shelf_exclusive_book_for_a_non_owner
 #[tokio::test]
 async fn delegate_routes_404_a_shelf_exclusive_book_for_a_non_owner_and_serve_it_for_the_owner() {
     // The byte-serving routes must agree with the feeds: a book that never
-    // surfaces in a listing must not be fetchable by uuid either. Uses a
-    // real on-disk file (unlike `seed_synced_ebook`) so a 200-vs-404 split
-    // proves the shelf gate, not a missing-file 404 either way.
+    // surfaces in a listing must not be fetchable by uuid either.
     let (app, pool, token) = fixture().await;
     let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
     let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
 
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp =
-        std::env::temp_dir().join(format!("omnibus_opds_shelf_visibility_test_{pid}_{nanos}"));
-    std::fs::create_dir_all(&tmp).unwrap();
-    std::fs::write(tmp.join("alpha.epub"), b"PK\x03\x04 fake-epub").unwrap();
-
-    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
-        .bind(tmp.to_str().unwrap())
-        .execute(&pool)
-        .await
-        .unwrap()
-        .last_insert_rowid();
     let uuid = "55555555-5555-5555-5555-555555555555";
-    let book_id =
-        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'Alpha')")
-            .bind(uuid)
-            .bind(lib_id)
-            .bind(tmp.to_str().unwrap())
-            .execute(&pool)
-            .await
-            .unwrap()
-            .last_insert_rowid();
-    sqlx::query(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
-         VALUES (?, 'EPUB', 'alpha', 0)",
-    )
-    .bind(book_id)
-    .execute(&pool)
-    .await
-    .unwrap();
+    let _tmp = seed_downloadable_book(&pool, uuid, "Alpha").await;
     seed_private_manual_shelf(&pool, owner.id, uuid.to_string()).await;
 
     let res = app
@@ -311,5 +316,58 @@ async fn delegate_routes_404_a_shelf_exclusive_book_for_a_non_owner_and_serve_it
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::OK, "owner must still fetch it");
-    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[tokio::test]
+async fn delegate_routes_404_a_shelf_hidden_book_requested_by_its_old_merged_uuid() {
+    // Regression (#932 review): the media handlers resolve a path uuid via
+    // `resolve_book_id_by_uuid`, which falls back to `merged_uuids` — a book
+    // merged away from an old uuid still serves under it. The shelf gate
+    // must canonicalize the same way, or an old/merged uuid walks straight
+    // past it and serves a book that's supposed to be hidden.
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+
+    let canonical_uuid = "66666666-6666-6666-6666-666666666666";
+    let _tmp = seed_downloadable_book(&pool, canonical_uuid, "Beta").await;
+    seed_private_manual_shelf(&pool, owner.id, canonical_uuid.to_string()).await;
+
+    // An old uuid that was merged away, now resolving to the same book —
+    // written directly rather than via `merge_books`, since only the
+    // `merged_uuids` fallback (not the merge transaction itself) is under
+    // test here.
+    let old_uuid = "77777777-7777-7777-7777-777777777777";
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE uuid = ?")
+        .bind(canonical_uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path) \
+         VALUES (?, ?, 'EPUB', '/lib')",
+    )
+    .bind(old_uuid)
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Both routes actually resolve the old uuid to a real, servable file via
+    // `merged_uuids` — so a 200 here (rather than a coincidental 404 for
+    // some other reason) is exactly what the bypass would have produced.
+    for uri in [
+        format!("/opds/ebooks/{old_uuid}/file"),
+        format!("/opds/ebooks/{old_uuid}/download"),
+    ] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&uri, &token))
+            .await
+            .unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::NOT_FOUND,
+            "old uuid must not bypass the shelf gate via merged_uuids: {uri}"
+        );
+    }
 }

--- a/server/src/backend/opds/tests/shelf_scoped_visibility.rs
+++ b/server/src/backend/opds/tests/shelf_scoped_visibility.rs
@@ -1,0 +1,315 @@
+//! Shelf-scoped feed visibility (#932): a book confined to a manual shelf
+//! the viewer cannot see must not surface in a browse/search/new/nav feed,
+//! or the byte-serving delegate routes, for anyone but the shelf's owner,
+//! a public-shelf viewer, or an admin — in both catalogs.
+
+use axum::http::StatusCode;
+use omnibus_db::{self as db, test_support::seed_synced_ebook};
+use tower::ServiceExt;
+
+use crate::auth::test_support as auth_test_support;
+use crate::backend::test_support::get_with_bearer;
+
+use super::{
+    author_id_by_name, body_string, fixture, seed_synced_ebook_with_series, series_id_by_name,
+};
+
+async fn seed_private_manual_shelf(
+    pool: &sqlx::SqlitePool,
+    owner_id: i64,
+    book_uuid: String,
+) -> omnibus_shared::Shelf {
+    db::create_shelf(
+        pool,
+        owner_id,
+        &omnibus_shared::CreateShelfRequest {
+            kind: omnibus_shared::ShelfKind::Manual,
+            name: "Secret Stack".into(),
+            description: None,
+            visibility: omnibus_shared::Visibility::Private,
+            match_mode: None,
+            rules: Vec::new(),
+            book_uuids: vec![book_uuid],
+        },
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn all_books_excludes_a_shelf_exclusive_book_for_a_non_owner_and_includes_it_for_the_owner_and_admin(
+) {
+    // AC2 (#932): a book confined to a private shelf must not appear in
+    // "All Books" for anyone but the owner or an admin — identically in
+    // both catalogs (AC3).
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+    let admin = auth_test_support::create_admin(&pool, "shelf-admin").await;
+    let admin_token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    seed_private_manual_shelf(&pool, owner.id, uuid).await;
+
+    for (tok, sees_it, who) in [
+        (&owner_token, true, "owner"),
+        (&admin_token, true, "admin"),
+        (&token, false, "other"),
+    ] {
+        for base in ["/opds/all", "/opds/v2/all"] {
+            let res = app
+                .clone()
+                .oneshot(get_with_bearer(base, tok))
+                .await
+                .unwrap();
+            assert_eq!(res.status(), StatusCode::OK, "{who} {base}");
+            let body = body_string(res).await;
+            assert_eq!(body.contains("Dune"), sees_it, "{who} {base}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_book_on_no_shelf_is_unaffected_by_shelf_visibility_filtering() {
+    // Guard against over-filtering: the overwhelming majority of library
+    // books are on no shelf at all and must show for every viewer exactly
+    // as before.
+    let (app, pool, token) = fixture().await;
+    seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+
+    for base in ["/opds/all", "/opds/v2/all"] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &token))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "{base}");
+        assert!(body_string(res).await.contains("Dune"), "{base}");
+    }
+}
+
+#[tokio::test]
+async fn a_book_on_a_public_shelf_shows_normally_for_every_viewer() {
+    // AC1's clarification: a book reachable through a *visible* shelf is
+    // not shelf-exclusive and must show normally.
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    db::create_shelf(
+        &pool,
+        owner.id,
+        &omnibus_shared::CreateShelfRequest {
+            kind: omnibus_shared::ShelfKind::Manual,
+            name: "Front Window".into(),
+            description: None,
+            visibility: omnibus_shared::Visibility::Public,
+            match_mode: None,
+            rules: Vec::new(),
+            book_uuids: vec![uuid],
+        },
+    )
+    .await
+    .unwrap();
+
+    for base in ["/opds/all", "/opds/v2/all"] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &token))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "{base}");
+        assert!(body_string(res).await.contains("Dune"), "{base}");
+    }
+}
+
+#[tokio::test]
+async fn new_arrivals_excludes_a_shelf_exclusive_book_for_a_non_owner() {
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    seed_private_manual_shelf(&pool, owner.id, uuid).await;
+
+    for base in ["/opds/new", "/opds/v2/new"] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &token))
+            .await
+            .unwrap();
+        assert!(!body_string(res).await.contains("Dune"), "other {base}");
+
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &owner_token))
+            .await
+            .unwrap();
+        assert!(body_string(res).await.contains("Dune"), "owner {base}");
+    }
+}
+
+#[tokio::test]
+async fn search_excludes_a_shelf_exclusive_book_for_a_non_owner() {
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    seed_private_manual_shelf(&pool, owner.id, uuid).await;
+
+    for base in ["/opds/search?q=dune", "/opds/v2/search?q=dune"] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &token))
+            .await
+            .unwrap();
+        assert!(!body_string(res).await.contains("Dune"), "other {base}");
+
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(base, &owner_token))
+            .await
+            .unwrap();
+        assert!(body_string(res).await.contains("Dune"), "owner {base}");
+    }
+}
+
+#[tokio::test]
+async fn author_acquisition_feed_excludes_a_shelf_exclusive_book_for_a_non_owner() {
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+    let uuid = seed_synced_ebook(&pool, "dune.epub", "Dune", "Frank Herbert").await;
+    seed_private_manual_shelf(&pool, owner.id, uuid).await;
+    let author_id = author_id_by_name(&pool, "Frank Herbert").await;
+
+    for base in [
+        format!("/opds/author/{author_id}"),
+        format!("/opds/v2/author/{author_id}"),
+    ] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&base, &token))
+            .await
+            .unwrap();
+        assert!(!body_string(res).await.contains("Dune"), "other {base}");
+
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&base, &owner_token))
+            .await
+            .unwrap();
+        assert!(body_string(res).await.contains("Dune"), "owner {base}");
+    }
+}
+
+#[tokio::test]
+async fn series_acquisition_feed_excludes_a_shelf_exclusive_book_for_a_non_owner() {
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+    seed_synced_ebook_with_series(
+        &pool,
+        "dune.epub",
+        "Dune",
+        "Frank Herbert",
+        &[],
+        ("Dune Saga", "1"),
+    )
+    .await;
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM books WHERE title = 'Dune'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    seed_private_manual_shelf(&pool, owner.id, uuid.clone()).await;
+    let series_id = series_id_by_name(&pool, "Dune Saga").await;
+
+    // Match on the book's own acquisition link (embeds its uuid), not the
+    // string "Dune" — the series feed's own <title> is "Dune Saga" and
+    // would false-positive a naive substring check.
+    let needle = format!("/opds/ebooks/{uuid}/");
+    for base in [
+        format!("/opds/series/{series_id}"),
+        format!("/opds/v2/series/{series_id}"),
+    ] {
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&base, &token))
+            .await
+            .unwrap();
+        assert!(!body_string(res).await.contains(&needle), "other {base}");
+
+        let res = app
+            .clone()
+            .oneshot(get_with_bearer(&base, &owner_token))
+            .await
+            .unwrap();
+        assert!(body_string(res).await.contains(&needle), "owner {base}");
+    }
+}
+
+#[tokio::test]
+async fn delegate_routes_404_a_shelf_exclusive_book_for_a_non_owner_and_serve_it_for_the_owner() {
+    // The byte-serving routes must agree with the feeds: a book that never
+    // surfaces in a listing must not be fetchable by uuid either. Uses a
+    // real on-disk file (unlike `seed_synced_ebook`) so a 200-vs-404 split
+    // proves the shelf gate, not a missing-file 404 either way.
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp =
+        std::env::temp_dir().join(format!("omnibus_opds_shelf_visibility_test_{pid}_{nanos}"));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("alpha.epub"), b"PK\x03\x04 fake-epub").unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'lib')")
+        .bind(tmp.to_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let uuid = "55555555-5555-5555-5555-555555555555";
+    let book_id =
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, 'Alpha')")
+            .bind(uuid)
+            .bind(lib_id)
+            .bind(tmp.to_str().unwrap())
+            .execute(&pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'EPUB', 'alpha', 0)",
+    )
+    .bind(book_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    seed_private_manual_shelf(&pool, owner.id, uuid.to_string()).await;
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/ebooks/{uuid}/file"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND, "other must 404");
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/ebooks/{uuid}/file"),
+            &owner_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "owner must still fetch it");
+    std::fs::remove_dir_all(&tmp).ok();
+}


### PR DESCRIPTION
## Summary
- Closes #932
- Threads the authenticated `OpdsAuthUser` through every `/opds` and `/opds/v2` handler (`all`, `new`, `search`, `authors`, `series`, and their JSON counterparts) so the caller's identity is available everywhere, not just on the shelves browse.
- Adds `db::shelves::shelf_exclusive_hidden_uuids`: given a candidate set of book uuids, returns the ones that are on at least one manual shelf and *none* of those shelves are visible to the viewer (owner match, public, or admin). A book that's on no shelf at all, or on any shelf the viewer can see, is never affected.
- Wires that predicate into every browse/search/new/nav/author/series read (`retain_shelf_visible`) and into the byte-serving `delegate` routes by uuid (`is_shelf_hidden`, answered as 404 — never 403, matching the existing `shelves::load_visible_shelf` no-existence-leak rule).

### Design interpretation (read before reviewing)
The issue's literal acceptance criteria ("a book only reachable via that shelf") turned out to have two very different possible readings once I dug into the data model, and I want to be explicit about which one I implemented and why:

1. **Fileless "shelf-exclusive" books** (wishlist-only entries, ghosted books referenced only by a manual shelf) — these already can't leak into an OPDS acquisition feed under any interpretation, because `retain_ereader_books` unconditionally strips any book without an EPUB/CBZ file (an acquisition entry with no download link is a documented, tested invariant of this module). So this reading has no observable effect to fix.
2. **A normal, file-backed book whose only shelf membership is a private shelf someone else owns** — this is the one I implemented. Today, `/opds/all` (and every other browse/search/new/nav feed) shows every book in the shared library to every authenticated user, with zero awareness of shelves at all. A book added to a private manual shelf is not thereby removed from that shared pool anywhere else in the app — shelves are a curation/organization layer on top of a library every user already sees. I judged this the intended, defensible reading because it's the only one that (a) produces an actual before/after difference between two users hitting the same endpoint, matching AC2's literal test description, and (b) is fully consistent with AC1's own clarifying sentence ("a book that's also reachable through the general library... should still show normally — only books whose sole path to visibility is a non-visible shelf are excluded").

**Scope containment, on purpose:** rather than adding a `viewer_id`/`is_admin` parameter to the widely-shared listing functions in `db/src/books/`, `db/src/browse.rs`, etc. (used by the web UI, RPC layer, and REST API — none of which the issue asked to change), I added the filter as a small additive post-query step (`retain_shelf_visible`) that only the OPDS handlers call. The general web/mobile library browsing experience is unchanged; this PR is OPDS-only, matching the issue title.

**Known, documented gap (not fixed here):** the per-author/per-series *navigation*-level `book_count` (shown in `/opds/authors/{letter}` and `/opds/series` as informational summary text, sourced from `db::list_authors`/`list_series`) is not narrowed by this filter — only the actual acquisition-feed *entries* are. Narrowing those counts would require reworking `db/src/browse.rs`'s single-pass `GROUP BY` count query to carry a per-book shelf-visibility join, which is a larger, separate change with its own test surface. Flagging this explicitly per the task's instructions rather than silently narrowing AC3's "including counts" — happy to follow up in a separate PR if that gap matters in practice.

## Test plan
- [x] `cargo fmt` — PASS (clean)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-db` — PASS (2078 passed, 0 failed vs. this change; 1 pre-existing failure in `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` is an environment gap — missing audiobook fixture, `just fixtures` not run in this sandbox — unrelated to this diff)
- [x] `cargo test -p omnibus` — PASS (821 passed, 0 failed vs. this change; 2 pre-existing failures in `backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` are an environment gap — the sandbox runs tests as root, which bypasses the `chmod 0o555` read-only simulation those tests rely on — unrelated to this diff and to files it touches)
- [x] New coverage: `db/src/shelves/tests.rs` (6 tests for `shelf_exclusive_hidden_uuids` — private-hides-for-non-owner, public-stays-visible, no-membership-untouched, admin-sees-everything, any-one-visible-shelf-wins, db-error propagation) and a new `server/src/backend/opds/tests/shelf_scoped_visibility.rs` (8 HTTP-level tests covering AC2 across `/opds/all`, `/opds/new`, `/opds/search`, `/opds/author/{id}`, `/opds/series/{id}` — both catalogs where applicable — plus the public-shelf and no-shelf-membership guard cases, an admin-bypass case, and a delegate-route 404-vs-200 test using a real on-disk fixture file)

## Version
- [x] **Patch** — left unlabeled (default)

## Notes
- Every OPDS handler doc comment (`opds/mod.rs`, `opds/shelves.rs`) was updated to describe the new shelf-visibility gate so future readers don't have to reconstruct it from the diff.
- `series.rs`, `new.rs`, and `search.rs` each grew a small `pub(super)` loader (`load_series`, `load_new_arrivals`, `load_matches`) shared with their `json_*` sibling, mirroring the existing `all::load_page` / `authors::load_author` pattern — this was needed so the shelf filter (and the format filter it sits next to) can't drift between the Atom and JSON catalogs, per the module's own stated design goal.
- Open question for a maintainer: should the per-author/series navigation-level counts get the same treatment (see the gap noted above)? I judged it out of scope for a first pass but flagging in case it should block merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_012DyPEce3qX2Lanco6EZoBr)_