### PR TITLE
feat: add provider registry and capability catalog (#1655)

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -98,8 +98,8 @@ pub use helpers::{build_fts_match, sanitize_fts_query};
 pub use kepub::{convert_book, kepub_path, kepubify_available, warn_if_unavailable, KepubError};
 pub use merge::{merge_books, undo_merge, MergeError, MergeOutcome};
 pub use metadata_lookup::{
-    search_provider_by_isbn, search_provider_by_title, MetadataLookupConfig, MetadataLookupError,
-    ProviderKeys,
+    catalog, search_provider_by_isbn, search_provider_by_title, MetadataLookupConfig,
+    MetadataLookupError, ProviderKeys,
 };
 pub use metadata_overrides::*;
 pub use missing_files::{

--- a/db/src/metadata_lookup/mod.rs
+++ b/db/src/metadata_lookup/mod.rs
@@ -14,7 +14,7 @@ mod providers;
 mod tests;
 
 pub use config::{MetadataLookupConfig, ProviderKeys};
-pub use providers::{openlibrary_enrich, OlEnrichment};
+pub use providers::{catalog, openlibrary_enrich, OlEnrichment};
 
 use omnibus_shared::isbn::{normalize_isbn, IsbnError};
 use omnibus_shared::metadata_lookup::ExternalBookMeta;

--- a/db/src/metadata_lookup/providers/mod.rs
+++ b/db/src/metadata_lookup/providers/mod.rs
@@ -30,9 +30,14 @@ pub(super) mod openlibrary;
 pub(super) use http::publication_year;
 pub use openlibrary::{enrich as openlibrary_enrich, OlEnrichment};
 
-use omnibus_shared::metadata_lookup::{ExternalBookMeta, MetadataProvider};
+use omnibus_shared::metadata_lookup::{
+    ExternalBookMeta, MetadataProvider, ProviderCapabilities, ProviderInfo,
+};
 
 use super::MetadataLookupConfig;
+
+#[cfg(test)]
+mod tests;
 
 /// The two things a rung can be asked. Carrying the operation as data (rather
 /// than passing an async closure) keeps the ladder a single non-generic
@@ -128,4 +133,50 @@ pub fn ladder(config: &MetadataLookupConfig) -> Vec<Rung> {
         });
     }
     rungs
+}
+
+/// Every provider a search *can* be run against, `by_isbn`/`by_title`,
+/// carrying a cover image. Common to all three providers today.
+const SEARCH_AND_COVER_CAPABILITIES: ProviderCapabilities = ProviderCapabilities {
+    search_by_title: true,
+    search_by_isbn: true,
+    carries_cover: true,
+    carries_ratings: false,
+    carries_genres: false,
+};
+
+/// The full provider catalog: identity, usability, and capabilities for
+/// every provider this instance knows about — display surface for the
+/// eventual provider-filter UI, and the one place a caller can ask "which
+/// sources exist" without matching on [`MetadataProvider`] itself.
+///
+/// `configured` reuses the exact key-presence check [`ladder`] uses for each
+/// provider, so the two can never disagree about what "configured" means:
+/// Open Library and Google Books are always usable (Google Books is tried
+/// keyless too, just not as the ladder's primary rung — see [`ladder`]'s
+/// docs), and Hardcover only when `config.keys.hardcover` is set.
+pub fn catalog(config: &MetadataLookupConfig) -> Vec<ProviderInfo> {
+    vec![
+        ProviderInfo {
+            id: MetadataProvider::OpenLibrary,
+            display_name: MetadataProvider::OpenLibrary.display_name().to_string(),
+            configured: true,
+            requires_key: false,
+            capabilities: SEARCH_AND_COVER_CAPABILITIES,
+        },
+        ProviderInfo {
+            id: MetadataProvider::GoogleBooks,
+            display_name: MetadataProvider::GoogleBooks.display_name().to_string(),
+            configured: true,
+            requires_key: false,
+            capabilities: SEARCH_AND_COVER_CAPABILITIES,
+        },
+        ProviderInfo {
+            id: MetadataProvider::Hardcover,
+            display_name: MetadataProvider::Hardcover.display_name().to_string(),
+            configured: config.keys.hardcover.is_some(),
+            requires_key: true,
+            capabilities: SEARCH_AND_COVER_CAPABILITIES,
+        },
+    ]
 }

