### PR TITLE
fix: add DB-failure-path tests for provider-configured routes (#1987)

### DIFF
--- a/server/src/backend/metadata/tests.rs
+++ b/server/src/backend/metadata/tests.rs
@@ -1,11 +1,33 @@
 //! Tests for `GET /api/metadata/providers`.
 
-use axum::{body::to_bytes, http::StatusCode};
-use omnibus_db::test_support::EnvVarGuard;
+use axum::{body::to_bytes, extract::State, http::StatusCode};
+use omnibus_db::{auth::SessionKind, test_support::EnvVarGuard};
 use tower::ServiceExt;
 
+use super::{get_providers, AppState};
 use crate::auth::test_support as auth_test_support;
+use crate::auth::AuthUser;
 use crate::backend::test_support::*;
+
+/// A minimal `AuthUser` for driving the handler directly (bypassing the
+/// `AuthUser` extractor), so a closed pool exercises the handler's own
+/// `Err(...) => internal(...)` branch rather than session extraction.
+fn fake_user(id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "reader".to_string(),
+        is_admin: false,
+        can_upload: false,
+        can_edit: false,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id: 1,
+        session_kind: SessionKind::Bearer,
+    }
+}
 
 async fn body_string(res: axum::response::Response) -> String {
     let bytes = to_bytes(res.into_body(), 1024 * 1024).await.unwrap();
@@ -73,4 +95,12 @@ async fn api_get_metadata_providers_requires_auth() {
         .await
         .expect("request should succeed");
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_get_providers_returns_500_when_db_unavailable() {
+    let (_app, _state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_providers(fake_user(1), State(AppState::new(pool))).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/server/src/backend/metadata/tests.rs
+++ b/server/src/backend/metadata/tests.rs
@@ -4,7 +4,7 @@ use axum::{body::to_bytes, extract::State, http::StatusCode};
 use omnibus_db::{auth::SessionKind, test_support::EnvVarGuard};
 use tower::ServiceExt;
 
-use super::{get_providers, AppState};
+use super::get_providers;
 use crate::auth::test_support as auth_test_support;
 use crate::auth::AuthUser;
 use crate::backend::test_support::*;
@@ -99,8 +99,8 @@ async fn api_get_metadata_providers_requires_auth() {
 
 #[tokio::test]
 async fn api_get_providers_returns_500_when_db_unavailable() {
-    let (_app, _state, pool) = fixture().await;
+    let (_app, state, pool) = fixture().await;
     pool.close().await;
-    let res = get_providers(fake_user(1), State(AppState::new(pool))).await;
+    let res = get_providers(fake_user(1), State(state)).await;
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/server/src/backend/scan/tests.rs
+++ b/server/src/backend/scan/tests.rs
@@ -5,15 +5,38 @@
 
 use axum::{
     body::{to_bytes, Body},
+    extract::State,
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
-use omnibus_db::test_support::EnvVarGuard;
+use omnibus_db::{auth::SessionKind, test_support::EnvVarGuard};
 use omnibus_shared::physical::WishlistSource;
 use omnibus_shared::{BookRef, ScanOutcome};
 use tower::ServiceExt;
 
+use super::{get_google_books_configured, AppState};
 use crate::auth::test_support as auth_test_support;
+use crate::auth::AuthUser;
 use crate::backend::test_support::*;
+
+/// A minimal `AuthUser` for driving the handler directly (bypassing the
+/// `AuthUser` extractor), so a closed pool exercises the handler's own
+/// `Err(...) => internal(...)` branch rather than session extraction.
+fn fake_user(id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "reader".to_string(),
+        is_admin: false,
+        can_upload: false,
+        can_edit: false,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id: 1,
+        session_kind: SessionKind::Bearer,
+    }
+}
 
 const ISBN: &str = "9780134685991";
 
@@ -792,6 +815,14 @@ async fn api_google_books_configured_requires_auth() {
         .await
         .unwrap();
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_google_books_configured_returns_500_when_db_unavailable() {
+    let (_app, _state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_google_books_configured(fake_user(1), State(AppState::new(pool))).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 #[test]

--- a/server/src/backend/scan/tests.rs
+++ b/server/src/backend/scan/tests.rs
@@ -13,7 +13,7 @@ use omnibus_shared::physical::WishlistSource;
 use omnibus_shared::{BookRef, ScanOutcome};
 use tower::ServiceExt;
 
-use super::{get_google_books_configured, AppState};
+use super::get_google_books_configured;
 use crate::auth::test_support as auth_test_support;
 use crate::auth::AuthUser;
 use crate::backend::test_support::*;
@@ -819,9 +819,9 @@ async fn api_google_books_configured_requires_auth() {
 
 #[tokio::test]
 async fn api_google_books_configured_returns_500_when_db_unavailable() {
-    let (_app, _state, pool) = fixture().await;
+    let (_app, state, pool) = fixture().await;
     pool.close().await;
-    let res = get_google_books_configured(fake_user(1), State(AppState::new(pool))).await;
+    let res = get_google_books_configured(fake_user(1), State(state)).await;
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 

--- a/server/src/backend/summary/tests.rs
+++ b/server/src/backend/summary/tests.rs
@@ -2,13 +2,36 @@
 
 use axum::{
     body::{to_bytes, Body},
+    extract::State,
     http::{header::AUTHORIZATION, Request, StatusCode},
 };
-use omnibus_db::test_support::EnvVarGuard;
+use omnibus_db::{auth::SessionKind, test_support::EnvVarGuard};
 use tower::ServiceExt;
 
+use super::{get_summary_sources, AppState};
 use crate::auth::test_support as auth_test_support;
+use crate::auth::AuthUser;
 use crate::backend::test_support::*;
+
+/// A minimal `AuthUser` for driving the handler directly (bypassing the
+/// `AuthUser` extractor), so a closed pool exercises the handler's own
+/// `Err(...) => internal(...)` branch rather than session extraction.
+fn fake_user(id: i64) -> AuthUser {
+    AuthUser {
+        id,
+        username: "reader".to_string(),
+        is_admin: false,
+        can_upload: false,
+        can_edit: false,
+        can_download: true,
+        kindle_email: None,
+        display_name: None,
+        has_avatar: false,
+        hidden_formats: Vec::new(),
+        session_id: 1,
+        session_kind: SessionKind::Bearer,
+    }
+}
 
 fn post_fetch(uri: &str, token: &str, source: &str) -> Request<Body> {
     let body = serde_json::json!({ "source": source });
@@ -146,4 +169,12 @@ async fn api_summary_sources_requires_auth() {
         .await
         .expect("request should succeed");
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn api_summary_sources_returns_500_when_db_unavailable() {
+    let (_app, _state, pool) = fixture().await;
+    pool.close().await;
+    let res = get_summary_sources(fake_user(1), State(AppState::new(pool))).await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/server/src/backend/summary/tests.rs
+++ b/server/src/backend/summary/tests.rs
@@ -8,7 +8,7 @@ use axum::{
 use omnibus_db::{auth::SessionKind, test_support::EnvVarGuard};
 use tower::ServiceExt;
 
-use super::{get_summary_sources, AppState};
+use super::get_summary_sources;
 use crate::auth::test_support as auth_test_support;
 use crate::auth::AuthUser;
 use crate::backend::test_support::*;
@@ -173,8 +173,8 @@ async fn api_summary_sources_requires_auth() {
 
 #[tokio::test]
 async fn api_summary_sources_returns_500_when_db_unavailable() {
-    let (_app, _state, pool) = fixture().await;
+    let (_app, state, pool) = fixture().await;
     pool.close().await;
-    let res = get_summary_sources(fake_user(1), State(AppState::new(pool))).await;
+    let res = get_summary_sources(fake_user(1), State(state)).await;
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## Summary
- Three sibling REST handlers (`get_providers` in `server/src/backend/metadata.rs`, `get_google_books_configured` in `server/src/backend/scan.rs`, `get_summary_sources` in `server/src/backend/summary.rs`) each have a real `Err(...) => internal(...)` branch that no test exercised.
- Adds one test per handler that closes the DB pool and invokes the handler directly (bypassing the `AuthUser` extractor via a hand-built fake user, mirroring the existing pattern in `server/src/backend/admin_health/tests.rs`), asserting `StatusCode::INTERNAL_SERVER_ERROR`.
- Test-only change — no production code touched.
- Closes #1987

## Test plan
- [x] `cargo fmt` — PASS (no changes)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (clean)
- [x] `cargo test -p omnibus` — PASS (841 passed, 0 failed among tests relevant to this change; 2 pre-existing failures in `backend::uploads::tests::{commit_rejects_read_only_library_with_400, audiobook_commit_rejects_read_only_library_with_400}` were confirmed to fail identically on `main` without this change — they rely on `chmod 0o555` to deny writes, which root bypasses in this sandbox, and are unrelated to this PR)
- [x] The three new tests specifically verified passing: `backend::metadata::tests::api_get_providers_returns_500_when_db_unavailable`, `backend::scan::tests::api_google_books_configured_returns_500_when_db_unavailable`, `backend::summary::tests::api_summary_sources_returns_500_when_db_unavailable`

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Test-only change (three sibling `tests.rs` files); no production code was modified.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Pb7hTvWBBNhb5Qx6EjM8)_