### PR TITLE
feat: guard entity resolution against reindex resurrection (#964)

### DIFF
--- a/db/src/entity_alias.rs
+++ b/db/src/entity_alias.rs
@@ -1,0 +1,48 @@
+//! Reindex-resurrection guard (#964): shared read-side of the
+//! `entity_aliases` ledger that `cleanup::entity_ops::write_entity_alias`
+//! writes when a library-cleanup merge absorbs an author, series, or tag.
+//! Consulted by every taxonomy resolver *before* it mints a new row, so a
+//! later reindex re-parsing a file that still names the merged-away entity
+//! resolves back to the surviving canonical id instead of recreating the
+//! row the merge just removed.
+
+use std::collections::HashMap;
+
+use omnibus_shared::CleanupKind;
+use sqlx::Transaction;
+
+#[cfg(test)]
+mod tests;
+
+/// Batched alias lookup: for each of `names`, report the canonical id it
+/// now resolves to, if any prior merge recorded it as an alias. A name
+/// absent from the returned map has never been merged away — the caller
+/// falls through to its normal insert-or-resolve path. One `SELECT ...
+/// WHERE alias_name IN (...)` per chunk rather than a query per name;
+/// chunked at 500 to stay under SQLite's bound-parameter cap alongside the
+/// `kind` bind.
+pub(crate) async fn resolve_entity_aliases(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    kind: CleanupKind,
+    names: &[&str],
+) -> Result<HashMap<String, i64>, sqlx::Error> {
+    let mut out = HashMap::new();
+    if names.is_empty() {
+        return Ok(out);
+    }
+    for chunk in names.chunks(500) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT alias_name, canonical_id FROM entity_aliases \
+             WHERE kind = ? AND alias_name IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String, i64)>(&sql).bind(kind.as_str());
+        for name in chunk {
+            q = q.bind(*name);
+        }
+        out.extend(q.fetch_all(&mut **tx).await?);
+    }
+    Ok(out)
+}

--- a/db/src/entity_alias.rs
+++ b/db/src/entity_alias.rs
@@ -21,6 +21,16 @@ mod tests;
 /// WHERE alias_name IN (...)` per chunk rather than a query per name;
 /// chunked at 500 to stay under SQLite's bound-parameter cap alongside the
 /// `kind` bind.
+///
+/// The match is `COLLATE NOCASE` (ASCII case-fold, matching SQLite's builtin
+/// collation and the `authors`/`series`/`tags` columns themselves — migration
+/// `0002`) so a reindex that yields a casing variant of a merged-away name
+/// still resolves to the canonical id rather than resurrecting it. Because
+/// the stored `alias_name` may carry different casing than the queried
+/// `names`, the returned map is keyed by the *input* name (matched via
+/// `eq_ignore_ascii_case`, mirroring SQLite's own fold) rather than the row's
+/// casing, so callers can look it up with the exact string they queried
+/// with.
 pub(crate) async fn resolve_entity_aliases(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     kind: CleanupKind,
@@ -36,13 +46,17 @@ pub(crate) async fn resolve_entity_aliases(
             .join(", ");
         let sql = format!(
             "SELECT alias_name, canonical_id FROM entity_aliases \
-             WHERE kind = ? AND alias_name IN ({placeholders})"
+             WHERE kind = ? AND alias_name COLLATE NOCASE IN ({placeholders})"
         );
         let mut q = sqlx::query_as::<_, (String, i64)>(&sql).bind(kind.as_str());
         for name in chunk {
             q = q.bind(*name);
         }
-        out.extend(q.fetch_all(&mut **tx).await?);
+        for (alias_name, canonical_id) in q.fetch_all(&mut **tx).await? {
+            for name in chunk.iter().filter(|n| n.eq_ignore_ascii_case(&alias_name)) {
+                out.insert((*name).to_string(), canonical_id);
+            }
+        }
     }
     Ok(out)
 }

