### PR TITLE
[OMNI-1972] Gate Audio Persistence on User Action and Guard Same-Spot Follow-Jumps

### DIFF
--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -488,12 +488,18 @@
           var jumpCfi = pendingJumpCfi;
           pendingJumpCfi = null;
           pendingJumpPct = null;
-          restoreEchoPending = false;
-          displaySettled(jumpCfi);
+          // Same-position guard as displayCfi: a parked jump that resolves
+          // to the page already on screen is a restatement — skipping it
+          // keeps the restore's echo tag pending so nothing writes (#1972).
+          if (!jumpIsCurrent(jumpCfi)) {
+            restoreEchoPending = false;
+            displaySettled(jumpCfi);
+          }
         } else if (book === locBook && pendingJumpPct !== null && book && book.locations) {
           var pct = pendingJumpPct;
           pendingJumpPct = null;
-          restoreEchoPending = false;
+          // `applyPercentage` clears the echo tag only when its
+          // same-position guard passes (#1972).
           applyPercentage(pct);
         }
       })
@@ -2048,6 +2054,26 @@
     });
   }
 
+  // A jump target that is already on screen (at the visible range's start
+  // or inside it) is a restatement, not movement — applying it lands a
+  // non-echo relocate that stamps a fresh clock on an unmoved row and
+  // shadows the counterpart at the cross-format clock gate (#1972). The
+  // observed loop: the reader restores at the row's CFI, the follow-jump
+  // derives that same CFI from the stale counterpart, and the "jump"
+  // re-clocks a position nobody moved.
+  function jumpIsCurrent(cfi) {
+    try {
+      if (!rendition || !rendition.location || !rendition.location.start) return false;
+      var c = new ePub.CFI();
+      var s = rendition.location.start.cfi;
+      if (c.compare(cfi, s) === 0) return true;
+      var e = rendition.location.end ? rendition.location.end.cfi : null;
+      return !!e && c.compare(cfi, s) >= 0 && c.compare(cfi, e) < 0;
+    } catch (err) {
+      return false;
+    }
+  }
+
   function applyPercentage(pct) {
     var frac = Math.min(Math.max(Number(pct) / 100, 0), 1);
     var cfi = book.locations.cfiFromPercentage(frac);
@@ -2062,7 +2088,13 @@
         /* leave the range CFI; display may still handle it */
       }
     }
-    if (cfi) displaySettled(cfi);
+    if (!cfi) return;
+    // Same-position guard (#1972): leave the restore's echo tag pending
+    // when nothing would move; clear it only for a real jump, whose
+    // landing must persist.
+    if (jumpIsCurrent(cfi)) return;
+    restoreEchoPending = false;
+    displaySettled(cfi);
   }
 
   // Jump to a whole-book percentage (0..100) via the generated locations
