### PR TITLE
[OMNI-1863] Deep-Review Fixes: Snapshot Ordering, iOS Decode, Echo and Sequence Guards

### DIFF
--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -132,8 +132,10 @@ pub async fn upsert_link(
     // button says exactly that, and a linked book that still prompts on
     // every surface switch reads as broken (live QA on #1944). The follow
     // toggle can still switch it off afterward; user anchors survive only
-    // when the audio set is unchanged — a new set is a new timeline, and
-    // the stored global seconds no longer mean anything on it.
+    // when the audio set (ordinal order included), mode, AND narrations
+    // primary are all unchanged — anchors store global seconds on one
+    // concrete timeline, and any of those three changing makes that
+    // timeline a different ruler the stored pairs no longer measure.
     sqlx::query(
         "INSERT INTO cross_format_links
             (user_id, book_uuid, mode, primary_book_file_id, audio_snapshot, confirmed_at, follow)
@@ -144,6 +146,9 @@ pub async fn upsert_link(
             primary_book_file_id = excluded.primary_book_file_id,
             user_anchors = CASE
                 WHEN cross_format_links.audio_snapshot = excluded.audio_snapshot
+                 AND cross_format_links.mode = excluded.mode
+                 AND COALESCE(cross_format_links.primary_book_file_id, -1)
+                     = COALESCE(excluded.primary_book_file_id, -1)
                 THEN cross_format_links.user_anchors ELSE '[]' END,
             audio_snapshot = excluded.audio_snapshot,
             confirmed_at = excluded.confirmed_at",
@@ -395,18 +400,22 @@ struct SnapshotEntry {
     etag: Option<String>,
 }
 
-/// Canonical JSON of an audio file set: `(scan_key, wire etag)` pairs
-/// sorted by scan_key, so comparison is order- and id-independent —
-/// `book_files.id` changes on every Changed re-index, scan_key doesn't.
+/// Canonical JSON of an audio file set: `(scan_key, wire etag)` pairs in
+/// **ordinal order**. Keyed on scan_key + etag so comparison is
+/// id-independent (`book_files.id` changes on every Changed re-index,
+/// scan_key doesn't) — but deliberately order-DEPENDENT: the sequence
+/// timeline concatenates by ordinal, so a re-order changes what every
+/// stored global second means and must read as a different set (stale
+/// links, cleared anchors). A sorted snapshot let `set_audio_order`
+/// permute the timeline under every user's live mapping undetected.
 fn snapshot_json(files: &[AudioFile]) -> String {
-    let mut entries: Vec<SnapshotEntry> = files
+    let entries: Vec<SnapshotEntry> = files
         .iter()
         .map(|f| SnapshotEntry {
             scan_key: f.scan_key.clone(),
             etag: omnibus_shared::file_etag(f.size_bytes, f.mtime_epoch),
         })
         .collect();
-    entries.sort();
     serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string())
 }
 

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -121,13 +121,36 @@ pub async fn upsert_link(
     mode: CrossFormatLinkMode,
     primary_book_file_id: Option<i64>,
 ) -> Result<CrossFormatLink, CrossFormatError> {
+    confirm_link(pool, user_id, book_uuid, mode, primary_book_file_id, None).await
+}
+
+/// Confirm a link, atomically applying an audio re-order when one rides
+/// along. One transaction on purpose: the re-order is a library-wide
+/// `book_files.ordinal` mutation, and committing it without the link (or
+/// the link against a half-applied order) leaves state no confirm ever
+/// described — the snapshot must also be taken from the ordinals the same
+/// transaction just wrote.
+pub async fn confirm_link(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_uuid: &str,
+    mode: CrossFormatLinkMode,
+    primary_book_file_id: Option<i64>,
+    audio_order: Option<&[i64]>,
+) -> Result<CrossFormatLink, CrossFormatError> {
     let book_uuid = resolve_canonical_book_uuid(pool, book_uuid)
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
     let book_id = resolve_book_id_by_uuid(pool, &book_uuid)
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
-    let snapshot = snapshot_json(&audio_files(pool, book_id).await?);
+    // BEGIN IMMEDIATE mirrors `upsert_progress` — take the write lock up
+    // front so a concurrent writer can't stale this snapshot mid-confirm.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    if let Some(order) = audio_order {
+        apply_audio_order_tx(&mut tx, book_id, order).await?;
+    }
+    let snapshot = snapshot_json(&audio_files(&mut *tx, book_id).await?);
     // Confirming the alignment IS turning sync on — the modal's confirm
     // button says exactly that, and a linked book that still prompts on
     // every surface switch reads as broken (live QA on #1944). The follow
@@ -158,8 +181,9 @@ pub async fn upsert_link(
     .bind(mode_str(mode))
     .bind(primary_book_file_id)
     .bind(&snapshot)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+    tx.commit().await?;
     get_link(pool, user_id, &book_uuid)
         .await?
         .ok_or(CrossFormatError::BookNotFound)
@@ -243,26 +267,50 @@ pub async fn declare_sync_point(
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
 
-    let link = match get_link(pool, user_id, &book_uuid).await? {
-        Some(link) => link,
+    let (link, created_here) = match get_link(pool, user_id, &book_uuid).await? {
+        Some(link) => (link, false),
         None => {
             if audio_files(pool, book_id).await?.len() != 1 {
                 return Err(CrossFormatError::LinkRequired);
             }
-            upsert_link(
+            let link = upsert_link(
                 pool,
                 user_id,
                 &book_uuid,
                 CrossFormatLinkMode::Sequence,
                 None,
             )
-            .await?
+            .await?;
+            (link, true)
         }
     };
-    if link_is_stale(pool, book_id, &link).await? {
+    // A declaration that fails past this point must not leave behind the
+    // link this call just auto-created — the UI reported failure, and a
+    // silently-confirmed follow link would start moving positions the
+    // user never agreed to sync. Best-effort compensation, not a
+    // transaction: the link insert has value only alongside its anchor.
+    let result = declare_against_link(pool, user_id, book_id, &book_uuid, &link, decl).await;
+    if created_here && result.is_err() {
+        let _ = delete_link(pool, user_id, &book_uuid).await;
+    }
+    result
+}
+
+/// The declaration proper, against an existing (or just-created) link —
+/// split from [`declare_sync_point`] so a failure there can compensate by
+/// removing a link it auto-created.
+async fn declare_against_link(
+    pool: &SqlitePool,
+    user_id: i64,
+    book_id: i64,
+    book_uuid: &str,
+    link: &CrossFormatLink,
+    decl: &omnibus_shared::cross_format::DeclareSyncPoint,
+) -> Result<CrossFormatLink, CrossFormatError> {
+    if link_is_stale(pool, book_id, link).await? {
         return Err(CrossFormatError::AudioSetMismatch);
     }
-    let timeline = audio_timeline(pool, book_id, &link)
+    let timeline = audio_timeline(pool, book_id, link)
         .await?
         .ok_or(CrossFormatError::LinkRequired)?;
 
@@ -278,7 +326,7 @@ pub async fn declare_sync_point(
             let frac = cfi_frac
                 .or_else(|| decl.ebook_fraction.filter(|f| (0.0..=1.0).contains(f)))
                 .ok_or(CrossFormatError::CounterpartMissing)?;
-            let row = progress::get_progress(pool, user_id, &book_uuid, ProgressFormat::Audio)
+            let row = progress::get_progress(pool, user_id, book_uuid, ProgressFormat::Audio)
                 .await?
                 .ok_or(CrossFormatError::CounterpartMissing)?;
             let seconds = row
@@ -305,7 +353,7 @@ pub async fn declare_sync_point(
             let global = audio_fraction(&timeline, file_id, seconds)
                 .ok_or(CrossFormatError::CounterpartMissing)?
                 * timeline.total_seconds;
-            let row = progress::get_progress(pool, user_id, &book_uuid, ProgressFormat::Epub)
+            let row = progress::get_progress(pool, user_id, book_uuid, ProgressFormat::Epub)
                 .await?
                 .ok_or(CrossFormatError::CounterpartMissing)?;
             let frac = epub_source_fraction(pool, book_id, &row)
@@ -331,10 +379,10 @@ pub async fn declare_sync_point(
     )
     .bind(&json)
     .bind(user_id)
-    .bind(&book_uuid)
+    .bind(book_uuid)
     .execute(pool)
     .await?;
-    get_link(pool, user_id, &book_uuid)
+    get_link(pool, user_id, book_uuid)
         .await?
         .ok_or(CrossFormatError::BookNotFound)
 }
@@ -367,7 +415,10 @@ struct AudioFile {
     duration_seconds: f64,
 }
 
-async fn audio_files(pool: &SqlitePool, book_id: i64) -> Result<Vec<AudioFile>, sqlx::Error> {
+async fn audio_files<'e, E>(exec: E, book_id: i64) -> Result<Vec<AudioFile>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let rows: Vec<(i64, String, i64, i64, f64)> = sqlx::query_as(
         "SELECT bf.id, COALESCE(bf.scan_key, ''), bf.size_bytes, bf.mtime_epoch,
                 COALESCE(SUM(bfp.duration_seconds), 0)
@@ -378,7 +429,7 @@ async fn audio_files(pool: &SqlitePool, book_id: i64) -> Result<Vec<AudioFile>, 
          ORDER BY bf.ordinal, bf.id",
     )
     .bind(book_id)
-    .fetch_all(pool)
+    .fetch_all(exec)
     .await?;
     Ok(rows
         .into_iter()
@@ -1060,7 +1111,21 @@ pub async fn set_audio_order(
     let book_id = resolve_book_id_by_uuid(pool, &book_uuid)
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
-    let current: std::collections::HashSet<i64> = audio_files(pool, book_id)
+    let mut tx = pool.begin().await?;
+    apply_audio_order_tx(&mut tx, book_id, order).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// The validated two-phase ordinal write, inside the caller's transaction —
+/// [`confirm_link`] runs it in the same transaction as the link upsert so a
+/// confirm can never commit a re-order without its link (or vice versa).
+async fn apply_audio_order_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    book_id: i64,
+    order: &[i64],
+) -> Result<(), CrossFormatError> {
+    let current: std::collections::HashSet<i64> = audio_files(&mut **tx, book_id)
         .await?
         .into_iter()
         .map(|f| f.book_file_id)
@@ -1069,13 +1134,12 @@ pub async fn set_audio_order(
     if proposed.len() != order.len() || proposed != current {
         return Err(CrossFormatError::AudioSetMismatch);
     }
-    let mut tx = pool.begin().await?;
     for (i, id) in order.iter().enumerate() {
         sqlx::query("UPDATE book_files SET ordinal = ? WHERE id = ? AND book_id = ?")
             .bind(-(i as i64) - 1)
             .bind(id)
             .bind(book_id)
-            .execute(&mut *tx)
+            .execute(&mut **tx)
             .await?;
     }
     sqlx::query(
@@ -1083,8 +1147,7 @@ pub async fn set_audio_order(
          WHERE book_id = ? AND format IN ('M4B', 'M4A', 'MP3') AND ordinal < 0",
     )
     .bind(book_id)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await?;
-    tx.commit().await?;
     Ok(())
 }

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1584,6 +1584,95 @@ async fn reconfirm_keeps_follow_and_clears_anchors_only_when_the_audio_set_chang
 }
 
 #[tokio::test]
+async fn reordering_audio_files_reads_as_a_different_set_and_clears_anchors() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0, 300.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 1_000))
+        .await
+        .unwrap();
+    declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 500.0))
+        .await
+        .unwrap();
+
+    // Swap the two files' ordinals — the concatenated timeline changes,
+    // so every stored global second now means a different spot. The
+    // snapshot must read as a different set: the link goes stale for
+    // everyone, and a re-confirm clears the old-ruler anchors.
+    // Three steps through a parking ordinal: the UNIQUE(book_id, format,
+    // ordinal) constraint is enforced per-row, so a single-statement swap
+    // trips it mid-UPDATE.
+    for (id, ordinal) in [(audio[0], 99), (audio[1], 0), (audio[0], 1)] {
+        sqlx::query("UPDATE book_files SET ordinal = ? WHERE id = ?")
+            .bind(ordinal)
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    let book_id = crate::resolve_book_id_by_uuid(&pool, &uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    let link = get_link(&pool, user, &uuid).await.unwrap().unwrap();
+    assert!(link_is_stale(&pool, book_id, &link).await.unwrap());
+
+    let link = upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    assert!(link.user_anchors.is_empty());
+}
+
+#[tokio::test]
+async fn reconfirm_with_a_different_mode_or_primary_clears_anchors() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid, audio) = seed_dual_book(&pool, &[600.0, 300.0]).await;
+    upsert_link(&pool, user, &uuid, CrossFormatLinkMode::Sequence, None)
+        .await
+        .unwrap();
+    progress::upsert_progress(&pool, user, &epub_percent_update(&uuid, 40, 1_000))
+        .await
+        .unwrap();
+    declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 500.0))
+        .await
+        .unwrap();
+
+    // Same files, different mode: the anchors' global seconds were
+    // measured on the sequence concatenation — meaningless against a
+    // narrations primary. Cleared.
+    let link = upsert_link(
+        &pool,
+        user,
+        &uuid,
+        CrossFormatLinkMode::Narrations,
+        Some(audio[0]),
+    )
+    .await
+    .unwrap();
+    assert!(link.user_anchors.is_empty());
+
+    // Re-anchor on the narrations primary, then switch primaries: a
+    // different recording is a different ruler too. Cleared again.
+    declare_sync_point(&pool, user, &declare_audio(&uuid, Some(audio[0]), 100.0))
+        .await
+        .unwrap();
+    let link = upsert_link(
+        &pool,
+        user,
+        &uuid,
+        CrossFormatLinkMode::Narrations,
+        Some(audio[1]),
+    )
+    .await
+    .unwrap();
+    assert!(link.user_anchors.is_empty());
+}
+
+#[tokio::test]
 async fn set_follow_flips_only_existing_links() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "alice").await;

--- a/db/src/progress/tests.rs
+++ b/db/src/progress/tests.rs
@@ -3217,3 +3217,32 @@ async fn upsert_progress_refuses_near_zero_audio_write_against_far_advanced_row(
         .unwrap();
     assert!(rec.audio_position_seconds.unwrap() < f64::EPSILON);
 }
+
+#[tokio::test]
+async fn upsert_progress_teardown_refusal_exempts_a_write_in_a_different_file() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    let (_, uuid) = seed(&pool, "/lib", "Switched").await;
+    upsert_progress(&pool, user, &audio_update(&uuid, 10_000.0, Some(7), 1_000))
+        .await
+        .unwrap();
+
+    // Near-zero, fresh clock — but naming a DIFFERENT file than the
+    // stored row: that is a real file switch (picker, mapped offer), not
+    // a dying element's flush, and refusing it would lose the switch.
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 0.5, Some(8), 2_000))
+        .await
+        .unwrap();
+    assert_eq!(rec.book_file_id, Some(8));
+    assert!((rec.audio_position_seconds.unwrap() - 0.5).abs() < f64::EPSILON);
+
+    // Same-file near-zero stays refused.
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 10_000.0, Some(8), 3_000))
+        .await
+        .unwrap();
+    assert!((rec.audio_position_seconds.unwrap() - 10_000.0).abs() < f64::EPSILON);
+    let rec = upsert_progress(&pool, user, &audio_update(&uuid, 0.0, Some(8), 4_000))
+        .await
+        .unwrap();
+    assert!((rec.audio_position_seconds.unwrap() - 10_000.0).abs() < f64::EPSILON);
+}