--- a/db/src/metadata_lookup/providers/tests.rs
+++ b/db/src/metadata_lookup/providers/tests.rs
@@ -1,0 +1,137 @@
+//! Tests for [`super::catalog`]: AC1's per-provider `configured` semantics,
+//! and AC3's cross-check against [`super::ladder`] — the two must never
+//! disagree about what "configured" means, across every key combination.
+
+use omnibus_shared::metadata_lookup::MetadataProvider;
+
+use super::*;
+use crate::metadata_lookup::ProviderKeys;
+use crate::test_support::EnvVarGuard;
+
+/// Build a config with explicit keys, no env involved — used for the
+/// AC1-focused tests, which only care about `ProviderKeys` values, not the
+/// environment.
+fn config_with(googlebooks: Option<&str>, hardcover: Option<&str>) -> MetadataLookupConfig {
+    MetadataLookupConfig::live(ProviderKeys {
+        googlebooks: googlebooks.map(str::to_string),
+        hardcover: hardcover.map(str::to_string),
+    })
+}
+
+/// Every provider `ladder` would invoke for `config` must be `configured` in
+/// `catalog(config)` — the AC3 cross-check, shared by every combo below.
+fn assert_catalog_agrees_with_ladder(config: &MetadataLookupConfig) {
+    let entries = catalog(config);
+    for rung in ladder(config) {
+        let entry = entries
+            .iter()
+            .find(|e| e.id == rung.provider)
+            .unwrap_or_else(|| panic!("catalog is missing a ladder provider: {:?}", rung.provider));
+        assert!(
+            entry.configured,
+            "ladder includes {:?} but catalog reports it unconfigured",
+            rung.provider
+        );
+    }
+}
+
+#[test]
+fn catalog_reports_open_library_configured_with_no_keys() {
+    let config = config_with(None, None);
+    let entry = catalog(&config)
+        .into_iter()
+        .find(|e| e.id == MetadataProvider::OpenLibrary)
+        .expect("catalog should list Open Library");
+    assert!(entry.configured);
+    assert!(!entry.requires_key);
+    assert_eq!(entry.display_name, "Open Library");
+}
+
+#[test]
+fn catalog_reports_hardcover_unconfigured_without_a_key() {
+    let config = config_with(None, None);
+    let entry = catalog(&config)
+        .into_iter()
+        .find(|e| e.id == MetadataProvider::Hardcover)
+        .expect("catalog should list Hardcover");
+    assert!(!entry.configured);
+    assert!(entry.requires_key);
+}
+
+#[test]
+fn catalog_reports_hardcover_configured_with_a_key() {
+    let config = config_with(None, Some("hc_test_key"));
+    let entry = catalog(&config)
+        .into_iter()
+        .find(|e| e.id == MetadataProvider::Hardcover)
+        .expect("catalog should list Hardcover");
+    assert!(entry.configured);
+}
+
+#[test]
+fn catalog_reports_google_books_configured_with_no_key() {
+    let config = config_with(None, None);
+    let entry = catalog(&config)
+        .into_iter()
+        .find(|e| e.id == MetadataProvider::GoogleBooks)
+        .expect("catalog should list Google Books");
+    assert!(
+        entry.configured,
+        "Google Books is tried keyless too, just not as the ladder's primary rung"
+    );
+    assert!(!entry.requires_key);
+}
+
+#[test]
+fn catalog_reports_google_books_configured_with_a_key() {
+    let config = config_with(Some("gb_test_key"), None);
+    let entry = catalog(&config)
+        .into_iter()
+        .find(|e| e.id == MetadataProvider::GoogleBooks)
+        .expect("catalog should list Google Books");
+    assert!(entry.configured);
+}
+
+#[test]
+fn catalog_never_carries_key_material() {
+    let config = config_with(Some("gb_secret_value"), Some("hc_secret_value"));
+    let json = serde_json::to_string(&catalog(&config)).expect("catalog should serialize");
+    assert!(!json.contains("gb_secret_value"));
+    assert!(!json.contains("hc_secret_value"));
+}
+
+// AC3: `catalog` and `ladder` never disagree about what "configured" means,
+// across all four (Hardcover key set/unset) x (Google Books key set/unset)
+// combinations. `EnvVarGuard` pins both env vars so a developer's real
+// `.env` can't change which branch `ProviderKeys::from_env()` takes.
+
+#[test]
+fn catalog_and_ladder_agree_when_no_keys_are_configured() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None).also_set("GOOGLE_BOOKS_API_KEY", None);
+    let config = MetadataLookupConfig::live(ProviderKeys::from_env());
+    assert_catalog_agrees_with_ladder(&config);
+}
+
+#[test]
+fn catalog_and_ladder_agree_when_only_google_books_key_is_configured() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None)
+        .also_set("GOOGLE_BOOKS_API_KEY", Some("gb_test_key"));
+    let config = MetadataLookupConfig::live(ProviderKeys::from_env());
+    assert_catalog_agrees_with_ladder(&config);
+}
+
+#[test]
+fn catalog_and_ladder_agree_when_only_hardcover_key_is_configured() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("hc_test_key"))
+        .also_set("GOOGLE_BOOKS_API_KEY", None);
+    let config = MetadataLookupConfig::live(ProviderKeys::from_env());
+    assert_catalog_agrees_with_ladder(&config);
+}
+
+#[test]
+fn catalog_and_ladder_agree_when_both_keys_are_configured() {
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", Some("hc_test_key"))
+        .also_set("GOOGLE_BOOKS_API_KEY", Some("gb_test_key"));
+    let config = MetadataLookupConfig::live(ProviderKeys::from_env());
+    assert_catalog_agrees_with_ladder(&config);
+}