@@ -2071,12 +2103,12 @@
   // mode auto-jump fires right after mount) is parked and applied by the
   // locations .then in init() rather than silently dropped.
   function displayPercentage(pct) {
-    // A percentage jump — user-accepted or follow-mode — is real movement:
-    // its landing (even one emitted by the restore-settle unmute) must
-    // persist, so it clears the pending echo tag.
-    restoreEchoPending = false;
+    // A percentage jump that actually moves the view is real movement and
+    // must persist — `applyPercentage` clears the pending echo tag once
+    // its same-position guard passes (#1972).
     pendingJumpCfi = null;
     if (!book || !book.locations || !book.locations.length()) {
+      restoreEchoPending = false;
       pendingJumpPct = pct;
       return;
     }
@@ -2089,13 +2121,18 @@
   // percentage jump.
   function displayCfi(cfi) {
     if (!cfi) return;
-    restoreEchoPending = false;
     pendingJumpPct = null;
     if (!rendition) {
+      restoreEchoPending = false;
       pendingJumpCfi = cfi;
       return;
     }
     pendingJumpCfi = null;
+    // Already on screen: skip the jump entirely, and leave the restore's
+    // echo tag pending — nothing user-visible moved, so nothing may write
+    // (#1972).
+    if (jumpIsCurrent(cfi)) return;
+    restoreEchoPending = false;
     displaySettled(cfi);
   }
 

--- a/frontend/src/pages/listen/bootstrap/js.rs
+++ b/frontend/src/pages/listen/bootstrap/js.rs
@@ -91,14 +91,15 @@ fn transport_controls_js() -> &'static str {
       // play/pause state across the swap.
       seek: function(absSeconds){
         this._seeded = true;
+        this._userActed = true;
         this._lastAbs = Math.max(0, absSeconds || 0);
         var s = Math.max(0, absSeconds || 0);
-        // Push the target time to the transport display immediately —
-        // don't wait for the element's own `timeupdate`, which some
-        // browsers fire unreliably (or not at all) for a seek issued while
-        // paused, leaving the readout and scrub position stuck at the old
-        // value until playback starts (#1897).
-        if (typeof window.__omnibusOnAudioTime === 'function') { window.__omnibusOnAudioTime(s); }
+        // A seek is discrete user intent: push it to the transport display
+        // AND persist it immediately through the dedicated seek callback —
+        // a paused element fires no `timeupdate` (#1897), and waiting for
+        // one loses the seek entirely if the page exits first (#1972).
+        if (typeof window.__omnibusOnAudioSeeked === 'function') { window.__omnibusOnAudioSeeked(s); }
+        else if (typeof window.__omnibusOnAudioTime === 'function') { window.__omnibusOnAudioTime(s, true); }
         if (this._mode === 'direct' && this._parts) {
           var i = 0;
           while (i < this._cumOffsets.length - 1 && s >= this._cumOffsets[i + 1]) i++;
@@ -213,8 +214,12 @@ fn listeners_js() -> &'static str {
       if (t < 1 && typeof oa._lastAbs === 'number' && oa._lastAbs > 60) return;
       // Last position this session really reached.
       oa._lastAbs = t;
+      // The second argument gates persistence on the Rust side: false
+      // until a real play or user seek this boot. The boot restore's own
+      // `currentTime` assignment fires a timeupdate, and persisting it
+      // re-clocked an unmoved row on every visit (#1972).
       if (window.__omnibusOnAudioTime) {
-        window.__omnibusOnAudioTime(t);
+        window.__omnibusOnAudioTime(t, !!oa._userActed);
       }
     });
     // A full-page navigation destroys the media element mid-session; the
@@ -230,6 +235,7 @@ fn listeners_js() -> &'static str {
       var oa = window.OmnibusAudio;
       if (!oa) return;
       oa._seeded = true;
+      oa._userActed = true;
       if (window.__omnibusOnAudioPlay) {
         window.__omnibusOnAudioPlay(absTime());
       }
@@ -243,8 +249,12 @@ fn listeners_js() -> &'static str {
       // _lastAbs through the ungated seek path before any pause fires.
       var t = absTime();
       if (t < 1 && typeof oa._lastAbs === 'number' && oa._lastAbs > 60) return;
+      // Second argument gates the pause-flush persist (Rust still flips
+      // the playing flag): a pause on an untouched boot — src swap,
+      // element teardown — must not re-state the seeded position with a
+      // fresh clock (#1972).
       if (window.__omnibusOnAudioPause) {
-        window.__omnibusOnAudioPause(t);
+        window.__omnibusOnAudioPause(t, !!oa._userActed);
       }
     });
     // Cross-part advance — direct mode only. HLS treats the whole
