### PR TITLE
feat(ios): remove a book from the wishlist, with a confirmation

### DIFF
--- a/.claude/rules/08-offline-writes.md
+++ b/.claude/rules/08-offline-writes.md
@@ -112,8 +112,18 @@ Not queued, by test:
 | Reindex, scan, FTS rebuild | 2 — commands |
 | Send to Kindle / Kobo | 2 — commands |
 | Shelf create (iOS) | 3 — no client-minted handle |
-| Check-in, physical-only, wishlist | 3 — payload comes from the server's lookup |
+| Check-in, physical-only, wishlist **add** | 3 — payload comes from the server's lookup |
+| Wishlist **remove** | none, on its own — held back to match its add (below) |
 | `POST /api/shelves/preview` | not a mutation; a read wearing POST |
+
+The wishlist remove is the one entry here that passes all four tests: it names
+its target with a uuid the device already holds and carries no payload. It
+stays direct anyway, because its *add* fails test 3 — and a queue that takes
+one direction of a toggle but not the other is a worse contract than an
+online-only pair, since a reader could empty a wishlist on a plane with no way
+to put anything back. `removeWishlistEntry` in
+[omnibus-ios/omnibus/Services/UserDataService.swift](../../omnibus-ios/omnibus/Services/UserDataService.swift)
+is the shape: direct call, `throws`, control disabled offline.
 
 ## Adding a write path
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,7 +289,11 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       account configuration, so it writes straight through
                       `AuthService` and never queues (rule 08), Save is disabled
                       while offline, and `ProfileDraft` holds the testable
