### PR TITLE
docs: reference #1620 in mobile secure-storage TODO

### DIFF
--- a/mobile/src/main.rs
+++ b/mobile/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     // iOS/desktop/Android this persists in every build (0o600 file under the
     // sandboxed app data dir), so users stay signed in across a cold start.
     //
-    // TODO: harden at-rest storage with iOS Keychain / Android Keystore.
+    // TODO(#1620): harden at-rest storage with iOS Keychain / Android Keystore.
     // Current protection is the iOS sandbox / Android per-app UID sandbox +
     // 0o600 — see the module docs on `omnibus_frontend::data::token_store` /
     // `app_dirs`.


### PR DESCRIPTION
## Summary
- Closes #1620
- Updates the `// TODO: harden at-rest storage with iOS Keychain / Android Keystore.` comment in `mobile/src/main.rs` to `// TODO(#1620): ...` so the documented gap is linked to its tracking issue.
- The actual Keystore/Keychain hardening work remains separately tracked future work per #1620's own acceptance criteria ("No code change needed now — this issue exists purely to make the already-documented gap trackable"); it is explicitly out of scope for this PR.

## Test plan
- [x] one-line comment change; `cargo check -p omnibus-mobile` attempted (failed locally on a missing `gdk-3.0` pkg-config dependency from the sandboxed environment, not related to this edit — the mobile crate needs the `.#mobile` Nix shell / Android toolchain, which CI's dedicated mobile job provides)

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- Comment-only change; no code or test behavior affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Pb7hTvWBBNhb5Qx6EjM8)_