### PR TITLE
refactor: dedupe OPDS shelf-visibility guard and add missing route tests (#1969)

### DIFF
--- a/server/src/backend/opds/delegate.rs
+++ b/server/src/backend/opds/delegate.rs
@@ -7,7 +7,7 @@
 //! headers) pass through untouched, so resume and 304 behaviour is
 //! identical to the `/api` originals.
 //!
-//! Each route also re-checks [`super::is_shelf_hidden`] (#932) before
+//! Each route also re-checks [`super::guard_shelf_hidden`] (#932) before
 //! delegating: a book that's confined to a manual shelf this viewer can't
 //! see must not be fetchable by a client that already knows (or guesses)
 //! its uuid, even though it never surfaced in a feed. Answered as a 404,
@@ -15,14 +15,14 @@
 
 use axum::{
     extract::{Path, Query, Request, State},
-    http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
+    http::HeaderMap,
+    response::Response,
 };
 
 use crate::auth::{MediaAuthUser, OpdsAuthUser};
 
 use super::super::{audiobooks, covers, deny_without_download, ebooks};
-use super::{is_shelf_hidden, AppState};
+use super::{guard_shelf_hidden, AppState};
 
 /// `GET /opds/covers/{uuid}` → [`covers::get_cover`].
 pub(super) async fn cover(
@@ -31,10 +31,8 @@ pub(super) async fn cover(
     path: Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    match is_shelf_hidden(&state.0, &user, &path.0).await {
-        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
-        Ok(false) => {}
-        Err(resp) => return resp,
+    if let Some(resp) = guard_shelf_hidden(&state.0, &user, &path.0).await {
+        return resp;
     }
     covers::get_cover(MediaAuthUser(user.0), state, path, headers).await
 }
@@ -47,10 +45,8 @@ pub(super) async fn thumb(
     headers: HeaderMap,
 ) -> Response {
     let (uuid, _size) = &path.0;
-    match is_shelf_hidden(&state.0, &user, uuid).await {
-        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
-        Ok(false) => {}
-        Err(resp) => return resp,
+    if let Some(resp) = guard_shelf_hidden(&state.0, &user, uuid).await {
+        return resp;
     }
     covers::get_thumb(MediaAuthUser(user.0), state, path, headers).await
 }
@@ -67,10 +63,8 @@ pub(super) async fn ebook_file(
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
     }
-    match is_shelf_hidden(&state.0, &user, &path.0).await {
-        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
-        Ok(false) => {}
-        Err(resp) => return resp,
+    if let Some(resp) = guard_shelf_hidden(&state.0, &user, &path.0).await {
+        return resp;
     }
     ebooks::get_ebook_file(MediaAuthUser(user.0), state, path, query, req).await
 }
@@ -87,10 +81,8 @@ pub(super) async fn ebook_download(
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
     }
-    match is_shelf_hidden(&state.0, &user, &path.0).await {
-        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
-        Ok(false) => {}
-        Err(resp) => return resp,
+    if let Some(resp) = guard_shelf_hidden(&state.0, &user, &path.0).await {
+        return resp;
     }
     ebooks::get_ebook_download(user.0, state, path, query, req).await
 }
@@ -106,10 +98,8 @@ pub(super) async fn audiobook_download(
     if let Some(denied) = deny_without_download(&user.0) {
         return denied;
     }
-    match is_shelf_hidden(&state.0, &user, &path.0).await {
-        Ok(true) => return StatusCode::NOT_FOUND.into_response(),
-        Ok(false) => {}
-        Err(resp) => return resp,
+    if let Some(resp) = guard_shelf_hidden(&state.0, &user, &path.0).await {
+        return resp;
     }
     audiobooks::get_audiobook_download(user.0, state, path, query, req).await
 }

--- a/server/src/backend/opds/mod.rs
+++ b/server/src/backend/opds/mod.rs
@@ -37,7 +37,7 @@
 //! that count without ever appearing as an entry.
 
 use axum::{
-    http::header,
+    http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Extension, Router,
@@ -273,4 +273,17 @@ async fn is_shelf_hidden(
     .await
     .map_err(|e| internal("check shelf-exclusive visibility", e))?;
     Ok(hidden.contains(&canonical))
+}
+
+/// Shared guard for the byte-serving [`delegate`] routes: collapses the
+/// `is_shelf_hidden` match block duplicated across all five of them into
+/// one call. Returns `Some(response)` to short-circuit the caller (a 404
+/// for a hidden book, or the propagated error), `None` to continue past
+/// the guard into the `/api` handler body.
+async fn guard_shelf_hidden(state: &AppState, user: &OpdsAuthUser, uuid: &str) -> Option<Response> {
+    match is_shelf_hidden(state, user, uuid).await {
+        Ok(true) => Some(StatusCode::NOT_FOUND.into_response()),
+        Ok(false) => None,
+        Err(resp) => Some(resp),
+    }
 }

--- a/server/src/backend/opds/tests/shelf_scoped_visibility.rs
+++ b/server/src/backend/opds/tests/shelf_scoped_visibility.rs
@@ -5,13 +5,15 @@
 
 use axum::http::StatusCode;
 use omnibus_db::{self as db, test_support::seed_synced_ebook};
+use omnibus_shared::EbookMetadata;
 use tower::ServiceExt;
 
 use crate::auth::test_support as auth_test_support;
-use crate::backend::test_support::get_with_bearer;
+use crate::backend::test_support::{get_with_bearer, CoversDirGuard, ThumbsDirGuard, TINY_PNG};
 
 use super::{
-    author_id_by_name, body_string, fixture, seed_synced_ebook_with_series, series_id_by_name,
+    author_id_by_name, body_string, fake_opds_user, fixture, retain_shelf_visible,
+    seed_synced_ebook_with_series, series_id_by_name, AppState,
 };
 
 /// Seed one book with a *real* on-disk EPUB file — unlike `seed_synced_ebook`,
@@ -47,6 +49,55 @@ async fn seed_downloadable_book(
          VALUES (?, 'EPUB', 'alpha', 0)",
     )
     .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    tmp
+}
+
+/// Audiobook counterpart to [`seed_downloadable_book`]: a real on-disk MP3
+/// part plus the `book_file_parts` row `hls::resolve_audiobook_file` and
+/// `get_parts` need, so the audiobook download delegate's 200-vs-404 split
+/// proves the shelf gate rather than a missing-file 404 either way.
+async fn seed_downloadable_audiobook(
+    pool: &sqlx::SqlitePool,
+    uuid: &str,
+    title: &str,
+) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("ch01.mp3"), b"ID3 fake-mp3").unwrap();
+
+    let lib_id = sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES (?, 'audiolib')")
+        .bind(tmp.path().to_str().unwrap())
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_rowid();
+    let book_id =
+        sqlx::query("INSERT INTO books (uuid, library_id, path, title) VALUES (?, ?, ?, ?)")
+            .bind(uuid)
+            .bind(lib_id)
+            .bind(tmp.path().to_str().unwrap())
+            .bind(title)
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_rowid();
+    let file_id = sqlx::query(
+        "INSERT INTO book_files (book_id, format, filename, size_bytes) \
+         VALUES (?, 'MP3', 'audiobook', 0)",
+    )
+    .bind(book_id)
+    .execute(pool)
+    .await
+    .unwrap()
+    .last_insert_rowid();
+    sqlx::query(
+        "INSERT INTO book_file_parts \
+         (book_file_id, ordinal, filename, size_bytes, mtime_epoch, duration_seconds) \
+         VALUES (?, 0, 'ch01.mp3', 0, 0, 60.0)",
+    )
+    .bind(file_id)
     .execute(pool)
     .await
     .unwrap();
@@ -370,4 +421,132 @@ async fn delegate_routes_404_a_shelf_hidden_book_requested_by_its_old_merged_uui
             "old uuid must not bypass the shelf gate via merged_uuids: {uri}"
         );
     }
+}
+
+#[tokio::test]
+async fn delegate_cover_route_404s_a_shelf_hidden_book_for_a_non_owner_and_serves_it_for_the_owner()
+{
+    // Same shape as the ebook_file/ebook_download coverage above, for the
+    // two delegate routes that were untested for the shelf gate (#1969).
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner-cover").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+
+    let uuid = "99999999-9999-9999-9999-999999999999";
+    let _tmp = seed_downloadable_book(&pool, uuid, "Delta").await;
+    sqlx::query("UPDATE books SET has_cover = 1 WHERE uuid = ?")
+        .bind(uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let _covers_guard = CoversDirGuard::new("opds_delegate_cover_shelf_hidden");
+    std::fs::write(db::covers_dir().join(format!("{uuid}.png")), TINY_PNG).unwrap();
+    seed_private_manual_shelf(&pool, owner.id, uuid.to_string()).await;
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(&format!("/opds/covers/{uuid}"), &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND, "other must 404");
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/covers/{uuid}"),
+            &owner_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "owner must still fetch it");
+}
+
+#[tokio::test]
+async fn delegate_thumb_route_404s_a_shelf_hidden_book_for_a_non_owner_and_serves_it_for_the_owner()
+{
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner-thumb").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+
+    let uuid = "aaaaaaaa-1111-1111-1111-111111111111";
+    let _tmp = seed_downloadable_book(&pool, uuid, "Epsilon").await;
+    sqlx::query("UPDATE books SET has_cover = 1 WHERE uuid = ?")
+        .bind(uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let _covers_guard = CoversDirGuard::new("opds_delegate_thumb_shelf_hidden");
+    let _thumbs_guard = ThumbsDirGuard::new("opds_delegate_thumb_shelf_hidden");
+    std::fs::write(db::covers_dir().join(format!("{uuid}.png")), TINY_PNG).unwrap();
+    seed_private_manual_shelf(&pool, owner.id, uuid.to_string()).await;
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(&format!("/opds/thumbs/{uuid}/sm"), &token))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND, "other must 404");
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/thumbs/{uuid}/sm"),
+            &owner_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "owner must still fetch it");
+}
+
+#[tokio::test]
+async fn delegate_audiobook_download_route_404s_a_shelf_hidden_book_for_a_non_owner_and_serves_it_for_the_owner(
+) {
+    let (app, pool, token) = fixture().await;
+    let owner = auth_test_support::create_user(&pool, "shelf-owner-audiobook").await;
+    let owner_token = auth_test_support::bearer_token(&pool, owner.id).await;
+
+    let uuid = "88888888-8888-8888-8888-888888888888";
+    let _tmp = seed_downloadable_audiobook(&pool, uuid, "Gamma").await;
+    seed_private_manual_shelf(&pool, owner.id, uuid.to_string()).await;
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/audiobooks/{uuid}/download"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND, "other must 404");
+
+    let res = app
+        .clone()
+        .oneshot(get_with_bearer(
+            &format!("/opds/audiobooks/{uuid}/download"),
+            &owner_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "owner must still fetch it");
+}
+
+#[tokio::test]
+async fn retain_shelf_visible_returns_500_when_the_pool_is_closed() {
+    // Isolates `retain_shelf_visible`'s own `internal(...)` 500 branch
+    // directly, rather than relying on an earlier-failing handler step to
+    // exercise it indirectly — every existing "returns_500_when_the_pool_is_
+    // closed" handler test actually fails earlier in the same request, at
+    // an upstream lookup, and never reaches this call.
+    let (_app, pool, _token) = fixture().await;
+    let state = AppState::new(pool.clone());
+    pool.close().await;
+
+    let mut books = vec![EbookMetadata {
+        unique_identifier: Some("some-uuid".to_string()),
+        ..Default::default()
+    }];
+    let err = retain_shelf_visible(&state, &fake_opds_user(), &mut books)
+        .await
+        .expect_err("closed pool must surface as an Err response");
+    assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary
- Closes #1969
- Collapse the `is_shelf_hidden` match block duplicated five times across `server/src/backend/opds/delegate.rs`'s routes into one `guard_shelf_hidden` helper in `server/src/backend/opds/mod.rs`, and update all five call sites (`cover`, `thumb`, `ebook_file`, `ebook_download`, `audiobook_download`) to use it.
- Add 404-for-a-shelf-hidden-book coverage (matching the existing `ebook_file`/`ebook_download` test shape — non-owner 404s, owner still fetches it) for the three delegate routes that had none: `cover`, `thumb`, `audiobook_download`, in `server/src/backend/opds/tests/shelf_scoped_visibility.rs`.
- Add a test that isolates `retain_shelf_visible`'s own `internal(...)` 500 branch directly via a closed-pool fixture, rather than relying on an earlier-failing handler step to exercise it indirectly.
- No production behavior change — this is closing test gaps plus a mechanical dedup.

## Test plan
- [x] `cargo fmt -p omnibus -- --check` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus` — PASS (824 passed, 2 failed; the 2 failures — `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `audiobook_commit_rejects_read_only_library_with_400` — are pre-existing and unrelated: they rely on a read-only directory actually rejecting writes, which doesn't hold when the test process runs as root (confirmed identical failure on `origin/main` with this change stashed out, in this sandbox environment))
- [x] `cargo test -p omnibus backend::opds::` — 79/79 passed, including the 4 new tests

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- The `db/src/shelves/tests.rs` 800-line file-cap issue mentioned in #1969's notes is intentionally out of scope here — it's tracked separately by #1881.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgtwbydcDBeHYxTv2iyWv4)_