-                      "what does Save actually send" rules
+                      "what does Save actually send" rules. BookDetail's
+                      `WishlistSection` is the native twin of the web page's
+                      rail tracking card (tracked-since line, store search,
+                      remove): same never-queued contract, plus a confirmation
+                      the web button doesn't ask for
 Models/             — Codable mirrors of the `shared/` wire DTOs
 Networking/         — APIClient, keychain-backed TokenStore
 Offline/            — Cache (read-through policies), OfflineStore (SQLite

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -116,7 +116,6 @@ struct BookDetailView: View {
     }
 
     @Environment(\.palette) private var palette
-    @Environment(\.openURL) private var openURL
     @Environment(AppState.self) private var app
     @Environment(AudioPlayer.self) private var player
     @Environment(\.bookZoomNamespace) private var bookZoom
@@ -249,10 +248,11 @@ struct BookDetailView: View {
                         // page, so the two rating surfaces read as one topic.
                         if !model.otherRatings.isEmpty { otherRatingsSection }
                         statusSection(book)
-                        if isWishlistOnly(book) {
-                            findAStoreSection(book)
-                        } else {
-                            librarySection(book)
+                        if !isWishlistOnly(book) { librarySection(book) }
+                        if let entry = model.wishlistEntry {
+                            WishlistSection(book: book, entry: entry) {
+                                model.wishlistEntry = nil
+                            }
                         }
                         metadataSection(book)
                         if !model.highlights.isEmpty { highlightsSection(book) }
@@ -489,49 +489,12 @@ struct BookDetailView: View {
     }
 
     /// A wishlisted book the library holds no files for: the shelving and
-    /// offline rows would describe files that don't exist, so the library
-    /// section gives way to a store link. A wishlisted book that *does* have
-    /// files keeps the library section — its downloads are still real.
+    /// offline rows would describe files that don't exist, so `WishlistSection`
+    /// stands in their place. A wishlisted book that *does* have files keeps
+    /// the library section — its downloads are still real — and carries the
+    /// wishlist card underneath, the way the web page's rail does.
     private func isWishlistOnly(_ book: Book) -> Bool {
         model.wishlistEntry != nil && !book.hasEbook && !book.hasAudiobook
-    }
-
-    /// Store link shown in place of the library section for a wishlist-only
-    /// book — an Amazon search like the web page's "Find a copy".
-    private func findAStoreSection(_ book: Book) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
-            SectionLabel("Wishlist")
-
-            Button {
-                Haptics.tap()
-                openStore(for: book)
-            } label: {
-                Label("Find a store", systemImage: "storefront")
-            }
-            .buttonStyle(FilledButtonStyle(prominent: false))
-
-            Text("Opens an Amazon search for this book.")
-                .font(.ui(12.5))
-                .foregroundStyle(palette.ink3Color)
-        }
-    }
-
-    /// Open the store search in the Amazon app when it's installed, else the
-    /// browser. The app's URL scheme is tried first because an https link only
-    /// reaches the app when Amazon's universal-link registration covers the
-    /// path — the scheme is the deterministic door.
-    private func openStore(for book: Book) {
-        guard let web = StoreLink.searchURL(
-            isbn: book.isbn13, title: book.displayTitle, author: book.authorDisplay
-        ) else { return }
-
-        guard let app = StoreLink.appURL(for: web) else {
-            openURL(web)
-            return
-        }
-        openURL(app) { accepted in
-            if !accepted { openURL(web) }
-        }
     }
 
     /// Shelving and offline state.

--- a/omnibus-ios/omnibus/Features/BookDetail/WishlistSection.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/WishlistSection.swift
@@ -1,0 +1,157 @@
+//  WishlistSection.swift
+//  The book-detail wishlist card: what is being tracked, where to buy it, and
+//  the way back off the wishlist. Mirrors the web page's rail tracking card
+//  (`BdWishlistTrackingCard` in frontend/src/pages/book_detail/physical.rs) —
+//  same three facts, same two actions — behind a confirmation the web button
+//  doesn't ask for, since a mis-tap here has nothing to undo it with.
+
+import SwiftUI
+
+struct WishlistSection: View {
+    let book: Book
+    let entry: WishlistEntry
+    /// Run once the server has dropped the entry, so the page can clear it.
+    var onRemoved: () -> Void
+
+    @Environment(\.palette) private var palette
+    @Environment(\.openURL) private var openURL
+    private var connectivity = Connectivity.shared
+
+    @State private var showRemoveConfirm = false
+    @State private var busy = false
+    @State private var error: String?
+
+    init(book: Book, entry: WishlistEntry, onRemoved: @escaping () -> Void) {
+        self.book = book
+        self.entry = entry
+        self.onRemoved = onRemoved
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            SectionLabel("Wishlist")
+
+            Text(Self.trackingLine(added: Format.relative(unix: entry.addedAt), source: entry.source))
+                .font(.ui(13))
+                .foregroundStyle(palette.ink2Color)
+
+            Button {
+                Haptics.tap()
+                openStore()
+            } label: {
+                Label("Find a store", systemImage: "storefront")
+            }
+            .buttonStyle(FilledButtonStyle(prominent: false))
+
+            Text("Opens an Amazon search for this book.")
+                .font(.ui(12.5))
+                .foregroundStyle(palette.ink3Color)
+
+            removeAction
+        }
+        .confirmationDialog(
+            "Remove from wishlist?", isPresented: $showRemoveConfirm, titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) { remove() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(Self.confirmMessage(hasFiles: book.hasEbook || book.hasAudiobook))
+        }
+    }
+
+    /// The way off the wishlist, plus whatever is standing in its way. Offline
+    /// it is disabled rather than left to fail after the fact (rule 08), so it
+    /// says why instead of going quiet.
+    private var removeAction: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Button(busy ? "Removing…" : "Remove from wishlist") {
+                Haptics.tap()
+                showRemoveConfirm = true
+            }
+            .font(.ui(13, weight: .medium))
+            .foregroundStyle(palette.badColor)
+            .disabled(busy || !connectivity.isOnline)
+            .accessibilityIdentifier("wishlist-remove")
+
+            if let error {
+                Text(error)
+                    .font(.ui(12.5))
+                    .foregroundStyle(palette.badColor)
+                    .accessibilityIdentifier("wishlist-error")
+            } else if !connectivity.isOnline {
+                Text("Removing needs a connection.")
+                    .font(.ui(12.5))
+                    .foregroundStyle(palette.ink3Color)
+            }
+        }
+        .padding(.top, Spacing.xs)
+    }
+
+    private func remove() {
+        busy = true
+        error = nil
+        Task {
+            do {
+                try await UserDataService.removeWishlistEntry(uuid: book.uuid)
+                busy = false
+                Haptics.success()
+                // The card goes with the entry, so the page owns the state
+                // rather than this view holding a removed row on screen.
+                withAnimation(Motion.settle) { onRemoved() }
+            } catch {
+                busy = false
+                self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
+            }
+        }
+    }
+
+    /// Open the store search in the Amazon app when it's installed, else the
+    /// browser. The app's URL scheme is tried first because an https link only
+    /// reaches the app when Amazon's universal-link registration covers the
+    /// path — the scheme is the deterministic door.
+    private func openStore() {
+        guard let web = StoreLink.searchURL(
+            isbn: book.isbn13, title: book.displayTitle, author: book.authorDisplay
+        ) else { return }
+
+        guard let app = StoreLink.appURL(for: web) else {
+            openURL(web)
+            return
+        }
+        openURL(app) { accepted in
+            if !accepted { openURL(web) }
+        }
+    }
+
+    // MARK: - Copy
+
+    // Pure and `nonisolated` so the suite can assert the wording without a
+    // main-actor hop, the way `LibraryModel.railShelves` is.
+
+    /// The card's one-line summary, worded like the web tracking card so the
+    /// two surfaces describe an entry the same way.
+    nonisolated static func trackingLine(added: String, source: WishlistSource) -> String {
+        "Tracking this title · added \(added) from \(sourceLabel(source))"
+    }
+
+    /// Human phrase for where an entry came from. Mirrors `source_label` on
+    /// the web page.
+    nonisolated static func sourceLabel(_ source: WishlistSource) -> String {
+        switch source {
+        case .scan: "a scan"
+        case .detail: "this page"
+        case .manual: "manual entry"
+        }
+    }
+
+    /// What the confirmation warns about, which differs by what else the
+    /// library holds. A book with files keeps everything but the tracking. One
+    /// without is reachable *because* of the entry: browse hides a fileless
+    /// book with no physical copy, and the add-to-shelf picker reads that same
+    /// listing, so the wishlist is the only place it surfaces.
+    nonisolated static func confirmMessage(hasFiles: Bool) -> String {
+        hasFiles
+            ? "This stops tracking a physical copy. The book stays in your library."
+            : "Your library holds no files for this book, so the wishlist is the only place it shows up."
+    }
+}

