### PR TITLE
[OMNI-1973] Dual Progress Bars on Book Detail and Two-Up Synced Continue Hero

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -7093,6 +7093,11 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   box-shadow: 0 8px 18px color-mix(in oklch, black 35%, transparent);
   overflow: hidden;
 }
+/* Two cards per page at wide widths (track gap is 16px, so each card
+   cedes half of it). The snap/dot logic stays per-card. */
+@media (min-width: 1100px) {
+  .ch-card { flex: 0 0 calc(50% - 8px); }
+}
 .ch-cover {
   flex: 0 0 96px;
   width: 96px;
@@ -7170,13 +7175,16 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   align-items: center;
   gap: 5px;
   padding: 7px 13px;
+  border: 0;
   border-radius: 999px;
   background: var(--accent);
   color: var(--accent-ink);
+  font-family: inherit;
   font-size: 12px;
   font-weight: 600;
   text-decoration: none;
   transition: filter 0.15s;
+  cursor: pointer;
 }
 .ch-cta svg { display: block; flex-shrink: 0; }
 @media (hover: hover) { .ch-cta:hover { filter: brightness(1.08); } }
@@ -9333,9 +9341,18 @@ html {
   border-top: 1px solid var(--line, rgba(127, 127, 127, 0.25));
 }
 .al-foot-spacer { flex: 1; }
