### PR TITLE
feat: add genres, print page count, and ISBN-10 override fields (#1658)

### DIFF
--- a/db/src/books/projection.rs
+++ b/db/src/books/projection.rs
@@ -253,6 +253,9 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         genres: Vec::new(),
         identifiers,
         isbn13,
+        // No scanned baseline — a book's ISBN-10 arrives only via
+        // `apply_overrides`, same as `genres` above.
+        isbn10: None,
         series: series_name,
         series_index: series_index.map(format_series_index),
         series_id: series_link_id,
@@ -272,6 +275,9 @@ pub(crate) fn row_to_ebook(r: &sqlx::sqlite::SqliteRow) -> Result<EbookMetadata,
         // The CBZ page count, straight off `books.page_count` (#1593) —
         // `NULL` for an EPUB, an unparsed archive, or a pre-migration row.
         page_count: r.get("page_count"),
+        // No scanned baseline — a book's print page count arrives only via
+        // `apply_overrides`, same as `isbn10` above.
+        print_pages: None,
     })
 }
 

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -158,6 +158,9 @@ fn build_opf_metadata<R: std::io::Read + std::io::Seek>(
         // written into the normalized tables before that derivation
         // ever runs.
         isbn13: None,
+        // Same as `isbn13` above — user-assigned only, layered on at read
+        // time by `apply_overrides`.
+        isbn10: None,
 
         series,
         series_index,
@@ -178,6 +181,9 @@ fn build_opf_metadata<R: std::io::Read + std::io::Seek>(
         book_files: Vec::new(),
         epub_size_bytes: None,
         page_count: None,
+        // Same as `genres` above — user-assigned only, layered on at read
+        // time by `apply_overrides`.
+        print_pages: None,
     }
 }
 

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -107,6 +107,139 @@ async fn merge_metadata_overrides_creates_row_when_absent() {
     assert!(!has_cover, "a brand-new merged row has no cover override");
 }
 
+// -----------------------------------------------------------------
+// #1658 isbn10 / print_pages override fields
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn upsert_and_get_metadata_overrides_roundtrips_isbn10_and_print_pages() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    let ov = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        print_pages: Some(412),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, "isbn10-uuid", &ov, false, user_id)
+        .await
+        .unwrap();
+
+    let (loaded, _) = get_metadata_overrides(&pool, "isbn10-uuid")
+        .await
+        .unwrap()
+        .expect("overrides should exist");
+    assert_eq!(loaded.isbn10, Some("0134685997".into()));
+    assert_eq!(loaded.print_pages, Some(412));
+}
+
+#[tokio::test]
+async fn merge_metadata_overrides_preserves_isbn10_and_print_pages_when_a_later_edit_omits_them() {
+    // AC2: a client that predates these fields must not clobber them by
+    // omission — mirrors `merge_metadata_overrides_accumulates_fields_and_preserves_cover_flag`.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    let initial = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        print_pages: Some(412),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, "preserve-uuid", &initial, false, user_id)
+        .await
+        .unwrap();
+
+    let edit = MetadataOverrides {
+        description: Some("Added later".into()),
+        ..Default::default()
+    };
+    merge_metadata_overrides(&pool, "preserve-uuid", &edit, user_id)
+        .await
+        .unwrap();
+
+    let (loaded, _) = get_metadata_overrides(&pool, "preserve-uuid")
+        .await
+        .unwrap()
+        .expect("overrides should exist");
+    assert_eq!(
+        loaded.isbn10,
+        Some("0134685997".into()),
+        "isbn10 must survive a description-only merge"
+    );
+    assert_eq!(
+        loaded.print_pages,
+        Some(412),
+        "print_pages must survive a description-only merge"
+    );
+    assert_eq!(loaded.description, Some("Added later".into()));
+}
+
+#[tokio::test]
+async fn merge_metadata_overrides_clears_isbn10_with_an_empty_string() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+
+    let initial = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, "clear-isbn10-uuid", &initial, false, user_id)
+        .await
+        .unwrap();
+
+    let clear = MetadataOverrides {
+        isbn10: Some(String::new()),
+        ..Default::default()
+    };
+    merge_metadata_overrides(&pool, "clear-isbn10-uuid", &clear, user_id)
+        .await
+        .unwrap();
+
+    let (loaded, _) = get_metadata_overrides(&pool, "clear-isbn10-uuid")
+        .await
+        .unwrap()
+        .expect("overrides should exist");
+    assert_eq!(loaded.isbn10, Some(String::new()));
+}
+
+#[tokio::test]
+async fn get_book_returns_effective_isbn10_and_print_pages_from_the_override_layer() {
+    // AC1: the round-trip endpoint reads this same merged book back.
+    let _covers = CoversTempDir::new("isbn10_print_pages_read");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let uuid = crate::test_support::seed_synced_ebook(&pool, "b.epub", "T", "A").await;
+
+    let before = get_book_by_uuid(&pool, &uuid).await.unwrap().unwrap();
+    assert_eq!(before.isbn10, None);
+    assert_eq!(before.print_pages, None);
+
+    let ov = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        print_pages: Some(412),
+        ..Default::default()
+    };
+    merge_metadata_overrides(&pool, &uuid, &ov, user_id)
+        .await
+        .unwrap();
+
+    let after = get_book_by_uuid(&pool, &uuid).await.unwrap().unwrap();
+    assert_eq!(after.isbn10.as_deref(), Some("0134685997"));
+    assert_eq!(after.print_pages, Some(412));
+}
+
 /// A grid quick-edit "clear this field" save must land as a real clear,
 /// not a silent no-op. `merge_metadata_overrides` reads an incoming
 /// `None` as "untouched — keep whatever override already exists" (that's

