### PR TITLE
[OMNI-1990] Return the Continue Hero to One Full-Width Card Per Page

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -7093,11 +7093,6 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   box-shadow: 0 8px 18px color-mix(in oklch, black 35%, transparent);
   overflow: hidden;
 }
-/* Two cards per page at wide widths (track gap is 16px, so each card
-   cedes half of it). The snap/dot logic stays per-card. */
-@media (min-width: 1100px) {
-  .ch-card { flex: 0 0 calc(50% - 8px); }
-}
 .ch-cover {
   flex: 0 0 96px;
   width: 96px;


### PR DESCRIPTION
## Summary
- Drops the `min-width: 1100px` two-up flex-basis rule so hero cards render one per carousel page at every width, per the revised design; linked-card CTAs, corner glyph, snap paging, and dots are untouched.

Closes #1990

## Test plan
- [x] `just lint-css` clean; CSS-only deletion, no markup or selector changes.
- [ ] CI E2E (hero flows) green.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.