@@ -319,6 +329,9 @@ fn direct_play_init_js() -> &'static str {
       initDirect: function(parts, initialPositionAbs){
         this._mode = 'direct';
         this._seeded = false;
+        // Nothing human has happened on this boot yet — the restore seek
+        // below must render, never persist (#1972).
+        this._userActed = false;
         this._parts = parts;
         var acc = 0;
         this._cumOffsets = [];
@@ -370,13 +383,18 @@ fn hls_init_js() -> &'static str {
       initHls: function(url, initialPositionAbs){
         this._mode = 'hls';
         this._seeded = false;
+        // Same rule as initDirect: the restore is not a human action, so
+        // it renders without persisting (#1972).
+        this._userActed = false;
         if (typeof Hls !== 'undefined' && Hls.isSupported()) {
           var hls = new Hls();
           hls.loadSource(url);
           hls.attachMedia(el);
           hls.on(Hls.Events.ERROR, function(_, d) {
             if (d.fatal && window.__omnibusOnAudioPause) {
-              window.__omnibusOnAudioPause(el.currentTime || 0);
+              // Fatal transport error: surface it without persisting —
+              // an errored element's clock is not a listening position.
+              window.__omnibusOnAudioPause(el.currentTime || 0, false);
             }
           });
         } else if (el.canPlayType('application/vnd.apple.mpegurl')) {
@@ -496,15 +514,27 @@ mod tests {
             js.contains("clearInterval(window.__omnibusStallWatchdog)"),
             "watchdog does not clear a prior boot's stale interval"
         );
-        // A paused seek must push the transport display immediately (#1897)
-        // rather than waiting on the element's own `timeupdate`.
+        // A paused seek must push the transport display AND persist
+        // immediately (#1897, #1972) rather than waiting on the element's
+        // own `timeupdate`, which a paused element never fires.
         assert!(
-            js.contains("typeof window.__omnibusOnAudioTime === 'function'"),
-            "seek does not guard the immediate time push with a typeof check"
+            js.contains("typeof window.__omnibusOnAudioSeeked === 'function'"),
+            "seek does not guard the immediate persist push with a typeof check"
         );
         assert!(
-            js.contains("__omnibusOnAudioTime(s)"),
-            "seek does not push the target time immediately"
+            js.contains("__omnibusOnAudioSeeked(s)"),
+            "seek does not persist the target position immediately"
+        );
+        // The heartbeat and pause flush carry the user-acted persistence
+        // gate — a boot restore's own timeupdate/pause must render without
+        // re-clocking the row (#1972).
+        assert!(
+            js.contains("__omnibusOnAudioTime(t, !!oa._userActed)"),
+            "timeupdate does not pass the user-acted persistence gate"
+        );
+        assert!(
+            js.contains("__omnibusOnAudioPause(t, !!oa._userActed)"),
+            "pause flush does not pass the user-acted persistence gate"
         );
         // Sanity: no stray `{{` / `}}` escape pairs leaked from a `format!`.
         assert!(!js.contains("{{"), "literal {{ leaked into JS");

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -19,7 +19,10 @@ use js::{control_surface_js, eval_hls_init, inject_hls_script};
 /// Owns the `Closure`s wired into `window.__omnibusOn*` callbacks. Held
 /// across re-renders by `use_hook` so the closures outlive the effect
 /// closure that registers them.
-type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Closure<dyn FnMut(f64)>>>>;
+// Boxed as `Any`: the held closures now span two arities (`FnMut(f64)` and
+// the persist-gated `FnMut(f64, bool)`), and the holder only exists to keep
+// them alive for the surface's lifetime — nothing ever downcasts.
+type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Box<dyn std::any::Any>>>>;
 
 // The pure resume-decision helpers (`resolve_boot_file`,
 // `resolve_boot_position`) live in `super::helpers` — this module is
@@ -303,16 +306,45 @@ fn register_js_callbacks(
         return;
     };
     let uuid_for_save = uuid_cb.clone();
-    let mut last_saved = 0.0_f64;
-    let on_time = Closure::<dyn FnMut(f64)>::new(move |secs: f64| {
-        elapsed.set(secs);
-        if (secs - last_saved).abs() < 5.0 {
-            return;
-        }
-        last_saved = secs;
-        crate::audiobook_progress::save(&uuid_for_save, secs);
-        post_audio_progress(uuid_for_save.clone(), *loaded_file_id.peek(), secs);
-    });
+    // Shared between the heartbeat and the seek path so a seek resets the
+    // heartbeat's 5s window rather than double-writing moments later.
+    let last_saved = std::rc::Rc::new(std::cell::Cell::new(0.0_f64));
+    let on_time = {
+        let last_saved = last_saved.clone();
+        let uuid_for_save = uuid_for_save.clone();
+        // `user_acted` is the shim's `_userActed`: false until a real play
+        // or user seek this boot. The boot restore sets `currentTime`,
+        // which fires a `timeupdate` — persisting that write re-clocked an
+        // unmoved row on every visit and shadowed the counterpart at the
+        // cross-format clock gate (#1972). Render the time; persist only
+        // positions a human produced.
+        Closure::<dyn FnMut(f64, bool)>::new(move |secs: f64, user_acted: bool| {
+            elapsed.set(secs);
+            if !user_acted {
+                return;
+            }
+            if (secs - last_saved.get()).abs() < 5.0 {
+                return;
+            }
+            last_saved.set(secs);
+            crate::audiobook_progress::save(&uuid_for_save, secs);
+            post_audio_progress(uuid_for_save.clone(), *loaded_file_id.peek(), secs);
+        })
+    };
+    // A seek is discrete user intent — persist it immediately, bypassing
+    // the heartbeat throttle. A paused element fires no further events, so
+    // waiting on the next timeupdate loses the seek if the page exits
+    // first (#1972).
+    let on_seeked = {
+        let last_saved = last_saved.clone();
+        let uuid_for_seek = uuid_for_save.clone();
+        Closure::<dyn FnMut(f64)>::new(move |secs: f64| {
+            elapsed.set(secs);
+            last_saved.set(secs);
+            crate::audiobook_progress::save(&uuid_for_seek, secs);
+            post_audio_progress(uuid_for_seek.clone(), *loaded_file_id.peek(), secs);
+        })
+    };
     let on_duration = Closure::<dyn FnMut(f64)>::new(move |d: f64| {
         duration.set(d);
     });
@@ -361,8 +393,15 @@ fn register_js_callbacks(
         });
     });
     let uuid_for_pause = uuid_cb;