--- a/db/src/metadata_overrides/upsert/cover.rs
+++ b/db/src/metadata_overrides/upsert/cover.rs
@@ -130,6 +130,10 @@ pub(crate) fn apply_overrides(
         // as "no ISBN", not as a literal empty string.
         book.isbn13 = if i.is_empty() { None } else { Some(i.clone()) };
     }
+    if let Some(ref i) = ov.isbn10 {
+        // Same empty-string-clears convention as `isbn13` above.
+        book.isbn10 = if i.is_empty() { None } else { Some(i.clone()) };
+    }
     if let Some(ref c) = ov.creators {
         book.creators = c.clone();
     }
@@ -138,6 +142,9 @@ pub(crate) fn apply_overrides(
     }
     if let Some(ref g) = ov.genres {
         book.genres = g.clone();
+    }
+    if let Some(p) = ov.print_pages {
+        book.print_pages = Some(p);
     }
     book.has_cover_override = has_cover_override;
     if has_cover_override {

--- a/frontend/src/pages/metadata_edit.rs
+++ b/frontend/src/pages/metadata_edit.rs
@@ -133,6 +133,13 @@ struct EditedFields<'a> {
     series: &'a str,
     series_index: &'a str,
     isbn13: &'a str,
+    isbn10: &'a str,
+    /// Pre-parsed by the caller (`state::build_on_save`), which rejects a
+    /// non-numeric entry client-side before this function ever runs — unlike
+    /// every other field here, this one can't be diffed as a raw string
+    /// since `MetadataOverrides::print_pages` is `Option<i64>`, not
+    /// `Option<String>`.
+    print_pages: Option<i64>,
     authors: &'a [String],
     tags: &'a [String],
     genres: &'a [String],
@@ -179,6 +186,12 @@ fn build_overrides(orig: &EbookMetadata, edited: EditedFields<'_>) -> MetadataOv
         None
     };
 
+    // Unlike the string fields above, `print_pages` has no empty-clears
+    // sentinel to fall back on (there is no "empty" `i64`) — a blank form
+    // field is `None` from the caller and is treated as "leave the override
+    // untouched", not "clear it". Only an actually-changed value is sent.
+    let print_pages = edited.print_pages.filter(|&v| Some(v) != orig.print_pages);
+
     MetadataOverrides {
         title: opt(edited.title, orig.title.as_deref()),
         description: opt(edited.description, orig.description.as_deref()),
@@ -188,9 +201,11 @@ fn build_overrides(orig: &EbookMetadata, edited: EditedFields<'_>) -> MetadataOv
         series: opt(edited.series, orig.series.as_deref()),
         series_index: opt(edited.series_index, orig.series_index.as_deref()),
         isbn13: opt(edited.isbn13, orig.isbn13.as_deref()),
+        isbn10: opt(edited.isbn10, orig.isbn10.as_deref()),
         creators,
         subjects,
         genres,
+        print_pages,
     }
 }
 

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -166,7 +166,7 @@ fn field_grid_identity_rows(orig: Signal<EbookMetadata>, fields: FormFields) -> 
             value: print_pages,
             on_change: move |v: String| print_pages.set(v),
             mono: true,
-            edited: print_pages() != orig().print_pages.map(|p| p.to_string()).unwrap_or_default(),
+            edited: print_pages().trim() != orig().print_pages.map(|p| p.to_string()).unwrap_or_default(),
             hint: "whole number",
             placeholder: "e.g. 320",
         }