-/* Contained per the Format Sync design: the entry is a compact card in
-   the progress cluster, never a full-bleed strip. */
-.bd-sync-panel { margin: 14px 0 0; max-width: 560px; }
+/* Contained per the Format Sync design: the whole "Your progress" block
+   (bars + entry row) is a compact cluster in the hero's title column,
+   below the CTA row — never a full-bleed strip. */
+.bd-sync-panel { margin: 26px 0 0; max-width: 560px; }
+.bd-prog-head { margin-bottom: 10px; }
+.bd-prog-rows { display: flex; flex-direction: column; gap: 10px; }
+.bd-prog-row { display: flex; align-items: center; gap: 12px; }
+.bd-prog-row .pbar { flex: 1; }
+.bd-prog-glyph { color: var(--ink-2); display: inline-flex; }
+.bd-prog-cap { font-size: 10.5px; color: var(--ink-2); white-space: nowrap; }
+.bd-prog-foot { font-size: 10px; color: var(--ink-3); margin-top: 6px; padding-left: 25px; }
+.bd-sync-panel .al-entry { margin-top: 14px; }
 .al-entry {
   display: flex;
   align-items: center;
@@ -9397,7 +9414,14 @@ html {
   font-size: 12.5px;
 }
 .rd-sync-copy { flex: 1; }
-.ch-cta-alt { opacity: 0.85; }
+/* Secondary CTA pill (counterpart-format link + the Immersive button),
+   per the Format Sync design's chCtaSecondary treatment. Scoped like
+   `.ch-hero .ch-cta` so it outranks the base pill's fill. */
+.ch-hero .ch-cta-alt {
+  background: color-mix(in oklch, var(--accent) 16%, var(--bg-1));
+  border: 1px solid color-mix(in oklch, var(--accent) 45%, transparent);
+  color: var(--ink-0);
+}
 
 /* ── Cross-format sync: design-fidelity additions (Format Sync design) ── */
 .al-modal { width: min(880px, calc(100vw - 48px)); }
@@ -9508,7 +9532,15 @@ html {
   color: var(--accent, #6a8bd7);
 }
 .lp-sync-kicker-spacer { flex: 1; }
-.ch-eyebrow-glyph { display: inline-flex; margin-left: 6px; vertical-align: -2px; color: var(--accent, #6a8bd7); opacity: 0.9; }
+/* Linked-card sync mark, pinned to the card's top-right corner. */
+.ch-sync-corner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: inline-flex;
+  color: var(--accent, #6a8bd7);
+  opacity: 0.9;
+}
 .ch-link-invite {
   display: flex;
   align-items: center;

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -49,7 +49,7 @@ pub(crate) fn recency(clock_epoch_secs: i64) -> String {
 /// Piecewise-linear map of a text fraction through the served anchor pairs
 /// (implicit `(0,0)`/`(1,1)` endpoints) — the same interpolation the jump
 /// runs server-side, so the preview cannot disagree with it.
-fn interpolate_pairs(pairs: &[(f64, f64)], frac: f64) -> f64 {
+pub(crate) fn interpolate_pairs(pairs: &[(f64, f64)], frac: f64) -> f64 {
     let frac = frac.clamp(0.0, 1.0);
     let mut prev = (0.0f64, 0.0f64);
     for (t, a) in pairs.iter().copied().chain(std::iter::once((1.0, 1.0))) {
@@ -114,7 +114,7 @@ fn ordered<'v>(view: &'v AlignmentView, order: &[i64]) -> Vec<&'v AlignmentAudio
 
 /// Whole-timeline fraction of the current listening position, given the
 /// working order; `None` when the position's file isn't on the timeline.
-fn listening_frac(view: &AlignmentView, files: &[&AlignmentAudioFile]) -> Option<f64> {
+pub(crate) fn listening_frac(view: &AlignmentView, files: &[&AlignmentAudioFile]) -> Option<f64> {
     let pos = view.listening.as_ref()?;
     let total: f64 = files.iter().map(|f| f.duration_seconds).sum();
     if total <= 0.0 {

--- a/frontend/src/components/glyphs.rs
+++ b/frontend/src/components/glyphs.rs
@@ -28,6 +28,23 @@ pub fn book_glyph(size: u32) -> Element {
     }
 }
 
+/// Headphones outline for the audiobook progress row on the book detail
+/// "Your progress" block.
+pub fn headphones_glyph(size: u32) -> Element {
+    rsx! {
+        svg {
+            width: "{size}", height: "{size}", view_box: "0 0 16 16", fill: "none",
+            stroke: "currentColor", stroke_width: "1.35", stroke_linecap: "round", stroke_linejoin: "round",
+            "aria-hidden": "true",
+            path { d: "M3 10V8.5a5 5 0 0 1 10 0V10" }
+            path {
+                d: "M2.75 10h2.5v3.75h-1.5a1 1 0 0 1-1-1zM13.25 10h-2.5v3.75h1.5a1 1 0 0 0 1-1z",
+                fill: "currentColor",
+            }
+        }
+    }
+}
+
 /// Magnifying-glass search icon, reused by the search palette's trigger
 /// button and query input, and the book-detail merge dialog's search box.
 /// `class` carries the caller's own sizing/positioning hook; `aria_hidden`

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -133,8 +133,9 @@ pub mod search_palette;
 #[cfg(not(feature = "mobile"))]
 pub mod worker_status;
 
-// Play / open-book marks shared by the two web "continue reading" surfaces:
-// the user-menu resume row and the landing hero CTA.
+// Play / open-book / headphones marks shared by the two web "continue
+// reading" surfaces (user-menu resume row, landing hero CTA) and the
+// book-detail "Your progress" rows.
 #[cfg(not(feature = "mobile"))]
 pub mod glyphs;
 

--- a/frontend/src/contexts/mod.rs
+++ b/frontend/src/contexts/mod.rs
@@ -325,6 +325,13 @@ pub struct PlaybackState {
     /// on a book swap — the sleep-timer fade in `pages::listen::sleep`
     /// restores to this value rather than always `1.0`.
     pub volume: Signal<f64>,
+    /// Bumped to force the app-level driver to re-run its boot (resume +
+    /// follow resolution) for the *current* book without tearing it down.
+    /// The Immersive Read CTA uses this for the same-book idle case: the
+    /// old `uuid` None→Some nudge unmounted the dock for a frame and raced
+    /// the reader's own mount — losing the race left the player closed or
+    /// the reader stuck loading (#1972 follow-up).
+    pub reload_epoch: Signal<u32>,
 }
 
 #[cfg(not(feature = "mobile"))]
@@ -348,6 +355,7 @@ impl PlaybackState {
             buffering: Signal::new(false),
             playback_failed: Signal::new(false),
             volume: Signal::new(1.0),
+            reload_epoch: Signal::new(0),
         }
     }
 }

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -73,6 +73,9 @@ pub(super) fn BdHeroSection(
     chrome: BdHeroChrome,
     avail: Availability,
     phys: PhysSignals,
+    /// The "Your progress" block (sync panel), rendered in the title column
+    /// below the CTA row — empty for single-format books.
+    sync_panel: Element,
 ) -> Element {
     let BdHeroChrome { kicker, crumbs } = chrome;
     let uuid = b.unique_identifier.clone().unwrap_or_default();
@@ -117,6 +120,7 @@ pub(super) fn BdHeroSection(
                     kicker: kicker.clone(),
                     uuid: uuid.clone(),
                     avail,
+                    sync_panel,
                 }
                 aside { class: "card bd-rating-card",
                     div { class: "label", "Your rating" }
@@ -153,6 +157,7 @@ fn BdTitleCol(
     kicker: String,
     uuid: String,
     avail: Availability,
+    sync_panel: Element,
 ) -> Element {
     let Availability {
         has_ebook,
@@ -240,6 +245,7 @@ fn BdTitleCol(
                     book_files: b.book_files.clone(),
                 },
             }
+            {sync_panel}
         }
     }
 }

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -60,26 +60,23 @@ pub(crate) fn retarget_and_open_immersive(uuid: String) {
     let same_book = uuid_sig.peek().as_deref() == Some(uuid.as_str());
     let live = same_book && *playback.playing.peek();
     if !live {
-        let mut book_sig = playback.book;
         let mut error_sig = playback.error;
         let mut loading_sig = playback.loading;
-        book_sig.set(None);
         error_sig.set(None);
         loading_sig.set(true);
         if same_book {
-            // Same uuid: the driver keys on the value CHANGING, and a
-            // None→Some pair inside one handler collapses to
-            // no-change — which left the dock cleared but never
-            // rebooted (the "Immersive Read doesn't open the player"
-            // regression). Commit the None now; the Some lands from a
-            // spawned task after this render.
-            uuid_sig.set(None);
-            let uuid_next = uuid.clone();
-            let mut uuid_sig_next = uuid_sig;
-            spawn(async move {
-                uuid_sig_next.set(Some(uuid_next));
-            });
+            // Same uuid, idle: force the driver to re-run its boot (resume
+            // + follow resolution against the stored rows, #1954) WITHOUT
+            // tearing the dock down. The old uuid None→Some nudge unmounted
+            // the dock for a frame and raced the reader's own mount — when
+            // the respawned Some lost that race the player stayed closed,
+            // or the reader wedged mid-load (#1972 QA).
+            let mut epoch = playback.reload_epoch;
+            let next = epoch.peek().wrapping_add(1);
+            epoch.set(next);
         } else {
+            let mut book_sig = playback.book;
+            book_sig.set(None);
             uuid_sig.set(Some(uuid.clone()));
         }
     }

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -1,8 +1,8 @@
 //! The Immersive Read CTA — the dual-format-only action that opens the EPUB
 //! reader with the audiobook docked. Compiled on every target (unlike the
-//! web-only [`super::hero`]): the web hero row and the mobile CTA column both
-//! render it, with a per-target click handler retargeting that platform's
-//! playback context before navigating to `/read`.
+//! web-only [`super::hero`]): the web hero row, the mobile CTA column, and
+//! the landing Continue hero's linked-card pill all trigger it, through one
+//! shared retarget-and-navigate handler with a per-target body.
 
 use dioxus::prelude::*;
 
@@ -29,101 +29,93 @@ fn bd_immersive_mark() -> Element {
     }
 }
 
-/// Immersive Read CTA (web): opens the reader and docks the audiobook player
-/// together. Clicking retargets the app-wide [`crate::PlaybackState`] at this
-/// book — the App-level audio bootstrap then loads its manifest and the `/read`
-/// route's [`crate::pages::MiniDock`] surfaces (paused, at the resume position)
-/// once book + uuid resolve — then navigates to the reader. Playback itself
-/// starts on the first transport action, not on load. The playback context and
-/// navigator are read inside the handler (not as render-time hooks) so the
-/// button renders under SSR and in unit tests without a provider, keeping
-/// hydration parity (rule 07).
+/// Retarget the app-wide playback context at `uuid` and open the reader —
+/// the Immersive Read action (web). The App-level audio bootstrap loads the
+/// book's manifest and the `/read` route's [`crate::pages::MiniDock`]
+/// surfaces (paused, at the resume position) once book + uuid resolve.
+/// Playback itself starts on the first transport action, not on load. The
+/// playback context and navigator are read here at click time (not as
+/// render-time hooks) so callers render under SSR and in unit tests without
+/// a provider, keeping hydration parity (rule 07).
 #[cfg(not(feature = "mobile"))]
-#[component]
-pub(super) fn BdImmersiveButton(uuid: String) -> Element {
-    let on_click = move |_: MouseEvent| {
-        let playback = consume_context::<crate::PlaybackState>();
-        // Retarget only when the book differs, mirroring the listen page: clear
-        // the previous book's metadata/error and flag loading first so the dock
-        // can't flash the old book under the new reader before the driver reloads.
-        let mut uuid_sig = playback.uuid;
-        let mut file_sig = playback.file_id;
-        // Default file selection, published before the uuid so the driver
-        // reads it when the load kicks off (mirrors the mobile variant and
-        // `use_retarget_playback`). Without this a stale picker selection
-        // from a previously-played book would override the bootstrap's
-        // progress-row file resolution — or 404 the new book's manifest.
-        file_sig.set(None);
-        // Re-resolve unless the SAME book is actively playing: the old
-        // same-uuid short-circuit kept whatever in-memory state the dock
-        // held, which on an idle target can be stale against the stored
-        // rows (issue #1954). A live playback is the one state that must
-        // not be interrupted — everything else re-runs the boot's resume
-        // + follow resolution.
-        let same_book = uuid_sig.peek().as_deref() == Some(uuid.as_str());
-        let live = same_book && *playback.playing.peek();
-        if !live {
-            let mut book_sig = playback.book;
-            let mut error_sig = playback.error;
-            let mut loading_sig = playback.loading;
-            book_sig.set(None);
-            error_sig.set(None);
-            loading_sig.set(true);
-            if same_book {
-                // Same uuid: the driver keys on the value CHANGING, and a
-                // None→Some pair inside one handler collapses to
-                // no-change — which left the dock cleared but never
-                // rebooted (the "Immersive Read doesn't open the player"
-                // regression). Commit the None now; the Some lands from a
-                // spawned task after this render.
-                uuid_sig.set(None);
-                let uuid_next = uuid.clone();
-                let mut uuid_sig_next = uuid_sig;
-                spawn(async move {
-                    uuid_sig_next.set(Some(uuid_next));
-                });
-            } else {
-                uuid_sig.set(Some(uuid.clone()));
-            }
-        }
-        dioxus_router::navigator().push(Route::BookRead { uuid: uuid.clone() });
-    };
-    rsx! {
-        button {
-            class: "btn lg bd-immersive-cta",
-            r#type: "button",
-            "data-testid": "immersive-read",
-            title: "Open the ereader and audiobook together, kept in sync",
-            onclick: on_click,
-            {bd_immersive_mark()}
-            "Immersive Read"
-        }
-    }
-}
-
-/// Immersive Read CTA (mobile): opens the reader with the audiobook docked.
-/// Clicking retargets the app-wide [`crate::pages::MobilePlayback`] at this
-/// book — the app-root `MobileAudioHost` then loads its manifest and installs
-/// the audio surface, and the `/read` route's docked
-/// [`crate::pages::MobileMiniPlayer`] surfaces once the view resolves — then
-/// navigates to the reader. Same handler-time context reads as the web
-/// variant so the button renders in unit tests without a provider.
-#[cfg(feature = "mobile")]
-#[component]
-pub(super) fn BdImmersiveButton(uuid: String) -> Element {
-    let on_click = move |_: MouseEvent| {
-        let ctx = consume_context::<crate::pages::MobilePlayback>();
-        let mut file_sig = ctx.file_id;
-        let mut uuid_sig = ctx.uuid;
-        // Default file selection (the host picks the first audio file), and
-        // publish it before the uuid so the load reads the right file —
-        // mirroring `MobilePlayer`'s retarget effect. Retarget only when the
-        // book differs so re-entering the playing book is seamless.
-        file_sig.set(None);
-        if uuid_sig.peek().as_deref() != Some(uuid.as_str()) {
+pub(crate) fn retarget_and_open_immersive(uuid: String) {
+    let playback = consume_context::<crate::PlaybackState>();
+    // Retarget only when the book differs, mirroring the listen page: clear
+    // the previous book's metadata/error and flag loading first so the dock
+    // can't flash the old book under the new reader before the driver reloads.
+    let mut uuid_sig = playback.uuid;
+    let mut file_sig = playback.file_id;
+    // Default file selection, published before the uuid so the driver
+    // reads it when the load kicks off (mirrors the mobile variant and
+    // `use_retarget_playback`). Without this a stale picker selection
+    // from a previously-played book would override the bootstrap's
+    // progress-row file resolution — or 404 the new book's manifest.
+    file_sig.set(None);
+    // Re-resolve unless the SAME book is actively playing: the old
+    // same-uuid short-circuit kept whatever in-memory state the dock
+    // held, which on an idle target can be stale against the stored
+    // rows (issue #1954). A live playback is the one state that must
+    // not be interrupted — everything else re-runs the boot's resume
+    // + follow resolution.
+    let same_book = uuid_sig.peek().as_deref() == Some(uuid.as_str());
+    let live = same_book && *playback.playing.peek();
+    if !live {
+        let mut book_sig = playback.book;
+        let mut error_sig = playback.error;
+        let mut loading_sig = playback.loading;
+        book_sig.set(None);
+        error_sig.set(None);
+        loading_sig.set(true);
+        if same_book {
+            // Same uuid: the driver keys on the value CHANGING, and a
+            // None→Some pair inside one handler collapses to
+            // no-change — which left the dock cleared but never
+            // rebooted (the "Immersive Read doesn't open the player"
+            // regression). Commit the None now; the Some lands from a
+            // spawned task after this render.
+            uuid_sig.set(None);
+            let uuid_next = uuid.clone();
+            let mut uuid_sig_next = uuid_sig;
+            spawn(async move {
+                uuid_sig_next.set(Some(uuid_next));
+            });
+        } else {
             uuid_sig.set(Some(uuid.clone()));
         }
-        dioxus_router::navigator().push(Route::BookRead { uuid: uuid.clone() });
+    }
+    dioxus_router::navigator().push(Route::BookRead { uuid });
+}
+
+/// Retarget the app-wide playback context at `uuid` and open the reader —
+/// the Immersive Read action (mobile). Retargets
+/// [`crate::pages::MobilePlayback`]: the app-root `MobileAudioHost` loads
+/// the book's manifest and installs the audio surface, and the `/read`
+/// route's docked [`crate::pages::MobileMiniPlayer`] surfaces once the view
+/// resolves. Same click-time context reads as the web variant.
+#[cfg(feature = "mobile")]
+pub(crate) fn retarget_and_open_immersive(uuid: String) {
+    let ctx = consume_context::<crate::pages::MobilePlayback>();
+    let mut file_sig = ctx.file_id;
+    let mut uuid_sig = ctx.uuid;
+    // Default file selection (the host picks the first audio file), and
+    // publish it before the uuid so the load reads the right file —
+    // mirroring `MobilePlayer`'s retarget effect. Retarget only when the
+    // book differs so re-entering the playing book is seamless.
+    file_sig.set(None);
+    if uuid_sig.peek().as_deref() != Some(uuid.as_str()) {
+        uuid_sig.set(Some(uuid.clone()));
+    }
+    dioxus_router::navigator().push(Route::BookRead { uuid });
+}
+
+/// Immersive Read CTA: opens the reader and docks the audiobook player
+/// together, via [`retarget_and_open_immersive`]. Renders identically on
+/// every target; only the handler internals differ per platform.
+#[component]
+pub(super) fn BdImmersiveButton(uuid: String) -> Element {
+    let on_click = {
+        let uuid = uuid.clone();
+        move |_: MouseEvent| retarget_and_open_immersive(uuid.clone())
     };
     rsx! {
         button {

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -22,6 +22,7 @@ mod journal_editor;
 mod merge;
 mod rating;
 mod read_status;
+#[cfg(not(feature = "mobile"))]
 mod sync_link;
 mod view;
 
@@ -43,6 +44,11 @@ mod offline;
 #[cfg(not(feature = "mobile"))]
 mod physical;
 
+// The landing Continue hero's Immersive pill shares the book-detail CTA's
+// retarget-and-navigate handler; the hero is web-only, so the re-export is
+// gated with it (the mobile CTA calls the fn inside `immersive` directly).
+#[cfg(not(feature = "mobile"))]
+pub(crate) use immersive::retarget_and_open_immersive;
 use view::{render_loaded, LoadedCtx, RailButtons};
 // Only `mobile.rs` (compiled solely under this feature) re-derives the loaded
 // view itself; the web branch calls `derive_loaded_view` directly inside

--- a/frontend/src/pages/book_detail/sync_link.rs
+++ b/frontend/src/pages/book_detail/sync_link.rs
@@ -1,15 +1,164 @@
-//! Cross-format sync entry panel on the book detail page (web): the
-//! unlinked nudge, the linked chip, and the stale re-confirm warning —
-//! each opening the alignment modal. SSR and the first WASM paint render
-//! the same neutral shell; a post-mount effect fills the state (rule 07).
+//! "Your progress" block + cross-format sync entry panel on the book
+//! detail page (web): per-format progress bars (or the single newest-format
+//! bar once linked), then the unlinked nudge / linked chip / stale
+//! re-confirm warning — each opening the alignment modal. SSR and the
+//! first WASM paint render the same neutral shell; a post-mount effect
+//! fills the state (rule 07).
 
 use dioxus::prelude::*;
-use omnibus_shared::AlignmentLink;
+use omnibus_shared::{AlignmentAudioFile, AlignmentView};
 
-use crate::components::alignment_modal::AlignmentModal;
+use crate::components::alignment_modal::{
+    fmt_hm, interpolate_pairs, listening_frac, recency, AlignmentModal,
+};
+use crate::components::glyphs::{book_glyph, headphones_glyph};
 use crate::data;
 
-/// The sync entry row + its modal. Mounted only for dual-format books.
+/// Whole-timeline listening fraction plus total seconds, in served file
+/// order; `None` when the position is absent or unplaceable.
+fn audio_frac_and_total(view: &AlignmentView) -> Option<(f64, f64)> {
+    let files: Vec<&AlignmentAudioFile> = view.audio_files.iter().collect();
+    let total: f64 = files.iter().map(|f| f.duration_seconds).sum();
+    let frac = listening_frac(view, &files)?;
+    Some((frac, total))
+}
+
+/// Ebook progress row: bar at the saved percent. Skipped when there is no
+/// reading position (or its percent derivation hasn't landed yet — a bar
+/// can't be drawn honestly without one).
+fn ebook_row(view: &AlignmentView) -> Option<Element> {
+    let reading = view.reading.as_ref()?;
+    let pct = reading.percent?;
+    let when = recency(reading.client_updated_at);
+    Some(rsx! {
+        div { class: "bd-prog-row", "data-testid": "bd-progress-ebook",
+            span { class: "bd-prog-glyph", {book_glyph(13)} }
+            span { class: "pbar", i { style: "width:{pct}%" } }
+            span { class: "mono bd-prog-cap", "{pct}% \u{b7} {when}" }
+        }
+    })
+}
+
+/// Audiobook progress row: bar at the whole-timeline fraction. Skipped
+/// when the position is absent or unplaceable on the timeline.
+fn audio_row(view: &AlignmentView) -> Option<Element> {
+    let listening = view.listening.as_ref()?;
+    let (frac, total) = audio_frac_and_total(view)?;
+    let pct = (frac * 100.0).round();
+    let at = fmt_hm(frac * total);
+    let of = fmt_hm(total);
+    let when = recency(listening.client_updated_at);
+    Some(rsx! {
+        div { class: "bd-prog-row", "data-testid": "bd-progress-audio",
+            span { class: "bd-prog-glyph", {headphones_glyph(13)} }
+            span { class: "pbar", i { style: "width:{pct}%" } }
+            span { class: "mono bd-prog-cap", "{at} of {of} \u{b7} {when}" }
+        }
+    })
+}
+
+/// Linked (non-stale) single row for the newest format, with the mapped
+/// counterpart footnote. The stricter-clock side wins; a missing side
+/// loses; an unplaceable newest side falls back to the other. `None` when
+/// neither side can render a row.
+fn newest_row(view: &AlignmentView) -> Option<Element> {
+    let read_clock = view.reading.as_ref().map(|r| r.client_updated_at);
+    let listen_clock = view.listening.as_ref().map(|l| l.client_updated_at);
+    let audio_newest = match (read_clock, listen_clock) {
+        (Some(r), Some(l)) => l > r,
+        (None, Some(_)) => true,
+        (Some(_), None) => false,
+        (None, None) => return None,
+    };
+    if audio_newest {
+        newest_audio_row(view).or_else(|| newest_ebook_row(view))
+    } else {
+        newest_ebook_row(view).or_else(|| newest_audio_row(view))
+    }
+}
+
+/// Newest-format row when the audiobook holds the freshest position.
+fn newest_audio_row(view: &AlignmentView) -> Option<Element> {
+    let listening = view.listening.as_ref()?;
+    let (frac, total) = audio_frac_and_total(view)?;
+    let pct = (frac * 100.0).round();
+    let at = fmt_hm(frac * total);
+    let when = recency(listening.client_updated_at);
+    // Map audio→text through the same anchor pairs the jump uses; the
+    // pairs are stored (text, audio), so swap them for this direction.
+    let swapped: Vec<(f64, f64)> = view.anchor_pairs.iter().map(|&(t, a)| (a, t)).collect();
+    let mapped_pct = (interpolate_pairs(&swapped, frac) * 100.0).round() as i64;
+    Some(rsx! {
+        div { class: "bd-prog-row", "data-testid": "bd-progress-newest",
+            span { class: "bd-prog-glyph", {headphones_glyph(13)} }
+            span { class: "pbar", i { style: "width:{pct}%" } }
+            span { class: "mono bd-prog-cap",
+                "newest: audiobook \u{b7} {at} \u{b7} {when}"
+            }
+        }
+        div { class: "mono bd-prog-foot",
+            "one spot, both formats \u{2014} the reader opens at the matching page (\u{2248} {mapped_pct}%)"
+        }
+    })
+}
+
+/// Newest-format row when the ebook holds the freshest position. The
+/// mapped-time parenthetical is omitted when the audio timeline is empty
+/// rather than showing a wrong number.
+fn newest_ebook_row(view: &AlignmentView) -> Option<Element> {
+    let reading = view.reading.as_ref()?;
+    let pct = reading.percent?;
+    let when = recency(reading.client_updated_at);
+    let total: f64 = view.audio_files.iter().map(|f| f.duration_seconds).sum();
+    let mapped = (total > 0.0).then(|| {
+        let audio_frac = interpolate_pairs(&view.anchor_pairs, pct as f64 / 100.0);
+        fmt_hm(audio_frac * total)
+    });
+    let foot = match mapped {
+        Some(hm) => format!(
+            "one spot, both formats \u{2014} the player opens at the matching time (\u{2248} {hm})"
+        ),
+        None => "one spot, both formats \u{2014} the player opens at the matching time".to_string(),
+    };
+    Some(rsx! {
+        div { class: "bd-prog-row", "data-testid": "bd-progress-newest",
+            span { class: "bd-prog-glyph", {book_glyph(13)} }
+            span { class: "pbar", i { style: "width:{pct}%" } }
+            span { class: "mono bd-prog-cap",
+                "newest: ebook \u{b7} {pct}% \u{b7} {when}"
+            }
+        }
+        div { class: "mono bd-prog-foot", "{foot}" }
+    })
+}
+
+/// The per-format progress rows: one row per format while the formats keep
+/// separate spots (unlinked or stale), one newest-format row + footnote
+/// once linked and fresh. Empty when no position can render a row.
+fn progress_rows(view: &AlignmentView) -> Element {
+    let linked_fresh = matches!(&view.link, Some(l) if !l.stale);
+    if linked_fresh {
+        rsx! {
+            if let Some(row) = newest_row(view) {
+                div { class: "bd-prog-rows", {row} }
+            }
+        }
+    } else {
+        let ebook = ebook_row(view);
+        let audio = audio_row(view);
+        rsx! {
+            if ebook.is_some() || audio.is_some() {
+                div { class: "bd-prog-rows",
+                    if let Some(row) = ebook { {row} }
+                    if let Some(row) = audio { {row} }
+                }
+            }
+        }
+    }
+}
+
+/// The "Your progress" block + sync entry row + its modal. Mounted only
+/// for dual-format books (threaded into the hero's title column).
 /// `refresh` re-fetches on the page's own reload signal; `after_merge`
 /// auto-opens the modal once when a merge just produced this dual-format
 /// book (the merge dialog's second entry point).
@@ -19,9 +168,8 @@ pub(super) fn BdSyncPanel(
     refresh: Signal<u32>,
     after_merge: Signal<bool>,
 ) -> Element {
-    // Outer None = state unknown (SSR / first paint); inner Option is the
-    // fetched link.
-    let mut link = use_signal(|| None::<Option<AlignmentLink>>);
+    // None = state unknown (SSR / first paint); Some is the fetched view.
+    let mut view = use_signal(|| None::<AlignmentView>);
     let mut fetch_failed = use_signal(|| false);
     let modal_open = use_signal(|| false);
     let mut epoch = use_signal(|| 0u32);
@@ -35,7 +183,7 @@ pub(super) fn BdSyncPanel(
             match data::get_alignment("", &uuid).await {
                 Ok(v) => {
                     fetch_failed.set(false);
-                    link.set(Some(v.link));
+                    view.set(Some(v));
                 }
                 // Keep any previously-fetched state; only flag the failure
                 // when there is nothing better to show, so the row never
@@ -59,7 +207,7 @@ pub(super) fn BdSyncPanel(
     let mut open_modal = modal_open;
     rsx! {
         section { class: "bd-sync-panel", "data-testid": "sync-link-row",
-            match link() {
+            match view() {
                 None if fetch_failed() => rsx! {
                     div { class: "al-entry al-entry-unlinked", role: "status",
                         span { class: "al-entry-copy",
@@ -74,52 +222,58 @@ pub(super) fn BdSyncPanel(
                     }
                 },
                 None => rsx! {},
-                Some(None) => rsx! {
-                    div { class: "al-entry al-entry-unlinked",
-                        span { class: "al-entry-glyph",
-                            crate::components::sync_glyph::SyncGlyph { size: 14 }
-                        }
-                        span { class: "al-entry-copy",
-                            "Positions aren't synced — each format keeps its own spot."
-                        }
-                        button {
-                            class: "btn sm",
-                            "data-testid": "sync-link-open",
-                            onclick: move |_| open_modal.set(true),
-                            "Link formats…"
-                        }
-                    }
-                },
-                Some(Some(l)) if l.stale => rsx! {
-                    div { class: "al-entry al-entry-stale", role: "status",
-                        span { class: "al-entry-copy",
-                            "The audiobook files changed since you linked — sync is paused "
-                            "until you re-confirm the alignment."
-                        }
-                        button {
-                            class: "btn sm",
-                            "data-testid": "sync-link-review",
-                            onclick: move |_| open_modal.set(true),
-                            "Review alignment"
-                        }
-                    }
-                },
-                Some(Some(l)) => rsx! {
-                    button {
-                        class: "al-entry al-entry-linked",
-                        "data-testid": "sync-link-manage",
-                        onclick: move |_| open_modal.set(true),
-                        span { class: "al-entry-glyph",
-                            crate::components::sync_glyph::SyncGlyph { size: 14 }
-                        }
-                        span { class: "al-entry-copy",
-                            if l.follow { "Positions synced — following" } else { "Positions synced" }
-                        }
-                        span { class: "al-entry-meta",
-                            "ebook \u{2194} audiobook \u{b7} confirmed "
-                            {crate::components::alignment_modal::recency(l.confirmed_at)}
-                        }
-                        span { class: "al-entry-chevron", "\u{203a}" }
+                Some(v) => rsx! {
+                    div { class: "label bd-prog-head", "Your progress" }
+                    {progress_rows(&v)}
+                    match v.link {
+                        None => rsx! {
+                            div { class: "al-entry al-entry-unlinked",
+                                span { class: "al-entry-glyph",
+                                    crate::components::sync_glyph::SyncGlyph { size: 14 }
+                                }
+                                span { class: "al-entry-copy",
+                                    "Positions aren't synced — each format keeps its own spot."
+                                }
+                                button {
+                                    class: "btn sm",
+                                    "data-testid": "sync-link-open",
+                                    onclick: move |_| open_modal.set(true),
+                                    "Link formats…"
+                                }
+                            }
+                        },
+                        Some(l) if l.stale => rsx! {
+                            div { class: "al-entry al-entry-stale", role: "status",
+                                span { class: "al-entry-copy",
+                                    "The audiobook files changed since you linked — sync is paused "
+                                    "until you re-confirm the alignment."
+                                }
+                                button {
+                                    class: "btn sm",
+                                    "data-testid": "sync-link-review",
+                                    onclick: move |_| open_modal.set(true),
+                                    "Review alignment"
+                                }
+                            }
+                        },
+                        Some(l) => rsx! {
+                            button {
+                                class: "al-entry al-entry-linked",
+                                "data-testid": "sync-link-manage",
+                                onclick: move |_| open_modal.set(true),
+                                span { class: "al-entry-glyph",
+                                    crate::components::sync_glyph::SyncGlyph { size: 14 }
+                                }
+                                span { class: "al-entry-copy",
+                                    if l.follow { "Positions synced — following" } else { "Positions synced" }
+                                }
+                                span { class: "al-entry-meta",
+                                    "ebook \u{2194} audiobook \u{b7} confirmed "
+                                    {recency(l.confirmed_at)}
+                                }
+                                span { class: "al-entry-chevron", "\u{203a}" }
+                            }
+                        },
                     }
                 },
             }
@@ -131,3 +285,6 @@ pub(super) fn BdSyncPanel(
         }
     }
 }
+
+#[cfg(all(test, feature = "server"))]
+mod tests;

--- a/frontend/src/pages/book_detail/sync_link/tests.rs
+++ b/frontend/src/pages/book_detail/sync_link/tests.rs
@@ -1,0 +1,148 @@
+//! SSR-rendered coverage of the "Your progress" rows: per-format bars
+//! while unlinked or stale, the single newest-format row + mapped
+//! footnote once linked and fresh.
+
+use omnibus_shared::{
+    AlignmentAudioFile, AlignmentAudioPosition, AlignmentLink, AlignmentPosition, AlignmentView,
+    CrossFormatLinkMode,
+};
+
+use super::progress_rows;
+
+fn base_view() -> AlignmentView {
+    AlignmentView {
+        link: None,
+        anchor_match: None,
+        ebook: None,
+        audio_files: vec![AlignmentAudioFile {
+            book_file_id: 1,
+            label: "part1.m4b".into(),
+            duration_seconds: 3600.0,
+            chapter_starts: vec![],
+        }],
+        reading: None,
+        listening: None,
+        anchor_pairs: vec![],
+        audio_chapter_marks: 0,
+    }
+}
+
+fn fresh_link() -> AlignmentLink {
+    AlignmentLink {
+        mode: CrossFormatLinkMode::Sequence,
+        primary_book_file_id: None,
+        stale: false,
+        confirmed_at: 0,
+        follow: false,
+        user_anchors: 0,
+    }
+}
+
+fn reading(percent: i64, clock: i64) -> AlignmentPosition {
+    AlignmentPosition {
+        percent: Some(percent),
+        client_updated_at: clock,
+    }
+}
+
+fn listening(seconds: f64, clock: i64) -> AlignmentAudioPosition {
+    AlignmentAudioPosition {
+        book_file_id: Some(1),
+        seconds,
+        client_updated_at: clock,
+    }
+}
+
+fn render(view: &AlignmentView) -> String {
+    dioxus::ssr::render_element(progress_rows(view))
+}
+
+#[test]
+fn progress_rows_renders_both_rows_when_unlinked_with_both_positions() {
+    let mut view = base_view();
+    view.reading = Some(reading(55, 100));
+    view.listening = Some(listening(1800.0, 200));
+    let html = render(&view);
+    assert!(html.contains("data-testid=\"bd-progress-ebook\""), "{html}");
+    assert!(html.contains("data-testid=\"bd-progress-audio\""), "{html}");
+    assert!(html.contains("55%"), "{html}");
+    assert!(html.contains("30m of 1h 00m"), "{html}");
+}
+
+#[test]
+fn progress_rows_skips_the_ebook_row_without_a_reading_position() {
+    let mut view = base_view();
+    view.listening = Some(listening(1800.0, 200));
+    let html = render(&view);
+    assert!(
+        !html.contains("data-testid=\"bd-progress-ebook\""),
+        "{html}"
+    );
+    assert!(html.contains("data-testid=\"bd-progress-audio\""), "{html}");
+}
+
+#[test]
+fn progress_rows_renders_the_newest_audio_row_with_mapped_page_footnote_when_linked() {
+    let mut view = base_view();
+    view.link = Some(fresh_link());
+    view.reading = Some(reading(40, 100));
+    view.listening = Some(listening(1800.0, 200));
+    let html = render(&view);
+    assert!(
+        html.contains("data-testid=\"bd-progress-newest\""),
+        "{html}"
+    );
+    assert!(html.contains("newest: audiobook"), "{html}");
+    // Linear default mapping: audio 50% → text 50%.
+    assert!(
+        html.contains("the reader opens at the matching page (\u{2248} 50%)"),
+        "{html}"
+    );
+    assert!(
+        !html.contains("data-testid=\"bd-progress-ebook\""),
+        "{html}"
+    );
+}
+
+#[test]
+fn progress_rows_renders_the_newest_ebook_row_with_mapped_time_footnote_when_linked() {
+    let mut view = base_view();
+    view.link = Some(fresh_link());
+    view.reading = Some(reading(40, 300));
+    view.listening = Some(listening(1800.0, 200));
+    let html = render(&view);
+    assert!(
+        html.contains("data-testid=\"bd-progress-newest\""),
+        "{html}"
+    );
+    assert!(html.contains("newest: ebook"), "{html}");
+    // Linear default mapping: text 40% of a 1h timeline → 24m.
+    assert!(
+        html.contains("the player opens at the matching time (\u{2248} 24m)"),
+        "{html}"
+    );
+}
+
+#[test]
+fn progress_rows_falls_back_to_per_format_rows_when_the_link_is_stale() {
+    let mut view = base_view();
+    view.link = Some(AlignmentLink {
+        stale: true,
+        ..fresh_link()
+    });
+    view.reading = Some(reading(55, 100));
+    view.listening = Some(listening(1800.0, 200));
+    let html = render(&view);
+    assert!(html.contains("data-testid=\"bd-progress-ebook\""), "{html}");
+    assert!(html.contains("data-testid=\"bd-progress-audio\""), "{html}");
+    assert!(
+        !html.contains("data-testid=\"bd-progress-newest\""),
+        "{html}"
+    );
+}
+
+#[test]
+fn progress_rows_renders_nothing_without_positions() {
+    let html = render(&base_view());
+    assert!(!html.contains("bd-prog-row"), "{html}");
+}

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -250,6 +250,19 @@ pub(super) fn render_loaded(
     // Extract the physical-panel inputs before `b` is moved into the rail.
     let is_fileless = b.formats.is_empty();
     let accent = b.accent.clone();
+    // The "Your progress" block lives inside the hero's title column (below
+    // the CTA row); it only exists for dual-format books.
+    let sync_panel = if has_ebook && has_audio {
+        rsx! {
+            sync_link::BdSyncPanel {
+                uuid: uuid.clone(),
+                refresh,
+                after_merge,
+            }
+        }
+    } else {
+        rsx! {}
+    };
     rsx! {
         div { class: "bd-root", style: "{accent_style}",
             BdHeroSection {
@@ -262,13 +275,7 @@ pub(super) fn render_loaded(
                     has_comic,
                 },
                 phys,
-            }
-            if has_ebook && has_audio {
-                sync_link::BdSyncPanel {
-                    uuid: uuid.clone(),
-                    refresh,
-                    after_merge,
-                }
+                sync_panel,
             }
             physical::BdPhysicalPanel {
                 uuid: uuid.clone(),

--- a/frontend/src/pages/landing/hero.rs
+++ b/frontend/src/pages/landing/hero.rs
@@ -12,6 +12,33 @@ use super::resume_meta::resume_meta;
 use crate::components::glyphs::{book_glyph, play_glyph};
 use crate::Route;
 
+/// Whether the book carries both an ebook and an audiobook — the
+/// dual-format gate for the link invitation (unlinked) and the Immersive
+/// pill (linked).
+fn has_both_formats(book: &omnibus_shared::EbookMetadata) -> bool {
+    book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"))
+        && book.formats.iter().any(|f| {
+            matches!(
+                f.to_ascii_lowercase().as_str(),
+                "m4b" | "m4a" | "mp3" | "aac" | "flac" | "ogg" | "opus" | "wav"
+            )
+        })
+}
+
+/// The book+soundwave Immersive mark on the linked card's pill, accent
+/// stroked to read as the sync feature's color.
+fn immersive_mark() -> Element {
+    rsx! {
+        svg {
+            width: "12", height: "12", view_box: "0 0 24 24", fill: "none",
+            stroke: "var(--accent)", stroke_width: "1.9", stroke_linecap: "round",
+            stroke_linejoin: "round", "aria-hidden": "true",
+            path { d: "M4 5.2A2 2 0 0 1 6 4h4.2a1.8 1.8 0 0 1 1.8 1.8V18a1.6 1.6 0 0 0-1.6-1.6H6A2 2 0 0 1 4 14.4V5.2z" }
+            path { d: "M15.5 8v8M18.5 6v12M21 9.5v5" }
+        }
+    }
+}
+
 /// Watch the hero cards and report the index of the mostly-visible one, so
 /// the dots track manual swipes/scrolls. Waits briefly for the track to exist
 /// (the eval can run before the DOM patch lands), then observes each card.
@@ -168,15 +195,10 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
         }
     };
     // Dual-format but unlinked: the hero carries the link invitation the
-    // design draws under the two-card state.
-    let dual_unlinked = !point.linked
-        && book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"))
-        && book.formats.iter().any(|f| {
-            matches!(
-                f.to_ascii_lowercase().as_str(),
-                "m4b" | "m4a" | "mp3" | "aac" | "flac" | "ogg" | "opus" | "wav"
-            )
-        });
+    // design draws under the two-card state. Linked dual-format cards get
+    // the Immersive pill instead.
+    let dual_unlinked = !point.linked && has_both_formats(&book);
+    let dual_linked = point.linked && has_both_formats(&book);
     // Linked books carry the mapped "resume in the other format" candidate;
     // the CTA routes to that surface, whose own prompt offers the precise
     // jump once loaded.
@@ -214,6 +236,13 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
 
     rsx! {
         article { class: "ch-card", "data-testid": "hero-card-{uuid}",
+            if point.linked {
+                span {
+                    class: "ch-sync-corner",
+                    title: "Positions synced across formats",
+                    crate::components::sync_glyph::SyncGlyph { size: 20 }
+                }
+            }
             Link {
                 to: Route::BookDetail { uuid: uuid.clone() },
                 class: "ch-cover",
@@ -226,14 +255,7 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
                 }
             }
             div { class: "ch-body",
-                span { class: "ch-eyebrow",
-                    "{eyebrow}"
-                    if point.linked {
-                        span { class: "ch-eyebrow-glyph",
-                            crate::components::sync_glyph::SyncGlyph { size: 11 }
-                        }
-                    }
-                }
+                span { class: "ch-eyebrow", "{eyebrow}" }
                 Link {
                     to: Route::BookDetail { uuid: uuid.clone() },
                     class: "ch-title-link",
@@ -261,6 +283,20 @@ fn HeroCard(point: ResumePoint, server_url: String) -> Element {
                             if is_audio { "audiobook \u{00b7} " } else { "ebook \u{00b7} " }
                         }
                         "{meta}"
+                    }
+                    if dual_linked {
+                        button {
+                            r#type: "button",
+                            class: "ch-cta ch-cta-alt",
+                            "data-testid": "hero-immersive-{uuid}",
+                            title: "Open the ereader and audiobook together, kept in sync",
+                            onclick: {
+                                let uuid = uuid.clone();
+                                move |_| crate::pages::retarget_and_open_immersive(uuid.clone())
+                            },
+                            {immersive_mark()}
+                            span { "Immersive" }
+                        }
                     }
                     if let Some((route, label)) = counterpart {
                         Link {

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -34,10 +34,17 @@ type JsCallbackHolder = std::rc::Rc<std::cell::RefCell<Vec<Closure<dyn FnMut(f64
 /// picker switches parts, while the mini-dock (which relinks with no
 /// `file_id`) resumes the current part instead of restarting from the first
 /// file. Mirrors `pages::listen::mobile::host::needs_reload`.
-fn needs_reload(loaded: &Option<(String, Option<i64>)>, uuid: &str, file_id: Option<i64>) -> bool {
+fn needs_reload(
+    loaded: &Option<(String, Option<i64>, u32)>,
+    uuid: &str,
+    file_id: Option<i64>,
+    epoch: u32,
+) -> bool {
     match loaded {
-        Some((loaded_uuid, loaded_file)) if loaded_uuid == uuid => {
-            file_id.is_some() && file_id != *loaded_file
+        Some((loaded_uuid, loaded_file, loaded_epoch)) if loaded_uuid == uuid => {
+            // A bumped epoch forces a same-book re-boot (resume + follow
+            // re-resolution) without the dock ever unmounting.
+            *loaded_epoch != epoch || (file_id.is_some() && file_id != *loaded_file)
         }
         _ => true,
     }
@@ -76,7 +83,7 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
     // What's currently booted: (book uuid, the file_id it was booted with).
     // Gates re-boot so a same-book file-pick reloads but a bare mini-dock
     // relink resumes the current part. Held across renders via `use_hook`.
-    let mut loaded_key = use_hook(|| Signal::new(None::<(String, Option<i64>)>));
+    let mut loaded_key = use_hook(|| Signal::new(None::<(String, Option<i64>, u32)>));
 
     use_effect(move || {
         let resolved_user = current_user();
@@ -96,9 +103,13 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
             return;
         }
         // Reactive dependencies — re-run when the active book *or* the selected
-        // file changes (the picker retargets `file_id` without changing uuid).
+        // file changes (the picker retargets `file_id` without changing uuid),
+        // or when a surface bumps `reload_epoch` to force a same-book re-boot
+        // (Immersive Read re-resolving resume + follow without unmounting the
+        // dock).
         let requested_uuid = playback.uuid.read().clone();
         let requested_file = *playback.file_id.read();
+        let requested_epoch = *playback.reload_epoch.read();
         let Some(uuid) = requested_uuid else {
             // Dismissed via the dock × button. The handler already stopped
             // the element; clear the book so the dock hides everywhere, and
@@ -108,10 +119,15 @@ pub(crate) fn install_audio_bootstrap(playback: crate::PlaybackState) {
             loaded_key.set(None);
             return;
         };
-        if !needs_reload(&loaded_key.peek().clone(), &uuid, requested_file) {
+        if !needs_reload(
+            &loaded_key.peek().clone(),
+            &uuid,
+            requested_file,
+            requested_epoch,
+        ) {
             return;
         }
-        loaded_key.set(Some((uuid.clone(), requested_file)));
+        loaded_key.set(Some((uuid.clone(), requested_file, requested_epoch)));
         let user_id = resolved_user.flatten().map(|user| user.id);
         boot_new_book(
             &cb_holder,
@@ -762,23 +778,32 @@ mod tests {
 
     #[test]
     fn needs_reload_when_nothing_booted_or_book_changed() {
-        assert!(needs_reload(&None, "book-a", None));
-        let booted = Some(("book-a".to_string(), Some(917)));
-        assert!(needs_reload(&booted, "book-b", Some(940)));
+        assert!(needs_reload(&None, "book-a", None, 0));
+        let booted = Some(("book-a".to_string(), Some(917), 0));
+        assert!(needs_reload(&booted, "book-b", Some(940), 0));
     }
 
     #[test]
     fn needs_reload_on_explicit_different_part_of_same_book() {
-        let booted = Some(("book-a".to_string(), Some(917)));
-        assert!(needs_reload(&booted, "book-a", Some(918)));
+        let booted = Some(("book-a".to_string(), Some(917), 0));
+        assert!(needs_reload(&booted, "book-a", Some(918), 0));
+    }
+
+    #[test]
+    fn needs_reload_when_the_reload_epoch_was_bumped() {
+        // Immersive Read forces a same-book re-boot without unmounting the
+        // dock — the epoch is the only thing that moved.
+        let booted = Some(("book-a".to_string(), Some(917), 0));
+        assert!(needs_reload(&booted, "book-a", None, 1));
+        assert!(needs_reload(&booted, "book-a", Some(917), 1));
     }
 
     #[test]
     fn no_reload_for_same_part_or_bare_relink_of_same_book() {
-        let booted = Some(("book-a".to_string(), Some(917)));
+        let booted = Some(("book-a".to_string(), Some(917), 0));
         // Same part re-selected → no restart.
-        assert!(!needs_reload(&booted, "book-a", Some(917)));
+        assert!(!needs_reload(&booted, "book-a", Some(917), 0));
         // Mini-dock relinks with no file_id → keep the current part.
-        assert!(!needs_reload(&booted, "book-a", None));
+        assert!(!needs_reload(&booted, "book-a", None, 0));
     }
 }

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -40,6 +40,8 @@ pub use admin_health::AdminHealthPage;
 pub use auth::{LoginPage, RegisterPage};
 pub use author::AuthorPage;
 pub use authors_index::AuthorsIndexPage;
+#[cfg(not(feature = "mobile"))]
+pub(crate) use book_detail::retarget_and_open_immersive;
 pub use book_detail::BookDetailPage;
 pub use check_in::{CheckInOpen, CheckInOverlay, CheckInPage};
 pub use comic_reader::ComicReadPage;

--- a/ui_tests/playwright/tests/flows/cross_format_link.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_link.spec.ts
@@ -78,6 +78,12 @@ test("renders the sync entry row for a dual-format book", async ({
 
   const row = page.getByTestId("sync-link-row");
   await expect(row).toBeVisible();
+  // The panel now lives in the hero's title column as the "Your progress"
+  // block: heading first, then the entry row. The per-format bars are NOT
+  // asserted either way here — other specs (immersive, mini-dock) open this
+  // shared fixture in readers/players in parallel, so its progress rows are
+  // racy; presence of the heading + entry row is the stable contract.
+  await expect(row.getByText("Your progress")).toBeVisible();
   // Unlinked by default: the nudge and its open affordance.
   await expect(page.getByTestId("sync-link-open")).toBeVisible();
   await expect(

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -176,6 +176,32 @@ test("the hero shows one synced card with the counterpart affordance", async ({
   await expect(cards).toHaveCount(1);
   await expect(cards).toContainText("synced");
   await expect(page.getByTestId(`hero-crossformat-${uuid}`)).toBeVisible();
+
+  // The linked dual-format card also carries the Immersive pill, which
+  // opens the reader with the audiobook docked (same handler as the
+  // book-detail CTA — immersive.spec.ts covers the dock itself).
+  const immersive = page.getByTestId(`hero-immersive-${uuid}`);
+  await expect(immersive).toBeVisible();
+  await immersive.click();
+  await expect(page).toHaveURL(new RegExp(`/read/${uuid}$`));
+});
+
+test("the book detail shows the newest-format progress row above the sync chip", async ({
+  page,
+}) => {
+  // Linked and fresh: the "Your progress" block collapses to ONE row for
+  // the newest format (either side may be newest here — earlier tests
+  // leave wall-clock reader/player writes on both), with the per-format
+  // bars absent and the linked chip beneath.
+  await gotoReady(page, `/books/${uuid}`);
+  const row = page.getByTestId("sync-link-row");
+  await expect(row.getByText("Your progress")).toBeVisible();
+  await expect(page.getByTestId("bd-progress-newest")).toBeVisible();
+  await expect(page.getByTestId("bd-progress-ebook")).toHaveCount(0);
+  await expect(page.getByTestId("bd-progress-audio")).toHaveCount(0);
+  await expect(page.getByTestId("sync-link-manage")).toBeVisible();
+  // The one-spot footnote explains the mapped hand-off.
+  await expect(row.getByText("one spot, both formats")).toBeVisible();
 });
 
 test("declaring a sync point turns on follow and the reader auto-applies", async ({


### PR DESCRIPTION
## Summary
- Book detail gains a "Your progress" block in the hero title column: per-format bars (ebook % / audiobook time-of-total) when unlinked or stale, one newest-format row plus a matching-position footnote when linked, with the sync entry row directly beneath — replacing the standalone section under the cover.
- The continue hero renders two cards per page at wide widths, moves the sync glyph to the card corner, and linked dual-format cards gain an Immersive pill alongside Read/Listen.
- Immersive Read's same-book path reboots the driver via a new `reload_epoch` on `PlaybackState` instead of the uuid None→Some nudge, so the dock never unmounts and can't race the reader's mount (the "player closes" / "ebook never loads" QA reports).

Closes #1973

## Test plan
- [x] Full matrix green; 41/41 E2E across cross-format, book-detail, immersive, and landing flows plus 21/21 on the combined verification run.
- [x] New unit tests: sync-panel SSR rows (6) and `needs_reload` epoch cases.
- [x] Visual verification at 1440px: bars + sync row placement, two-up hero, Immersive pill opening `/read` with the dock.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.