-    let on_pause = Closure::<dyn FnMut(f64)>::new(move |secs: f64| {
+    // The playing flag flips on every pause (src swaps and teardown fire
+    // them too), but only a session the user actually drove persists its
+    // position — a programmatic pause on an untouched boot re-states the
+    // seeded spot with a fresh clock (#1972).
+    let on_pause = Closure::<dyn FnMut(f64, bool)>::new(move |secs: f64, user_acted: bool| {
         playing.set(false);
+        if !user_acted {
+            return;
+        }
         crate::audiobook_progress::save(&uuid_for_pause, secs);
         post_audio_progress(uuid_for_pause.clone(), *loaded_file_id.peek(), secs);
     });
@@ -380,6 +419,11 @@ fn register_js_callbacks(
         &window,
         &JsValue::from_str("__omnibusOnAudioTime"),
         on_time.as_ref().unchecked_ref(),
+    );
+    let _ = js_sys::Reflect::set(
+        &window,
+        &JsValue::from_str("__omnibusOnAudioSeeked"),
+        on_seeked.as_ref().unchecked_ref(),
     );
     let _ = js_sys::Reflect::set(
         &window,
@@ -407,12 +451,13 @@ fn register_js_callbacks(
         on_init_timeout.as_ref().unchecked_ref(),
     );
     *cb_holder.borrow_mut() = vec![
-        on_time,
-        on_duration,
-        on_play,
-        on_pause,
-        on_ended,
-        on_init_timeout,
+        Box::new(on_time),
+        Box::new(on_seeked),
+        Box::new(on_duration),
+        Box::new(on_play),
+        Box::new(on_pause),
+        Box::new(on_ended),
+        Box::new(on_init_timeout),
     ];
 }
 
@@ -460,9 +505,11 @@ fn register_readiness_callbacks(
         &JsValue::from_str("__omnibusOnAudioStalled"),
         on_stalled.as_ref().unchecked_ref(),
     );
-    cb_holder
-        .borrow_mut()
-        .extend([on_booted, on_buffering, on_stalled]);
+    cb_holder.borrow_mut().extend([
+        Box::new(on_booted) as Box<dyn std::any::Any>,
+        Box::new(on_buffering),
+        Box::new(on_stalled),
+    ]);
 }
 
 /// Install the `window.OmnibusAudio` control surface immediately so
@@ -566,13 +613,12 @@ async fn run_manifest_init(
     // Resolve follow at boot: when the link follows the counterpart and the
     // reading position maps newer, seed playback with the mapped spot
     // instead of the stored row — a post-boot corrective seek would race
-    // `initDirect`'s one-shot restore seek and lose. Skipped entirely for an
-    // explicit picker `?file_id=` (see `resolve_follow_boot`).
-    let follow_resume = if file_id.is_none() {
-        super::sync_prompt::fetch_resume_with(&uuid_for_fetch, "audio", false).await
-    } else {
-        None
-    };
+    // `initDirect`'s one-shot restore seek and lose. Fetched even for an
+    // explicit `?file_id=` — every Continue card carries the row's file id,
+    // and skipping follow there reopened books at the stale spot (#1972);
+    // `resolve_follow_boot` still stands aside when the pick names a
+    // *different* file than the candidate maps to.
+    let follow_resume = super::sync_prompt::fetch_resume_with(&uuid_for_fetch, "audio", false).await;
     if !is_current() {
         return;
     }

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -618,7 +618,8 @@ async fn run_manifest_init(
     // and skipping follow there reopened books at the stale spot (#1972);
     // `resolve_follow_boot` still stands aside when the pick names a
     // *different* file than the candidate maps to.
-    let follow_resume = super::sync_prompt::fetch_resume_with(&uuid_for_fetch, "audio", false).await;
+    let follow_resume =
+        super::sync_prompt::fetch_resume_with(&uuid_for_fetch, "audio", false).await;
     if !is_current() {
         return;
     }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -164,17 +164,18 @@ pub(super) fn resolve_boot_position(
 /// Follow-at-boot override: with follow on and a mapped Candidate, the
 /// boot seeds the mapped `(file, seconds)` instead of the stored row — a
 /// post-boot corrective seek would race `initDirect`'s one-shot restore
-/// seek and lose. An explicit picker `?file_id=` outranks follow: that is
-/// a deliberate navigation to a specific file, not a resume.
+/// seek and lose. An explicit picker `?file_id=` outranks follow only
+/// when it names a *different* file than the candidate maps to: picking
+/// the file the mapping already lands in (which every Continue card does
+/// — it always carries the row's file id) is a resume, not a divergent
+/// navigation, and skipping follow there reopened books at the stale spot
+/// (issue #1972).
 #[cfg(not(feature = "mobile"))]
 #[cfg_attr(not(feature = "web"), allow(dead_code))]
 pub(super) fn resolve_follow_boot(
     explicit_file: Option<i64>,
     resume: Option<&omnibus_shared::cross_format::CrossFormatResume>,
 ) -> Option<(Option<i64>, f64)> {
-    if explicit_file.is_some() {
-        return None;
-    }
     let resume = resume?;
     if !resume.follow
         || resume.state != omnibus_shared::cross_format::CrossFormatResumeState::Candidate
@@ -182,6 +183,15 @@ pub(super) fn resolve_follow_boot(
         return None;
     }
     let c = resume.candidate.as_ref()?;
+    if let (Some(picked), Some(mapped)) = (explicit_file, c.book_file_id) {
+        if picked != mapped {
+            return None;
+        }
+    } else if explicit_file.is_some() {
+        // Candidate names no file (shouldn't happen for an audio target,
+        // but a malformed payload must not hijack an explicit pick).
+        return None;
+    }
     Some((c.book_file_id, c.audio_position_seconds?))
 }
 
@@ -525,8 +535,23 @@ mod boot_resume_tests {
     #[cfg(not(feature = "mobile"))]
     #[test]
     fn resolve_follow_boot_stands_aside_for_an_explicit_picker_file() {
+        // 919 names a different file than the candidate maps to (917) — a
+        // deliberate divergent navigation, so follow yields.
         let resume = follow_resume(true, CrossFormatResumeState::Candidate);
         assert_eq!(resolve_follow_boot(Some(919), Some(&resume)), None);
+    }
+
+    #[cfg(not(feature = "mobile"))]
+    #[test]
+    fn resolve_follow_boot_engages_when_the_explicit_file_matches_the_candidate() {
+        // Every Continue card carries the row's file id, which is the same
+        // file the mapping lands in — that is a resume, not a divergent
+        // pick, and follow must still seed the mapped position (#1972).
+        let resume = follow_resume(true, CrossFormatResumeState::Candidate);
+        assert_eq!(
+            resolve_follow_boot(Some(917), Some(&resume)),
+            Some((Some(917), 21_822.0))
+        );
     }
 
     #[cfg(not(feature = "mobile"))]

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -411,12 +411,16 @@ test("persists listening progress when the audio element pauses", async ({
     async () => {
       await page.evaluate((secs) => {
         const cb = (
-          window as unknown as { __omnibusOnAudioPause?: (s: number) => void }
+          window as unknown as {
+            __omnibusOnAudioPause?: (s: number, userActed: boolean) => void;
+          }
         ).__omnibusOnAudioPause;
         if (typeof cb !== "function") {
           throw new Error("__omnibusOnAudioPause not installed");
         }
-        cb(secs);
+        // `true` mirrors the shim's user-acted gate: only a session the
+        // user actually drove persists its pause position (#1972).
+        cb(secs, true);
       }, PAUSE_AT_SEC);
     },
   );
@@ -466,12 +470,16 @@ test("surfaces a 5xx progress POST without crashing the player", async ({
     async () => {
       await page.evaluate((secs) => {
         const cb = (
-          window as unknown as { __omnibusOnAudioPause?: (s: number) => void }
+          window as unknown as {
+            __omnibusOnAudioPause?: (s: number, userActed: boolean) => void;
+          }
         ).__omnibusOnAudioPause;
         if (typeof cb !== "function") {
           throw new Error("__omnibusOnAudioPause not installed");
         }
-        cb(secs);
+        // `true` mirrors the shim's user-acted gate: only a session the
+        // user actually drove persists its pause position (#1972).
+        cb(secs, true);
       }, PAUSE_AT_SEC);
     },
   );


### PR DESCRIPTION
## Summary
- Audio persistence now requires a real user action this boot: the restore's own timeupdate/pause can render the position but never re-clock the row, killing the stale-follow feedback loop QA hit on For We Are Many.
- User seeks persist immediately through a dedicated callback instead of waiting for a timeupdate a paused element never fires.
- The reader skips a follow-jump that is already on screen (restore echo stays pending), and `resolve_follow_boot` now engages for an explicit `?file_id=` naming the same file the candidate maps to (every Continue card).

Closes #1972

## Test plan
- [x] `just check` full matrix green; 45/45 targeted E2E (cross-format, reader, immersive, listen) on a fresh DB.
- [x] Two listen specs updated to drive the pause callback with the new user-acted gate.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.