--- a/db/src/progress/upsert.rs
+++ b/db/src/progress/upsert.rs
@@ -126,9 +126,19 @@ pub async fn upsert_progress_tx(
     // audio write against a row that sits far into the book: the write is
     // dropped, the stored row returned. A genuine restart-from-the-start
     // persists within one heartbeat anyway — its next report is already
-    // past the cutoff.
+    // past the cutoff. Scoped to the SAME file as the stored row: a dying
+    // element flushes the file it was playing, while a near-zero write in
+    // a *different* file is a real file switch (picker, mapped offer) and
+    // refusing it would lose the switch itself.
     if update.format == ProgressFormat::Audio {
-        if let (Some(new), Some(old)) = (update.audio_position_seconds, existing.1) {
+        let same_file = match (update.book_file_id, existing.2) {
+            (Some(new_file), Some(old_file)) => new_file == old_file,
+            // A file-less write can't prove it's a switch — treat as the
+            // stored file, keeping the guard for single-file books.
+            _ => true,
+        };
+        if let (true, Some(new), Some(old)) = (same_file, update.audio_position_seconds, existing.1)
+        {
             if new < AUDIO_TEARDOWN_ZERO_CUTOFF_SECONDS
                 && old > AUDIO_TEARDOWN_ZERO_MIN_STORED_SECONDS
             {
@@ -218,10 +228,10 @@ async fn existing_progress_snapshot(
     user_id: i64,
     book_uuid: &str,
     fmt: &str,
-) -> Result<(Option<i64>, Option<f64>), ProgressError> {
+) -> Result<(Option<i64>, Option<f64>, Option<i64>), ProgressError> {
     let Some(row) = sqlx::query(
         "SELECT COALESCE(client_updated_at, updated_at) AS client_updated_at,
-                audio_position_seconds
+                audio_position_seconds, book_file_id
          FROM reading_progress
          WHERE user_id = ? AND book_uuid = ? AND format = ?",
     )
@@ -231,11 +241,12 @@ async fn existing_progress_snapshot(
     .fetch_optional(&mut **tx)
     .await?
     else {
-        return Ok((None, None));
+        return Ok((None, None, None));
     };
     Ok((
         Some(row.try_get::<i64, _>("client_updated_at")?),
         row.try_get::<Option<f64>, _>("audio_position_seconds")?,
+        row.try_get::<Option<i64>, _>("book_file_id")?,
     ))
 }
 

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -93,7 +93,7 @@ pub enum Task {
     /// scan on the same library); does not consume the scan semaphore
     /// (light per-file IO, mirrors [`Task::BackfillWordCounts`]).
     BackfillPageCounts { library_path: String },
-    /// Backfill `epub_spine_stats` + `ebook_chapters` (migration `0071`)
+    /// Backfill `epub_spine_stats` + `ebook_chapters` (migration `0074`)
     /// for EPUB files with no extracted structure yet. Posted by the
     /// [`Task::Scan`] handler on success like its sibling backfills; the
     /// Changed sync path re-creates a file's `book_files` row, so cascade

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -2105,10 +2105,12 @@
   function displayPercentage(pct) {
     // A percentage jump that actually moves the view is real movement and
     // must persist — `applyPercentage` clears the pending echo tag once
-    // its same-position guard passes (#1972).
+    // its same-position guard passes (#1972). Parking must NOT clear it:
+    // on a locations cache miss the pct path always parks (generation
+    // waits on first paint), and an eagerly-cleared tag let the restore's
+    // own settle emission post the unmoved position with a fresh clock.
     pendingJumpCfi = null;
     if (!book || !book.locations || !book.locations.length()) {
-      restoreEchoPending = false;
       pendingJumpPct = pct;
       return;
     }

--- a/frontend/src/pages/book_detail/immersive.rs
+++ b/frontend/src/pages/book_detail/immersive.rs
@@ -45,12 +45,6 @@ pub(crate) fn retarget_and_open_immersive(uuid: String) {
     // can't flash the old book under the new reader before the driver reloads.
     let mut uuid_sig = playback.uuid;
     let mut file_sig = playback.file_id;
-    // Default file selection, published before the uuid so the driver
-    // reads it when the load kicks off (mirrors the mobile variant and
-    // `use_retarget_playback`). Without this a stale picker selection
-    // from a previously-played book would override the bootstrap's
-    // progress-row file resolution — or 404 the new book's manifest.
-    file_sig.set(None);
     // Re-resolve unless the SAME book is actively playing: the old
     // same-uuid short-circuit kept whatever in-memory state the dock
     // held, which on an idle target can be stale against the stored
@@ -59,6 +53,16 @@ pub(crate) fn retarget_and_open_immersive(uuid: String) {
     // + follow resolution.
     let same_book = uuid_sig.peek().as_deref() == Some(uuid.as_str());
     let live = same_book && *playback.playing.peek();
+    // Default file selection, published before the uuid so the driver
+    // reads it when the load kicks off (mirrors the mobile variant and
+    // `use_retarget_playback`). Without this a stale picker selection
+    // from a previously-played book would override the bootstrap's
+    // progress-row file resolution — or 404 the new book's manifest.
+    // Left untouched for a LIVE same-book session: clearing it there
+    // degrades a picker-launched part mid-playback for no reason.
+    if !live {
+        file_sig.set(None);
+    }
     if !live {
         let mut error_sig = playback.error;
         let mut loading_sig = playback.loading;

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -125,10 +125,14 @@ pub(super) fn derive_loaded_view(b: &EbookMetadata) -> LoadedBookView {
         .as_deref()
         .map(|a| format!("--accent: {a};"))
         .unwrap_or_default();
-    let has_audio = b
-        .formats
-        .iter()
-        .any(|f| f.eq_ignore_ascii_case("m4b") || f.eq_ignore_ascii_case("mp3"));
+    // M4A is a first-class indexed audio format (`db::audiobook`); leaving
+    // it out here made the landing hero's link invite dead-end on a detail
+    // page with no sync affordance for EPUB+M4A books.
+    let has_audio = b.formats.iter().any(|f| {
+        f.eq_ignore_ascii_case("m4b")
+            || f.eq_ignore_ascii_case("m4a")
+            || f.eq_ignore_ascii_case("mp3")
+    });
     let has_ebook = b
         .formats
         .iter()

--- a/frontend/src/pages/landing/hero.rs
+++ b/frontend/src/pages/landing/hero.rs
@@ -16,13 +16,14 @@ use crate::Route;
 /// dual-format gate for the link invitation (unlinked) and the Immersive
 /// pill (linked).
 fn has_both_formats(book: &omnibus_shared::EbookMetadata) -> bool {
+    // Only the formats the indexer actually attaches (`db::audiobook`) —
+    // matching the detail page's `has_audio`, so an invite here can never
+    // point at a detail page with no sync affordance.
     book.formats.iter().any(|f| f.eq_ignore_ascii_case("epub"))
-        && book.formats.iter().any(|f| {
-            matches!(
-                f.to_ascii_lowercase().as_str(),
-                "m4b" | "m4a" | "mp3" | "aac" | "flac" | "ogg" | "opus" | "wav"
-            )
-        })
+        && book
+            .formats
+            .iter()
+            .any(|f| matches!(f.to_ascii_lowercase().as_str(), "m4b" | "m4a" | "mp3"))
 }
 
 /// The book+soundwave Immersive mark on the linked card's pill, accent

--- a/frontend/src/pages/listen/bootstrap/mod.rs
+++ b/frontend/src/pages/listen/bootstrap/mod.rs
@@ -674,7 +674,16 @@ async fn run_manifest_init(
     };
 
     let (loaded_file, audio_file_count) = manifest.file_identity();
-    NEXT_SEQUENCE_FILE.with(|c| c.set(manifest.next_file_id()));
+    // Sequence auto-advance is a DIRECT-mode contract only: the HLS
+    // playlist is book-level and file-blind (`get_audiobook_playlist`
+    // takes no file id), so "advancing" an HLS book reboots the same
+    // stream at 0:00 forever instead of finishing it. HLS keeps the
+    // ended-means-finished behavior.
+    let next_file = match &manifest {
+        omnibus_shared::AudiobookManifest::Direct { .. } => manifest.next_file_id(),
+        omnibus_shared::AudiobookManifest::Hls { .. } => None,
+    };
+    NEXT_SEQUENCE_FILE.with(|c| c.set(next_file));
     // `0` = a server predating the identity fields; keep posting no file id
     // rather than inventing one (`resolve_boot_position` degrades the same
     // way via `audio_file_count == 0`).

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -187,9 +187,11 @@ pub(super) fn resolve_follow_boot(
         if picked != mapped {
             return None;
         }
-    } else if explicit_file.is_some() {
-        // Candidate names no file (shouldn't happen for an audio target,
-        // but a malformed payload must not hijack an explicit pick).
+    } else if explicit_file.is_some() || c.book_file_id.is_none() {
+        // Candidate names no file: the server always sets one for an
+        // audio target, so a file-less candidate is malformed — it must
+        // neither hijack an explicit pick nor seed seconds into whatever
+        // file the stored row resolves (the #1888 splice).
         return None;
     }
     Some((c.book_file_id, c.audio_position_seconds?))

--- a/frontend/src/pages/listen/sync_prompt.rs
+++ b/frontend/src/pages/listen/sync_prompt.rs
@@ -61,7 +61,11 @@ pub(super) fn SyncHereButton() -> Element {
                     format: omnibus_shared::ProgressFormat::Audio,
                     ebook_fraction: None,
                     epub_cfi: None,
-                    audio_book_file_id: (playback.file_id)(),
+                    // The RESOLVED file, not the picker request: `file_id`
+                    // is `None` on every ordinary resume path, and a
+                    // file-less audio declaration on a multi-file timeline
+                    // is (correctly) rejected server-side.
+                    audio_book_file_id: (playback.loaded_file_id)(),
                     audio_seconds: Some((playback.elapsed)()),
                 };
                 spawn(async move {

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -127,11 +127,13 @@ fn register_window_callbacks(
     } = sigs;
 
     let uuid_for_save = uuid_cb;
-    // Last SEEN position (echoes included), mirroring the mobile reader:
-    // a later non-echo re-emit of the same CFI (a layout re-render) stays
-    // deduped rather than re-posting — and re-clocking — the unmoved
-    // position.
-    let mut last_seen_cfi: Option<String> = None;
+    // Last POSTED position — deliberately NOT last-seen (the mobile
+    // variant's rule): the web glue's locations-ready re-emit is an echo
+    // that races a turn's debounced relocate and reads epub.js's already-
+    // updated location, so a last-seen key would swallow the turn's own
+    // write. Echoes never advance this key; a layout re-emission at the
+    // last POSTED spot still dedups, which is the bug this exists for.
+    let mut last_posted_cfi: Option<String> = None;
     let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
         if let Ok(mut data) = serde_json::from_str::<super::RelocateData>(&json) {
             // Re-derive chapter/total from the TOC's own order rather than
@@ -151,15 +153,13 @@ fn register_window_callbacks(
             // dedup mirrors the mobile reader: layout re-emissions (window
             // resize, Aa panel changes) re-fire `relocated` at the current
             // CFI, and a re-post would re-clock the unmoved position too.
-            let moved = match (&data.cfi, &last_seen_cfi) {
-                (Some(new), Some(seen)) => new != seen,
+            let moved = match (&data.cfi, &last_posted_cfi) {
+                (Some(new), Some(posted)) => new != posted,
                 (Some(_), None) => true,
                 (None, _) => false,
             };
-            if data.cfi.is_some() {
-                last_seen_cfi = data.cfi.clone();
-            }
             if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo && moved) {
+                last_posted_cfi = Some(cfi.clone());
                 crate::reader_progress::save(&uuid_for_save, &cfi);
                 let uuid_for_post = uuid_for_save.clone();
                 let cfi_for_post = cfi;

--- a/frontend/src/pages/reader/interop.rs
+++ b/frontend/src/pages/reader/interop.rs
@@ -127,6 +127,11 @@ fn register_window_callbacks(
     } = sigs;
 
     let uuid_for_save = uuid_cb;
+    // Last SEEN position (echoes included), mirroring the mobile reader:
+    // a later non-echo re-emit of the same CFI (a layout re-render) stays
+    // deduped rather than re-posting — and re-clocking — the unmoved
+    // position.
+    let mut last_seen_cfi: Option<String> = None;
     let relocate = Closure::<dyn FnMut(String)>::new(move |json: String| {
         if let Ok(mut data) = serde_json::from_str::<super::RelocateData>(&json) {
             // Re-derive chapter/total from the TOC's own order rather than
@@ -142,8 +147,19 @@ fn register_window_callbacks(
             // Echo emissions re-state a position the server already holds —
             // persisting one would stamp a fresh clock on an unmoved
             // position and shadow a newer audiobook spot at the
-            // cross-format clock gate. Render, don't write.
-            if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo) {
+            // cross-format clock gate. Render, don't write. The same-CFI
+            // dedup mirrors the mobile reader: layout re-emissions (window
+            // resize, Aa panel changes) re-fire `relocated` at the current
+            // CFI, and a re-post would re-clock the unmoved position too.
+            let moved = match (&data.cfi, &last_seen_cfi) {
+                (Some(new), Some(seen)) => new != seen,
+                (Some(_), None) => true,
+                (None, _) => false,
+            };
+            if data.cfi.is_some() {
+                last_seen_cfi = data.cfi.clone();
+            }
+            if let Some(cfi) = data.cfi.clone().filter(|_| !data.echo && moved) {
                 crate::reader_progress::save(&uuid_for_save, &cfi);
                 let uuid_for_post = uuid_for_save.clone();
                 let cfi_for_post = cfi;

--- a/frontend/src/pages/reader/sync_banner.rs
+++ b/frontend/src/pages/reader/sync_banner.rs
@@ -64,13 +64,23 @@ pub(super) fn SyncHerePill(uuid: String, loc: Signal<super::signals::RelocateDat
     // Seeded online for SSR parity (rule 07); reconciled post-mount.
     let mut online = use_signal(|| true);
     use_effect(move || online.set(crate::pages::listen::sync_prompt::browser_online()));
+    // An anchor is only as good as the fraction it records: until the
+    // locations pass resolves, `frac` is the rounded spine approximation
+    // (and before the first relocate it's the 0.0 default with no CFI) —
+    // declaring from either would bend every later mapping around a wrong
+    // "ground truth" pair. Reactive read: the pill enables itself the
+    // moment a precise relocate lands.
+    let precise = {
+        let l = loc.read();
+        !l.pct_approx && l.cfi.is_some()
+    };
     rsx! {
         button {
             class: "btn ghost sm rd-sync-here",
             r#type: "button",
             "data-testid": "reader-sync-here",
             title: "Declare the ebook and audiobook aligned at this spot",
-            disabled: !online(),
+            disabled: !online() || !precise,
             onclick: move |_| {
                 if !crate::pages::listen::sync_prompt::browser_online() {
                     return;

--- a/frontend/src/rpc/cross_format.rs
+++ b/frontend/src/rpc/cross_format.rs
@@ -45,35 +45,27 @@ pub async fn rpc_confirm_cross_format_link(update: ConfirmCrossFormatLink) -> Re
     if let Err(msg) = update.validate() {
         return Err(ServerFnError::new(msg).into());
     }
-    if let Some(order) = &update.audio_order {
-        if !user.can_edit {
-            return Err(
-                ServerFnError::new("reordering audio files requires edit permission").into(),
-            );
-        }
-        if let Err(e) = db::cross_format::set_audio_order(&pool.0, &update.book_uuid, order).await {
-            let msg = match &e {
-                db::cross_format::CrossFormatError::AudioSetMismatch => {
-                    Some(format!("{e} — reopen and retry"))
-                }
-                _ => None,
-            };
-            return Err(match msg {
-                Some(msg) => ServerFnError::new(msg).into(),
-                None => rpc_error("set audio order", e).into(),
-            });
-        }
+    if update.audio_order.is_some() && !user.can_edit {
+        return Err(ServerFnError::new("reordering audio files requires edit permission").into());
     }
-    db::cross_format::upsert_link(
+    // One transactional confirm: a riding re-order is a library-wide
+    // mutation and must never commit without its link (or vice versa).
+    db::cross_format::confirm_link(
         &pool.0,
         user.id,
         &update.book_uuid,
         update.mode,
         update.primary_book_file_id,
+        update.audio_order.as_deref(),
     )
     .await
     .map(|_| ())
-    .map_err(|e| rpc_error("confirm cross-format link", e).into())
+    .map_err(|e| match &e {
+        db::cross_format::CrossFormatError::AudioSetMismatch => {
+            ServerFnError::new(format!("{e} — reopen and retry")).into()
+        }
+        _ => rpc_error("confirm cross-format link", e).into(),
+    })
 }
 
 /// Turn sync off for one book; returns whether a link existed.

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1638,7 +1638,10 @@ struct AlignmentView: Codable, Hashable, Sendable {
     /// marks" and nonzero means "marks exist but couldn't be aligned".
     var audioChapterMarks: Int64?
     /// Matched anchor pairs (text_frac, audio_frac) — the mapped-preview
-    /// interpolation, identical to the pairs the jump uses.
+    /// interpolation, identical to the pairs the jump uses. Decoded via
+    /// `decodeIfPresent`: synthesized Codable ignores the `= []` default
+    /// and throws `keyNotFound` on an absent key, and older servers omit
+    /// the key for linear-tier books.
     var anchorPairs: [[Double]] = []
 
     enum CodingKeys: String, CodingKey {
@@ -1650,6 +1653,18 @@ struct AlignmentView: Codable, Hashable, Sendable {
         case listening
         case audioChapterMarks = "audio_chapter_marks"
         case anchorPairs = "anchor_pairs"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        link = try c.decodeIfPresent(AlignmentLink.self, forKey: .link)
+        anchorMatch = try c.decodeIfPresent(AlignmentMatch.self, forKey: .anchorMatch)
+        ebook = try c.decodeIfPresent(AlignmentEbook.self, forKey: .ebook)
+        audioFiles = try c.decode([AlignmentAudioFile].self, forKey: .audioFiles)
+        reading = try c.decodeIfPresent(AlignmentPosition.self, forKey: .reading)
+        listening = try c.decodeIfPresent(AlignmentAudioPosition.self, forKey: .listening)
+        audioChapterMarks = try c.decodeIfPresent(Int64.self, forKey: .audioChapterMarks)
+        anchorPairs = try c.decodeIfPresent([[Double]].self, forKey: .anchorPairs) ?? []
     }
 }
 

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -200,7 +200,14 @@ struct ReaderView: View {
                 if !chromeVisible { showMenu = false }
             }
         }
-        .onChange(of: controller.location?.cfi) { _, _ in
+        .onChange(of: controller.location?.cfi) { old, _ in
+            // The boot restore's nil→CFI transition is an echo of the
+            // position the server already holds — persisting it stamps a
+            // fresh clock on an unmoved row and shadows a newer audiobook
+            // spot at the cross-format clock gate (the same #1972 class
+            // the web reader suppresses via echo-tagged relocates). Only
+            // CFI→CFI transitions are movement worth recording.
+            guard old != nil else { return }
             Task { await persist(force: false) }
         }
         .onChange(of: controller.location?.atEnd) { _, atEnd in

--- a/server/src/backend/cross_format.rs
+++ b/server/src/backend/cross_format.rs
@@ -102,25 +102,22 @@ pub(super) async fn post_cross_format_link(
     if let Err(msg) = update.validate() {
         return (axum::http::StatusCode::UNPROCESSABLE_ENTITY, msg).into_response();
     }
-    if let Some(order) = &update.audio_order {
-        if !user.can_edit {
-            return (
-                axum::http::StatusCode::FORBIDDEN,
-                "reordering audio files requires edit permission",
-            )
-                .into_response();
-        }
-        match db::cross_format::set_audio_order(&state.pool, &update.book_uuid, order).await {
-            Ok(()) => {}
-            Err(e) => return error_response("set_audio_order", e),
-        }
+    if update.audio_order.is_some() && !user.can_edit {
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            "reordering audio files requires edit permission",
+        )
+            .into_response();
     }
-    match db::cross_format::upsert_link(
+    // One transactional confirm: a riding re-order is a library-wide
+    // mutation and must never commit without its link (or vice versa).
+    match db::cross_format::confirm_link(
         &state.pool,
         user.id,
         &update.book_uuid,
         update.mode,
         update.primary_book_file_id,
+        update.audio_order.as_deref(),
     )
     .await
     {

--- a/server/src/backend/kobo/sync.rs
+++ b/server/src/backend/kobo/sync.rs
@@ -163,14 +163,29 @@ async fn enrich_states_with_derived_spans(
         // older CFI. Response-only — the progress row keeps its real
         // provenance; the device's own PUT makes the position real once
         // the reader picks it up there.
-        if let Ok(resume) = db::cross_format::resume_candidate(
-            state.pool(),
-            user_id,
-            &book.uuid,
-            omnibus_shared::ProgressFormat::Epub,
-        )
-        .await
-        {
+        //
+        // Cheap pre-filter before the multi-query mapping composition:
+        // most changed books have no follow link, and one indexed
+        // `get_link` read skips the timeline/progress/structure reads for
+        // all of them (a large first sync touches every book). Falls
+        // through to the normal derivation lane below either way.
+        let follow_linked = matches!(
+            db::cross_format::get_link(state.pool(), user_id, &book.uuid).await,
+            Ok(Some(link)) if link.follow
+        );
+        let resume = if follow_linked {
+            db::cross_format::resume_candidate(
+                state.pool(),
+                user_id,
+                &book.uuid,
+                omnibus_shared::ProgressFormat::Epub,
+            )
+            .await
+            .ok()
+        } else {
+            None
+        };
+        if let Some(resume) = resume {
             if resume.follow
                 && resume.state == omnibus_shared::cross_format::CrossFormatResumeState::Candidate
             {

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -144,8 +144,11 @@ pub struct AlignmentView {
     /// Matched anchor pairs `(text_frac, audio_frac)` in `0.0..=1.0`, in
     /// text order — the modal's connector threads and its anchored
     /// mapped-preview interpolation (the same pairs the jump uses, so the
-    /// preview cannot lie). Empty when anchoring is off.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// preview cannot lie). Empty when anchoring is off. Always serialized
+    /// (no `skip_serializing_if`): the iOS `Codable` decode requires the
+    /// key, and omitting it broke the alignment sheet for exactly the
+    /// linear-tier books that most need linking.
+    #[serde(default)]
     pub anchor_pairs: Vec<(f64, f64)>,
     /// Usable (titled, non-synthetic) audio chapter marks on the preview
     /// timeline. With `anchor_match` absent on a *non-stale* view, zero

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -135,7 +135,11 @@ test("a linked book resolves silently on the player — no prompt, mapped seek",
 
   await gotoReady(page, `/listen/${uuid}`);
   await page.waitForLoadState("networkidle");
-  await expect(page.getByTestId("sync-prompt")).toHaveCount(0);
+  // "No prompt card" pinned to selectors that exist: the toolbar carries
+  // the declare pill, and no dialog/alert surface is mounted. (The old
+  // `sync-prompt` testid never existed, so that assertion was vacuous.)
+  await expect(page.getByTestId("listen-sync-here")).toBeVisible();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
   const seek = page.getByRole("slider", { name: "Seek" });
   await expect
     .poll(async () => Number(await seek.inputValue()), {
@@ -153,6 +157,12 @@ test("the hero shows one synced card with the counterpart affordance", async ({
   // and the 2-second fixture MP3 finishes on any playback, which flips
   // read status to `finished`. Reset to `reading`, re-stamp, and reload
   // until the card lands (the established hero-spec pattern).
+  //
+  // Re-anchor the synthetic clock to wall time first (test 4's pattern):
+  // the file-level clock starts at wall−60 and gains one second per
+  // write, while parallel specs stamp wall-clock positions — without the
+  // re-anchor this card can be out-ranked for the entire retry window.
+  clock = Math.floor(Date.now() / 1000) - 3;
   await expect
     .poll(
       async () => {

--- a/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
+++ b/ui_tests/playwright/tests/flows/cross_format_prompts.spec.ts
@@ -135,11 +135,12 @@ test("a linked book resolves silently on the player — no prompt, mapped seek",
 
   await gotoReady(page, `/listen/${uuid}`);
   await page.waitForLoadState("networkidle");
-  // "No prompt card" pinned to selectors that exist: the toolbar carries
-  // the declare pill, and no dialog/alert surface is mounted. (The old
-  // `sync-prompt` testid never existed, so that assertion was vacuous.)
+  // "No prompt card": the declare pill is the only sync affordance, and
+  // the removed offer card's user-facing copy ("Jump ahead?" / "Sync to")
+  // appears nowhere — pinned to the historical strings so a resurrected
+  // prompt would fail this, unlike a role/testid that never existed.
   await expect(page.getByTestId("listen-sync-here")).toBeVisible();
-  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+  await expect(page.getByText(/Jump ahead|Sync to \d/)).toHaveCount(0);
   const seek = page.getByRole("slider", { name: "Seek" });
   await expect
     .poll(async () => Number(await seek.inputValue()), {


### PR DESCRIPTION
## Summary
- Fixes the confirmed findings from the multi-agent deep review of #1975 plus both Copilot comments: the order-blind audio snapshot (re-orders now stale links and clear anchors, as do mode/primary changes), the iOS `anchor_pairs` decode blocker, the HLS sequence-advance loop, wrong-file sync declarations, two reader echo/re-clock leaks, the cross-file teardown-refusal exemption, the M4A dual-format gate divergence, a follow-boot splice guard, the sync pill's precision gate, the iOS boot-restore persist echo, the Kobo follow-lane pre-filter, a stale doc migration number, and two spec defects (vacuous assertion, clock starvation).

Part of #1863 — review feedback for #1975.

## Test plan
- [x] Full `just check` matrix green; `just lint-ts` clean.
- [x] `just ios-test`: 295 passed, exit 0 (includes the cross-format codec decode cases).
- [x] New unit tests: ordinal re-order stales + clears, mode/primary re-confirm clears, cross-file teardown exemption.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — add the `no release` label to skip cutting a release.