--- a/db/src/entity_alias/tests.rs
+++ b/db/src/entity_alias/tests.rs
@@ -1,0 +1,88 @@
+//! Unit tests for [`resolve_entity_aliases`]: empty input, no match, a
+//! single hit, a mixed batch, and kind-scoping (an alias recorded under one
+//! `CleanupKind` must never leak into a lookup for another).
+
+use omnibus_shared::CleanupKind;
+
+use super::*;
+use crate::pool::init_db;
+
+async fn insert_alias(
+    pool: &sqlx::SqlitePool,
+    kind: CleanupKind,
+    alias_name: &str,
+    canonical_id: i64,
+) {
+    sqlx::query("INSERT INTO entity_aliases (kind, alias_name, canonical_id) VALUES (?, ?, ?)")
+        .bind(kind.as_str())
+        .bind(alias_name)
+        .bind(canonical_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_returns_empty_map_for_empty_names() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    let found = resolve_entity_aliases(&mut tx, CleanupKind::Author, &[])
+        .await
+        .unwrap();
+    assert!(found.is_empty());
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_returns_empty_map_when_no_alias_recorded() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    let found = resolve_entity_aliases(&mut tx, CleanupKind::Author, &["Nobody"])
+        .await
+        .unwrap();
+    assert!(found.is_empty());
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_finds_a_recorded_alias() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    insert_alias(&pool, CleanupKind::Author, "John Smith", 42).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let found = resolve_entity_aliases(&mut tx, CleanupKind::Author, &["John Smith"])
+        .await
+        .unwrap();
+    assert_eq!(found.get("John Smith"), Some(&42));
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_returns_only_the_names_that_hit_in_a_mixed_batch() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    insert_alias(&pool, CleanupKind::Series, "The Wheel of Time", 7).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let found = resolve_entity_aliases(
+        &mut tx,
+        CleanupKind::Series,
+        &["The Wheel of Time", "Unrelated Series"],
+    )
+    .await
+    .unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found.get("The Wheel of Time"), Some(&7));
+    assert!(!found.contains_key("Unrelated Series"));
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_does_not_leak_across_kinds() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    insert_alias(&pool, CleanupKind::Author, "Ambiguous Name", 1).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    let found = resolve_entity_aliases(&mut tx, CleanupKind::Series, &["Ambiguous Name"])
+        .await
+        .unwrap();
+    assert!(
+        found.is_empty(),
+        "an author-kind alias must not answer a series-kind lookup"
+    );
+}

--- a/db/src/entity_alias/tests.rs
+++ b/db/src/entity_alias/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for [`resolve_entity_aliases`]: empty input, no match, a
-//! single hit, a mixed batch, and kind-scoping (an alias recorded under one
-//! `CleanupKind` must never leak into a lookup for another).
+//! single hit, a mixed batch, kind-scoping (an alias recorded under one
+//! `CleanupKind` must never leak into a lookup for another), and a
+//! casing-variant hit (the NOCASE match).
 
 use omnibus_shared::CleanupKind;
 
@@ -70,6 +71,21 @@ async fn resolve_entity_aliases_returns_only_the_names_that_hit_in_a_mixed_batch
     assert_eq!(found.len(), 1);
     assert_eq!(found.get("The Wheel of Time"), Some(&7));
     assert!(!found.contains_key("Unrelated Series"));
+}
+
+#[tokio::test]
+async fn resolve_entity_aliases_matches_a_casing_variant_of_a_recorded_alias() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    insert_alias(&pool, CleanupKind::Author, "John Smith", 42).await;
+
+    let mut tx = pool.begin().await.unwrap();
+    // A reindex can hand back a different casing of the same merged-away
+    // name (e.g. the OPF was edited); the guard must still catch it rather
+    // than minting a fresh row (#964).
+    let found = resolve_entity_aliases(&mut tx, CleanupKind::Author, &["JOHN SMITH"])
+        .await
+        .unwrap();
+    assert_eq!(found.get("JOHN SMITH"), Some(&42));
 }
 
 #[tokio::test]

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -22,6 +22,7 @@ pub mod covers;
 pub mod deletion;
 pub mod discovery;
 pub mod ebook;
+mod entity_alias;
 pub mod epub_rewrite;
 pub mod error_ring;
 pub mod helpers;

--- a/db/src/sync/authors.rs
+++ b/db/src/sync/authors.rs
@@ -1,10 +1,18 @@
 //! Batched author-link writer for the indexer sync path. Resolves the
 //! merged `creators + contributors` list against the `ignored_authors`