--- a/omnibus-ios/omnibus/Services/UserDataService.swift
+++ b/omnibus-ios/omnibus/Services/UserDataService.swift
@@ -787,11 +787,44 @@ enum UserDataService {
     // MARK: - Wishlist
 
     /// The caller's wishlist entry for a book, or `nil` when not tracked.
-    /// Read-only here: wishlist writes fail rule 08's test 3 (the payload
-    /// comes from the server's lookup), so they never queue offline.
+    /// Adds happen elsewhere (the scan flow) and fail rule 08's test 3 — the
+    /// payload comes from the server's lookup — so they never queue offline.
     static func wishlistEntry(uuid: String) -> AsyncThrowingStream<CacheRead<WishlistEntry?>, Error> {
         Cache.live(CacheKey.wishlistEntry(uuid)) {
             try await APIClient.shared.get("/api/physical/\(uuid)/wishlist")
+        }
+    }
+
+    /// Stop tracking a book on the caller's wishlist. Direct call, never
+    /// queued — the caller surfaces the failure.
+    ///
+    /// A removal names its target with a uuid it already holds, so on its own
+    /// it would pass rule 08's four tests. Its other half wouldn't: the add is
+    /// what fails test 3, and a queue that accepts one direction of a toggle
+    /// but not the other is a worse contract than an online-only pair — you
+    /// could clear the wishlist on a plane and not put anything back. The
+    /// control is disabled while offline, per the rule's corollary.
+    static func removeWishlistEntry(uuid: String) async throws {
+        let _: Empty = try await APIClient.shared.delete("/api/physical/\(uuid)/wishlist")
+        // Record "not tracked" rather than dropping the key: an absent replica
+        // makes the next read throw offline, and the answer is now known.
+        await Cache.write(CacheKey.wishlistEntry(uuid), WishlistEntry?.none)
+        // The wishlist is a real shelf whose membership derives from these
+        // entries, so its page still lists the book and the shelf lists still
+        // count it. Drop the page before invalidating the lists — the shelf id
+        // this route doesn't carry is read off the cached list.
+        await dropCachedWishlistPages()
+        await invalidateShelves()
+    }
+
+    /// Forget any cached wishlist shelf page, so the shelf doesn't keep showing
+    /// a book that is no longer on it. Deliberately over-broad on an admin's
+    /// device, whose cached list carries other accounts' wishlist shelves too:
+    /// a needless drop there costs one refetch, and this only ever runs online.
+    private static func dropCachedWishlistPages() async {
+        guard let shelves: [ShelfSummary] = await Cache.cachedOnly(CacheKey.shelves) else { return }
+        for shelf in shelves where shelf.kind == .wishlist {
+            await OfflineStore.shared.cacheDelete(CacheKey.shelfPage(shelf.id))
         }
     }
 

--- a/omnibus-ios/omnibusTests/WishlistSectionTests.swift
+++ b/omnibus-ios/omnibusTests/WishlistSectionTests.swift
@@ -1,0 +1,54 @@
+//  WishlistSectionTests.swift
+//  The book-detail wishlist card's copy: how an entry describes itself, and
+//  what the removal confirmation warns about.
+//
+//  The source phrases mirror `source_label` on the web page, so the two
+//  surfaces can't drift on what "from a scan" means. The confirmation is the
+//  part worth pinning: a fileless book is only *visible* because of its
+//  wishlist entry — the browse query hides a fileless book with no physical
+//  copy — so the warning has to differ from the one a book with files gets.
+
+import Testing
+
+@testable import omnibus
+
+@Suite("Wishlist card copy")
+struct WishlistSectionTests {
+    @Test("names where a scanned entry came from")
+    func labelsAScan() {
+        #expect(WishlistSection.sourceLabel(.scan) == "a scan")
+    }
+
+    @Test("names the detail page as its own source")
+    func labelsTheDetailPage() {
+        #expect(WishlistSection.sourceLabel(.detail) == "this page")
+    }
+
+    @Test("names a hand-made entry")
+    func labelsManualEntry() {
+        #expect(WishlistSection.sourceLabel(.manual) == "manual entry")
+    }
+
+    @Test("states what is tracked, when, and from where")
+    func trackingLineReadsAsOneSentence() {
+        #expect(
+            WishlistSection.trackingLine(added: "3d ago", source: .scan)
+                == "Tracking this title · added 3d ago from a scan"
+        )
+    }
+
+    @Test("a book with files is told it keeps them")
+    func confirmMessageReassuresWhenFilesRemain() {
+        let message = WishlistSection.confirmMessage(hasFiles: true)
+        #expect(message == "This stops tracking a physical copy. The book stays in your library.")
+    }
+
+    @Test("a book with no files is warned the wishlist is all there is")
+    func confirmMessageWarnsWhenTheEntryIsTheOnlyThingHoldingIt() {
+        // Removing the entry takes the last way back to a book the browse
+        // query already hides — the reader must be told before, not after.
+        let message = WishlistSection.confirmMessage(hasFiles: false)
+        #expect(message != WishlistSection.confirmMessage(hasFiles: true))
+        #expect(message.contains("the only place it shows up"))
+    }
+}


