### PR TITLE
[OMNI-1974] Alignment Modal Percentage-Mode States and Per-Mode Confirm Copy

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -9367,6 +9367,10 @@ html {
   padding: 9px 12px;
   margin: 14px 0 0;
 }
+.al-matched-warn {
+  border-color: rgba(214, 158, 46, 0.5);
+  background: rgba(214, 158, 46, 0.08);
+}
 /* ── Cross-format resume prompts (player card + reader banner) ──────── */
 .lp-sync-prompt {
   position: absolute;

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -65,6 +65,109 @@ fn interpolate_pairs(pairs: &[(f64, f64)], frac: f64) -> f64 {
     frac
 }
 
+/// Which notice/confirm mode the modal is in, derived from the served
+/// view. Stale wins — anchoring and the marks count are suppressed while
+/// a link is stale, so their zeros must not be read as a linear mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum AlignMode {
+    /// The audio set drifted since confirmation; re-confirm re-checks.
+    Stale,
+    /// Chapter anchoring engaged — jumps land chapter-accurately.
+    Anchored,
+    /// Marks exist but can't be paired 1:1 — percent mapping.
+    Mismatch,
+    /// No usable marks at all — percent mapping.
+    NoMarks,
+}
+
+fn align_mode(view: &AlignmentView) -> AlignMode {
+    if view.link.as_ref().is_some_and(|l| l.stale) {
+        AlignMode::Stale
+    } else if view.anchor_match.is_some() {
+        AlignMode::Anchored
+    } else if view.audio_chapter_marks > 0 {
+        AlignMode::Mismatch
+    } else {
+        AlignMode::NoMarks
+    }
+}
+
+/// The ebook chapter count the mismatch copy quotes; `None` while the
+/// structure backfill hasn't reached the book (no lane ticks either).
+fn ebook_chapter_count(view: &AlignmentView) -> Option<usize> {
+    view.ebook
+        .as_ref()
+        .map(|e| e.chapters.len())
+        .filter(|n| *n > 0)
+}
+
+/// The default judgement prompt under the title.
+const SUB_DEFAULT: &str =
+    "Check that the mapped position lands about where it should, then confirm.";
+
+/// The intro line under the title: the default prompt, or the honest
+/// explanation of why the mapping is percentage-based.
+fn sub_header(mode: AlignMode, marks: i64, ebook_chapters: Option<usize>) -> String {
+    match mode {
+        AlignMode::Stale | AlignMode::Anchored => SUB_DEFAULT.into(),
+        AlignMode::NoMarks => "This audiobook carries no chapter markers, so there\u{2019}s \
+             nothing to anchor the mapping to."
+            .into(),
+        AlignMode::Mismatch => match ebook_chapters {
+            Some(m) => format!(
+                "The audio carries {marks} chapter marks but the book has {m} chapters, \
+                 so the chapters can\u{2019}t be paired up exactly."
+            ),
+            None => format!(
+                "The audio carries {marks} chapter marks, but they can\u{2019}t be \
+                 paired up with the book\u{2019}s chapters exactly."
+            ),
+        },
+    }
+}
+
+/// The `~` warn pill's text for the two percentage modes. Without an
+/// ebook chapter count the mismatch line drops the vs-clause rather than
+/// quoting a number it doesn't have.
+fn linear_pill(marks: i64, ebook_chapters: Option<usize>) -> String {
+    if marks == 0 {
+        "no chapter marks in the audio — linear estimate".into()
+    } else {
+        match ebook_chapters {
+            Some(m) => format!("{marks} audio marks vs {m} chapters — no 1:1 match"),
+            None => format!("{marks} audio marks — no 1:1 match"),
+        }
+    }
+}
+
+/// The fresh-confirm button names what confirming turns on; a pending
+/// sequence reorder rides along as a prefix. The stale re-confirm keeps
+/// its original labels — anchoring is suppressed there, so neither mode
+/// name would be honest.
+fn confirm_label(mode: AlignMode, save_order: bool) -> &'static str {
+    match (mode, save_order) {
+        (AlignMode::Stale, false) => "Looks right — turn on sync",
+        (AlignMode::Stale, true) => "Save order & turn on sync",
+        (AlignMode::Anchored, false) => "Sync Based On Chapters",
+        (AlignMode::Anchored, true) => "Save order — Sync Based On Chapters",
+        (AlignMode::Mismatch | AlignMode::NoMarks, false) => "Sync Based Off Percentage",
+        (AlignMode::Mismatch | AlignMode::NoMarks, true) => {
+            "Save order — Sync Based Off Percentage"
+        }
+    }
+}
+
+/// The mono footer line; the percentage modes omit it per the design —
+/// the warn banner already carries the caveat.
+fn foot_note(mode: AlignMode) -> Option<&'static str> {
+    match mode {
+        AlignMode::Stale | AlignMode::Anchored => {
+            Some("Sync stays off until you confirm. You can unlink any time.")
+        }
+        AlignMode::Mismatch | AlignMode::NoMarks => None,
+    }
+}
+
 /// The distinguishing tail of a library-relative label: real libraries
 /// nest under `Author/Book/…`, so the shared prefix carries nothing and
 /// ellipsis truncation would hide the part that differs.