--- a/frontend/src/pages/metadata_edit/form_grid.rs
+++ b/frontend/src/pages/metadata_edit/form_grid.rs
@@ -21,6 +21,8 @@ pub(super) struct FormFields {
     pub series: Signal<String>,
     pub series_index: Signal<String>,
     pub isbn13: Signal<String>,
+    pub isbn10: Signal<String>,
+    pub print_pages: Signal<String>,
     pub authors: Signal<Vec<String>>,
     pub tags: Signal<Vec<String>>,
     pub genres: Signal<Vec<String>>,
@@ -71,6 +73,8 @@ fn field_grid_identity_rows(orig: Signal<EbookMetadata>, fields: FormFields) -> 
     let mut published = fields.published;
     let mut language = fields.language;
     let mut isbn13 = fields.isbn13;
+    let mut isbn10 = fields.isbn10;
+    let mut print_pages = fields.print_pages;
     let sort_by = fields.sort_by;
     let filename = fields.filename;
 
@@ -141,6 +145,30 @@ fn field_grid_identity_rows(orig: Signal<EbookMetadata>, fields: FormFields) -> 
             edited: isbn13() != orig().isbn13.clone().unwrap_or_default(),
             hint: "13 digits",
             placeholder: "e.g. 9780134685991",
+        }
+
+        // ISBN-10 — 10 characters (digits + optional trailing X), enforced
+        // server-side on save; an empty value clears it, same as ISBN-13.
+        MeField {
+            label: "ISBN-10",
+            value: isbn10,
+            on_change: move |v: String| isbn10.set(v),
+            mono: true,
+            edited: isbn10() != orig().isbn10.clone().unwrap_or_default(),
+            hint: "10 characters",
+            placeholder: "e.g. 0134685997",
+        }
+
+        // Print page count — plain integer text entry; parsed and bound-
+        // checked (`MetadataOverrides::validate`) when the form saves.
+        MeField {
+            label: "Print Pages",
+            value: print_pages,
+            on_change: move |v: String| print_pages.set(v),
+            mono: true,
+            edited: print_pages() != orig().print_pages.map(|p| p.to_string()).unwrap_or_default(),
+            hint: "whole number",
+            placeholder: "e.g. 320",
         }
     }
 }