### PR DESCRIPTION
## Summary
- The native book-detail page could show a wishlist entry but never clear one, so an entry added by scanning a barcode on the phone had to be removed on a desktop. Adds a **Remove from wishlist** action behind a confirmation.
- New `WishlistSection` is the native twin of the web rail tracking card (`BdWishlistTrackingCard` in `frontend/src/pages/book_detail/physical.rs`) — same three facts (tracked-since, source, store search) and the same Remove action. It now renders **whenever an entry exists** rather than only for a fileless book, which is what web already does: a book with files keeps its library section and carries the card underneath, a fileless one still gets the card in the library section's place. Without that, a wishlisted book that also has an EPUB had no removal affordance at all.
- Removal goes behind a confirmation the web button doesn't ask for, since a mis-tap has nothing to undo it with. The message differs by what else the library holds: a book with files keeps everything but the tracking, while a fileless book is reachable *because* of the entry — `fetch_list_rows` hides a fileless book with no physical copy, and the add-to-shelf picker reads that same listing.
- `UserDataService.removeWishlistEntry` calls `DELETE /api/physical/{uuid}/wishlist` directly and throws; it is never queued and its control is disabled offline. On its own a removal passes all four of rule 08's tests — it names its target with a uuid the device already holds and carries no payload — but its **add** fails test 3, and a queue that takes one direction of a toggle and not the other would let a reader empty a wishlist on a plane with no way to put anything back.
- Replica upkeep: writes "not tracked" into the cache rather than dropping the key (a dropped key throws on the next offline read), then drops any cached wishlist shelf page before invalidating the shelf lists, so the derived shelf stops listing the book.