--- a/server/src/backend.rs
+++ b/server/src/backend.rs
@@ -39,6 +39,7 @@ mod image_upload;
 mod journals;
 mod kindle;
 mod kobo;
+mod metadata;
 mod opds;
 mod overrides;
 mod physical;

--- a/server/src/backend/metadata.rs
+++ b/server/src/backend/metadata.rs
@@ -1,0 +1,31 @@
+//! Metadata-provider catalog REST handlers — mobile- and web-facing
+//! (`GET /api/metadata/providers`). Any authenticated user may read it; it
+//! carries no key material, only `configured: bool`.
+
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    Json,
+};
+use omnibus_db as db;
+
+use super::{internal, AppState};
+use crate::auth::AuthUser;
+
+/// The provider catalog for this instance: identity, whether each provider
+/// is usable right now, and what each can answer. Drives a future
+/// provider-filter UI; today it lets any client enumerate sources without
+/// hardcoding a `match` on `MetadataProvider`.
+///
+/// Keys resolve settings-over-env through `db::provider_keys` — the same
+/// resolution the check-in scan ladder uses — so a saved Settings key and an
+/// env-var key report `configured: true` identically.
+pub(super) async fn get_providers(_user: AuthUser, State(state): State<AppState>) -> Response {
+    match db::provider_keys(&state.pool).await {
+        Ok(keys) => Json(db::catalog(&db::MetadataLookupConfig::live(keys))).into_response(),
+        Err(e) => internal("metadata provider catalog", e),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/backend/metadata/tests.rs
+++ b/server/src/backend/metadata/tests.rs
@@ -1,0 +1,76 @@
+//! Tests for `GET /api/metadata/providers`.
+
+use axum::{body::to_bytes, http::StatusCode};
+use omnibus_db::test_support::EnvVarGuard;
+use tower::ServiceExt;
+
+use crate::auth::test_support as auth_test_support;
+use crate::backend::test_support::*;
+
+async fn body_string(res: axum::response::Response) -> String {
+    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn api_get_metadata_providers_returns_the_catalog_for_an_authenticated_user() {
+    // Pin both keys off so this test's expectations don't drift with a
+    // developer's real `.env`.
+    let _env = EnvVarGuard::set("HARDCOVER_API_KEY", None).also_set("GOOGLE_BOOKS_API_KEY", None);
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(get_with_bearer("/api/metadata/providers", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body: serde_json::Value = serde_json::from_str(&body_string(res).await).unwrap();
+    let entries = body.as_array().expect("catalog should be a JSON array");
+    assert_eq!(entries.len(), 3, "catalog should list all three providers");
+
+    let hardcover = entries
+        .iter()
+        .find(|e| e["id"] == "hardcover")
+        .expect("catalog should include hardcover");
+    assert_eq!(hardcover["configured"], false);
+    assert_eq!(hardcover["requires_key"], true);
+
+    let open_library = entries
+        .iter()
+        .find(|e| e["id"] == "open_library")
+        .expect("catalog should include open_library");
+    assert_eq!(open_library["configured"], true);
+}
+
+#[tokio::test]
+async fn api_get_metadata_providers_never_leaks_key_material() {
+    let (app, _state, pool) = fixture().await;
+    omnibus_db::set_hardcover_api_key(&pool, Some("hc_super_secret_value"))
+        .await
+        .unwrap();
+    let user = auth_test_support::create_user(&pool, "reader").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+
+    let res = app
+        .oneshot(get_with_bearer("/api/metadata/providers", &token))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_string(res).await;
+    assert!(!body.contains("hc_super_secret_value"));
+    assert!(!body.contains("masked"));
+    assert!(!body.contains("source"));
+}
+
+#[tokio::test]
+async fn api_get_metadata_providers_requires_auth() {
+    let (app, _state, _pool) = fixture().await;
+    let res = app
+        .oneshot(get_anon("/api/metadata/providers"))
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}

--- a/server/src/backend/metadata/tests.rs
+++ b/server/src/backend/metadata/tests.rs
@@ -8,7 +8,7 @@ use crate::auth::test_support as auth_test_support;
 use crate::backend::test_support::*;
 
 async fn body_string(res: axum::response::Response) -> String {
-    let bytes = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let bytes = to_bytes(res.into_body(), 1024 * 1024).await.unwrap();
     String::from_utf8(bytes.to_vec()).unwrap()
 }
 

--- a/server/src/backend/routes.rs
+++ b/server/src/backend/routes.rs
@@ -12,9 +12,9 @@ use axum::{
 
 use super::{
     account, admin_health, admin_sessions, audiobooks, author_photos, authors, bookmarks, covers,
-    ebooks, genres, highlights, journals, kindle, overrides, physical, profile, progress, ratings,
-    read_status, scan, search, series, settings, shelves, stats, suggestions, summary, tags,
-    uploads, users, AppState,
+    ebooks, genres, highlights, journals, kindle, metadata, overrides, physical, profile, progress,
+    ratings, read_status, scan, search, series, settings, shelves, stats, suggestions, summary,
+    tags, uploads, users, AppState,
 };
 use crate::rate_limit::{rate_limit_by_ip, RateLimiter};
 
@@ -131,6 +131,7 @@ pub(super) fn data_routes(search_limiter: Arc<RateLimiter>) -> Router<AppState> 
         .merge(discovery_routes())
         .merge(suggestion_routes())
         .merge(summary_routes())
+        .merge(metadata_routes())
         .merge(kindle_routes())
 }
 
@@ -379,6 +380,12 @@ fn summary_routes() -> Router<AppState> {
             post(summary::post_ebook_summary_fetch),
         )
         .route("/api/summary/sources", get(summary::get_summary_sources))
+}
+
+/// The metadata-provider catalog — mobile- and web-facing REST, no RPC
+/// analogue yet. Read-only, any authenticated user.
+fn metadata_routes() -> Router<AppState> {
+    Router::new().route("/api/metadata/providers", get(metadata::get_providers))
 }
 
 /// F4.3 Send-to-Kindle — mobile-facing REST. Web hits the analogous

--- a/shared/src/metadata_lookup.rs
+++ b/shared/src/metadata_lookup.rs
@@ -16,9 +16,7 @@ pub enum MetadataProvider {
 }
 
 impl MetadataProvider {
-    /// Human-readable provider name, for the check-in note, the settings
-    /// panel, and the provider catalog — one string, one place, rather than a
-    /// `match` re-written at every render site.
+    /// Human-readable provider name for display (check-in note, settings panel, provider catalog).
     pub fn display_name(self) -> &'static str {
         match self {
             MetadataProvider::OpenLibrary => "Open Library",
@@ -29,14 +27,10 @@ impl MetadataProvider {
 }
 
 /// What one provider can be asked and what it can return, independent of
-/// whether it is currently configured. Lets a caller (the eventual
-/// provider-filter UI) skip asking a provider a question it can never
-/// answer, and skip rendering a column no provider actually fills.
+/// whether it is currently configured.
 ///
-/// `carries_ratings` and `carries_genres` are `false` for every provider
-/// today: [`ExternalBookMeta`] has no field for either yet, so claiming
-/// either capability would be a promise no provider can keep. Flip a
-/// provider's flag to `true` in the same change that adds the field.
+/// `carries_ratings`/`carries_genres` are `false` for every provider today —
+/// flip one only in the same change that adds the field to [`ExternalBookMeta`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderCapabilities {
     pub search_by_title: bool,
@@ -46,15 +40,11 @@ pub struct ProviderCapabilities {
     pub carries_genres: bool,
 }
 
-/// One entry in the provider catalog: identity, whether it is usable right
-/// now, and what it can answer. Built by `providers::catalog` in `omnibus-db`
-/// and served by `GET /api/metadata/providers`.
+/// One entry in the provider catalog, built by `providers::catalog` in
+/// `omnibus-db` and served by `GET /api/metadata/providers`.
 ///
-/// **Never carries key material.** `configured` is a bool, not a masked
-/// preview — unlike [`GoogleBooksKeyStatus`] and
-/// `omnibus_db::HardcoverKeyStatus`, this type has no `masked` field at all,
-/// because this endpoint is reachable by any authenticated user, not just an
-/// admin.
+/// **Never carries key material** — `configured` is a bool, not a masked
+/// preview, because this endpoint is reachable by any authenticated user.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderInfo {
     pub id: MetadataProvider,

--- a/shared/src/metadata_lookup.rs
+++ b/shared/src/metadata_lookup.rs
@@ -15,6 +15,61 @@ pub enum MetadataProvider {
     Hardcover,
 }
 
+impl MetadataProvider {
+    /// Human-readable provider name, for the check-in note, the settings
+    /// panel, and the provider catalog — one string, one place, rather than a
+    /// `match` re-written at every render site.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            MetadataProvider::OpenLibrary => "Open Library",
+            MetadataProvider::GoogleBooks => "Google Books",
+            MetadataProvider::Hardcover => "Hardcover",
+        }
+    }
+}
+
+/// What one provider can be asked and what it can return, independent of
+/// whether it is currently configured. Lets a caller (the eventual
+/// provider-filter UI) skip asking a provider a question it can never
+/// answer, and skip rendering a column no provider actually fills.
+///
+/// `carries_ratings` and `carries_genres` are `false` for every provider
+/// today: [`ExternalBookMeta`] has no field for either yet, so claiming
+/// either capability would be a promise no provider can keep. Flip a
+/// provider's flag to `true` in the same change that adds the field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderCapabilities {
+    pub search_by_title: bool,
+    pub search_by_isbn: bool,
+    pub carries_cover: bool,
+    pub carries_ratings: bool,
+    pub carries_genres: bool,
+}
+
+/// One entry in the provider catalog: identity, whether it is usable right
+/// now, and what it can answer. Built by `providers::catalog` in `omnibus-db`
+/// and served by `GET /api/metadata/providers`.
+///
+/// **Never carries key material.** `configured` is a bool, not a masked
+/// preview — unlike [`GoogleBooksKeyStatus`] and
+/// `omnibus_db::HardcoverKeyStatus`, this type has no `masked` field at all,
+/// because this endpoint is reachable by any authenticated user, not just an
+/// admin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderInfo {
+    pub id: MetadataProvider,
+    pub display_name: String,
+    /// Whether the ladder would actually invoke this provider right now —
+    /// always `true` for a keyless-capable provider, key-gated otherwise.
+    /// Mirrors the same check `providers::ladder` uses, so the two can never
+    /// disagree about what "configured" means.
+    pub configured: bool,
+    /// Whether an API key is required to reach this provider at all (as
+    /// opposed to optional — present or not, the provider still answers).
+    pub requires_key: bool,
+    pub capabilities: ProviderCapabilities,
+}
+
 /// Maximum byte length of a stored Google Books API key. Google keys are short
 /// (~39 chars), so this is a generous guard against an unbounded blob.
 pub const GOOGLE_BOOKS_API_KEY_MAX_LEN: usize = 512;


### PR DESCRIPTION
## Summary
- Adds `GET /api/metadata/providers`, a REST endpoint that exposes the configured metadata-provider catalog (Open Library, Google Books, Hardcover) without leaking key material — a client can show which providers are active without a key ever crossing the wire.
- The catalog is derived from the same configuration the ISBN-lookup ladder already reads, so "configured" always agrees with what the ladder will actually try.
- New: `server/src/backend/metadata.rs` (+ `tests.rs`), `db/src/metadata_lookup/providers/tests.rs`. Wired into `server/src/backend/routes.rs`; catalog type added to `shared/src/metadata_lookup.rs`.
- No frontend changes — this is a mobile-facing REST route (no web UI consumer yet), so no Playwright coverage is required for it.

Closes #1655

## Test plan
- [x] `cargo fmt --check` on every touched/new file — clean.
- [x] `cargo clippy -p omnibus-db -p omnibus -p omnibus-shared --all-targets -- -D warnings` — clean, no warnings.
- [x] `cargo check -p omnibus-frontend --features server` — compiles clean.
- [x] `cargo check -p omnibus` — compiles clean.
- [x] `cargo test -p omnibus-db` — 2113 passed, including all 10 new `metadata_lookup::providers::tests` (catalog-vs-ladder agreement across every key-configuration combination, plus a "never carries key material" test).
- [x] `cargo test -p omnibus` — 827 passed, 2 failed. The 2 failures (`backend::uploads::tests::commit_rejects_read_only_library_with_400` and its audiobook counterpart) are **pre-existing and unrelated**: they `chmod` a directory read-only to force a `PermissionDenied` write, but these CI/dev containers run as `root`, which bypasses Unix permission checks, so the write succeeds instead of failing. Confirmed via `git log` that `uploads/tests.rs` was last touched by an unrelated prior PR (#1836) — not introduced by this change. Independently reproduced by another agent. Re-ran the 3 new `backend::metadata::tests` in isolation: all pass.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- The catalog and the ISBN-lookup ladder are asserted to agree in every key-configuration combination (`catalog_and_ladder_agree_when_*` tests in `db/src/metadata_lookup/providers/tests.rs`) so the two can't silently drift apart.
- `catalog_never_carries_key_material` and `api_get_metadata_providers_never_leaks_key_material` guard the "no key ever crosses the wire" property at both the db and HTTP layers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7BXSStsWbu91wQJ27RUZi)_