@@ -192,9 +295,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
     let confirm_uuid = uuid.clone();
     let has_link = view().as_ref().is_some_and(|v| v.link.is_some());
     let multi = view().as_ref().is_some_and(|v| v.audio_files.len() > 1);
-    let low_conf = view()
-        .as_ref()
-        .is_some_and(|v| v.anchor_match.is_none() && !v.link.as_ref().is_some_and(|l| l.stale));
+    let align = view().as_ref().map(align_mode);
     let reordered = view().as_ref().is_some_and(|v| {
         order()
             != v.audio_files
@@ -202,18 +303,20 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                 .map(|f| f.book_file_id)
                 .collect::<Vec<_>>()
     });
-    let confirm_label = if reordered && mode() == CrossFormatLinkMode::Sequence {
-        "Save order & turn on sync"
-    } else if low_conf {
-        "Turn on sync anyway"
-    } else {
-        "Looks right — turn on sync"
-    };
-    let foot_note = if low_conf {
-        "It's approximate — Omnibus will always say ≈ when it jumps."
-    } else {
-        "Sync stays off until you confirm. You can unlink any time."
-    };
+    let save_order = reordered && mode() == CrossFormatLinkMode::Sequence;
+    // While the view is loading the confirm button is disabled, so its
+    // label and the footer only need a sane default.
+    let confirm_text = align.map_or("Looks right — turn on sync", |a| {
+        confirm_label(a, save_order)
+    });
+    let foot = align.map_or(
+        Some("Sync stays off until you confirm. You can unlink any time."),
+        foot_note,
+    );
+    let sub_text = view().as_ref().map_or_else(
+        || SUB_DEFAULT.to_string(),
+        |v| sub_header(align_mode(v), v.audio_chapter_marks, ebook_chapter_count(v)),
+    );
 
     // The design themes the whole modal off the BOOK's accent — fills,
     // chips, markers, and the header wash all derive from it. Absent an
@@ -244,9 +347,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                     }
                 }
                 {render_identity(&book())}
-                p { class: "al-sub",
-                    "Check that the mapped position lands about where it should, then confirm."
-                }
+                p { class: "al-sub", "{sub_text}" }
             }
             if let Some(v) = view() {
                 {render_lanes(&v, &order(), mode(), primary())}
@@ -265,24 +366,25 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                         "\u{2713} {m.matched} of {m.ebook_chapters} chapters matched — "
                         "jumps land chapter-accurately."
                     }
-                } else if v.audio_chapter_marks > 0 {
-                    div { class: "al-lowconf-callout", role: "note", "data-testid": "alignment-lowconf",
-                        span { class: "al-warn-badge", "!" }
-                        div {
-                            strong { "The audio's chapter marks couldn't be aligned with this ebook. " }
-                            "This mapping is a straight percent-for-percent estimate — jumps "
-                            "land close, not exact. A \"synced here\" declaration from the "
-                            "reader or player tightens it up."
-                        }
-                    }
                 } else {
+                    p { class: "al-matched al-matched-warn", role: "note", "data-testid": "alignment-linear-pill",
+                        "~ {linear_pill(v.audio_chapter_marks, ebook_chapter_count(&v))}"
+                    }
                     div { class: "al-lowconf-callout", role: "note", "data-testid": "alignment-lowconf",
                         span { class: "al-warn-badge", "!" }
-                        div {
-                            strong { "No chapter marks in the audio. " }
-                            "This mapping is a straight percent-for-percent estimate — jumps "
-                            "land close, not exact. A \"synced here\" declaration from the "
-                            "reader or player tightens it up."
+                        if v.audio_chapter_marks > 0 {
+                            div {
+                                strong { "The chapter counts don\u{2019}t match, so sync will go by percentage instead. " }
+                                "Jumps will land close, but not exactly. Extra marks are usually "
+                                "opening notes, bonus scenes, credits, remarks, or part numbers."
+                            }
+                        } else {
+                            div {
+                                strong { "This mapping is a straight percent-for-percent estimate. " }
+                                "Jumps will land close, not exact — expect drift of several "
+                                "minutes, especially mid-book. Adding chapter marks to the audio "
+                                "file later will tighten it up."
+                            }
                         }
                     }
                 }
@@ -293,7 +395,9 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                 p { role: "alert", class: "bd-merge-error", "{e}" }
             }
             div { class: "al-foot",
-                span { class: "al-foot-note", "{foot_note}" }
+                if let Some(note) = foot {
+                    span { class: "al-foot-note", "{note}" }
+                }
                 if has_link {
                     button {
                         class: "btn ghost sm",
@@ -370,7 +474,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                             }
                         });
                     },
