### PR TITLE
fix: multi-file sync — unseeded boots, unload guards, denser anchors

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -215,7 +215,10 @@ pub async fn set_follow(
 
 /// Text-fraction slack inside which a new "synced here" declaration
 /// replaces an existing pair instead of stacking beside it.
-const SYNC_POINT_REPLACE_SLACK: f64 = 0.02;
+// Tight on purpose: on a marks-less multi-hour book every declaration is
+// hard-won calibration, and 2% of a 50-hour timeline discarded re-syncs an
+// hour apart. Only a true re-declaration of the same spot replaces.
+const SYNC_POINT_REPLACE_SLACK: f64 = 0.005;
 
 /// Record a "synced here" declaration: pair the declaring surface's
 /// position with the counterpart format's stored row, store it as a user

--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -80,7 +80,23 @@ struct TextMark {
 /// One: The Pigeon Drop: In Which…") pairs with a nav's terser "Chapter 1".
 pub(super) fn chapter_number(raw: &str) -> Option<u32> {
     let lower = strip_track_prefix(raw).trim_start().to_lowercase();
-    let rest = lower.strip_prefix("chapter")?;
+    let Some(rest) = lower.strip_prefix("chapter") else {
+        // Bare leading-ordinal shape — "1.\u{9}Sky God", "12) …", "3: …" —
+        // the dominant ebook-nav convention when chapters are numbered
+        // without the word. Parsed from the RAW title: `strip_track_prefix`
+        // above eats exactly this shape as track noise. The separator is
+        // required so a title that merely IS a number ("1984") never reads
+        // as chapter 1984, and a spaced track prefix ("03 - …") stays out.
+        let bare = raw.trim_start();
+        let digits: String = bare.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if digits.is_empty() || digits.len() > 4 {
+            return None;
+        }
+        return match bare[digits.len()..].chars().next() {
+            Some('.' | ')' | ':' | '-') => digits.parse().ok(),
+            _ => None,
+        };
+    };
     let rest = rest.trim_start_matches([' ', '.', '-', '_', ':']);
     if rest.is_empty() || rest.len() == lower.len() - "chapter".len() {
         // No separator after "chapter" ("chapterhouse") is a word, not a
@@ -422,6 +438,40 @@ fn monotonic(anchors: Vec<Anchor>) -> Vec<Anchor> {
 /// `(0,0)`/`(1,1)` endpoints). `axis_text_to_audio` picks the direction.
 pub(super) fn interpolate(anchors: &[Anchor], frac: f64, text_to_audio: bool) -> f64 {
     let frac = frac.clamp(0.0, 1.0);
+    // Past the last anchor, extend the MEASURED local rate (the slope of
+    // the final anchor-to-anchor segment) instead of pinning to the (1,1)
+    // endpoint: with sparse anchors on a multi-hour book the linear-to-end
+    // segment swallows the whole remainder, and the pin quietly asserts a
+    // correspondence nobody measured. Engages only with two or more
+    // anchors — a single point has no measured slope, and extending the
+    // origin segment can fling a steep early anchor past the end of the
+    // book. Clamped to the book either way.
+    if anchors.len() >= 2 {
+        let last = &anchors[anchors.len() - 1];
+        let prev = &anchors[anchors.len() - 2];
+        let (from_last, to_last, pf, pt) = if text_to_audio {
+            (
+                last.text_frac,
+                last.audio_frac,
+                prev.text_frac,
+                prev.audio_frac,
+            )
+        } else {
+            (
+                last.audio_frac,
+                last.text_frac,
+                prev.audio_frac,
+                prev.text_frac,
+            )
+        };
+        if frac > from_last {
+            let denom = from_last - pf;
+            if denom > f64::EPSILON {
+                let slope = (to_last - pt) / denom;
+                return (to_last + slope * (frac - from_last)).clamp(0.0, 1.0);
+            }
+        }
+    }
     let mut prev = (0.0f64, 0.0f64);
     for a in anchors.iter().chain(std::iter::once(&Anchor {
         text_frac: 1.0,

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1703,3 +1703,104 @@ async fn alignment_view_serves_the_anchor_pairs_the_jump_uses() {
         view.anchor_pairs
     );
 }
+
+#[test]
+fn interpolate_extends_the_measured_slope_past_two_or_more_anchors() {
+    use super::anchors::{interpolate, Anchor};
+    // Two anchors measure a local rate of 1.0 audio per text; past the
+    // last one the map extends that rate — text 0.75 lands at 0.65, not
+    // at the endpoint-linear 0.7.
+    let anchors = vec![
+        Anchor {
+            text_frac: 0.4,
+            audio_frac: 0.3,
+        },
+        Anchor {
+            text_frac: 0.5,
+            audio_frac: 0.4,
+        },
+    ];
+    let mapped = interpolate(&anchors, 0.75, true);
+    assert!(
+        (mapped - 0.65).abs() < 1e-9,
+        "expected measured-slope extension 0.65, got {mapped}"
+    );
+    // Clamped at the end of the book, never past it.
+    assert!(interpolate(&anchors, 1.0, true) <= 1.0);
+    // A single anchor keeps the endpoint-linear behavior — one point has
+    // no measured slope to extend.
+    let single = vec![Anchor {
+        text_frac: 0.2,
+        audio_frac: 0.4,
+    }];
+    assert!((interpolate(&single, 0.6, true) - 0.7).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn declare_sync_point_accumulates_nearby_anchors() {
+    // Two declarations 1% of the book apart must BOTH survive — on a
+    // 50-hour timeline the old 2% replace slack silently discarded
+    // re-syncs an hour apart (#1954).
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[1_000.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 1_000))
+        .await
+        .unwrap();
+    declare_sync_point(
+        &pool,
+        user,
+        &DeclareSyncPoint {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Audio,
+            ebook_fraction: None,
+            epub_cfi: None,
+            audio_book_file_id: Some(audio[0]),
+            audio_seconds: Some(400.0),
+        },
+    )
+    .await
+    .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 41, 2_000))
+        .await
+        .unwrap();
+    let link = declare_sync_point(
+        &pool,
+        user,
+        &DeclareSyncPoint {
+            book_uuid: uuid.clone(),
+            format: ProgressFormat::Audio,
+            ebook_fraction: None,
+            epub_cfi: None,
+            audio_book_file_id: Some(audio[0]),
+            audio_seconds: Some(410.0),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        link.user_anchors.len(),
+        2,
+        "a re-sync 1% away must accumulate, not replace: {:?}",
+        link.user_anchors
+    );
+}
+
+#[test]
+fn chapter_number_parses_bare_ordinals_and_noisy_audio_marks() {
+    use super::anchors::chapter_number;
+    // The Bobiverse shape (live #1954 evidence): the ebook nav numbers
+    // chapters without the word, the audio marks pad and append a runtime.
+    assert_eq!(chapter_number("1.\u{9}Sky God"), Some(1));
+    assert_eq!(chapter_number("12. Colony Site"), Some(12));
+    assert_eq!(chapter_number("3) Life in Camelot"), Some(3));
+    assert_eq!(chapter_number(" Chapter 001  - 00:17:05"), Some(1));
+    // A title that merely IS a number never reads as its chapter.
+    assert_eq!(chapter_number("1984"), None);
+    // Front matter stays unnumbered.
+    assert_eq!(chapter_number("Acknowledgements"), None);
+    assert_eq!(chapter_number("Table of Contents"), None);
+}

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -126,6 +126,46 @@ pub async fn upsert_progress(
     Ok(record)
 }
 
+/// Read the current row back as a [`ProgressRecord`] — shared by the
+/// normal post-write read-back and the teardown-signature early return.
+async fn read_progress_row(
+    tx: &mut Transaction<'_, Sqlite>,
+    user_id: i64,
+    book_uuid: String,
+    format: ProgressFormat,
+    fmt: &str,
+) -> Result<ProgressRecord, ProgressError> {
+    let row = sqlx::query(
+        "SELECT epub_cfi, audio_position_seconds, progress_percent, kobo_location,
+                book_file_id, updated_at,
+                COALESCE(client_updated_at, updated_at) AS client_updated_at
+         FROM reading_progress
+         WHERE user_id = ? AND book_uuid = ? AND format = ?",
+    )
+    .bind(user_id)
+    .bind(&book_uuid)
+    .bind(fmt)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(ProgressRecord {
+        book_uuid,
+        format,
+        epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
+        audio_position_seconds: row.try_get::<Option<f64>, _>("audio_position_seconds")?,
+        progress_percent: row.try_get::<Option<i64>, _>("progress_percent")?,
+        kobo_location: row.try_get::<Option<String>, _>("kobo_location")?,
+        book_file_id: row.try_get::<Option<i64>, _>("book_file_id")?,
+        updated_at: row.try_get::<i64, _>("updated_at")?,
+        client_updated_at: row.try_get::<i64, _>("client_updated_at")?,
+    })
+}
+
+/// A near-zero audio write against a row this far into the book is the
+/// teardown signature, not a listen (see the refusal in
+/// [`upsert_progress_tx`]).
+const AUDIO_TEARDOWN_ZERO_CUTOFF_SECONDS: f64 = 1.0;
+const AUDIO_TEARDOWN_ZERO_MIN_STORED_SECONDS: f64 = 600.0;
+
 /// Transaction-scoped [`upsert_progress`], for callers that batch it with
 /// other writes (e.g. the Kobo `put_state` handler) inside one shared
 /// `Transaction` so a mid-batch failure rolls back every entry, not just the
@@ -144,6 +184,31 @@ pub async fn upsert_progress_tx(
     // this function logs (#1861) — neither reads back into the upsert itself.
     let existing = existing_progress_snapshot(tx, user_id, &book_uuid, fmt).await?;
     warn_if_rejected_by_timestamp_guard(&book_uuid, update.client_updated_at, existing.0);
+
+    // Teardown signature, last line of defense (#1954): a dying page's
+    // media element flushes its reset clock — audio position ~0 — with a
+    // perfectly fresh event time, and the client-side gates cannot cover
+    // every event ordering every browser invents. Refuse a near-zero
+    // audio write against a row that sits far into the book: the write is
+    // dropped, the stored row returned. A genuine restart-from-the-start
+    // persists within one heartbeat anyway — its next report is already
+    // past the cutoff.
+    if update.format == ProgressFormat::Audio {
+        if let (Some(new), Some(old)) = (update.audio_position_seconds, existing.1) {
+            if new < AUDIO_TEARDOWN_ZERO_CUTOFF_SECONDS
+                && old > AUDIO_TEARDOWN_ZERO_MIN_STORED_SECONDS
+            {
+                tracing::warn!(
+                    book_uuid = %book_uuid,
+                    old_position_seconds = old,
+                    new_position_seconds = new,
+                    client_updated_at = update.client_updated_at,
+                    "refused near-zero audio write against a far-advanced row (teardown signature)"
+                );
+                return read_progress_row(tx, user_id, book_uuid, update.format, fmt).await;
+            }
+        }
+    }
 
     // `strftime('%s','now')` returns TEXT; SQLite's default storage-class
     // sort order ranks every INTEGER below every TEXT value regardless of
@@ -199,29 +264,7 @@ pub async fn upsert_progress_tx(
     .execute(&mut **tx)
     .await?;
 
-    let row = sqlx::query(
-        "SELECT epub_cfi, audio_position_seconds, progress_percent, kobo_location,
-                book_file_id, updated_at,
-                COALESCE(client_updated_at, updated_at) AS client_updated_at
-         FROM reading_progress
-         WHERE user_id = ? AND book_uuid = ? AND format = ?",
-    )
-    .bind(user_id)
-    .bind(&book_uuid)
-    .bind(fmt)
-    .fetch_one(&mut **tx)
-    .await?;
-    let record = ProgressRecord {
-        book_uuid,
-        format: update.format,
-        epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
-        audio_position_seconds: row.try_get::<Option<f64>, _>("audio_position_seconds")?,
-        progress_percent: row.try_get::<Option<i64>, _>("progress_percent")?,
-        kobo_location: row.try_get::<Option<String>, _>("kobo_location")?,
-        book_file_id: row.try_get::<Option<i64>, _>("book_file_id")?,
-        updated_at: row.try_get::<i64, _>("updated_at")?,
-        client_updated_at: row.try_get::<i64, _>("client_updated_at")?,
-    };
+    let record = read_progress_row(tx, user_id, book_uuid, update.format, fmt).await?;
 
     // If this write was rejected (by either guard above), the row is
     // unchanged, so `new` equals the pre-write snapshot and this can't

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -3155,3 +3155,34 @@ async fn upsert_progress_tx_logs_nothing_when_a_write_is_rejected_by_the_audio_f
         "the audio-file-guard rejection is out of #1861's scope"
     );
 }
+
+#[tokio::test]
+async fn upsert_progress_refuses_near_zero_audio_write_against_far_advanced_row() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Guarded").await;
+    upsert_progress(&pool, user, &audio_update(&uuid, 10_000.0, None, 1_000))
+        .await
+        .unwrap();
+
+    // The teardown signature: ~0 with a fresh clock. Dropped — the stored
+    // row comes back untouched.
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 0.0, None, 2_000))
+        .await
+        .unwrap();
+    assert!((rec.audio_position_seconds.unwrap() - 10_000.0).abs() < f64::EPSILON);
+
+    // A genuine restart persists within one heartbeat: the next report is
+    // already past the cutoff and lands normally.
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 5.0, None, 3_000))
+        .await
+        .unwrap();
+    assert!((rec.audio_position_seconds.unwrap() - 5.0).abs() < f64::EPSILON);
+
+    // A barely-started book restarts instantly — the refusal only guards
+    // rows already far into the book.
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 0.0, None, 4_000))
+        .await
+        .unwrap();
+    assert!(rec.audio_position_seconds.unwrap() < f64::EPSILON);
+}

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -54,13 +54,26 @@ pub(super) fn BdImmersiveButton(uuid: String) -> Element {
         // from a previously-played book would override the bootstrap's
         // progress-row file resolution — or 404 the new book's manifest.
         file_sig.set(None);
-        if uuid_sig.peek().as_deref() != Some(uuid.as_str()) {
+        // Re-resolve unless the SAME book is actively playing: the old
+        // same-uuid short-circuit kept whatever in-memory state the dock
+        // held, which on an idle target can be stale against the stored
+        // rows (issue #1954). A live playback is the one state that must
+        // not be interrupted — everything else re-runs the boot's resume
+        // + follow resolution.
+        let same_book = uuid_sig.peek().as_deref() == Some(uuid.as_str());
+        let live = same_book && *playback.playing.peek();
+        if !live {
             let mut book_sig = playback.book;
             let mut error_sig = playback.error;
             let mut loading_sig = playback.loading;
             book_sig.set(None);
             error_sig.set(None);
             loading_sig.set(true);
+            if same_book {
+                // Same uuid: nudge the driver by clearing first — the
+                // reactive load keys on the uuid value changing.
+                uuid_sig.set(None);
+            }
             uuid_sig.set(Some(uuid.clone()));
         }
         dioxus_router::navigator().push(Route::BookRead { uuid: uuid.clone() });

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -70,11 +70,21 @@ pub(super) fn BdImmersiveButton(uuid: String) -> Element {
             error_sig.set(None);
             loading_sig.set(true);
             if same_book {
-                // Same uuid: nudge the driver by clearing first — the
-                // reactive load keys on the uuid value changing.
+                // Same uuid: the driver keys on the value CHANGING, and a
+                // None→Some pair inside one handler collapses to
+                // no-change — which left the dock cleared but never
+                // rebooted (the "Immersive Read doesn't open the player"
+                // regression). Commit the None now; the Some lands from a
+                // spawned task after this render.
                 uuid_sig.set(None);
+                let uuid_next = uuid.clone();
+                let mut uuid_sig_next = uuid_sig;
+                spawn(async move {
+                    uuid_sig_next.set(Some(uuid_next));
+                });
+            } else {
+                uuid_sig.set(Some(uuid.clone()));
             }
-            uuid_sig.set(Some(uuid.clone()));
         }
         dioxus_router::navigator().push(Route::BookRead { uuid: uuid.clone() });
     };

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -205,11 +205,16 @@ fn listeners_js() -> &'static str {
     el.addEventListener('timeupdate', function(){
       var oa = window.OmnibusAudio;
       if (!oa || !oa._seeded) return;
-      // Last position this session really reached — the teardown-artifact
-      // guard on `pause` below compares against it.
-      oa._lastAbs = absTime();
+      var t = absTime();
+      // Same teardown-artifact rule as `pause` below: a media element
+      // being destroyed can fire one last timeupdate with its clock
+      // already reset to 0 — BEFORE pagehide dispatches. A real restart
+      // reaches 0 through the seek path, which resets _lastAbs first.
+      if (t < 1 && typeof oa._lastAbs === 'number' && oa._lastAbs > 60) return;
+      // Last position this session really reached.
+      oa._lastAbs = t;
       if (window.__omnibusOnAudioTime) {
-        window.__omnibusOnAudioTime(absTime());
+        window.__omnibusOnAudioTime(t);
       }
     });
     // A full-page navigation destroys the media element mid-session; the

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -340,8 +340,12 @@ fn hls_init_js() -> &'static str {
         } else {
           console.warn('OmnibusAudio: no HLS support in this browser');
         }
-        if (typeof initialPositionAbs !== 'number' || initialPositionAbs <= 0) {
-          // No stored position to apply: the element's 0 IS the position.
+        if (typeof initialPositionAbs === 'number' && initialPositionAbs <= 0) {
+          // An explicit zero is a real position (a fresh book boots as
+          // number 0). JSON `null` is an UNATTRIBUTABLE resume — the
+          // row's seconds live in another file — and must stay unseeded,
+          // exactly like initDirect, or the HLS arm re-opens the
+          // zero-wipe path (#1954).
           this._seeded = true;
         }
         if (typeof initialPositionAbs === 'number' && initialPositionAbs > 0) {

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -91,6 +91,7 @@ fn transport_controls_js() -> &'static str {
       // play/pause state across the swap.
       seek: function(absSeconds){
         this._seeded = true;
+        this._lastAbs = Math.max(0, absSeconds || 0);
         var s = Math.max(0, absSeconds || 0);
         // Push the target time to the transport display immediately —
         // don't wait for the element's own `timeupdate`, which some
@@ -204,9 +205,21 @@ fn listeners_js() -> &'static str {
     el.addEventListener('timeupdate', function(){
       var oa = window.OmnibusAudio;
       if (!oa || !oa._seeded) return;
+      // Last position this session really reached — the teardown-artifact
+      // guard on `pause` below compares against it.
+      oa._lastAbs = absTime();
       if (window.__omnibusOnAudioTime) {
         window.__omnibusOnAudioTime(absTime());
       }
+    });
+    // A full-page navigation destroys the media element mid-session; the
+    // browser's teardown can zero currentTime BEFORE the final pause event
+    // dispatches, and that dying flush overwrote a real 2h48m position
+    // with 0.0 live (#1954). The heartbeat persisted a ≤5s-stale position
+    // moments earlier, so closing the gate loses nothing meaningful.
+    window.addEventListener('pagehide', function(){
+      var oa = window.OmnibusAudio;
+      if (oa) oa._seeded = false;
     });
     el.addEventListener('play', function(){
       var oa = window.OmnibusAudio;
@@ -219,8 +232,14 @@ fn listeners_js() -> &'static str {
     el.addEventListener('pause', function(){
       var oa = window.OmnibusAudio;
       if (!oa || !oa._seeded) return;
+      // Teardown artifact: a pause reporting ~0 when this session was
+      // materially past it is the element being reset, not a listener
+      // rewinding — a real jump-to-start arrives as a seek, which updates
+      // _lastAbs through the ungated seek path before any pause fires.
+      var t = absTime();
+      if (t < 1 && typeof oa._lastAbs === 'number' && oa._lastAbs > 60) return;
       if (window.__omnibusOnAudioPause) {
-        window.__omnibusOnAudioPause(absTime());
+        window.__omnibusOnAudioPause(t);
       }
     });
     // Cross-part advance — direct mode only. HLS treats the whole

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -253,6 +253,10 @@ fn direct_play_init_js() -> &'static str {
     r#"      // Direct-play init: parts is the array from the manifest endpoint
       // (`[{ordinal, url, duration_seconds, mime}]`), initialPositionAbs
       // is the absolute resume position in seconds.
+      // `initialPositionAbs` may be null: an unattributable resume (the
+      // row's seconds live in another file) boots at the top of the file
+      // WITHOUT seeding — the transport's gate stays closed, so nothing
+      // can persist this element's position until a real play or seek.
       initDirect: function(parts, initialPositionAbs){
         this._mode = 'direct';
         this._seeded = false;
@@ -270,7 +274,8 @@ fn direct_play_init_js() -> &'static str {
           window.__omnibusOnAudioDuration(this._totalDuration);
         }
         // Pick the starting part for the resume position.
-        var s = Math.max(0, initialPositionAbs || 0);
+        var seedKnown = typeof initialPositionAbs === 'number';
+        var s = Math.max(0, seedKnown ? initialPositionAbs : 0);
         var idx = 0;
         while (idx < this._cumOffsets.length - 1 && s >= this._cumOffsets[idx + 1]) idx++;
         this._index = idx;
@@ -278,8 +283,10 @@ fn direct_play_init_js() -> &'static str {
         var oa = this;
         var onMeta = function(){
           el.removeEventListener('loadedmetadata', onMeta);
-          try { el.currentTime = local; } catch(_) {}
-          oa._seeded = true;
+          if (seedKnown) {
+            try { el.currentTime = local; } catch(_) {}
+            oa._seeded = true;
+          }
         };
         el.addEventListener('loadedmetadata', onMeta);
         el.src = parts[idx].url;

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -537,18 +537,20 @@ async fn run_manifest_init(
             None => true,
         })
         .map(|(_, seconds)| *seconds);
-    let resume_pos = match follow_pos {
-        Some(mapped) => mapped,
-        None => resolve_boot_position(
+    // `None` = unseeded: `initDirect` gets a JSON `null`, applies no seek,
+    // and leaves the transport's seed gate closed — an unattributable boot
+    // must stay unpersistable until the user really plays or seeks.
+    let resume_pos = follow_pos.or_else(|| {
+        resolve_boot_position(
             server_row
                 .as_ref()
                 .map(|r| (r.book_file_id, r.audio_position_seconds)),
             initial_position,
             loaded_file,
             audio_file_count,
-        ),
-    };
-    let pos_lit = serde_json::to_string(&resume_pos).unwrap_or_else(|_| "0".into());
+        )
+    });
+    let pos_lit = serde_json::to_string(&resume_pos).unwrap_or_else(|_| "null".into());
 
     match manifest {
         omnibus_shared::AudiobookManifest::Direct {

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -160,6 +160,8 @@ fn boot_new_book(
         playback.elapsed,
         playback.playing,
         playback.playback_failed,
+        playback.file_id,
+        playback.uuid,
     );
     inject_hls_script();
     install_control_surface(uuid, initial_rate, initial_volume);
@@ -189,6 +191,7 @@ fn reset_per_book_signals(playback: &crate::PlaybackState, user_id: Option<i64>,
     let mut playing = playback.playing;
     let mut hls_ready = playback.hls_ready;
     let mut playback_failed = playback.playback_failed;
+    NEXT_SEQUENCE_FILE.with(|c| c.set(None));
     let mut rate = playback.rate;
     let mut rate_error = playback.rate_error;
     let mut book = playback.book;
@@ -276,6 +279,7 @@ fn spawn_manifest_init(
 /// closures are registered before the manifest lands (#1888). A file switch
 /// always re-boots (see [`needs_reload`]), which resets the signal before
 /// the next manifest fills it again.
+#[expect(clippy::too_many_arguments, reason = "one closure per JS callback")]
 fn register_js_callbacks(
     cb_holder: &JsCallbackHolder,
     uuid_cb: String,
@@ -284,6 +288,8 @@ fn register_js_callbacks(
     mut elapsed: Signal<f64>,
     mut playing: Signal<bool>,
     mut playback_failed: Signal<bool>,
+    file_sig: Signal<Option<i64>>,
+    uuid_sig: Signal<Option<String>>,
 ) {
     let Some(window) = web_sys::window() else {
         return;
@@ -320,10 +326,27 @@ fn register_js_callbacks(
             crate::read_status_auto::apply_auto_read_status("", &uuid, false).await;
         });
     });
-    // Every file played through — see the `ended` handler in `js.rs`, which
-    // only calls this once there is no next part to advance to.
+    // This FILE played through (the `ended` handler in `js.rs` only calls
+    // once there is no next part). On a multi-file sequence the book is
+    // not done — advance the player to the next file's start (paused;
+    // the boot leaves it unseeded until a real play) instead of marking
+    // five-hours-in as finished. Only the last file finishes the book.
     let uuid_for_end = uuid_cb.clone();
     let on_ended = Closure::<dyn FnMut(f64)>::new(move |_: f64| {
+        if let Some(next) = NEXT_SEQUENCE_FILE.with(|c| c.get()) {
+            let uuid = uuid_for_end.clone();
+            let mut file_sig = file_sig;
+            let mut uuid_sig = uuid_sig;
+            file_sig.set(Some(next));
+            // The driver keys on the uuid changing; a None→Some pair in
+            // one render collapses to no-change, so the Some lands from a
+            // spawned task after the None commits.
+            uuid_sig.set(None);
+            wasm_bindgen_futures::spawn_local(async move {
+                uuid_sig.set(Some(uuid));
+            });
+            return;
+        }
         let uuid = uuid_for_end.clone();
         wasm_bindgen_futures::spawn_local(async move {
             crate::read_status_auto::apply_auto_read_status("", &uuid, true).await;
@@ -395,6 +418,14 @@ fn install_control_surface(uuid: &str, initial_rate: f64, initial_volume: f64) {
     let vol_lit = serde_json::to_string(&initial_volume).unwrap_or_else(|_| "1".into());
     let uuid_lit = serde_json::to_string(uuid).unwrap_or_else(|_| "\"\"".into());
     let _ = dioxus::document::eval(&control_surface_js(&rate_lit, &vol_lit, &uuid_lit));
+}
+
+thread_local! {
+    /// The manifest's next-file pointer for the CURRENT boot — read by the
+    /// `ended` callback (registered before any manifest exists) to decide
+    /// between sequence-advance and marking the book finished. Reset at
+    /// every boot entry so a failed load can't leave a stale advance.
+    static NEXT_SEQUENCE_FILE: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
 }
 
 /// Fetch `/api/audiobooks/{uuid}/manifest` — targeting the picker's
@@ -522,6 +553,7 @@ async fn run_manifest_init(
     };
 
     let (loaded_file, audio_file_count) = manifest.file_identity();
+    NEXT_SEQUENCE_FILE.with(|c| c.set(manifest.next_file_id()));
     // `0` = a server predating the identity fields; keep posting no file id
     // rather than inventing one (`resolve_boot_position` degrades the same
     // way via `audio_file_count == 0`).

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -147,13 +147,21 @@ pub(super) fn resolve_boot_position(
     local_pos: f64,
     loaded_file_id: i64,
     audio_file_count: i64,
-) -> f64 {
+) -> Option<f64> {
     if audio_file_count <= 1 {
-        return resolve_resume_pos(row.and_then(|(_, seconds)| seconds), local_pos);
+        return Some(resolve_resume_pos(
+            row.and_then(|(_, seconds)| seconds),
+            local_pos,
+        ));
     }
     match row {
-        Some((Some(row_file), Some(seconds))) if row_file == loaded_file_id => seconds,
-        _ => 0.0,
+        Some((Some(row_file), Some(seconds))) if row_file == loaded_file_id => Some(seconds),
+        // Seconds recorded in another file (or in none) can't be spliced
+        // into this one (#1888) — and `None` here means UNSEEDED, not
+        // "position 0": a zero seed marks the element's 0 as a real
+        // position, which the transport then persists over the row the
+        // seconds actually live in (#1954's data-loss arm).
+        _ => None,
     }
 }
 
@@ -558,19 +566,20 @@ mod boot_resume_tests {
     #[test]
     fn resolve_boot_position_applies_row_seconds_when_the_row_names_the_loaded_file() {
         let row = Some((Some(919), Some(23_718.0)));
-        assert!((resolve_boot_position(row, 5.0, 919, 5) - 23_718.0).abs() < f64::EPSILON);
+        assert!((resolve_boot_position(row, 5.0, 919, 5).unwrap() - 23_718.0).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn resolve_boot_position_starts_at_zero_when_multi_file_seconds_are_unattributable() {
-        // Row names a different file than the one loaded.
+    fn resolve_boot_position_stays_unseeded_when_multi_file_seconds_are_unattributable() {
+        // Row names a different file than the one loaded: `None` (unseeded),
+        // never a zero seed the transport could persist (#1954).
         let other_file = Some((Some(919), Some(23_718.0)));
-        assert_eq!(resolve_boot_position(other_file, 5.0, 917, 5), 0.0);
+        assert_eq!(resolve_boot_position(other_file, 5.0, 917, 5), None);
         // Row names no file at all — seconds can't be attributed.
         let fileless = Some((None, Some(23_718.0)));
-        assert_eq!(resolve_boot_position(fileless, 5.0, 917, 5), 0.0);
+        assert_eq!(resolve_boot_position(fileless, 5.0, 917, 5), None);
         // No row; the local cache never names a file either.
-        assert_eq!(resolve_boot_position(None, 5.0, 917, 5), 0.0);
+        assert_eq!(resolve_boot_position(None, 5.0, 917, 5), None);
     }
 
     #[test]
@@ -578,9 +587,9 @@ mod boot_resume_tests {
         // Server seconds win; the stored file id (even a stale one from a
         // replaced `book_files` row) doesn't gate a single-file book.
         let row = Some((Some(1), Some(120.0)));
-        assert!((resolve_boot_position(row, 5.0, 2, 1) - 120.0).abs() < f64::EPSILON);
+        assert!((resolve_boot_position(row, 5.0, 2, 1).unwrap() - 120.0).abs() < f64::EPSILON);
         // No server row → locally cached position, as before.
-        assert!((resolve_boot_position(None, 42.5, 2, 1) - 42.5).abs() < f64::EPSILON);
+        assert!((resolve_boot_position(None, 42.5, 2, 1).unwrap() - 42.5).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -588,7 +597,7 @@ mod boot_resume_tests {
         // `audio_file_count == 0` = a server predating the identity fields;
         // degrade to the historic resume behavior rather than zeroing.
         let row = Some((None, Some(300.0)));
-        assert!((resolve_boot_position(row, 5.0, 0, 0) - 300.0).abs() < f64::EPSILON);
+        assert!((resolve_boot_position(row, 5.0, 0, 0).unwrap() - 300.0).abs() < f64::EPSILON);
     }
 }
 

--- a/server/src/backend/audiobooks.rs
+++ b/server/src/backend/audiobooks.rs
@@ -125,7 +125,7 @@ pub(super) async fn get_audiobook_playlist(
 /// top-level `book_files.format` is one of `M4B` / `M4A` / `MP3`, so
 /// pure-AAC or pure-FLAC sources never reach direct mode today.
 pub(super) async fn get_audiobook_manifest(
-    _user: AuthUser,
+    user: AuthUser,
     State(state): State<AppState>,
     Path(uuid): Path<String>,
     Query(query): Query<ManifestQuery>,
@@ -152,6 +152,23 @@ pub(super) async fn get_audiobook_manifest(
     let audio_file_count = match hls::count_audio_files(&state.pool, resolved.book_id).await {
         Ok(count) => count,
         Err(e) => return internal("count_audio_files", e),
+    };
+
+    // The next file in ordinal order (sequence playback's auto-advance
+    // target). Absent on the last file — and suppressed entirely when the
+    // requesting user's link says the files are separate narrations, where
+    // "next" would replay the same book in another voice.
+    let next_file_id = match next_sequence_file_id(
+        &state.pool,
+        user.id,
+        &uuid,
+        resolved.book_id,
+        resolved.book_file_id,
+    )
+    .await
+    {
+        Ok(next) => next,
+        Err(e) => return internal("next_sequence_file_id", e),
     };
 
     let filenames: Vec<&str> = parts.iter().map(|p| p.filename.as_str()).collect();
@@ -181,6 +198,7 @@ pub(super) async fn get_audiobook_manifest(
             AudiobookManifest::Direct {
                 book_file_id: resolved.book_file_id,
                 audio_file_count,
+                next_file_id,
                 parts: manifest_parts,
                 total_duration_seconds,
                 chapters,
@@ -189,11 +207,41 @@ pub(super) async fn get_audiobook_manifest(
         PlaybackMode::Hls => AudiobookManifest::Hls {
             book_file_id: resolved.book_file_id,
             audio_file_count,
+            next_file_id,
             playlist_url: format!("/api/audiobooks/{uuid}/playlist.m3u8"),
         },
     };
 
     Json(manifest).into_response()
+}
+
+/// The next audio file in ordinal order after `book_file_id`, or `None`
+/// on the last file — and `None` when this user's cross-format link says
+/// the files are separate narrations (each file IS the whole book, so
+/// auto-advancing would replay it in another voice).
+async fn next_sequence_file_id(
+    pool: &sqlx::SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+    book_id: i64,
+    book_file_id: i64,
+) -> anyhow::Result<Option<i64>> {
+    if let Some(link) = omnibus_db::cross_format::get_link(pool, user_id, book_uuid).await? {
+        if link.mode == omnibus_shared::CrossFormatLinkMode::Narrations {
+            return Ok(None);
+        }
+    }
+    Ok(sqlx::query_scalar(
+        "SELECT id FROM book_files
+         WHERE book_id = ? AND format IN ('M4B', 'M4A', 'MP3')
+           AND ordinal > (SELECT ordinal FROM book_files WHERE id = ?)
+         ORDER BY ordinal LIMIT 1",
+    )
+    .bind(book_id)
+    .bind(book_file_id)
+    .fetch_optional(pool)
+    .await
+    .map(|row: Option<i64>| row)?)
 }
 
 /// Query parameters for `GET /api/audiobooks/{uuid}/parts/{ordinal}`.

--- a/shared/src/audiobook.rs
+++ b/shared/src/audiobook.rs
@@ -79,6 +79,12 @@ pub enum AudiobookManifest {
         book_file_id: i64,
         #[serde(default)]
         audio_file_count: i64,
+        /// The next `book_files` row in ordinal order, absent on the last
+        /// file (and for narrations-linked books, where each file is the
+        /// whole book): the player advances here when this file ends
+        /// instead of marking the book finished.
+        #[serde(default)]
+        next_file_id: Option<i64>,
         parts: Vec<ManifestPart>,
         total_duration_seconds: f64,
         #[serde(default)]
@@ -89,6 +95,12 @@ pub enum AudiobookManifest {
         book_file_id: i64,
         #[serde(default)]
         audio_file_count: i64,
+        /// The next `book_files` row in ordinal order, absent on the last
+        /// file (and for narrations-linked books, where each file is the
+        /// whole book): the player advances here when this file ends
+        /// instead of marking the book finished.
+        #[serde(default)]
+        next_file_id: Option<i64>,
         playlist_url: String,
     },
 }
@@ -108,6 +120,14 @@ impl AudiobookManifest {
                 audio_file_count,
                 ..
             } => (*book_file_id, *audio_file_count),
+        }
+    }
+
+    /// The next file in ordinal order, when one exists (see the field doc).
+    pub fn next_file_id(&self) -> Option<i64> {
+        match self {
+            AudiobookManifest::Direct { next_file_id, .. }
+            | AudiobookManifest::Hls { next_file_id, .. } => *next_file_id,
         }
     }
 }

--- a/shared/src/audiobook.rs
+++ b/shared/src/audiobook.rs
@@ -172,6 +172,7 @@ mod tests {
         let direct = AudiobookManifest::Direct {
             book_file_id: 919,
             audio_file_count: 5,
+            next_file_id: Some(922),
             parts: vec![],
             total_duration_seconds: 1.0,
             chapters: vec![],
@@ -179,10 +180,13 @@ mod tests {
         let hls = AudiobookManifest::Hls {
             book_file_id: 7,
             audio_file_count: 2,
+            next_file_id: None,
             playlist_url: "/x.m3u8".into(),
         };
         assert_eq!(direct.file_identity(), (919, 5));
         assert_eq!(hls.file_identity(), (7, 2));
+        assert_eq!(direct.next_file_id(), Some(922));
+        assert_eq!(hls.next_file_id(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Multi-file boots whose stored seconds live in another file stay UNSEEDED (`resolve_boot_position` returns `Option`, `initDirect` takes a JSON `null` and leaves the transport gate closed) — the refuse-to-splice arm can no longer bless a zero the heartbeat then persists over the real row.
- Unload guards: `pagehide` closes the seed gate for the dying document, and a `pause` reporting ~0 after a materially non-zero session is dropped as a media-teardown artifact (live repro: a full-page navigation flushed 10,089s → 0.0; a genuine restart still persists via the seek path, which updates `_lastAbs` first).
- Immersive Read re-runs the resume+follow resolution unless the same book is actively playing — the old same-uuid short-circuit trusted stale in-memory dock state.
- Precision: bare leading-ordinal ebook chapters ("1.\tSky God") now parse — For We Are Many pairs all 77 chapters against its " Chapter 001 - …" marks; sync-point declarations accumulate (replace slack 2% → 0.5%); past two or more anchors the map extends the measured narration rate instead of pinning linear to the endpoint.

Closes #1954

## Test plan
- [x] db: 47 cross-format tests (new: ordinal parsing, anchor accumulation, measured-slope extrapolation); frontend: 804 incl. reworked `resolve_boot_position` cases
- [x] clippy (`server`, `mobile`, `web`/wasm32) + fmt clean
- [x] `cross_format_prompts` + `reader` + `listen` E2E — 32/32 on a fresh dev DB
- [x] Validated live on omnibus-test as `omni-1954-rc1`/`rc2` (zero-wipe repro confirmed fixed by the reporter's own session)