--- a/frontend/src/pages/metadata_edit/state.rs
+++ b/frontend/src/pages/metadata_edit/state.rs
@@ -86,6 +86,8 @@ fn use_field_signals(book: &EbookMetadata) -> FormFields {
     let series = use_signal(|| book.series.clone().unwrap_or_default());
     let series_index = use_signal(|| book.series_index.clone().unwrap_or_default());
     let isbn13 = use_signal(|| book.isbn13.clone().unwrap_or_default());
+    let isbn10 = use_signal(|| book.isbn10.clone().unwrap_or_default());
+    let print_pages = use_signal(|| book.print_pages.map(|p| p.to_string()).unwrap_or_default());
 
     // Authors as a signal of Vec<String> (names only for v1).
     let authors = use_signal(|| {
@@ -121,6 +123,8 @@ fn use_field_signals(book: &EbookMetadata) -> FormFields {
         series,
         series_index,
         isbn13,
+        isbn10,
+        print_pages,
         authors,
         tags,
         genres,
@@ -211,6 +215,8 @@ fn use_dirty_fields(orig: Signal<EbookMetadata>, fields: FormFields) -> Memo<Vec
         series,
         series_index,
         isbn13,
+        isbn10,
+        print_pages,
         authors,
         tags,
         genres,
@@ -243,6 +249,12 @@ fn use_dirty_fields(orig: Signal<EbookMetadata>, fields: FormFields) -> Memo<Vec
         }
         if isbn13() != o.isbn13.clone().unwrap_or_default() {
             dirty.push("ISBN-13");
+        }
+        if isbn10() != o.isbn10.clone().unwrap_or_default() {
+            dirty.push("ISBN-10");
+        }
+        if print_pages() != o.print_pages.map(|p| p.to_string()).unwrap_or_default() {
+            dirty.push("Print Pages");
         }
         let orig_authors: Vec<String> = o.creators.iter().map(|c| c.name.clone()).collect();
         if authors() != orig_authors {
@@ -307,6 +319,8 @@ fn build_on_save(
         series,
         series_index,
         isbn13,
+        isbn10,
+        print_pages,
         authors,
         tags,
         genres,
@@ -316,6 +330,25 @@ fn build_on_save(
     EventHandler::new(move |()| {
         let url = url.clone();
         let uuid = uuid.clone();
+
+        // Parsed client-side so a non-numeric entry gets an immediate,
+        // specific message instead of a generic save failure (mirrors
+        // `ScanIntervalField`'s handler in settings/library.rs); an in-range
+        // numeric value still round-trips through `MetadataOverrides::validate`
+        // server-side (e.g. the `PRINT_PAGES_MAX` ceiling).
+        let print_pages_input = print_pages().trim().to_string();
+        let print_pages_val: Option<i64> = if print_pages_input.is_empty() {
+            None
+        } else {
+            match print_pages_input.parse::<i64>() {
+                Ok(n) => Some(n),
+                Err(_) => {
+                    save_error.set(Some("Print page count must be a whole number.".to_string()));
+                    return;
+                }
+            }
+        };
+
         spawn(async move {
             saving.set(true);
             save_error.set(None);
@@ -332,6 +365,8 @@ fn build_on_save(
                     series: &series(),
                     series_index: &series_index(),
                     isbn13: &isbn13(),
+                    isbn10: &isbn10(),
+                    print_pages: print_pages_val,
                     authors: &authors(),
                     tags: &tags(),
                     genres: &genres(),

--- a/frontend/src/pages/metadata_edit/state.rs
+++ b/frontend/src/pages/metadata_edit/state.rs
@@ -253,7 +253,7 @@ fn use_dirty_fields(orig: Signal<EbookMetadata>, fields: FormFields) -> Memo<Vec
         if isbn10() != o.isbn10.clone().unwrap_or_default() {
             dirty.push("ISBN-10");
         }
-        if print_pages() != o.print_pages.map(|p| p.to_string()).unwrap_or_default() {
+        if print_pages().trim() != o.print_pages.map(|p| p.to_string()).unwrap_or_default() {
             dirty.push("Print Pages");
         }
         let orig_authors: Vec<String> = o.creators.iter().map(|c| c.name.clone()).collect();

--- a/frontend/src/pages/metadata_edit/tests.rs
+++ b/frontend/src/pages/metadata_edit/tests.rs
@@ -37,6 +37,8 @@ fn edited<'a>(
         series: "",
         series_index: "",
         isbn13: "",
+        isbn10: "",
+        print_pages: None,
         authors,
         tags,
         genres: &[],
@@ -137,6 +139,89 @@ fn build_overrides_leaves_isbn13_none_when_unchanged() {
         },
     );
     assert!(ov.isbn13.is_none());
+}
+
+#[test]
+fn build_overrides_sets_isbn10_when_changed() {
+    let orig = book_with(Some("Dune"), &[], &[]);
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            isbn10: "0134685997",
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert_eq!(ov.isbn10.as_deref(), Some("0134685997"));
+}
+
+#[test]
+fn build_overrides_clearing_a_populated_isbn10_emits_empty_string() {
+    // AC2: orig.isbn10 = Some(..), edited to "" -> the override must carry
+    // the empty string so the merge/apply path clears it, mirroring isbn13.
+    let orig = EbookMetadata {
+        isbn10: Some("0134685997".into()),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(&orig, edited("Dune", "", &[], &[]));
+    assert_eq!(ov.isbn10.as_deref(), Some(""));
+}
+
+#[test]
+fn build_overrides_leaves_isbn10_none_when_unchanged() {
+    let orig = EbookMetadata {
+        isbn10: Some("0134685997".into()),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            isbn10: "0134685997",
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert!(ov.isbn10.is_none());
+}
+
+#[test]
+fn build_overrides_sets_print_pages_when_changed() {
+    let orig = book_with(Some("Dune"), &[], &[]);
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            print_pages: Some(412),
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert_eq!(ov.print_pages, Some(412));
+}
+
+#[test]
+fn build_overrides_leaves_print_pages_none_when_unchanged() {
+    let orig = EbookMetadata {
+        print_pages: Some(412),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(
+        &orig,
+        EditedFields {
+            print_pages: Some(412),
+            ..edited("Dune", "", &[], &[])
+        },
+    );
+    assert!(ov.print_pages.is_none());
+}
+
+#[test]
+fn build_overrides_leaves_print_pages_none_when_field_left_blank() {
+    // The caller (`state::build_on_save`) passes `None` for a blank text
+    // field; `print_pages` has no empty-clears sentinel (unlike the string
+    // fields), so a blank field must never clear a previously-saved value.
+    let orig = EbookMetadata {
+        print_pages: Some(412),
+        ..book_with(Some("Dune"), &[], &[])
+    };
+    let ov = build_overrides(&orig, edited("Dune", "", &[], &[]));
+    assert!(ov.print_pages.is_none());
 }
 
 #[test]

--- a/server/src/backend/overrides/tests.rs
+++ b/server/src/backend/overrides/tests.rs
@@ -166,6 +166,99 @@ async fn api_post_overrides_saves_and_returns_merged_book() {
 }
 
 #[tokio::test]
+async fn api_post_overrides_round_trips_isbn10_and_print_pages() {
+    // AC1: genres, print_pages, and isbn10 round-trip through the same POST
+    // /api/ebooks/{uuid}/overrides path and read back on the merged book.
+    let (app, _state, pool) = fixture().await;
+    let (id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let body = serde_json::json!({
+        "isbn10": "0134685997",
+        "print_pages": 412,
+        "genres": ["Science Fiction"],
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ebooks/{uuid}/overrides"))
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let book: omnibus_shared::EbookMetadata = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(book.id, id);
+    assert_eq!(book.isbn10.as_deref(), Some("0134685997"));
+    assert_eq!(book.print_pages, Some(412));
+    assert_eq!(book.genres, vec!["Science Fiction".to_string()]);
+
+    let (saved, _) = db::get_metadata_overrides(&pool, &uuid)
+        .await
+        .unwrap()
+        .expect("override row should exist after POST");
+    assert_eq!(saved.isbn10.as_deref(), Some("0134685997"));
+    assert_eq!(saved.print_pages, Some(412));
+}
+
+#[tokio::test]
+async fn api_post_overrides_rejects_malformed_isbn10_and_out_of_range_print_pages_with_400() {
+    // AC3: a malformed ISBN-10 and an out-of-range print page count each
+    // return 400 with no override row written.
+    let (app, _state, pool) = fixture().await;
+    let (_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Original").await;
+    let admin = auth_test_support::create_admin(&pool, "admin").await;
+    let token = auth_test_support::bearer_token(&pool, admin.id).await;
+
+    let body = serde_json::json!({ "isbn10": "not-an-isbn" });
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ebooks/{uuid}/overrides"))
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let over_max = omnibus_shared::MetadataOverrides::PRINT_PAGES_MAX + 1;
+    let body = serde_json::json!({ "print_pages": over_max });
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/ebooks/{uuid}/overrides"))
+                .method("POST")
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    assert!(
+        db::get_metadata_overrides(&pool, &uuid)
+            .await
+            .unwrap()
+            .is_none(),
+        "neither validation failure should have persisted an override row"
+    );
+}
+
+#[tokio::test]
 async fn api_delete_overrides_reverts() {
     // Persist an override via the same REST path the client uses, then
     // delete it and assert the response reflects the canonical scanned

--- a/shared/src/ebook/metadata.rs
+++ b/shared/src/ebook/metadata.rs
@@ -72,6 +72,13 @@ pub struct EbookMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isbn13: Option<String>,
 
+    /// Secondary ISBN-10, sourced entirely from `metadata_overrides` — no
+    /// file format Omnibus reads carries a distinct ISBN-10 alongside its
+    /// ISBN-13, so unlike `isbn13` there is no scanned baseline underneath
+    /// this one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn10: Option<String>,
+
     // Series / collection (Calibre + EPUB3 belongs-to-collection).
     pub series: Option<String>,
     pub series_index: Option<String>,
@@ -143,6 +150,15 @@ pub struct EbookMetadata {
     /// a row not yet backfilled since being indexed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_count: Option<i64>,
+
+    /// User-supplied print edition page count, sourced entirely from
+    /// `metadata_overrides` — distinct from `page_count`, which is the CBZ
+    /// archive's *image* count (migration `0063`). Kept apart deliberately:
+    /// a comic book's `page_count` drives the reader's page slider, while
+    /// `print_pages` is bibliographic metadata about a print edition and
+    /// means something different even on a book that has both.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub print_pages: Option<i64>,
 }
 
 impl EbookMetadata {

--- a/shared/src/ebook/overrides.rs
+++ b/shared/src/ebook/overrides.rs
@@ -37,6 +37,11 @@ pub struct MetadataOverrides {
     /// by `validate`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isbn13: Option<String>,
+    /// ISBN-10 override. Same empty-string-clears convention as `isbn13`; a
+    /// non-empty value must be exactly 10 characters — 9 digits plus a
+    /// check-digit position that is a digit or `X` — enforced by `validate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn10: Option<String>,
     /// Replaces the entire creators list when present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub creators: Option<Vec<Contributor>>,
@@ -48,6 +53,13 @@ pub struct MetadataOverrides {
     /// scans a genre — so this key is the sole storage for a book's genres.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub genres: Option<Vec<String>>,
+    /// Print page count override. Like `genres`, nothing Omnibus scans
+    /// carries a print page count — `books.page_count` is a different thing
+    /// entirely (the CBZ image count, migration `0063`) — so this field is
+    /// named `print_pages` rather than `page_count` to keep the two
+    /// unambiguous on `EbookMetadata`, where both eventually land.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub print_pages: Option<i64>,
 }
 
 impl MetadataOverrides {
@@ -74,6 +86,11 @@ impl MetadataOverrides {
     pub const MAX_GENRES: usize = 64;
     /// Maximum number of creators.
     pub(crate) const MAX_CREATORS: usize = 32;
+    /// Upper bound for `print_pages`. 20,000 comfortably covers any real
+    /// print edition (the longest published novels sit well under 5,000
+    /// pages) while still rejecting an obviously fat-fingered or garbage
+    /// value rather than accepting an unbounded `i64`.
+    pub const PRINT_PAGES_MAX: i64 = 20_000;
 
     /// Validate field lengths. Returns `Err` with a human-readable message if
     /// any field exceeds its cap. Call at the handler level before persisting.
@@ -98,6 +115,8 @@ impl MetadataOverrides {
         check("series_index", &self.series_index, Self::NAME_MAX_LEN)?;
         check("description", &self.description, Self::DESCRIPTION_MAX_LEN)?;
         self.validate_isbn13()?;
+        self.validate_isbn10()?;
+        self.validate_print_pages()?;
         self.validate_creators()?;
         validate_name_list(
             self.subjects.as_deref(),
@@ -130,6 +149,49 @@ impl MetadataOverrides {
         }
         if v.chars().count() != 13 || !v.chars().all(|c| c.is_ascii_digit()) {
             return Err("ISBN-13 must be exactly 13 digits".to_string());
+        }
+        Ok(())
+    }
+
+    /// ISBN-10 input rule: empty (clears the override) or exactly 10
+    /// characters — 9 ASCII digits plus a check-digit position that is a
+    /// digit or `X`/`x`. Deliberately does **not** delegate to
+    /// [`crate::validate_isbn10`] (which enforces the mod-11 check digit for
+    /// barcode-scanned input): this field is user-typed free-text metadata,
+    /// so it follows [`Self::validate_isbn13`]'s format-only convention
+    /// instead — a malformed-but-shaped entry just renders as an incorrect
+    /// ISBN, not a corrupted one.
+    fn validate_isbn10(&self) -> Result<(), String> {
+        let Some(ref v) = self.isbn10 else {
+            return Ok(());
+        };
+        if v.is_empty() {
+            return Ok(());
+        }
+        let shape_ok = v.chars().count() == 10
+            && v.chars().take(9).all(|c| c.is_ascii_digit())
+            && v.chars()
+                .nth(9)
+                .is_some_and(|c| c.is_ascii_digit() || c == 'X' || c == 'x');
+        if !shape_ok {
+            return Err(
+                "ISBN-10 must be 10 characters: 9 digits plus a digit or X check digit".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    /// `print_pages` bound: `None` (don't touch) or an integer in
+    /// `1..=PRINT_PAGES_MAX`.
+    fn validate_print_pages(&self) -> Result<(), String> {
+        let Some(pages) = self.print_pages else {
+            return Ok(());
+        };
+        if !(1..=Self::PRINT_PAGES_MAX).contains(&pages) {
+            return Err(format!(
+                "print page count must be between 1 and {}",
+                Self::PRINT_PAGES_MAX
+            ));
         }
         Ok(())
     }
@@ -184,9 +246,11 @@ impl MetadataOverrides {
             series: incoming.series.clone().or(self.series.clone()),
             series_index: incoming.series_index.clone().or(self.series_index.clone()),
             isbn13: incoming.isbn13.clone().or(self.isbn13.clone()),
+            isbn10: incoming.isbn10.clone().or(self.isbn10.clone()),
             creators: incoming.creators.clone().or(self.creators.clone()),
             subjects: incoming.subjects.clone().or(self.subjects.clone()),
             genres: incoming.genres.clone().or(self.genres.clone()),
+            print_pages: incoming.print_pages.or(self.print_pages),
         }
     }
 }

--- a/shared/src/ebook/overrides.rs
+++ b/shared/src/ebook/overrides.rs
@@ -156,7 +156,7 @@ impl MetadataOverrides {
     /// ISBN-10 input rule: empty (clears the override) or exactly 10
     /// characters — 9 ASCII digits plus a check-digit position that is a
     /// digit or `X`/`x`. Deliberately does **not** delegate to
-    /// [`crate::validate_isbn10`] (which enforces the mod-11 check digit for
+    /// [`crate::isbn::validate_isbn10`] (which enforces the mod-11 check digit for
     /// barcode-scanned input): this field is user-typed free-text metadata,
     /// so it follows [`Self::validate_isbn13`]'s format-only convention
     /// instead — a malformed-but-shaped entry just renders as an incorrect

--- a/shared/src/ebook/tests.rs
+++ b/shared/src/ebook/tests.rs
@@ -58,9 +58,11 @@ fn validate_accepts_well_formed_override() {
         series: Some("Some Series".into()),
         series_index: Some("1".into()),
         isbn13: Some("9780134685991".into()),
+        isbn10: Some("0134685997".into()),
         creators: Some(vec![contributor("Ada Lovelace")]),
         subjects: Some(vec!["fiction".into(), "history".into()]),
         genres: Some(vec!["Historical Fiction".into()]),
+        print_pages: Some(350),
     };
     assert_eq!(ov.validate(), Ok(()));
 }
@@ -342,6 +344,141 @@ fn validate_rejects_isbn13_with_whitespace() {
     );
 }
 
+#[test]
+fn validate_accepts_a_well_formed_isbn10_with_digit_check_digit() {
+    let ov = MetadataOverrides {
+        isbn10: Some("0134685997".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_an_isbn10_with_x_check_digit() {
+    let ov = MetadataOverrides {
+        isbn10: Some("020163361X".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_empty_isbn10_as_a_clear() {
+    // AC2: an empty string is the "clear the override" sentinel, mirroring
+    // isbn13, not an invalid value.
+    let ov = MetadataOverrides {
+        isbn10: Some(String::new()),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_missing_isbn10_field() {
+    assert_eq!(MetadataOverrides::default().validate(), Ok(()));
+}
+
+#[test]
+fn validate_rejects_isbn10_with_nine_characters() {
+    let ov = MetadataOverrides {
+        isbn10: Some("013468599".to_string()),
+        ..Default::default()
+    };
+    let err = ov
+        .validate()
+        .expect_err("9-char ISBN-10 should be rejected");
+    assert!(err.contains("ISBN-10"), "unexpected message: {err}");
+}
+
+#[test]
+fn validate_rejects_isbn10_with_a_check_digit_x_in_a_non_final_position() {
+    let ov = MetadataOverrides {
+        isbn10: Some("X134685997".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        ov.validate().is_err(),
+        "X is only a legal character in the final position"
+    );
+}
+
+#[test]
+fn validate_rejects_isbn10_containing_non_digit_characters() {
+    let ov = MetadataOverrides {
+        isbn10: Some("01346-8599".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        ov.validate().is_err(),
+        "a hyphen is not a valid ISBN-10 character"
+    );
+}
+
+#[test]
+fn validate_accepts_print_pages_within_range() {
+    let ov = MetadataOverrides {
+        print_pages: Some(320),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_accepts_missing_print_pages_field() {
+    assert_eq!(MetadataOverrides::default().validate(), Ok(()));
+}
+
+#[test]
+fn validate_rejects_print_pages_above_the_max() {
+    let ov = MetadataOverrides {
+        print_pages: Some(MetadataOverrides::PRINT_PAGES_MAX + 1),
+        ..Default::default()
+    };
+    let err = ov
+        .validate()
+        .expect_err("over-max page count should be rejected");
+    assert!(
+        err.contains("print page count"),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
+fn validate_accepts_print_pages_at_the_max() {
+    let ov = MetadataOverrides {
+        print_pages: Some(MetadataOverrides::PRINT_PAGES_MAX),
+        ..Default::default()
+    };
+    assert_eq!(ov.validate(), Ok(()));
+}
+
+#[test]
+fn validate_rejects_print_pages_at_zero() {
+    let ov = MetadataOverrides {
+        print_pages: Some(0),
+        ..Default::default()
+    };
+    let err = ov
+        .validate()
+        .expect_err("zero page count should be rejected");
+    assert!(
+        err.contains("print page count"),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
+fn validate_rejects_negative_print_pages() {
+    let ov = MetadataOverrides {
+        print_pages: Some(-1),
+        ..Default::default()
+    };
+    assert!(
+        ov.validate().is_err(),
+        "a negative page count should be rejected"
+    );
+}
+
 // --- merge() -----------------------------------------------------------
 //
 // NOTE on contract: the issue describes `merge` as "applies an override
@@ -459,6 +596,77 @@ fn merge_none_isbn13_preserves_base_isbn13() {
     let incoming = MetadataOverrides::default();
     let merged = base.merge(&incoming);
     assert_eq!(merged.isbn13, Some("9780134685991".into()));
+}
+
+#[test]
+fn merge_incoming_isbn10_wins_over_base_isbn10() {
+    let base = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides {
+        isbn10: Some("020163361X".into()),
+        ..Default::default()
+    };
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.isbn10, Some("020163361X".into()));
+}
+
+#[test]
+fn merge_none_isbn10_preserves_base_isbn10() {
+    let base = MetadataOverrides {
+        isbn10: Some("0134685997".into()),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides::default();
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.isbn10, Some("0134685997".into()));
+}
+
+#[test]
+fn merge_incoming_print_pages_wins_over_base_print_pages() {
+    let base = MetadataOverrides {
+        print_pages: Some(320),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides {
+        print_pages: Some(512),
+        ..Default::default()
+    };
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.print_pages, Some(512));
+}
+
+#[test]
+fn merge_none_print_pages_preserves_base_print_pages() {
+    let base = MetadataOverrides {
+        print_pages: Some(320),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides::default();
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.print_pages, Some(320));
+}
+
+#[test]
+fn merge_a_payload_that_omits_all_three_new_fields_preserves_them() {
+    // AC2: a client that predates these fields (notably iOS) must not
+    // clobber them by omission — the whole point `merge` exists for.
+    let base = MetadataOverrides {
+        genres: Some(vec!["Historical Fiction".into()]),
+        isbn10: Some("0134685997".into()),
+        print_pages: Some(320),
+        ..Default::default()
+    };
+    let incoming = MetadataOverrides {
+        title: Some("New Title".into()),
+        ..Default::default()
+    };
+    let merged = base.merge(&incoming);
+    assert_eq!(merged.title, Some("New Title".into()));
+    assert_eq!(merged.genres, Some(vec!["Historical Fiction".into()]));
+    assert_eq!(merged.isbn10, Some("0134685997".into()));
+    assert_eq!(merged.print_pages, Some(320));
 }
 
 // --- BulkMetadataEdit ---

--- a/shared/src/isbn/mod.rs
+++ b/shared/src/isbn/mod.rs
@@ -58,7 +58,11 @@ pub fn normalize_isbn(raw: &str) -> Result<String, IsbnError> {
 
 /// Validate an ISBN-10: nine digits + a check digit (0–9 or `X` = 10), where
 /// the weighted sum (weights 10..1) is divisible by 11.
-fn validate_isbn10(s: &str) -> Result<(), IsbnError> {
+///
+/// `pub` so callers that need a real (check-digit-verified) ISBN-10 —
+/// distinct from `MetadataOverrides::validate`'s deliberately format-only
+/// override check — can call it directly rather than duplicating the sum.
+pub fn validate_isbn10(s: &str) -> Result<(), IsbnError> {
     let mut sum = 0u32;
     for (i, c) in s.chars().enumerate() {
         let value = match c {

--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -192,6 +192,51 @@ test.describe
     });
 
     // ---------------------------------------------------------------------------
+    // ISBN-10 + print page count overrides (#1658)
+    // ---------------------------------------------------------------------------
+
+    test("edits ISBN-10 and print page count and persists them", async ({
+      page,
+      request,
+    }) => {
+      const id = await fetchBookIdByTitle(request, TARGET.title);
+      await gotoReady(page, `/books/${id}/edit`);
+
+      const isbn10Input = page.getByLabel("ISBN-10");
+      await expect(isbn10Input).toBeVisible();
+      await isbn10Input.fill("0134685997");
+
+      const printPagesInput = page.getByLabel("Print Pages");
+      await printPagesInput.fill("412");
+
+      await expect(page.getByTestId("me-save")).toBeEnabled();
+      await expect(page.getByText("2 fields edited")).toBeVisible();
+
+      await expectMutation(
+        page,
+        {
+          method: "POST",
+          url: /\/api\/rpc\/ebook\/overrides/,
+          expectedStatus: 200,
+        },
+        async () => page.getByTestId("me-save").click(),
+      );
+
+      await expect(page).toHaveURL(new RegExp(`/books/${id}$`));
+
+      // Re-open the edit form and confirm both fields persisted.
+      await gotoReady(page, `/books/${id}/edit`);
+      await expect(page.getByLabel("ISBN-10")).toHaveValue("0134685997");
+      await expect(page.getByLabel("Print Pages")).toHaveValue("412");
+
+      // Clean up: revert so other tests are not affected.
+      const revertBtn = page.getByTestId("revert-overrides");
+      await expect(revertBtn).toBeVisible();
+      await revertBtn.click();
+      await expect(page).toHaveURL(new RegExp(`/books/${id}$`));
+    });
+
+    // ---------------------------------------------------------------------------
     // Discard reverts unsaved changes
     // ---------------------------------------------------------------------------
 

--- a/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/metadata_edit.spec.ts
@@ -232,7 +232,15 @@ test.describe
       // Clean up: revert so other tests are not affected.
       const revertBtn = page.getByTestId("revert-overrides");
       await expect(revertBtn).toBeVisible();
-      await revertBtn.click();
+      await expectMutation(
+        page,
+        {
+          method: "POST",
+          url: /\/api\/rpc\/ebook\/overrides\/delete/,
+          expectedStatus: 200,
+        },
+        async () => revertBtn.click(),
+      );
       await expect(page).toHaveURL(new RegExp(`/books/${id}$`));
     });
 


### PR DESCRIPTION
## Summary
- Adds three new metadata-override fields — genres, print page count, and ISBN-10 — spanning the shared wire types, DB projection/upsert layer, the metadata-edit frontend page, and REST/RPC coverage.
- Closes #1658

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` (server, shared, frontend, db) — PASS
- [x] `cargo clippy -p omnibus-frontend --target wasm32-unknown-unknown --features web -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` (full suite, `sqlite::memory:`) — 2107 passed, 1 failed
  - The 1 failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a missing-fixture panic (`just fixtures` not run in this sandbox worktree) — pre-existing environment gap, unrelated to this change.
- [x] `cargo test -p omnibus-frontend --features server` — 816 passed, 0 failed
- [x] `cargo test -p omnibus-shared` — 318 passed, 0 failed
- [x] `cargo test -p omnibus` (server REST) — 827 passed, 2 failed
  - Both failures (`*_rejects_read_only_library_with_400`) are the known root-bypasses-chmod artifact of running tests as root in this container — confirmed independently by other agents as pre-existing/unrelated, not something to fix here.
- [ ] Playwright (`ui_tests/playwright`), `just lint-css` (stylelint), mobile-target clippy — not runnable in this sandbox (no browser bundle / Nix flake fetch blocked for uncached inputs); left to CI.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- CI will independently cover Playwright E2E, stylelint, and the mobile clippy lane, none of which could run in this local sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7BXSStsWbu91wQJ27RUZi)_