-                    "{confirm_label}"
+                    "{confirm_text}"
                 }
             }
             }
@@ -718,7 +822,122 @@ fn render_choice(
 
 #[cfg(test)]
 mod tests {
-    use super::{basename, fmt_hm, interpolate_pairs, tick_step};
+    use omnibus_shared::{
+        AlignmentLink, AlignmentMatch, AlignmentView, CrossFormatLinkMode, MappingConfidence,
+    };
+
+    use super::{
+        align_mode, basename, confirm_label, fmt_hm, foot_note, interpolate_pairs, linear_pill,
+        sub_header, tick_step, AlignMode, SUB_DEFAULT,
+    };
+
+    fn bare_view(marks: i64) -> AlignmentView {
+        AlignmentView {
+            link: None,
+            anchor_match: None,
+            ebook: None,
+            audio_files: Vec::new(),
+            reading: None,
+            listening: None,
+            anchor_pairs: Vec::new(),
+            audio_chapter_marks: marks,
+        }
+    }
+
+    #[test]
+    fn align_mode_splits_stale_anchored_and_the_two_linear_modes() {
+        let mut v = bare_view(0);
+        assert_eq!(align_mode(&v), AlignMode::NoMarks);
+        v.audio_chapter_marks = 23;
+        assert_eq!(align_mode(&v), AlignMode::Mismatch);
+        v.anchor_match = Some(AlignmentMatch {
+            matched: 12,
+            ebook_chapters: 14,
+            confidence: MappingConfidence::ChapterAnchored,
+        });
+        assert_eq!(align_mode(&v), AlignMode::Anchored);
+        // Stale wins over everything — the suppressed counts must not be
+        // misread as a linear mode.
+        v.link = Some(AlignmentLink {
+            mode: CrossFormatLinkMode::Sequence,
+            primary_book_file_id: None,
+            stale: true,
+            confirmed_at: 0,
+            follow: false,
+            user_anchors: 0,
+        });
+        assert_eq!(align_mode(&v), AlignMode::Stale);
+    }
+
+    #[test]
+    fn sub_header_explains_each_linear_mode_and_defaults_elsewhere() {
+        assert_eq!(sub_header(AlignMode::Anchored, 23, Some(14)), SUB_DEFAULT);
+        assert_eq!(sub_header(AlignMode::Stale, 0, None), SUB_DEFAULT);
+        assert_eq!(
+            sub_header(AlignMode::Mismatch, 23, Some(14)),
+            "The audio carries 23 chapter marks but the book has 14 chapters, \
+             so the chapters can\u{2019}t be paired up exactly."
+        );
+        assert_eq!(
+            sub_header(AlignMode::Mismatch, 23, None),
+            "The audio carries 23 chapter marks, but they can\u{2019}t be \
+             paired up with the book\u{2019}s chapters exactly."
+        );
+        assert_eq!(
+            sub_header(AlignMode::NoMarks, 0, None),
+            "This audiobook carries no chapter markers, so there\u{2019}s \
+             nothing to anchor the mapping to."
+        );
+    }
+
+    #[test]
+    fn linear_pill_quotes_both_counts_and_degrades_without_the_ebook_side() {
+        assert_eq!(
+            linear_pill(23, Some(14)),
+            "23 audio marks vs 14 chapters — no 1:1 match"
+        );
+        assert_eq!(linear_pill(23, None), "23 audio marks — no 1:1 match");
+        assert_eq!(
+            linear_pill(0, Some(14)),
+            "no chapter marks in the audio — linear estimate"
+        );
+    }
+
+    #[test]
+    fn confirm_label_names_the_mapping_mode_and_keeps_the_stale_wording() {
+        assert_eq!(
+            confirm_label(AlignMode::Anchored, false),
+            "Sync Based On Chapters"
+        );
+        assert_eq!(
+            confirm_label(AlignMode::Anchored, true),
+            "Save order — Sync Based On Chapters"
+        );
+        assert_eq!(
+            confirm_label(AlignMode::Mismatch, false),
+            "Sync Based Off Percentage"
+        );
+        assert_eq!(
+            confirm_label(AlignMode::NoMarks, true),
+            "Save order — Sync Based Off Percentage"
+        );
+        assert_eq!(
+            confirm_label(AlignMode::Stale, false),
+            "Looks right — turn on sync"
+        );
+        assert_eq!(
+            confirm_label(AlignMode::Stale, true),
+            "Save order & turn on sync"
+        );
+    }
+
+    #[test]
+    fn foot_note_is_omitted_for_the_percentage_modes_only() {
+        assert!(foot_note(AlignMode::Anchored).is_some());
+        assert!(foot_note(AlignMode::Stale).is_some());
+        assert_eq!(foot_note(AlignMode::Mismatch), None);
+        assert_eq!(foot_note(AlignMode::NoMarks), None);
+    }
 
     #[test]
     fn fmt_hm_floors_and_renders_hours_and_bare_minutes() {

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -449,8 +449,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                     onclick: move |_| open.set(false),
                     "Cancel"
                 }
-                // Full-size primary per the design: the confirm carries the
-                // book's accent, not the grey neutral.
+                // Full-size accent primary per the design.
                 button {
                     class: "btn primary",
                     "data-testid": "alignment-confirm",

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -105,23 +105,39 @@ fn ebook_chapter_count(view: &AlignmentView) -> Option<usize> {
 const SUB_DEFAULT: &str =
     "Check that the mapped position lands about where it should, then confirm.";
 
+/// Singular/plural noun for a count, so one mark never reads "1 marks".
+fn plural(n: i64, one: &str, many: &str) -> String {
+    if n == 1 {
+        format!("{n} {one}")
+    } else {
+        format!("{n} {many}")
+    }
+}
+
 /// The intro line under the title: the default prompt, or the honest
 /// explanation of why the mapping is percentage-based.
 fn sub_header(mode: AlignMode, marks: i64, ebook_chapters: Option<usize>) -> String {
+    let marks_n = plural(marks, "chapter mark", "chapter marks");
     match mode {
         AlignMode::Stale | AlignMode::Anchored => SUB_DEFAULT.into(),
         AlignMode::NoMarks => "This audiobook carries no chapter markers, so there\u{2019}s \
              nothing to anchor the mapping to."
             .into(),
         AlignMode::Mismatch => match ebook_chapters {
-            Some(m) => format!(
-                "The audio carries {marks} chapter marks but the book has {m} chapters, \
-                 so the chapters can\u{2019}t be paired up exactly."
-            ),
-            None => format!(
-                "The audio carries {marks} chapter marks, but they can\u{2019}t be \
-                 paired up with the book\u{2019}s chapters exactly."
-            ),
+            Some(m) => {
+                let chapters_n = plural(m as i64, "chapter", "chapters");
+                format!(
+                    "The audio carries {marks_n} but the book has {chapters_n}, \
+                     so the chapters can\u{2019}t be paired up exactly."
+                )
+            }
+            None => {
+                let pronoun = if marks == 1 { "it" } else { "they" };
+                format!(
+                    "The audio carries {marks_n}, but {pronoun} can\u{2019}t be \
+                     paired up with the book\u{2019}s chapters exactly."
+                )
+            }
         },
     }
 }
@@ -133,9 +149,13 @@ fn linear_pill(marks: i64, ebook_chapters: Option<usize>) -> String {
     if marks == 0 {
         "no chapter marks in the audio — linear estimate".into()
     } else {
+        let marks_n = plural(marks, "audio mark", "audio marks");
         match ebook_chapters {
-            Some(m) => format!("{marks} audio marks vs {m} chapters — no 1:1 match"),
-            None => format!("{marks} audio marks — no 1:1 match"),
+            Some(m) => {
+                let chapters_n = plural(m as i64, "chapter", "chapters");
+                format!("{marks_n} vs {chapters_n} — no 1:1 match")
+            }
+            None => format!("{marks_n} — no 1:1 match"),
         }
     }
 }
@@ -900,6 +920,16 @@ mod tests {
         assert_eq!(
             linear_pill(0, Some(14)),
             "no chapter marks in the audio — linear estimate"
+        );
+        // One of anything reads singular — "1 audio marks" shipped once.
+        assert_eq!(
+            linear_pill(1, Some(1)),
+            "1 audio mark vs 1 chapter — no 1:1 match"
+        );
+        assert_eq!(
+            sub_header(AlignMode::Mismatch, 1, None),
+            "The audio carries 1 chapter mark, but it can\u{2019}t be \
+             paired up with the book\u{2019}s chapters exactly."
         );
     }
 

--- a/frontend/src/components/alignment_modal.rs
+++ b/frontend/src/components/alignment_modal.rs
@@ -359,13 +359,7 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                     span { class: "al-kicker-glyph", SyncGlyph { size: 13 } }
                     "Cross-format sync"
                 }
-                h3 {
-                    if multi {
-                        "Several audio files — what are they?"
-                    } else {
-                        "Do these line up?"
-                    }
-                }
+                h3 { "Link formats" }
                 {render_identity(&book())}
                 p { class: "al-sub", "{sub_text}" }
             }
@@ -449,14 +443,16 @@ pub fn AlignmentModal(uuid: String, open: Signal<bool>, on_changed: EventHandler
                 }
                 span { class: "al-foot-spacer" }
                 button {
-                    class: "btn ghost sm",
+                    class: "btn ghost",
                     "data-testid": "alignment-cancel",
                     disabled: busy(),
                     onclick: move |_| open.set(false),
                     "Cancel"
                 }
+                // Full-size primary per the design: the confirm carries the
+                // book's accent, not the grey neutral.
                 button {
-                    class: "btn sm",
+                    class: "btn primary",
                     "data-testid": "alignment-confirm",
                     disabled: busy() || view().is_none(),
                     onclick: move |_| {

--- a/ui_tests/playwright/tests/flows/cross_format_link.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_link.spec.ts
@@ -99,6 +99,19 @@ test("links the formats, shows the chip, then unlinks", async ({
   // renders: lanes, no sequence/narrations choice.
   await expect(page.getByTestId("alignment-lanes")).toBeVisible();
   await expect(page.getByTestId("alignment-choice")).toHaveCount(0);
+  // The fixture's lone audio mark can't pair with the ebook's chapters, so
+  // the mismatch (percentage) state renders: warn banner, ~ pill, no
+  // footer note, and a confirm that names the mapping. The pill's counts
+  // vary with the structure-backfill race, so assert only the stable tail.
+  await expect(page.getByTestId("alignment-lowconf")).toContainText(
+    "so sync will go by percentage instead",
+  );
+  await expect(page.getByTestId("alignment-linear-pill")).toContainText(
+    "no 1:1 match",
+  );
+  await expect(page.getByText("Sync stays off until you confirm")).toHaveCount(
+    0,
+  );
 
   await expectMutation(
     page,
@@ -107,7 +120,8 @@ test("links the formats, shows the chip, then unlinks", async ({
       url: "/api/rpc/cross-format/link",
       expectedStatus: 200,
     },
-    async () => page.getByTestId("alignment-confirm").click(),
+    async () =>
+      modal.getByRole("button", { name: "Sync Based Off Percentage" }).click(),
   );
   await expect(modal).toHaveCount(0);
   await expect(page.getByTestId("sync-link-manage")).toBeVisible();
@@ -151,7 +165,8 @@ test("surfaces a failed link confirm and keeps sync off", async ({
       url: "/api/rpc/cross-format/link",
       expectedStatus: 500,
     },
-    async () => page.getByTestId("alignment-confirm").click(),
+    async () =>
+      page.getByRole("button", { name: "Sync Based Off Percentage" }).click(),
   );
   // The modal stays up with the error surfaced; sync stayed off.
   await expect(page.getByRole("alert")).toBeVisible();


### PR DESCRIPTION
## Summary
- The modal's generic "couldn't be aligned" notice splits into two honest percentage states: unpairable marks (counts quoted, "sync will go by percentage instead") and no-marks ("straight percent-for-percent estimate"), with singular/plural copy handled.
- Confirm buttons name the mode — "Sync Based On Chapters" / "Save order — …" vs "Sync Based Off Percentage" — and the modal title is now "Link formats" with a full-size accent primary confirm per the design.

Closes #1974

## Test plan
- [x] 9 alignment-modal unit tests (5 new state/copy cases) green; clippy/fmt clean.
- [x] `cross_format_link.spec.ts` updated to the new banner/pill/button copy, 3/3 green; both mismatch variants visually verified.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.