-//! blocklist, upserts surviving names into `authors`, and writes the
+//! blocklist and the `entity_aliases` reindex-resurrection guard (#964),
+//! upserts surviving unmerged names into `authors`, and writes the
 //! per-book join rows in a constant handful of statements.
 
-use omnibus_shared::EbookMetadata;
+use std::collections::{HashMap, HashSet};
+
+use omnibus_shared::{CleanupKind, EbookMetadata};
 use sqlx::Transaction;
+
+use crate::entity_alias::resolve_entity_aliases;
+
+#[cfg(test)]
+mod tests;
 
 /// Batch-insert author join rows from the merged `creators` list. The OPF
 /// parser appends `<dc:contributor>` entries onto `creators` in source
@@ -48,8 +56,21 @@ pub(super) async fn insert_author_links(
         return Ok(());
     }
 
-    upsert_authors(tx, &kept, &sort_for).await?;
-    insert_books_authors_link(tx, book_id, &entries, &ignored).await?;
+    // #964: a name a completed library-cleanup merge absorbed must resolve
+    // to the surviving canonical id rather than mint a fresh `authors` row
+    // when the same file is reindexed. Only the unmerged remainder goes
+    // through the normal upsert.
+    let aliased = resolve_entity_aliases(tx, CleanupKind::Author, &kept).await?;
+    let to_upsert: Vec<&str> = kept
+        .iter()
+        .copied()
+        .filter(|n| !aliased.contains_key(*n))
+        .collect();
+    if !to_upsert.is_empty() {
+        upsert_authors(tx, &to_upsert, &sort_for).await?;
+    }
+
+    insert_books_authors_link(tx, book_id, &entries, &ignored, &aliased).await?;
     Ok(())
 }
 
@@ -124,18 +145,19 @@ async fn upsert_authors(
     Ok(())
 }
 
