### PR TITLE
fix: pin avatar photos square so border-radius draws a circle

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1629,6 +1629,10 @@ button.spoiler {
 .disc-avatar--photo {
   width: 100%;
   height: 100%;
+  /* Same grid-row percentage collapse as the user-avatar photos: without a
+     pinned ratio the img box goes natural-aspect and the crop over-zooms
+     (the parent's overflow clip hides the spill but not the zoom). */
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   display: block;
   background: var(--bg-2);
@@ -1968,6 +1972,8 @@ a.idx-letter-on:focus-visible {
 .idx-card-avatar--photo {
   width: 100%;
   height: 100%;
+  /* Same grid-row percentage collapse as `.disc-avatar--photo`. */
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   display: block;
 }
@@ -9141,6 +9147,11 @@ html {
 .m-account-initials-photo,
 .profile-initials-photo {
   width: 100%; height: 100%;
+  /* The monogram spans are grids with an auto implicit row, so `height:
+     100%` can collapse to auto and the photo reverts to its natural
+     aspect ratio — an ellipse once the 50% radius applies. Pinning the
+     ratio keeps the box square wherever the percentage fails. */
+  aspect-ratio: 1 / 1;
   border-radius: 50%;
   object-fit: cover;
   display: block;


### PR DESCRIPTION
## Summary
- User avatar photos rendered as ellipses: the photo `img` sits in a `display: grid` monogram span whose implicit row is auto-sized, so `height: 100%` collapses to auto and the image reverts to its natural aspect ratio — `border-radius: 50%` then draws an oval.
- Adds `aspect-ratio: 1 / 1` to the shared user-avatar photo rule and to `.disc-avatar--photo` / `.idx-card-avatar--photo`, pinning the box square wherever the percentage height fails (inert where both dimensions already resolve).
- The author-photo circles clip their spill with `overflow: hidden` so they didn't look broken, but the oversized box was over-zooming their `object-fit: cover` crop.

## Test plan
- [x] Reproduced with a 300×500 portrait avatar upload: trigger img measured 28×46.7, panel img 42×70; with the rule applied both measure square (28×28 / 42×42) and render as true circles in the user menu trigger and panel.
- [x] `just lint-css` passes.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.