No server, `db/`, or web-frontend changes — the `DELETE` route already existed and is what the web card calls.

## Test plan
- [x] `omnibusTests/WishlistSectionTests.swift` — new suite over the pure copy helpers: the three source labels (mirroring web's `source_label`), the tracking-line composition, and both confirmation messages (including that the fileless one differs and names the consequence).
- [x] `unit tests (omnibusTests)` green in CI. This change was authored in a Linux container with no Swift toolchain or Xcode, so nothing was compiled locally — `ios-tests.yml` was the first real build, and it passed along with `UI tests (omnibusUITests)`.
- [ ] Manual pass on a simulator (`just ios-sim`): wishlist a book from the detail page, confirm the card shows tracked-since + source, remove it and confirm the dialog copy, then check the Wishlist shelf no longer lists it. **Not done — the one thing still unverified**, since the suite covers the copy helpers but nothing renders the card or exercises the request.
- [x] No Rust touched, so the Rust/TS/Playwright lanes are path-skipped and unaffected by this diff.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes

> [!NOTE]
> Codecov reports 10.8% patch coverage. That is the SwiftUI view body and the network path in `removeWishlistEntry` — `omnibusTests` has no store/network harness to drive a write end to end, so the tests pin the pure copy helpers instead, matching how the rest of the iOS suite is written. Report-only per `codecov.yml`, and the gap is the simulator pass above rather than something a unit test would close.

Two doc files move with the code, per rule 99:
- `.claude/rules/08-offline-writes.md` — the inventory now separates wishlist **add** from **remove** and explains why the remove is held back despite passing all four tests. It was the one row where "fails test 3" was doing double duty for two different writes.
- `docs/architecture.md` — `WishlistSection` noted alongside the existing `ProfileEditSheet` never-queued note.

**Deliberately out of scope:** no removal from the wishlist *shelf* screen. Web's shelf page offers no per-book removal for a wishlist (membership is derived from `wishlist_entries`, not `shelf_books`), and the iOS shelf context menu's "Remove from shelf" is gated to manual shelves for that same reason — so adding one would diverge rather than mirror. Happy to add it as a follow-up if the wishlist shelf is where you'd expect to reach for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqfxuZr4CUMHEN7QuNTuNX