-/// Insert the per-book link rows in one statement. Dedupes by name, keeping
-/// the first (lowest) position so a name repeated in the merged
-/// creators+contributors list keeps its first position — matching the old
-/// `INSERT OR IGNORE` loop. The id is resolved in SQL via the NOCASE join,
-/// so casing differences don't need handling in Rust.
+/// Insert the per-book link rows. Dedupes by name, keeping the first
+/// (lowest) position so a name repeated in the merged creators+contributors
+/// list keeps its first position — matching the old `INSERT OR IGNORE`
+/// loop. Splits on whether `aliased` already knows the target id (#964: a
+/// merged-away name) or needs the usual NOCASE join against `authors`.
 async fn insert_books_authors_link(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
     entries: &[(&str, Option<&str>, i64)],
-    ignored: &std::collections::HashSet<String>,
+    ignored: &HashSet<String>,
+    aliased: &HashMap<String, i64>,
 ) -> Result<(), sqlx::Error> {
-    let mut linked: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut linked: HashSet<&str> = HashSet::new();
     let link_entries: Vec<(&str, i64)> = entries
         .iter()
         .filter(|(name, _, _)| !ignored.contains(*name))
@@ -145,7 +167,48 @@ async fn insert_books_authors_link(
     if link_entries.is_empty() {
         return Ok(());
     }
-    let link_rows = std::iter::repeat_n("(?, ?)", link_entries.len())
+    let (direct, by_name): (Vec<_>, Vec<_>) = link_entries
+        .into_iter()
+        .partition(|(name, _)| aliased.contains_key(*name));
+
+    if !direct.is_empty() {
+        insert_direct_author_links(tx, book_id, &direct, aliased).await?;
+    }
+    if !by_name.is_empty() {
+        insert_named_author_links(tx, book_id, &by_name).await?;
+    }
+    Ok(())
+}
+
+/// Link rows whose author id is already known (a merged-away name resolved
+/// via `entity_aliases`) — a plain `VALUES` insert, no join needed.
+async fn insert_direct_author_links(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    entries: &[(&str, i64)],
+    aliased: &HashMap<String, i64>,
+) -> Result<(), sqlx::Error> {
+    let rows = std::iter::repeat_n("(?, ?, ?)", entries.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql =
+        format!("INSERT OR IGNORE INTO books_authors_link (book, author, position) VALUES {rows}");
+    let mut q = sqlx::query(&sql);
+    for (name, pos) in entries {
+        q = q.bind(book_id).bind(aliased[*name]).bind(*pos);
+    }
+    q.execute(&mut **tx).await?;
+    Ok(())
+}
+
+/// Link rows resolved by name via the NOCASE join against `authors`, for
+/// the (common) case of a name with no alias — unchanged from before #964.
+async fn insert_named_author_links(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    entries: &[(&str, i64)],
+) -> Result<(), sqlx::Error> {
+    let link_rows = std::iter::repeat_n("(?, ?)", entries.len())
         .collect::<Vec<_>>()
         .join(", ");
     let link_sql = format!(
@@ -155,7 +218,7 @@ async fn insert_books_authors_link(
          JOIN authors a ON a.name = v.column1"
     );
     let mut q = sqlx::query(&link_sql).bind(book_id);
-    for (name, pos) in &link_entries {
+    for (name, pos) in entries {
         q = q.bind(*name).bind(*pos);
     }
     q.execute(&mut **tx).await?;

--- a/db/src/sync/authors/tests.rs
+++ b/db/src/sync/authors/tests.rs
@@ -1,0 +1,105 @@
+//! Unit tests for [`insert_author_links`]'s reindex-resurrection guard
+//! (#964): an aliased name resolves straight to its canonical id without
+//! minting a new `authors` row, while an unaliased name still goes through
+//! the normal upsert-and-join path unchanged.
+
+use omnibus_shared::{Contributor, EbookMetadata};
+
+use super::*;
+use crate::pool::init_db;
+
+fn metadata_with_creator(name: &str) -> EbookMetadata {
+    EbookMetadata {
+        filename: "book.epub".into(),
+        creators: vec![Contributor {
+            name: name.into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+async fn seed_book(pool: &sqlx::SqlitePool) -> i64 {
+    let lib_id: i64 = sqlx::query_scalar(
+        "INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib') RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query_scalar(
+        "INSERT INTO books (uuid, library_id, path, title) VALUES ('u', ?, '/lib/u', 'T') RETURNING id",
+    )
+    .bind(lib_id)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn author_id(pool: &sqlx::SqlitePool, name: &str) -> Option<i64> {
+    sqlx::query_scalar("SELECT id FROM authors WHERE name = ?")
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+}
+
+async fn linked_author_ids(pool: &sqlx::SqlitePool, book_id: i64) -> Vec<i64> {
+    sqlx::query_scalar("SELECT author FROM books_authors_link WHERE book = ? ORDER BY position")
+        .bind(book_id)
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn insert_author_links_upserts_and_links_an_unaliased_name() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_book(&pool).await;
+    let m = metadata_with_creator("Ada Lovelace");
+
+    let mut tx = pool.begin().await.unwrap();
+    insert_author_links(&mut tx, book_id, &m).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let id = author_id(&pool, "Ada Lovelace")
+        .await
+        .expect("author row must exist");
+    assert_eq!(linked_author_ids(&pool, book_id).await, vec![id]);
+}
+
+#[tokio::test]
+async fn insert_author_links_resolves_a_merged_away_name_to_its_canonical_id() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_book(&pool).await;
+
+    let canonical_id: i64 =
+        sqlx::query_scalar("INSERT INTO authors (name) VALUES ('J. Smith') RETURNING id")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    sqlx::query(
+        "INSERT INTO entity_aliases (kind, alias_name, canonical_id) \
+         VALUES ('author', 'John Smith', ?)",
+    )
+    .bind(canonical_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Simulates a reindex of a file the parser still reports as "John
+    // Smith" — the on-disk metadata a completed merge doesn't rewrite.
+    let m = metadata_with_creator("John Smith");
+    let mut tx = pool.begin().await.unwrap();
+    insert_author_links(&mut tx, book_id, &m).await.unwrap();
+    tx.commit().await.unwrap();
+
+    assert!(
+        author_id(&pool, "John Smith").await.is_none(),
+        "AC2: the merged-away name must not be recreated"
+    );
+    assert_eq!(
+        linked_author_ids(&pool, book_id).await,
+        vec![canonical_id],
+        "AC1: the book must link to the surviving canonical author"
+    );
+}

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -6,10 +6,11 @@
 
 use std::collections::HashSet;
 
-use omnibus_shared::EbookMetadata;
+use omnibus_shared::{CleanupKind, EbookMetadata};
 use sqlx::Transaction;
 
 use crate::covers::write_cover_file;
+use crate::entity_alias::resolve_entity_aliases;
 use crate::helpers::{
     cleaned_series_name, mint_uuid, resolved_series_index, sanitize_accent_color, scan_key_for,
     split_filename, stable_uuid,
@@ -431,7 +432,10 @@ pub(super) async fn insert_metadata_links(
 
 /// Batch-insert the book's tag (subject) join rows: one `INSERT OR IGNORE`
 /// into `tags` for all distinct non-empty subjects, then one link insert that
-/// resolves ids via a NOCASE join.
+/// resolves ids via a NOCASE join. A subject a completed library-cleanup
+/// merge already absorbed (#964) skips the `tags` insert and links straight
+/// to its `entity_aliases` canonical id instead, so reindexing a file that
+/// still names the merged-away tag can't resurrect it.
 async fn insert_tag_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -448,10 +452,18 @@ async fn insert_tag_links(
     if tags.is_empty() {
         return Ok(());
     }
+
+    let aliased = resolve_entity_aliases(tx, CleanupKind::Tag, &tags).await?;
+    let to_insert: Vec<&str> = tags
+        .iter()
+        .copied()
+        .filter(|t| !aliased.contains_key(*t))
+        .collect();
+
     // Both statements bind ~1 param per tag; chunk so a tag-heavy book can't
     // exceed SQLite's bound-parameter cap (999 by default). 500 keeps the link
     // statement (book_id + one per tag) safely under the limit.
-    for chunk in tags.chunks(500) {
+    for chunk in to_insert.chunks(500) {
         let rows = std::iter::repeat_n("(?)", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");
@@ -471,6 +483,32 @@ async fn insert_tag_links(
             link_q = link_q.bind(*t);
         }
         link_q.execute(&mut **tx).await?;
+    }
+
+    link_aliased_tags(tx, book_id, &aliased).await
+}
+
+/// Link the book straight to each already-known canonical tag id, for
+/// subjects [`insert_tag_links`] found in `entity_aliases`.
+async fn link_aliased_tags(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    aliased: &std::collections::HashMap<String, i64>,
+) -> Result<(), sqlx::Error> {
+    if aliased.is_empty() {
+        return Ok(());
+    }
+    let canonical_ids: Vec<i64> = aliased.values().copied().collect();
+    for chunk in canonical_ids.chunks(500) {
+        let rows = std::iter::repeat_n("(?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("INSERT OR IGNORE INTO books_tags_link (book, tag) VALUES {rows}");
+        let mut q = sqlx::query(&sql);
+        for tag_id in chunk {
+            q = q.bind(book_id).bind(*tag_id);
+        }
+        q.execute(&mut **tx).await?;
     }
     Ok(())
 }

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -498,8 +498,10 @@ async fn link_aliased_tags(
     if aliased.is_empty() {
         return Ok(());
     }
+    // Each row binds 2 params (book_id, tag_id), so chunk at 499 to stay
+    // under SQLite's 999-parameter cap (499 * 2 = 998).
     let canonical_ids: Vec<i64> = aliased.values().copied().collect();
-    for chunk in canonical_ids.chunks(500) {
+    for chunk in canonical_ids.chunks(499) {
         let rows = std::iter::repeat_n("(?, ?)", chunk.len())
             .collect::<Vec<_>>()
             .join(", ");

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -9,10 +9,13 @@ use sqlx::SqlitePool;
 
 use super::shared::{insert_book_row, insert_metadata_links};
 use super::{sync_books, sync_changed, sync_new, sync_removed, wipe_per_book_link_rows, SyncPlan};
+use crate::cleanup::{apply_merge_authors, apply_merge_series, apply_merge_tags};
 use crate::ebook::IndexedBook;
 use crate::indexer::diff_library;
 use crate::pool::init_db;
-use crate::test_support::{count_rows, indexed, CoversTempDir};
+use crate::test_support::{
+    author_id_by_name, count_rows, indexed, series_id_by_name, CoversTempDir,
+};
 
 /// Insert a `scan_roots` row for `/lib` and return its id — the
 /// `library_id` every bucket helper needs.
@@ -447,6 +450,240 @@ async fn sync_changed_is_a_noop_for_empty_batch() {
         .unwrap();
     tx.commit().await.unwrap();
     assert!(covers.is_empty());
+}
+
+/// Look up a `tags.id` by name. Panics on miss — test helper only.
+async fn tag_id_by_name(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT id FROM tags WHERE name = ?")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// `true` when `table.name = ? table` has no row for the given name.
+async fn taxonomy_row_missing(pool: &SqlitePool, table: &str, name: &str) -> bool {
+    let sql = format!("SELECT COUNT(*) FROM {table} WHERE name = ?");
+    count_rows_bound(pool, &sql, name).await == 0
+}
+
+async fn count_rows_bound(pool: &SqlitePool, sql: &str, bind: &str) -> i64 {
+    sqlx::query_scalar(sql)
+        .bind(bind)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// `true` when `book_id` is linked to `entity_id` in `link_table` via `col`.
+async fn is_linked(
+    pool: &SqlitePool,
+    link_table: &str,
+    col: &str,
+    book_id: i64,
+    entity_id: i64,
+) -> bool {
+    let sql = format!("SELECT COUNT(*) FROM {link_table} WHERE book = ? AND {col} = ?");
+    let n: i64 = sqlx::query_scalar(&sql)
+        .bind(book_id)
+        .bind(entity_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    n == 1
+}
+
+/// #964 AC2: merging an author, series, and tag away, then reindexing the
+/// book whose file still names the merged-away entities (`sync_changed`,
+/// the real `Task::Scan` write path for an unchanged-on-disk-but-reparsed
+/// file), must resolve every one of them to the surviving canonical row —
+/// never mint a fresh `authors`/`series`/`tags` row for a name a completed
+/// merge already absorbed.
+#[tokio::test]
+async fn sync_changed_reindex_does_not_resurrect_a_merged_away_author_series_or_tag() {
+    let _covers = CoversTempDir::new("resurrection_guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+
+    let source = indexed(
+        "source.epub",
+        Some("Source Book"),
+        &["John Smith"],
+        &["Sci-Fi"],
+        Some(("The Wheel of Time", "1")),
+        None,
+    );
+    let canonical = indexed(
+        "canonical.epub",
+        Some("Canonical Book"),
+        &["J. Smith"],
+        &["Science Fiction"],
+        Some(("Wheel of Time", "1")),
+        None,
+    );
+    let mut tx = pool.begin().await.unwrap();
+    sync_new(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[source, canonical],
+        &[],
+        |_| {},
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let source_book_id: i64 =
+        sqlx::query_scalar("SELECT id FROM books WHERE scan_key = 'source.epub'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let author_source_id = author_id_by_name(&pool, "John Smith").await;
+    let author_canonical_id = author_id_by_name(&pool, "J. Smith").await;
+    let series_source_id = series_id_by_name(&pool, "The Wheel of Time").await;
+    let series_canonical_id = series_id_by_name(&pool, "Wheel of Time").await;
+    let tag_source_id = tag_id_by_name(&pool, "Sci-Fi").await;
+    let tag_canonical_id = tag_id_by_name(&pool, "Science Fiction").await;
+
+    apply_merge_authors(&pool, &[author_source_id], author_canonical_id, None, None)
+        .await
+        .unwrap();
+    apply_merge_series(&pool, &[series_source_id], series_canonical_id, None, None)
+        .await
+        .unwrap();
+    apply_merge_tags(&pool, &[tag_source_id], tag_canonical_id, None, None)
+        .await
+        .unwrap();
+
+    // A second reindex of the source book: its file on disk never changed,
+    // so the parser still reports the names the merges just absorbed.
+    let reparsed = indexed(
+        "source.epub",
+        Some("Source Book"),
+        &["John Smith"],
+        &["Sci-Fi"],
+        Some(("The Wheel of Time", "1")),
+        None,
+    );
+    let mut tx = pool.begin().await.unwrap();
+    sync_changed(&mut tx, library_id, "/lib", &[reparsed], |_| {})
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert!(
+        taxonomy_row_missing(&pool, "authors", "John Smith").await,
+        "AC2: the merged-away author must not be recreated"
+    );
+    assert!(
+        taxonomy_row_missing(&pool, "series", "The Wheel of Time").await,
+        "AC2: the merged-away series must not be recreated"
+    );
+    assert!(
+        taxonomy_row_missing(&pool, "tags", "Sci-Fi").await,
+        "AC2: the merged-away tag must not be recreated"
+    );
+
+    assert!(
+        is_linked(
+            &pool,
+            "books_authors_link",
+            "author",
+            source_book_id,
+            author_canonical_id
+        )
+        .await,
+        "AC1: reindexed book resolves to the canonical author"
+    );
+    assert!(
+        is_linked(
+            &pool,
+            "books_series_link",
+            "series",
+            source_book_id,
+            series_canonical_id
+        )
+        .await,
+        "AC1: reindexed book resolves to the canonical series"
+    );
+    assert!(
+        is_linked(
+            &pool,
+            "books_tags_link",
+            "tag",
+            source_book_id,
+            tag_canonical_id
+        )
+        .await,
+        "AC1: reindexed book resolves to the canonical tag"
+    );
+}
+
+/// AC3: with no alias recorded, `sync_changed` behaves exactly as before —
+/// the reindexed name resolves to its own (unmerged) row, not some other
+/// entity's.
+#[tokio::test]
+async fn sync_changed_reindex_leaves_unmerged_entities_unaffected() {
+    let _covers = CoversTempDir::new("resurrection_guard_unaffected");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+
+    let book = indexed(
+        "plain.epub",
+        Some("Plain Book"),
+        &["Ordinary Author"],
+        &["Ordinary Tag"],
+        Some(("Ordinary Series", "1")),
+        None,
+    );
+    let mut tx = pool.begin().await.unwrap();
+    sync_new(&mut tx, library_id, "/lib", &[book], &[], |_| {})
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE scan_key = 'plain.epub'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let author_id = author_id_by_name(&pool, "Ordinary Author").await;
+    let series_id = series_id_by_name(&pool, "Ordinary Series").await;
+    let tag_id = tag_id_by_name(&pool, "Ordinary Tag").await;
+
+    let reparsed = indexed(
+        "plain.epub",
+        Some("Plain Book"),
+        &["Ordinary Author"],
+        &["Ordinary Tag"],
+        Some(("Ordinary Series", "1")),
+        None,
+    );
+    let mut tx = pool.begin().await.unwrap();
+    sync_changed(&mut tx, library_id, "/lib", &[reparsed], |_| {})
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM authors").await,
+        1,
+        "no extra author row minted"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM series").await,
+        1,
+        "no extra series row minted"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM tags").await,
+        1,
+        "no extra tag row minted"
+    );
+    assert!(is_linked(&pool, "books_authors_link", "author", book_id, author_id).await);
+    assert!(is_linked(&pool, "books_series_link", "series", book_id, series_id).await);
+    assert!(is_linked(&pool, "books_tags_link", "tag", book_id, tag_id).await);
 }
 
 /// A helper on the `IndexedBook` boundary: `insert_book_row` returns the

--- a/db/src/taxonomy.rs
+++ b/db/src/taxonomy.rs
@@ -4,7 +4,10 @@
 //! exposed to siblings via `pub(crate)`. The multi-valued relations
 //! (authors, tags, identifiers) are inserted in batches directly in `sync`.
 
+use omnibus_shared::CleanupKind;
 use sqlx::Transaction;
+
+use crate::entity_alias::resolve_entity_aliases;
 
 /// Taxonomy resolve-or-insert helpers. Each returns the row id for the given
 /// (case-insensitive) name, inserting a row if one doesn't exist yet.
@@ -37,10 +40,35 @@ macro_rules! resolve_or_insert_simple {
     };
 }
 
-resolve_or_insert_simple!(resolve_or_insert_series, "series", "name");
 resolve_or_insert_simple!(resolve_or_insert_tag, "tags", "name");
 resolve_or_insert_simple!(resolve_or_insert_publisher, "publishers", "name");
 resolve_or_insert_simple!(resolve_or_insert_language, "languages", "code");
+
+/// Resolve `value` to a `series.id`, consulting the reindex-resurrection
+/// guard first (#964): if `value` was absorbed into another series by a
+/// completed library-cleanup merge, return the surviving canonical id
+/// instead of minting a fresh row for the merged-away name. On a miss,
+/// falls through to the same `INSERT OR IGNORE` / `SELECT` shape the other
+/// taxonomy resolvers use.
+pub(crate) async fn resolve_or_insert_series(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    value: &str,
+) -> Result<i64, sqlx::Error> {
+    if let Some(canonical_id) = resolve_entity_aliases(tx, CleanupKind::Series, &[value])
+        .await?
+        .remove(value)
+    {
+        return Ok(canonical_id);
+    }
+    sqlx::query("INSERT OR IGNORE INTO series (name) VALUES (?)")
+        .bind(value)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query_scalar("SELECT id FROM series WHERE name = ?")
+        .bind(value)
+        .fetch_one(&mut **tx)
+        .await
+}
 
 /// Delete taxonomy rows (`authors`, `series`, `publishers`, `languages`)
 /// no longer referenced by any book, then reap orphaned tags and genres via

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -80,6 +80,41 @@ async fn resolve_or_insert_series_collapses_case_variants_to_one_row() {
 }
 
 #[tokio::test]
+async fn resolve_or_insert_series_returns_the_canonical_id_for_a_merged_away_name() {
+    // #964: a name a completed library-cleanup merge absorbed must resolve
+    // straight to the surviving canonical id, not mint a fresh row.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    let canonical_id = resolve_or_insert_series(&mut tx, "Wheel of Time")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO entity_aliases (kind, alias_name, canonical_id) VALUES ('series', ?, ?)",
+    )
+    .bind("The Wheel of Time")
+    .bind(canonical_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mut tx = pool.begin().await.unwrap();
+    let resolved = resolve_or_insert_series(&mut tx, "The Wheel of Time")
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(resolved, canonical_id);
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM series WHERE name = ?")
+        .bind("The Wheel of Time")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 0, "the merged-away name must not be recreated");
+}
+
+#[tokio::test]
 async fn resolve_or_insert_publisher_inserts_and_is_idempotent() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let mut tx = pool.begin().await.unwrap();


### PR DESCRIPTION
## Summary
- Closes #964
- Extends the author, series, and tag resolvers to consult the `entity_aliases` ledger before inserting: `resolve_entity_aliases` (new `db/src/entity_alias.rs`) does one batched `SELECT canonical_id FROM entity_aliases WHERE kind = ? AND alias_name IN (...)` lookup per reindex batch, and a hit short-circuits straight to the surviving canonical id instead of the normal upsert-or-resolve path.
- On an alias miss, behavior is unchanged — falls through to the existing INSERT-ON-CONFLICT / NOCASE-join path, so non-merged entities are unaffected (AC3).
- Covered by an integration test that merges two authors, runs a second reindex, and asserts the merged-away source row is not re-created (AC2), plus author/series/tag unit coverage for the alias-hit and alias-miss branches (AC1).

## Test plan
- [x] `cd /home/user/omnibus-wt-964 && CARGO_TARGET_DIR=/tmp/omnibus-target-964 cargo test -p omnibus-db` — PASS (2114 passed, 0 failed; two transient failure batches during the run were disk-space/missing-fixture artifacts of concurrent worktree builds, not this change — see Notes)
- [x] `cd /home/user/omnibus-wt-964 && CARGO_TARGET_DIR=/tmp/omnibus-target-964 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- The first full test run hit 12 failures, all `StorageFull` errors from tempfile-backed `pool::tests::*`/`physical::tests::*` writes while sibling worktree builds had driven `/` to ~0 free; a second full run (after disk recovered) left exactly one failure, a missing audiobook fixture (`run `just fixtures``) — fetched via `scripts/fetch-fixtures.sh`, then reran that single test to confirm green. Neither failure touched code this PR changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7BXSStsWbu91wQJ27RUZi)_