### PR TITLE
docs: split README mobile section into Android and iOS (#2006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **The Plex / Jellyfin for your books.**
 A self-hosted ebook & audiobook library — read in the browser, listen anywhere, and browse a collection that belongs entirely to you.
 
-Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dioxuslabs.com/)), SQLite, and a native iOS / Android shell.
+Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dioxuslabs.com/)), SQLite, a native SwiftUI iOS app, and an Android shell.
 
 [![Clippy & Tests](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/rust.yml?branch=main&label=Clippy%20%26%20Tests&logo=rust&logoColor=white)](https://github.com/seamus-sloan/omnibus/actions/workflows/rust.yml)
 [![Playwright](https://img.shields.io/github/actions/workflow/status/seamus-sloan/omnibus/e2e.yml?branch=main&label=Playwright&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MDAgNDAwIj4KPHBhdGggZmlsbD0iIzJFQUQzMyIgZD0iTTM0MS44IDEyOS4yYy0xMi40IDIuMi00Mi4zIDQuOS03OS4yLTUtMzYuOS05LjktNjEuNC0yNy4yLTcxLjEtMzUuMy0xMy44LTExLjUtMTkuOC0xOS41LTI1LjctNy40LTUuMyAxMC43LTEyIDI4LjEtMTguNSA1Mi40LTE0LjEgNTIuNy0yNC43IDE2My44IDYyLjYgMTg3LjIgODcuMiAyMy40IDEzMy43LTc4LjIgMTQ3LjgtMTMwLjkgNi41LTI0LjMgOS40LTQyLjcgMTAuMi01NC42LjktMTMuNC04LjQtOS41LTI2LjEtNi40eiIvPgo8cGF0aCBmaWxsPSIjMUQ4RDIyIiBkPSJNMjI1LjMgMjY5LjJjLTQxLTEyLTQ5LjItNDUuMi00OS4yLTQ1LjJsNTYuOCAxNS45IDMwLjEtMTE1LjZjLTM2LjktOS45LTYxLjctMjcuMy03MS40LTM1LjQtMTMuOC0xMS41LTE5LjgtMTkuNS0yNS43LTcuNC01LjMgMTAuNy0xMiAyOC4xLTE4LjUgNTIuNC0xNC4xIDUyLjctMjQuNyAxNjMuOCA2Mi42IDE4Ny4ybDEuOC40eiIvPgo8cGF0aCBmaWxsPSIjMkQ0NTUyIiBkPSJNMTkzLjkgMTY3LjZjMTEuOSAzLjQgMTguMiAxMS43IDIxLjUgMTkuMWwxMy4yIDMuOHMtMS44LTI1LjgtMjUuMS0zMi40Yy0yMS44LTYuMi0zNS4zIDEyLjEtMzYuOSAxNC41IDYuNC00LjUgMTUuNy04LjIgMjcuMy01ek0yOTkuNCAxODYuOGMtMjEuOS02LjItMzUuMyAxMi4xLTM2LjkgMTQuNSA2LjQtNC41IDE1LjctOC4yIDI3LjMtNSAxMS45IDMuNCAxOC4yIDExLjcgMjEuNSAxOS4xbDEzLjMgMy44cy0xLjktMjUuOC0yNS4yLTMyLjR6Ii8%2BCjxwYXRoIGZpbGw9IiNFMjU3NEMiIGQ9Ik0xNjEuNyAyMjAuMXYtOTJoMzEuMmMtMy40LTEwLjUtNi43LTE4LjYtOS41LTI0LjItNC42LTkuMy05LjMtMy4xLTE5LjkgNS44LTcuNSA2LjMtMjYuNCAxOS42LTU0LjkgMjcuMy0yOC41IDcuNy01MS41IDUuNi02MS4xIDMuOS0xMy42LTIuNC0yMC44LTUuNC0yMCA1IC42IDkuMSAyLjggMjMuMyA3LjcgNDIuMSAxMC44IDQwLjUgNDYuNCAxMTguNiAxMTMuOCAxMDAuNSAxNy42LTQuNyAzMC0xNC4xIDM4LjYtMjYuMWgtMjUuOXYtMjIuNWwtNjIuNCAxNy43czQuNi0yNi44IDM3LjEtMzZjOS45LTIuOCAxOC40LTIuOCAyNS4zLTEuNXoiLz4KPHBhdGggZmlsbD0iI0Q2NTM0OCIgZD0iTTEzOS45IDI0NmwtNDAuNiAxMS41czQuNC0yNS4xIDM0LjMtMzVsLTIyLjktODYuMi0yIC42Yy0yOC41IDcuNy01MS41IDUuNi02MS4xIDMuOS0xMy42LTIuNC0yMC44LTUuNC0yMCA1IC42IDkuMSAyLjggMjMuMyA3LjcgNDIuMSAxMC44IDQwLjUgNDYuNCAxMTguNiAxMTMuOCAxMDAuNWwyLS42eiIvPgo8cGF0aCBmaWxsPSIjMkQ0NTUyIiBkPSJNMTM2LjQgMjIxLjZjLTEyLjkgMy43LTIxLjMgMTAuMS0yNi45IDE2LjUgNS4zLTQuNyAxMi41LTkgMjIuMS0xMS43IDkuOS0yLjggMTguMy0yLjggMjUuMi0xLjR2LTUuNGMtNS45LS41LTEyLjctLjItMjAuNCAyek0xMDguOSAxNzUuOWwtNDcuOCAxMi42czEwLjYgMTUuMyAyOC41IDEwLjVjMTcuOS00LjcgMTkuMy0yMy4xIDE5LjMtMjMuMXoiLz4KPC9zdmc%2B&logoColor=white)](https://seamus-sloan.github.io/omnibus/)
@@ -39,7 +39,7 @@ Built with Rust ([Axum](https://github.com/tokio-rs/axum) + [Dioxus](https://dio
 - ⌘ **Command-palette search** — `⌘K` for full-text search across titles, authors, series, and tags.
 - 🧭 **Rich book pages** — your own ratings, reading journals, series tracking, and reading insights on your own database.
 - 🔗 **Discovery** — browse by author, series, and tag; "readers also enjoyed" suggestions via Hardcover.
-- 📱 **Native mobile app** — an iOS / Android shell over the same backend.
+- 📱 **Mobile apps** — a native SwiftUI app on iOS and a WebView shell on Android, both over the same backend.
 - 🐳 **Self-hosted, Jellyfin-style** — bind-mount your library, one `docker compose up`.
 
 ## Screenshots
@@ -116,7 +116,7 @@ it (the `just` recipes above pick the right one for you):
 | `default` | Daily `cargo` / `clippy` / `test` / editor — what direnv auto-loads |
 | `.#web` | `dx serve --platform web`, `just dev-up`, anything that bundles WASM |
 | `.#e2e` | `pnpm exec playwright test` (the Chromium bundle lives here) |
-| `.#mobile` | Android / iOS builds (Rust cross-targets + JDK + Android NDK detect) |
+| `.#mobile` | Android builds (Rust cross-targets + JDK + Android NDK detect) — the native iOS app needs no Nix shell |
 | `.#audit` | `cargo audit` / `cargo deny` |
 
 | Variable | Default |
@@ -128,20 +128,24 @@ Secret-bearing config lives in a gitignored `.env` — copy [`.env.example`](.en
 on first checkout. It's the canonical, annotated reference for every supported
 variable.
 
-## Mobile app
+## Mobile apps
 
-The mobile app is a Dioxus Native shell that connects to `http://127.0.0.1:3000`,
-so **start the server first** (`just serve` handles this). The iOS and Android
-panes inside `just serve` build and launch the app for you; the one-time platform
-setup below still applies.
+The two mobile surfaces are separate apps built in different ways: Android is
+the Dioxus shell in the `mobile/` crate, iOS is a native SwiftUI project under
+`omnibus-ios/`. Both talk to a running Omnibus server, so **start the server
+first** (`just serve` handles this).
 
-### iOS Simulator
+In both multiplexers only the server starts on its own — the `android`, `ios`,
+and `playwright` panes are preloaded but idle (press Enter in the Zellij pane,
+or select it and press F7 in process-compose).
 
-Requires macOS with Xcode and at least one iOS Simulator installed (add one via
-**Xcode → Window → Devices and Simulators**). The iOS pane then launches the
-simulator and installs the app with no extra commands.
+### Android — Dioxus shell (`mobile/` crate)
 
-### Android Emulator
+A thin native shell hosting the system WebView over the shared Dioxus frontend,
+pointed at `http://127.0.0.1:3000`. The `android` pane runs
+`dx serve --platform android --package omnibus-mobile` inside the `.#mobile`
+shell; start it yourself with the same command once the emulator is up. One-time
+setup:
 
 1. **Install Android Studio** — [developer.android.com/studio](https://developer.android.com/studio)
 2. **Install the NDK** — **Tools → SDK Manager → SDK Tools → check "NDK (Side by side)" → Apply**
@@ -162,6 +166,27 @@ simulator and installs the app with no extra commands.
    ```
 
 5. If the app can't reach the server after boot, run `adb reverse tcp:3000 tcp:3000`.
+
+### iOS — native SwiftUI app (`omnibus-ios/`)
+
+An Xcode project (`omnibus-ios/omnibus.xcodeproj`, scheme `omnibus`) rather than
+a Cargo crate — it speaks the same `/api/*` REST surface, and `cargo` never
+builds it. Its recipes drive system `xcodebuild` / `simctl`, so none of them
+enter a Nix shell:
+
+```bash
+just ios-sim      # boot the newest iPhone simulator, build, install, launch
+just ios-build    # compile check against a generic simulator destination
+just ios-test     # omnibusTests unit suite — the invocation CI runs
+just ios-test-ui  # omnibusUITests
+```
+
+Requires macOS with Xcode and at least one iOS Simulator installed (add one via
+**Xcode → Window → Devices and Simulators**); `just ios-sim` also needs `jq` to
+pick the newest iPhone runtime, unless you pin one with `OMNIBUS_IOS_SIM_UDID`.
+The app has no baked-in server URL — `just ios-sim` prints this workspace's dev
+server URL to enter on the Connect screen. The `ios` pane in `just serve` runs
+that same script.
 
 ## Tests
 
@@ -199,7 +224,10 @@ Five-crate Cargo workspace:
 | `db/` | data layer, indexer, migrations |
 | `frontend/` | Dioxus UI + server functions |
 | `server/` | fullstack binary + REST router |
-| `mobile/` | thin native shell |
+| `mobile/` | thin native Android shell over the system WebView |
+
+Alongside it, `omnibus-ios/` holds the native SwiftUI iOS client — an Xcode
+project, not a Cargo crate, so `cargo` / `just lint` / `just test` never touch it.
 
 Deeper architecture — module maps, request-flow diagrams, mobile-auth — is in
 [docs/architecture.md](docs/architecture.md). Contributor conventions live


### PR DESCRIPTION
## Summary
- Split README's `## Mobile app` into `## Mobile apps` with two subsections: **Android — Dioxus shell (`mobile/` crate)** (keeps the existing Android Studio / NDK / emulator / `adb reverse` steps verbatim, plus the real `dx serve --platform android --package omnibus-mobile` command the `android` pane runs in `.#mobile`) and **iOS — native SwiftUI app (`omnibus-ios/`)**.
- Replaced the old `### iOS Simulator` subsection: it claimed `just serve`'s iOS pane builds/installs the Dioxus shell. It now describes the real flow — an Xcode project (`omnibus-ios/omnibus.xcodeproj`, scheme `omnibus`) driven by `just ios-sim` / `ios-build` / `ios-test` / `ios-test-ui` on system `xcodebuild` + `simctl` with no Nix shell, the `jq` / `OMNIBUS_IOS_SIM_UDID` requirement, and the Connect-screen URL hint `scripts/ios-sim.sh` prints.
- Corrected the multiplexer claim: only the server pane auto-starts; `android` / `ios` / `playwright` are preloaded but idle (Enter in Zellij, F7 in process-compose).
- Swept the rest of the file for the same stale framing — the tagline, the `📱` feature bullet, the `.#mobile` Nix-shell row ("Android / iOS builds" → Android builds; the native iOS app needs no Nix shell), and the crate table's `mobile/` row, plus a line noting `omnibus-ios/` is an Xcode project rather than a Cargo crate.

Closes #2006

## Test plan
- [x] Docs-only change — no code, no behavior impact; `git diff --stat` touches `README.md` only.
- [x] Cross-checked every claim against the source of truth rather than the issue's suggested wording: `CLAUDE.md` (Architecture + Quick commands), `Justfile` (`serve`, `serve-pc`, `ios-build`, `ios-test`, `ios-test-ui`, `ios-sim`), `scripts/ios-sim.sh`, `.zellij/layout.kdl` + `process-compose.yaml` (pane suspension/disabled defaults), `flake.nix` (`.#mobile` is Android-targeted), and `docs/architecture.md`.
- [x] Re-read the rendered section against README's later "Tests" section — the new iOS block and the existing `omnibusUITests` / `just ios-test-ui` note now agree.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The Android emulator setup steps are unchanged, only re-homed under the renamed subsection.
- Two details the issue's suggested wording didn't have, taken from the actual scripts: the panes start suspended/disabled rather than launching for you, and `just ios-sim` needs `jq` unless `OMNIBUS_IOS_SIM_UDID` pins a device.
- Diff is scoped to mobile/iOS content; no unrelated section was reflowed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDwS33VhPGY3wkoRvdXN1p)_