### PR TITLE
refactor: batch entity-alias lookups per reindex batch (#1985)

### DIFF
--- a/db/src/sync/authors.rs
+++ b/db/src/sync/authors.rs
@@ -6,10 +6,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use omnibus_shared::{CleanupKind, EbookMetadata};
+use omnibus_shared::EbookMetadata;
 use sqlx::Transaction;
-
-use crate::entity_alias::resolve_entity_aliases;
 
 #[cfg(test)]
 mod tests;
@@ -21,10 +19,15 @@ mod tests;
 /// skipped — leaving a gap in `position` rather than renumbering — identical
 /// to the previous per-author loop, but resolved in a constant handful of
 /// statements instead of ~4 per author.
+///
+/// `author_aliases` is the whole-batch reindex-resurrection guard (#964)
+/// lookup built once by `super::books::collect_entity_alias_maps` before the
+/// per-book write loop starts, not re-resolved here (#1985).
 pub(super) async fn insert_author_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
     m: &EbookMetadata,
+    author_aliases: &HashMap<String, i64>,
 ) -> Result<(), sqlx::Error> {
     // (name, sort, position) in OPF order: creators + contributors are
     // already merged into `m.creators` by the parser.
@@ -59,8 +62,12 @@ pub(super) async fn insert_author_links(
     // #964: a name a completed library-cleanup merge absorbed must resolve
     // to the surviving canonical id rather than mint a fresh `authors` row
     // when the same file is reindexed. Only the unmerged remainder goes
-    // through the normal upsert.
-    let aliased = resolve_entity_aliases(tx, CleanupKind::Author, &kept).await?;
+    // through the normal upsert. #1985: filtered from the whole-batch map
+    // rather than re-queried per book.
+    let aliased: HashMap<String, i64> = kept
+        .iter()
+        .filter_map(|n| author_aliases.get(*n).map(|id| ((*n).to_string(), *id)))
+        .collect();
     let to_upsert: Vec<&str> = kept
         .iter()
         .copied()

--- a/db/src/sync/authors/tests.rs
+++ b/db/src/sync/authors/tests.rs
@@ -3,6 +3,8 @@
 //! minting a new `authors` row, while an unaliased name still goes through
 //! the normal upsert-and-join path unchanged.
 
+use std::collections::HashMap;
+
 use omnibus_shared::{Contributor, EbookMetadata};
 
 use super::*;
@@ -58,7 +60,9 @@ async fn insert_author_links_upserts_and_links_an_unaliased_name() {
     let m = metadata_with_creator("Ada Lovelace");
 
     let mut tx = pool.begin().await.unwrap();
-    insert_author_links(&mut tx, book_id, &m).await.unwrap();
+    insert_author_links(&mut tx, book_id, &m, &HashMap::new())
+        .await
+        .unwrap();
     tx.commit().await.unwrap();
 
     let id = author_id(&pool, "Ada Lovelace")
@@ -88,9 +92,15 @@ async fn insert_author_links_resolves_a_merged_away_name_to_its_canonical_id() {
 
     // Simulates a reindex of a file the parser still reports as "John
     // Smith" — the on-disk metadata a completed merge doesn't rewrite.
+    // #1985: the alias map is now pre-resolved by the caller (here, built
+    // directly from the row just inserted) rather than looked up inside
+    // `insert_author_links` itself.
     let m = metadata_with_creator("John Smith");
+    let author_aliases = HashMap::from([("John Smith".to_string(), canonical_id)]);
     let mut tx = pool.begin().await.unwrap();
-    insert_author_links(&mut tx, book_id, &m).await.unwrap();
+    insert_author_links(&mut tx, book_id, &m, &author_aliases)
+        .await
+        .unwrap();
     tx.commit().await.unwrap();
 
     assert!(

--- a/db/src/sync/books/changed.rs
+++ b/db/src/sync/books/changed.rs
@@ -15,6 +15,7 @@ use super::super::fts::upsert_fts;
 use super::shared::{
     attach_ebook_file, insert_book_row, insert_metadata_links, rewrite_book_in_place,
 };
+use super::EntityAliasMaps;
 
 /// Apply Changed entries: wipe-and-rewrite the per-book link rows for each,
 /// UPDATE the `books` row in place (preserving id), and re-insert the FTS
@@ -24,11 +25,15 @@ use super::shared::{
 /// If the diff said this uuid existed but a concurrent process removed it
 /// between Phase A and the write, fall back to inserting it as a new book
 /// rather than failing the whole sync over a TOCTOU.
+///
+/// `alias_maps` is the whole New+Changed batch's reindex-resurrection guard
+/// lookup (#1985), pre-resolved by `super::collect_entity_alias_maps`.
 pub(super) async fn sync_changed(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
     library_path: &str,
     changed_books: &[crate::ebook::IndexedBook],
+    alias_maps: &EntityAliasMaps,
     mut on_book_written: impl FnMut(&str),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
     if changed_books.is_empty() {
@@ -75,6 +80,7 @@ pub(super) async fn sync_changed(
             b,
             scan_key,
             &id_map,
+            alias_maps,
             &mut changed_covers,
         )
         .await?;
@@ -85,6 +91,7 @@ pub(super) async fn sync_changed(
 
 /// Apply a single Changed entry — extracted so `sync_changed`'s outer
 /// loop stays a clean per-book progress tick.
+#[allow(clippy::too_many_arguments)]
 async fn sync_changed_one(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
@@ -92,6 +99,7 @@ async fn sync_changed_one(
     b: &crate::ebook::IndexedBook,
     scan_key: &str,
     id_map: &HashMap<String, (i64, String)>,
+    alias_maps: &EntityAliasMaps,
     changed_covers: &mut Vec<(String, String, Vec<u8>)>,
 ) -> Result<(), sqlx::Error> {
     let Some((book_id, uuid)) = id_map.get(scan_key).map(|(id, u)| (*id, u.clone())) else {
@@ -125,7 +133,7 @@ async fn sync_changed_one(
         // the write. Promote to a New insert so the file still gets
         // indexed.
         let inserted = insert_book_row(tx, library_id, library_path, b).await?;
-        insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
+        insert_metadata_links(tx, inserted.book_id, &b.metadata, alias_maps).await?;
         // Source the FTS row from the rows we just wrote via the door.
         upsert_fts(tx, inserted.book_id).await?;
         super::super::push_cover(changed_covers, &inserted.uuid, &b.cover);
@@ -135,6 +143,6 @@ async fn sync_changed_one(
     // Rewrites in place, re-creating the `book_files` row whether the book
     // had one (a real content change) or not (a fileless book whose file
     // returned — the re-attach path, F2). `books.uuid` is preserved.
-    rewrite_book_in_place(tx, book_id, &uuid, b, changed_covers).await?;
+    rewrite_book_in_place(tx, book_id, &uuid, b, alias_maps, changed_covers).await?;
     Ok(())
 }

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -3,10 +3,20 @@
 //! / `sync_new`), `replace_books`, and post-commit cover materialization.
 //! All `books_fts` maintenance is delegated to the [`super::fts`]
 //! choke-point (`upsert_fts` / `delete_fts`) rather than written inline.
+//!
+//! Also owns [`EntityAliasMaps`] and [`collect_entity_alias_maps`]: the
+//! reindex-resurrection guard (#964) lookups are resolved once for the
+//! whole New+Changed batch here, before either per-book loop starts, and
+//! threaded down through `insert_metadata_links` (#1985).
 
+use std::collections::{HashMap, HashSet};
+
+use omnibus_shared::CleanupKind;
 use sqlx::{SqlitePool, Transaction};
 
 use crate::covers::delete_cover_files_for;
+use crate::entity_alias::resolve_entity_aliases;
+use crate::helpers::cleaned_series_name;
 use crate::settings::upsert_library;
 
 use super::attach;
@@ -70,6 +80,61 @@ pub struct MovedFile {
     /// The file's new library-relative path — its new `scan_key`, and the
     /// source of the new `books.path` / `book_files.filename`.
     pub filename: String,
+}
+
+/// Pre-resolved reindex-resurrection guard (#964) lookups for one whole
+/// sync batch: the canonical id every distinct author/series/tag name
+/// across the batch resolves to, if a prior library-cleanup merge absorbed
+/// it. Built once per [`CleanupKind`] by [`collect_entity_alias_maps`]
+/// before the per-book write loop starts, then threaded down through
+/// `insert_metadata_links` — replacing what used to be a
+/// `resolve_entity_aliases` call issued once per book (#1985).
+#[derive(Debug, Default)]
+pub(super) struct EntityAliasMaps {
+    pub(super) authors: HashMap<String, i64>,
+    pub(super) series: HashMap<String, i64>,
+    pub(super) tags: HashMap<String, i64>,
+}
+
+/// Collect the distinct author, series, and tag names appearing anywhere in
+/// `changed_books` or `new_books` — the whole New+Changed batch one
+/// [`sync_books_with_progress`] call writes — and resolve each
+/// [`CleanupKind`]'s alias guard once for the union, rather than once per
+/// book inside the per-bucket write loops.
+pub(super) async fn collect_entity_alias_maps(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    changed_books: &[crate::ebook::IndexedBook],
+    new_books: &[crate::ebook::IndexedBook],
+) -> Result<EntityAliasMaps, sqlx::Error> {
+    let mut author_names: HashSet<&str> = HashSet::new();
+    let mut series_names: HashSet<String> = HashSet::new();
+    let mut tag_names: HashSet<&str> = HashSet::new();
+
+    for b in changed_books.iter().chain(new_books.iter()) {
+        let m = &b.metadata;
+        author_names.extend(m.creators.iter().map(|c| c.name.as_str()));
+        // `cleaned_series_name` returns an owned String (embedded-index
+        // stripped, #1912), so the dedup set holds owned values too.
+        if let Some(series) = cleaned_series_name(m) {
+            series_names.insert(series);
+        }
+        tag_names.extend(
+            m.subjects
+                .iter()
+                .map(String::as_str)
+                .filter(|s| !s.is_empty()),
+        );
+    }
+
+    let author_list: Vec<&str> = author_names.into_iter().collect();
+    let series_list: Vec<&str> = series_names.iter().map(String::as_str).collect();
+    let tag_list: Vec<&str> = tag_names.into_iter().collect();
+
+    Ok(EntityAliasMaps {
+        authors: resolve_entity_aliases(tx, CleanupKind::Author, &author_list).await?,
+        series: resolve_entity_aliases(tx, CleanupKind::Series, &series_list).await?,
+        tags: resolve_entity_aliases(tx, CleanupKind::Tag, &tag_list).await?,
+    })
 }
 
 /// Per-bucket payload for [`sync_books`]. Built by
@@ -165,12 +230,20 @@ pub async fn sync_books_with_progress(
     // could claim a book by title+author and the moved file would then find
     // its own format slot occupied.
     sync_moved(&mut tx, library_id, library_path, &plan.moved).await?;
+
+    // #1985: resolve the reindex-resurrection guard once for the whole
+    // New+Changed batch, before either per-book loop starts, instead of
+    // once per book inside them.
+    let alias_maps =
+        collect_entity_alias_maps(&mut tx, &plan.changed_books, &plan.new_books).await?;
+
     let mut processed: u32 = 0;
     let changed_covers = sync_changed(
         &mut tx,
         library_id,
         library_path,
         &plan.changed_books,
+        &alias_maps,
         |filename| {
             processed = processed.saturating_add(1);
             on_progress(processed, total, Some(filename));
@@ -183,6 +256,7 @@ pub async fn sync_books_with_progress(
         library_path,
         &plan.new_books,
         &plan.removed_uuids,
+        &alias_maps,
         |filename| {
             processed = processed.saturating_add(1);
             on_progress(processed, total, Some(filename));

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -3,11 +3,9 @@
 //! / `sync_new`), `replace_books`, and post-commit cover materialization.
 //! All `books_fts` maintenance is delegated to the [`super::fts`]
 //! choke-point (`upsert_fts` / `delete_fts`) rather than written inline.
-//!
-//! Also owns [`EntityAliasMaps`] and [`collect_entity_alias_maps`]: the
-//! reindex-resurrection guard (#964) lookups are resolved once for the
-//! whole New+Changed batch here, before either per-book loop starts, and
-//! threaded down through `insert_metadata_links` (#1985).
+//! Also owns [`EntityAliasMaps`] and [`collect_entity_alias_maps`], which
+//! resolve the reindex-resurrection guard's alias lookups once for the
+//! whole New+Changed batch, before either per-book loop starts.
 
 use std::collections::{HashMap, HashSet};
 

--- a/db/src/sync/books/new.rs
+++ b/db/src/sync/books/new.rs
@@ -13,6 +13,7 @@ use super::super::fts::upsert_fts;
 use super::shared::{
     insert_book_row, insert_metadata_links, rewrite_book_in_place, try_attach_new_ebook,
 };
+use super::EntityAliasMaps;
 
 /// Insert a batch of New entries: canonical `books` + `book_files` row,
 /// metadata link rows, FTS row. Returns the post-commit cover triples.
@@ -20,12 +21,15 @@ use super::shared::{
 /// `removed_uuids` is this same sync's Removed-bucket output — passed through
 /// to the attach heuristic so it can tell a relocation (the matched target's
 /// own file just vanished this scan) from a genuine cross-format attachment.
+/// `alias_maps` is the whole New+Changed batch's reindex-resurrection guard
+/// lookup (#1985), pre-resolved by `super::collect_entity_alias_maps`.
 pub(super) async fn sync_new(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     library_id: i64,
     library_path: &str,
     new_books: &[crate::ebook::IndexedBook],
     removed_uuids: &[String],
+    alias_maps: &EntityAliasMaps,
     mut on_book_written: impl FnMut(&str),
 ) -> Result<Vec<(String, String, Vec<u8>)>, sqlx::Error> {
     if new_books.is_empty() {
@@ -73,16 +77,25 @@ pub(super) async fn sync_new(
         // which would otherwise mis-bind the returning file to the fileless row as
         // an attachment.
         if let Some((book_id, uuid)) = id_map.get(scan_key).map(|(id, u)| (*id, u.clone())) {
-            rewrite_book_in_place(tx, book_id, &uuid, b, &mut new_covers).await?;
+            rewrite_book_in_place(tx, book_id, &uuid, b, alias_maps, &mut new_covers).await?;
             on_book_written(&b.metadata.filename);
             continue;
         }
-        if try_attach_new_ebook(tx, library_path, b, &removed_this_scan, &mut new_covers).await? {
+        if try_attach_new_ebook(
+            tx,
+            library_path,
+            b,
+            &removed_this_scan,
+            alias_maps,
+            &mut new_covers,
+        )
+        .await?
+        {
             on_book_written(&b.metadata.filename);
             continue;
         }
         let inserted = insert_book_row(tx, library_id, library_path, b).await?;
-        insert_metadata_links(tx, inserted.book_id, &b.metadata).await?;
+        insert_metadata_links(tx, inserted.book_id, &b.metadata, alias_maps).await?;
         upsert_fts(tx, inserted.book_id).await?;
         super::super::push_cover(&mut new_covers, &inserted.uuid, &b.cover);
         on_book_written(&b.metadata.filename);

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -4,13 +4,12 @@
 //! the rewrite-in-place and cross-format attach paths, and the
 //! post-commit cover materialization + missing-files marker helper.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use omnibus_shared::{CleanupKind, EbookMetadata};
+use omnibus_shared::EbookMetadata;
 use sqlx::Transaction;
 
 use crate::covers::write_cover_file;
-use crate::entity_alias::resolve_entity_aliases;
 use crate::helpers::{
     cleaned_series_name, mint_uuid, resolved_series_index, sanitize_accent_color, scan_key_for,
     split_filename, stable_uuid,
@@ -18,13 +17,13 @@ use crate::helpers::{
 use crate::normalize::{normalize_author, normalize_title};
 use crate::sort_keys::series_sort_value;
 use crate::taxonomy::{
-    resolve_or_insert_language, resolve_or_insert_publisher, resolve_or_insert_series,
+    resolve_or_insert_language, resolve_or_insert_publisher, resolve_or_insert_series_with_aliases,
 };
 
 use super::super::attach;
 use super::super::authors::insert_author_links;
 use super::super::fts::upsert_fts;
-use super::wipe_per_book_link_rows;
+use super::{wipe_per_book_link_rows, EntityAliasMaps};
 
 /// Rewrite an existing book in place from a freshly-parsed entry: refresh
 /// the `books` scalars, wipe + re-insert this format's `book_files` and the
@@ -35,13 +34,14 @@ pub(super) async fn rewrite_book_in_place(
     book_id: i64,
     uuid: &str,
     b: &crate::ebook::IndexedBook,
+    alias_maps: &EntityAliasMaps,
     covers: &mut Vec<(String, String, Vec<u8>)>,
 ) -> Result<(), sqlx::Error> {
     update_book_row(tx, book_id, b).await?;
     let (_, _, file_ext) = split_filename(&b.metadata.filename);
     wipe_per_book_link_rows(tx, book_id, &file_ext).await?;
     insert_book_file_row(tx, book_id, b).await?;
-    insert_metadata_links(tx, book_id, &b.metadata).await?;
+    insert_metadata_links(tx, book_id, &b.metadata, alias_maps).await?;
     upsert_fts(tx, book_id).await?;
     super::super::push_cover(covers, uuid, &b.cover);
     Ok(())
@@ -68,6 +68,7 @@ pub(super) async fn try_attach_new_ebook(
     library_path: &str,
     b: &crate::ebook::IndexedBook,
     removed_this_scan: &HashSet<&str>,
+    alias_maps: &EntityAliasMaps,
     covers: &mut Vec<(String, String, Vec<u8>)>,
 ) -> Result<bool, sqlx::Error> {
     if b.metadata.error.is_some() {
@@ -115,7 +116,7 @@ pub(super) async fn try_attach_new_ebook(
         return Ok(false);
     };
     if removed_this_scan.contains(target_uuid.as_str()) {
-        rewrite_book_in_place(tx, target_id, &target_uuid, b, covers).await?;
+        rewrite_book_in_place(tx, target_id, &target_uuid, b, alias_maps, covers).await?;
         return Ok(true);
     }
     // A brand-new attachment: mint a stable handle for the ledger row (the
@@ -384,12 +385,17 @@ pub(super) async fn insert_book_row(
 /// constant handful per book, which keeps the SQLite write lock from being
 /// held for the whole of a bulk import. Series / publisher / language are
 /// single-valued per book, so they keep the simple resolve-then-link path.
+///
+/// `alias_maps` is the whole-batch reindex-resurrection guard (#964) lookup
+/// built once by `super::collect_entity_alias_maps` before the per-book
+/// write loop starts — not re-resolved here (#1985).
 pub(super) async fn insert_metadata_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
     m: &EbookMetadata,
+    alias_maps: &EntityAliasMaps,
 ) -> Result<(), sqlx::Error> {
-    insert_author_links(tx, book_id, m).await?;
+    insert_author_links(tx, book_id, m, &alias_maps.authors).await?;
 
     // Cleaned (trimmed, embedded-index-stripped — #1912) so the linked
     // `series.name` matches the `series_sort` denormalized onto the row
@@ -397,7 +403,8 @@ pub(super) async fn insert_metadata_links(
     // dedups whitespace variants, and collapses "Name #1"/"Name #2" onto one
     // series row instead of fragmenting.
     if let Some(series_name) = cleaned_series_name(m) {
-        let series_id = resolve_or_insert_series(tx, &series_name).await?;
+        let series_id =
+            resolve_or_insert_series_with_aliases(tx, &series_name, &alias_maps.series).await?;
         sqlx::query("INSERT OR IGNORE INTO books_series_link (book, series) VALUES (?, ?)")
             .bind(book_id)
             .bind(series_id)
@@ -405,7 +412,7 @@ pub(super) async fn insert_metadata_links(
             .await?;
     }
 
-    insert_tag_links(tx, book_id, m).await?;
+    insert_tag_links(tx, book_id, m, &alias_maps.tags).await?;
 
     if let Some(pub_name) = m.publisher.as_deref().filter(|s| !s.is_empty()) {
         let pub_id = resolve_or_insert_publisher(tx, pub_name).await?;
@@ -436,10 +443,16 @@ pub(super) async fn insert_metadata_links(
 /// merge already absorbed (#964) skips the `tags` insert and links straight
 /// to its `entity_aliases` canonical id instead, so reindexing a file that
 /// still names the merged-away tag can't resurrect it.
+///
+/// `tag_aliases` is the whole-batch alias map (#1985) — filtered down here to
+/// just this book's own tags before being handed to [`link_aliased_tags`],
+/// which links straight to every id it's given; a batch-wide map would wrongly
+/// link this book to another book's aliased tags too.
 async fn insert_tag_links(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
     m: &EbookMetadata,
+    tag_aliases: &HashMap<String, i64>,
 ) -> Result<(), sqlx::Error> {
     let mut seen = std::collections::HashSet::new();
     let tags: Vec<&str> = m
@@ -453,7 +466,10 @@ async fn insert_tag_links(
         return Ok(());
     }
 
-    let aliased = resolve_entity_aliases(tx, CleanupKind::Tag, &tags).await?;
+    let aliased: HashMap<String, i64> = tags
+        .iter()
+        .filter_map(|t| tag_aliases.get(*t).map(|id| ((*t).to_string(), *id)))
+        .collect();
     let to_insert: Vec<&str> = tags
         .iter()
         .copied()

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -1945,11 +1945,16 @@ async fn sync_new_keeps_explicit_series_index_and_only_fills_the_gap_from_the_em
 /// which is thread-local): `sqlx-sqlite` runs every statement — including
 /// each one this counts — on a dedicated per-connection worker thread (see
 /// `sqlx_sqlite::connection::worker`), so a thread-local override on the
-/// test's own async task never sees them. A global default is process-wide
-/// and permanent for the rest of the test binary, which is why the
-/// assertion below uses a loose upper bound rather than an exact count — a
-/// concurrently-running unrelated test's own `entity_aliases` query could
-/// add a stray hit to this counter too.
+/// test's own async task never sees them. Measured, not assumed: the scoped
+/// form counts 0 here and the assertion below then passes vacuously, which
+/// is the failure mode the lower bound exists to catch.
+///
+/// A global default is process-wide and permanent for the rest of the test
+/// binary. That is safe because this is the only `set_global_default` in the
+/// crate, so nothing races it for the slot — and the workspace runs on
+/// nextest, which gives each test its own process anyway. It is still why
+/// the upper bound is loose rather than exact: a concurrently-running
+/// unrelated test's own `entity_aliases` query could add a stray hit.
 struct EntityAliasQueryCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
 
 impl tracing::Subscriber for EntityAliasQueryCounter {
@@ -1992,11 +1997,14 @@ impl tracing::Subscriber for EntityAliasQueryCounter {
 /// `3 * BOOK_COUNT` such queries (`insert_author_links`/`insert_tag_links`/
 /// `resolve_or_insert_series` each called `resolve_entity_aliases` once per
 /// book); the batched shape issues 3 total regardless of `BOOK_COUNT`. The
-/// assertion checks `< BOOK_COUNT` rather than `== 3` — see
+/// upper bound checks `< BOOK_COUNT` rather than `== 3` — see
 /// `EntityAliasQueryCounter`'s doc for why an exact count isn't safe to
 /// assert against a process-wide subscriber — but `BOOK_COUNT` is picked
 /// large enough that the old shape would fail this bound by a wide margin
-/// while the new shape passes with room to spare.
+/// while the new shape passes with room to spare. The lower bound is what
+/// keeps that upper bound honest: a subscriber that never sees an event
+/// counts 0, and `0 < BOOK_COUNT` would pass no matter how the batching
+/// regressed.
 #[tokio::test]
 async fn sync_books_issues_one_entity_alias_query_per_kind_not_per_book() {
     let _covers = CoversTempDir::new("sync_books_alias_query_count");
@@ -2046,6 +2054,12 @@ async fn sync_books_issues_one_entity_alias_query_per_kind_not_per_book() {
     .unwrap();
 
     let queries = count.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        queries > 0,
+        "counted no entity_aliases queries at all — the subscriber never saw \
+         sqlx's events, so the bound below would pass vacuously however the \
+         batching regressed"
+    );
     assert!(
         queries < BOOK_COUNT,
         "expected an entity_aliases query count bounded by the touched \

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -8,7 +8,10 @@ use omnibus_shared::{Contributor, EbookMetadata, Identifier};
 use sqlx::SqlitePool;
 
 use super::shared::{insert_book_row, insert_metadata_links};
-use super::{sync_books, sync_changed, sync_new, sync_removed, wipe_per_book_link_rows, SyncPlan};
+use super::{
+    collect_entity_alias_maps, sync_books, sync_changed, sync_new, sync_removed,
+    wipe_per_book_link_rows, EntityAliasMaps, SyncPlan,
+};
 use crate::cleanup::{apply_merge_authors, apply_merge_series, apply_merge_tags};
 use crate::ebook::IndexedBook;
 use crate::indexer::diff_library;
@@ -67,9 +70,14 @@ async fn seed_book_with_file(pool: &SqlitePool, library_id: i64, filename: &str)
     let inserted = insert_book_row(&mut tx, library_id, "/lib", &b)
         .await
         .unwrap();
-    insert_metadata_links(&mut tx, inserted.book_id, &b.metadata)
-        .await
-        .unwrap();
+    insert_metadata_links(
+        &mut tx,
+        inserted.book_id,
+        &b.metadata,
+        &EntityAliasMaps::default(),
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
     inserted.book_id
 }
@@ -326,9 +334,17 @@ async fn sync_new_inserts_a_new_book_and_its_link_rows() {
 
     let new_books = vec![book_with_all_links("fresh.epub", "Fresh")];
     let mut tx = pool.begin().await.unwrap();
-    let covers = sync_new(&mut tx, library_id, "/lib", &new_books, &[], |_| {})
-        .await
-        .unwrap();
+    let covers = sync_new(
+        &mut tx,
+        library_id,
+        "/lib",
+        &new_books,
+        &[],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     assert!(covers.is_empty(), "no cover was supplied");
@@ -402,9 +418,16 @@ async fn sync_changed_updates_an_existing_book_row_in_place() {
         None,
     )];
     let mut tx = pool.begin().await.unwrap();
-    sync_changed(&mut tx, library_id, "/lib", &changed, |_| {})
-        .await
-        .unwrap();
+    sync_changed(
+        &mut tx,
+        library_id,
+        "/lib",
+        &changed,
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     // Exactly one row, same id + uuid, refreshed scalars.
@@ -445,9 +468,16 @@ async fn sync_changed_is_a_noop_for_empty_batch() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let library_id = seed_scan_root(&pool).await;
     let mut tx = pool.begin().await.unwrap();
-    let covers = sync_changed(&mut tx, library_id, "/lib", &[], |_| {})
-        .await
-        .unwrap();
+    let covers = sync_changed(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
     assert!(covers.is_empty());
 }
@@ -528,6 +558,7 @@ async fn sync_changed_reindex_does_not_resurrect_a_merged_away_author_series_or_
         "/lib",
         &[source, canonical],
         &[],
+        &EntityAliasMaps::default(),
         |_| {},
     )
     .await
@@ -559,16 +590,22 @@ async fn sync_changed_reindex_does_not_resurrect_a_merged_away_author_series_or_
 
     // A second reindex of the source book: its file on disk never changed,
     // so the parser still reports the names the merges just absorbed.
-    let reparsed = indexed(
+    let reparsed = [indexed(
         "source.epub",
         Some("Source Book"),
         &["John Smith"],
         &["Sci-Fi"],
         Some(("The Wheel of Time", "1")),
         None,
-    );
+    )];
     let mut tx = pool.begin().await.unwrap();
-    sync_changed(&mut tx, library_id, "/lib", &[reparsed], |_| {})
+    // #1985: the caller now pre-resolves the batch's alias map itself,
+    // reflecting the merges just applied above, instead of `sync_changed`
+    // resolving it per book internally.
+    let alias_maps = collect_entity_alias_maps(&mut tx, &reparsed, &[])
+        .await
+        .unwrap();
+    sync_changed(&mut tx, library_id, "/lib", &reparsed, &alias_maps, |_| {})
         .await
         .unwrap();
     tx.commit().await.unwrap();
@@ -639,9 +676,17 @@ async fn sync_changed_reindex_leaves_unmerged_entities_unaffected() {
         None,
     );
     let mut tx = pool.begin().await.unwrap();
-    sync_new(&mut tx, library_id, "/lib", &[book], &[], |_| {})
-        .await
-        .unwrap();
+    sync_new(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[book],
+        &[],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     let book_id: i64 = sqlx::query_scalar("SELECT id FROM books WHERE scan_key = 'plain.epub'")
@@ -661,9 +706,16 @@ async fn sync_changed_reindex_leaves_unmerged_entities_unaffected() {
         None,
     );
     let mut tx = pool.begin().await.unwrap();
-    sync_changed(&mut tx, library_id, "/lib", &[reparsed], |_| {})
-        .await
-        .unwrap();
+    sync_changed(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[reparsed],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     assert_eq!(
@@ -757,9 +809,16 @@ async fn word_count_persists_on_insert_and_refreshes_on_change() {
     let mut changed = indexed("wc.epub", Some("Counted"), &[], &[], None, None);
     changed.word_count = Some(2500);
     let mut tx = pool.begin().await.unwrap();
-    sync_changed(&mut tx, library_id, "/lib", &[changed], |_| {})
-        .await
-        .unwrap();
+    sync_changed(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[changed],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     let refreshed: Option<i64> = sqlx::query_scalar("SELECT word_count FROM books WHERE id = ?")
@@ -798,9 +857,16 @@ async fn page_count_persists_on_insert_and_refreshes_on_change() {
     let mut changed = indexed("pc.cbz", Some("Paged"), &[], &[], None, None);
     changed.metadata.page_count = Some(20);
     let mut tx = pool.begin().await.unwrap();
-    sync_changed(&mut tx, library_id, "/lib", &[changed], |_| {})
-        .await
-        .unwrap();
+    sync_changed(
+        &mut tx,
+        library_id,
+        "/lib",
+        &[changed],
+        &EntityAliasMaps::default(),
+        |_| {},
+    )
+    .await
+    .unwrap();
     tx.commit().await.unwrap();
 
     let refreshed: Option<i64> = sqlx::query_scalar("SELECT page_count FROM books WHERE id = ?")
@@ -1862,5 +1928,128 @@ async fn sync_new_keeps_explicit_series_index_and_only_fills_the_gap_from_the_em
     assert_eq!(
         embedded_index, 3.0,
         "the embedded index fills the gap when no explicit value was scanned"
+    );
+}
+
+// ── #1985: alias-lookup query count is batch-bounded, not per-book ────────
+
+/// Counts `tracing` events sqlx emits (target `"sqlx::query"`, one per
+/// executed statement) whose `db.statement` field mentions `entity_aliases` —
+/// i.e. a `resolve_entity_aliases` lookup specifically, not every query the
+/// sync writes. Mirrors the `QueryCounter` pattern in
+/// `db/src/epub_rewrite/tests.rs`, narrowed to the one table this test cares
+/// about so the assertion isn't swamped by the per-book `books`/link-table
+/// writes a reindex batch also issues.
+///
+/// Installed as the **global** default (not `tracing::subscriber::set_default`,
+/// which is thread-local): `sqlx-sqlite` runs every statement — including
+/// each one this counts — on a dedicated per-connection worker thread (see
+/// `sqlx_sqlite::connection::worker`), so a thread-local override on the
+/// test's own async task never sees them. A global default is process-wide
+/// and permanent for the rest of the test binary, which is why the
+/// assertion below uses a loose upper bound rather than an exact count — a
+/// concurrently-running unrelated test's own `entity_aliases` query could
+/// add a stray hit to this counter too.
+struct EntityAliasQueryCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+impl tracing::Subscriber for EntityAliasQueryCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.target() == "sqlx::query"
+    }
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        struct MentionsEntityAliases(bool);
+        impl tracing::field::Visit for MentionsEntityAliases {
+            fn record_debug(
+                &mut self,
+                _field: &tracing::field::Field,
+                _value: &dyn std::fmt::Debug,
+            ) {
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                if field.name().ends_with("statement") && value.contains("entity_aliases") {
+                    self.0 = true;
+                }
+            }
+        }
+        let mut visitor = MentionsEntityAliases(false);
+        event.record(&mut visitor);
+        if visitor.0 {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// #1985 AC3: a multi-book reindex batch issues an `entity_aliases` lookup
+/// count bounded by the touched `CleanupKind`s (author, series, tag — a
+/// small constant), not by book count. The old per-book shape issued
+/// `3 * BOOK_COUNT` such queries (`insert_author_links`/`insert_tag_links`/
+/// `resolve_or_insert_series` each called `resolve_entity_aliases` once per
+/// book); the batched shape issues 3 total regardless of `BOOK_COUNT`. The
+/// assertion checks `< BOOK_COUNT` rather than `== 3` — see
+/// `EntityAliasQueryCounter`'s doc for why an exact count isn't safe to
+/// assert against a process-wide subscriber — but `BOOK_COUNT` is picked
+/// large enough that the old shape would fail this bound by a wide margin
+/// while the new shape passes with room to spare.
+#[tokio::test]
+async fn sync_books_issues_one_entity_alias_query_per_kind_not_per_book() {
+    let _covers = CoversTempDir::new("sync_books_alias_query_count");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+
+    const BOOK_COUNT: usize = 20;
+    let new_books: Vec<IndexedBook> = (0..BOOK_COUNT)
+        .map(|i| {
+            let filename = format!("book-{i}.epub");
+            let title = format!("Book {i}");
+            let author = format!("Author {i}");
+            let tag = format!("Tag {i}");
+            let series = format!("Series {i}");
+            indexed(
+                &filename,
+                Some(&title),
+                &[&author],
+                &[&tag],
+                Some((&series, "1")),
+                None,
+            )
+        })
+        .collect();
+
+    let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Best-effort: a prior test in this binary may have already claimed the
+    // global default (it can only be set once per process). If so, this
+    // counter simply stays at 0 and the loose bound below still holds —
+    // it just stops being a meaningful check for this particular run.
+    let _ = tracing::subscriber::set_global_default(EntityAliasQueryCounter(count.clone()));
+    // Interest in the `sqlx::query` callsite is cached process-wide the
+    // first time it fires and is *not* refreshed by installing a new
+    // default alone — `init_db`'s migrations above already fired it under
+    // whatever (no-op) dispatcher preceded this one, which would otherwise
+    // leave it permanently cached "never interested".
+    tracing::callsite::rebuild_interest_cache();
+
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            new_books,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let queries = count.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        queries < BOOK_COUNT,
+        "expected an entity_aliases query count bounded by the touched \
+         CleanupKinds (author, series, tag — 3, not {BOOK_COUNT}), got \
+         {queries} for a {BOOK_COUNT}-book batch"
     );
 }

--- a/db/src/taxonomy.rs
+++ b/db/src/taxonomy.rs
@@ -4,6 +4,8 @@
 //! exposed to siblings via `pub(crate)`. The multi-valued relations
 //! (authors, tags, identifiers) are inserted in batches directly in `sync`.
 
+use std::collections::HashMap;
+
 use omnibus_shared::CleanupKind;
 use sqlx::Transaction;
 
@@ -50,6 +52,13 @@ resolve_or_insert_simple!(resolve_or_insert_language, "languages", "code");
 /// instead of minting a fresh row for the merged-away name. On a miss,
 /// falls through to the same `INSERT OR IGNORE` / `SELECT` shape the other
 /// taxonomy resolvers use.
+///
+/// Issues its own single-name `resolve_entity_aliases` lookup — the right
+/// shape for its callers (`series_normalize`'s boot backfill, `merge::undo`'s
+/// rare admin restore), each resolving a handful of names outside the
+/// reindex hot path. The reindex write loop instead calls
+/// [`resolve_or_insert_series_with_aliases`] with a lookup pre-resolved once
+/// for the whole batch (#1985).
 pub(crate) async fn resolve_or_insert_series(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     value: &str,
@@ -60,6 +69,30 @@ pub(crate) async fn resolve_or_insert_series(
     {
         return Ok(canonical_id);
     }
+    insert_or_select_series(tx, value).await
+}
+
+/// Batch-aware sibling of [`resolve_or_insert_series`] for the reindex write
+/// loop: consults `aliases`, a lookup resolved once for the whole sync batch
+/// (`sync::books::collect_entity_alias_maps`), instead of issuing its own
+/// per-call `resolve_entity_aliases` query — the per-book fan-out #1985
+/// eliminates.
+pub(crate) async fn resolve_or_insert_series_with_aliases(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    value: &str,
+    aliases: &HashMap<String, i64>,
+) -> Result<i64, sqlx::Error> {
+    if let Some(canonical_id) = aliases.get(value) {
+        return Ok(*canonical_id);
+    }
+    insert_or_select_series(tx, value).await
+}
+
+/// Shared `INSERT OR IGNORE` / `SELECT` tail for both series resolvers above.
+async fn insert_or_select_series(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    value: &str,
+) -> Result<i64, sqlx::Error> {
     sqlx::query("INSERT OR IGNORE INTO series (name) VALUES (?)")
         .bind(value)
         .execute(&mut **tx)

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -3,6 +3,11 @@
 //! `publishers`, `languages`. `delete_orphan_taxonomy`, `delete_orphan_tags`,
 //! and `delete_orphan_genres` each get drop/keep/override-aware/case-fold
 //! tests, plus a purge-path regression test for genres.
+//! `resolve_or_insert_series_with_aliases` gets its own mint/hit pair,
+//! mirroring `resolve_or_insert_series`'s but against a caller-supplied map
+//! instead of its own internal lookup (#1985).
+
+use std::collections::HashMap;
 
 use omnibus_shared::MetadataOverrides;
 
@@ -112,6 +117,50 @@ async fn resolve_or_insert_series_returns_the_canonical_id_for_a_merged_away_nam
         .await
         .unwrap();
     assert_eq!(count, 0, "the merged-away name must not be recreated");
+}
+
+#[tokio::test]
+async fn resolve_or_insert_series_with_aliases_mints_a_fresh_row_when_the_map_has_no_hit() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    let id = resolve_or_insert_series_with_aliases(&mut tx, "Dune Chronicles", &HashMap::new())
+        .await
+        .unwrap();
+    assert!(id > 0, "expected a positive row id, got {id}");
+    tx.commit().await.unwrap();
+
+    let stored: String = sqlx::query_scalar("SELECT name FROM series WHERE id = ?")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(stored, "Dune Chronicles");
+}
+
+#[tokio::test]
+async fn resolve_or_insert_series_with_aliases_returns_the_mapped_id_without_querying_entity_aliases(
+) {
+    // #1985: the caller pre-resolves the whole reindex batch's alias map
+    // once, so this resolver must trust it outright rather than issuing its
+    // own `resolve_entity_aliases` lookup for a name the map already
+    // answers — proven here by a canonical id that isn't backed by any real
+    // `entity_aliases` row.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let aliases = HashMap::from([("The Wheel of Time".to_string(), 999_i64)]);
+
+    let mut tx = pool.begin().await.unwrap();
+    let resolved = resolve_or_insert_series_with_aliases(&mut tx, "The Wheel of Time", &aliases)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(resolved, 999, "the pre-resolved map's id wins outright");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM series WHERE name = ?")
+        .bind("The Wheel of Time")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 0, "a mapped name must not mint a fresh row either");
 }
 
 #[tokio::test]

--- a/db/src/taxonomy/tests.rs
+++ b/db/src/taxonomy/tests.rs
@@ -3,9 +3,6 @@
 //! `publishers`, `languages`. `delete_orphan_taxonomy`, `delete_orphan_tags`,
 //! and `delete_orphan_genres` each get drop/keep/override-aware/case-fold
 //! tests, plus a purge-path regression test for genres.
-//! `resolve_or_insert_series_with_aliases` gets its own mint/hit pair,
-//! mirroring `resolve_or_insert_series`'s but against a caller-supplied map
-//! instead of its own internal lookup (#1985).
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary
- Closes #1985
- `resolve_entity_aliases` (`db/src/entity_alias.rs`) is internally batched (one `SELECT ... IN (...)` per 500-name chunk), but every caller in the reindex write loop — `insert_author_links`, `insert_tag_links` (`db/src/sync/books/shared.rs`), `resolve_or_insert_series` (`db/src/taxonomy.rs`) — invoked it once *per book*, reintroducing exactly the per-book query fan-out the surrounding `insert_metadata_links` batching was written to eliminate.
- Added `EntityAliasMaps` + `collect_entity_alias_maps` in `db/src/sync/books/mod.rs`: collects the distinct author/series/tag names across the whole New+Changed reindex batch and resolves each `CleanupKind`'s alias guard exactly once, before either per-book write loop starts.
- Threaded the pre-resolved maps down through `insert_metadata_links` → `insert_author_links` / `insert_tag_links` / a new `resolve_or_insert_series_with_aliases` (which consults the pre-resolved map instead of issuing its own lookup). `resolve_or_insert_series` itself is left untouched for its two other, non-hot-path callers (`series_normalize`'s boot backfill, `merge::undo`'s rare admin restore), which still resolve one name at a time by design.
- No behavior change to the reindex-resurrection guard (#964) itself — a merged-away author/series/tag still resolves to its canonical id on reindex; only *when* the lookup happens changed (once per batch instead of once per book).

## Test plan
- [x] `cargo fmt -p omnibus-db` — PASS (no diff)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (2201 passed, 1 pre-existing unrelated failure: `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture` needs `just fixtures`, unavailable in this sandbox)
- [x] New test `sync::books::tests::sync_books_issues_one_entity_alias_query_per_kind_not_per_book` (AC3): asserts the `entity_aliases` lookup count for a 20-book batch is bounded well below book count (old per-book shape would have issued `3 * 20 = 60`; the batched shape issues 3). Also extended `db/src/sync/authors/tests.rs` and `db/src/taxonomy/tests.rs` with coverage for the new pre-resolved-map call shapes.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Issue #1985 explicitly excludes issue #1986 (style nits in the same files) from this change — not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1Pb7hTvWBBNhb5Qx6EjM8)_