### PR TITLE
fix: add contentShape to iOS grid cells so tap gaps register

### DIFF
--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -548,6 +548,10 @@ struct BookGridCell: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        // Without an explicit content shape the tappable region is only the
+        // union of the subviews' own shapes — the gap under the cover and the
+        // strip beside a short caption are dead to taps.
+        .contentShape(Rectangle())
     }
 
     /// Offline state rides on the art rather than the caption, which keeps the

--- a/omnibus-ios/omnibus/Features/Search/SearchTab.swift
+++ b/omnibus-ios/omnibus/Features/Search/SearchTab.swift
@@ -157,6 +157,8 @@ struct BrowseDirectory: View {
             }
         }
         .frame(width: 100)
+        // Fill the tap gaps between cover and caption; see BookGridCell.
+        .contentShape(Rectangle())
     }
 
     private func loadFinished() async {

--- a/omnibus-ios/omnibus/Features/Shelves/ShelfCard.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelfCard.swift
@@ -130,6 +130,8 @@ struct ShelfCard: View {
             }
         }
         .frame(width: width)
+        // Fill the tap gaps between mosaic and caption; see BookGridCell.
+        .contentShape(Rectangle())
     }
 
     /// Only non-default states get a badge: an unmarked tile is a plain private


### PR DESCRIPTION
## Summary
- Add `.contentShape(Rectangle())` to the outer container of `BookGridCell`, `ShelfCard`, and the search tab's `finishedCard` so the whole cell is tappable — previously the hit region was only the cover box plus the literal glyph rects of the caption text, leaving the cover/caption gap and the strip beside short titles dead to taps.
- `BookGridCell` is reused by the library grid, shelf detail grid, author detail grid, and full search results; `ShelfCard` covers the shelves grid and landing rail tiles.

## Test plan
- [x] `xcodebuild build` (generic iOS Simulator destination) — BUILD SUCCEEDED.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.