### PR TITLE
refactor: cover cross-format DTO validate() error paths with unit tests (#2009)

### DIFF
--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::progress::ProgressFormat;
 
+#[cfg(test)]
+mod tests;
+
 /// How a book's multiple audio files relate — declared by the user when
 /// confirming a link, never guessed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/shared/src/cross_format/tests.rs
+++ b/shared/src/cross_format/tests.rs
@@ -1,0 +1,165 @@
+//! Unit tests for the cross-format wire-type validators: the per-format
+//! position boundaries `DeclareSyncPoint::validate` enforces, and the
+//! primary-narration and duplicate-ordinal rules in
+//! `ConfirmCrossFormatLink::validate`.
+
+use super::*;
+
+fn reading_declaration(ebook_fraction: Option<f64>) -> DeclareSyncPoint {
+    DeclareSyncPoint {
+        book_uuid: "uuid-1".into(),
+        format: ProgressFormat::Epub,
+        ebook_fraction,
+        epub_cfi: None,
+        audio_book_file_id: None,
+        audio_seconds: None,
+    }
+}
+
+fn listening_declaration(audio_seconds: Option<f64>) -> DeclareSyncPoint {
+    DeclareSyncPoint {
+        book_uuid: "uuid-1".into(),
+        format: ProgressFormat::Audio,
+        ebook_fraction: None,
+        epub_cfi: None,
+        audio_book_file_id: Some(7),
+        audio_seconds,
+    }
+}
+
+fn ok_link(mode: CrossFormatLinkMode) -> ConfirmCrossFormatLink {
+    ConfirmCrossFormatLink {
+        book_uuid: "uuid-1".into(),
+        mode,
+        primary_book_file_id: None,
+        audio_order: None,
+    }
+}
+
+#[test]
+fn declare_sync_point_validate_accepts_ebook_fraction_inside_range() {
+    assert!(reading_declaration(Some(0.5)).validate().is_ok());
+}
+
+#[test]
+fn declare_sync_point_validate_accepts_ebook_fraction_at_both_bounds() {
+    assert!(reading_declaration(Some(0.0)).validate().is_ok());
+    assert!(reading_declaration(Some(1.0)).validate().is_ok());
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_ebook_fraction_above_one() {
+    let err = reading_declaration(Some(1.1))
+        .validate()
+        .expect_err("a fraction past the end of the book must be rejected");
+    assert!(err.contains("ebook_fraction"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_ebook_fraction_below_zero() {
+    let err = reading_declaration(Some(-0.1))
+        .validate()
+        .expect_err("a negative fraction must be rejected");
+    assert!(err.contains("ebook_fraction"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_nan_ebook_fraction() {
+    let err = reading_declaration(Some(f64::NAN))
+        .validate()
+        .expect_err("NaN compares false against the range and must be rejected");
+    assert!(err.contains("ebook_fraction"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_reading_declaration_without_a_fraction() {
+    let err = reading_declaration(None)
+        .validate()
+        .expect_err("a reading declaration naming no position must be rejected");
+    assert!(err.contains("ebook_fraction"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_accepts_positive_audio_seconds() {
+    assert!(listening_declaration(Some(1234.5)).validate().is_ok());
+}
+
+#[test]
+fn declare_sync_point_validate_accepts_audio_seconds_at_zero() {
+    assert!(listening_declaration(Some(0.0)).validate().is_ok());
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_negative_audio_seconds() {
+    let err = listening_declaration(Some(-1.0))
+        .validate()
+        .expect_err("a position before the start of the file must be rejected");
+    assert!(err.contains("audio_seconds"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_nan_audio_seconds() {
+    let err = listening_declaration(Some(f64::NAN))
+        .validate()
+        .expect_err("NaN compares false against the floor and must be rejected");
+    assert!(err.contains("audio_seconds"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_rejects_listening_declaration_without_seconds() {
+    let err = listening_declaration(None)
+        .validate()
+        .expect_err("a listening declaration naming no position must be rejected");
+    assert!(err.contains("audio_seconds"), "got: {err}");
+}
+
+#[test]
+fn declare_sync_point_validate_checks_only_the_declaring_surfaces_half() {
+    // The counterpart half comes from the server's stored row, so an
+    // out-of-range value in the other format's field is not this
+    // declaration's business.
+    let mut d = listening_declaration(Some(10.0));
+    d.ebook_fraction = Some(99.0);
+    assert!(d.validate().is_ok());
+
+    let mut d = reading_declaration(Some(0.25));
+    d.audio_seconds = Some(-5.0);
+    assert!(d.validate().is_ok());
+}
+
+#[test]
+fn confirm_cross_format_link_validate_accepts_sequence_mode_without_a_primary() {
+    assert!(ok_link(CrossFormatLinkMode::Sequence).validate().is_ok());
+}
+
+#[test]
+fn confirm_cross_format_link_validate_rejects_narrations_mode_without_a_primary() {
+    let err = ok_link(CrossFormatLinkMode::Narrations)
+        .validate()
+        .expect_err("narrations mode with no primary must be rejected");
+    assert!(err.contains("primary narration"), "got: {err}");
+}
+
+#[test]
+fn confirm_cross_format_link_validate_accepts_narrations_mode_with_a_primary() {
+    let mut c = ok_link(CrossFormatLinkMode::Narrations);
+    c.primary_book_file_id = Some(3);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn confirm_cross_format_link_validate_accepts_an_audio_order_of_distinct_ids() {
+    let mut c = ok_link(CrossFormatLinkMode::Sequence);
+    c.audio_order = Some(vec![3, 1, 2]);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn confirm_cross_format_link_validate_rejects_an_audio_order_repeating_an_id() {
+    let mut c = ok_link(CrossFormatLinkMode::Sequence);
+    c.audio_order = Some(vec![1, 2, 1]);
+    let err = c
+        .validate()
+        .expect_err("an order list that repeats a file must be rejected");
+    assert!(err.contains("repeat"), "got: {err}");
+}

--- a/shared/src/cross_format/tests.rs
+++ b/shared/src/cross_format/tests.rs
@@ -115,9 +115,7 @@ fn declare_sync_point_validate_rejects_listening_declaration_without_seconds() {
 
 #[test]
 fn declare_sync_point_validate_checks_only_the_declaring_surfaces_half() {
-    // The counterpart half comes from the server's stored row, so an
-    // out-of-range value in the other format's field is not this
-    // declaration's business.
+    // The counterpart half comes from the server's stored row, not this declaration.
     let mut d = listening_declaration(Some(10.0));
     d.ebook_fraction = Some(99.0);
     assert!(d.validate().is_ok());


### PR DESCRIPTION
## Summary
- Closes #2009.
- Adds a sibling `shared/src/cross_format/tests.rs` (declared `#[cfg(test)] mod tests;` in `shared/src/cross_format.rs`), matching the layout every other `shared/` DTO already uses (`progress/tests.rs`, `bookmark/tests.rs`) — the file is *not* converted to `mod.rs`, because the siblings don't.
- Test-only change: no production code was touched beyond the `mod tests;` declaration.
- Branches covered, derived from the actual `validate()` bodies rather than the issue's guessed list:
  - `DeclareSyncPoint::validate()` — `Epub` arm: in-range fraction accepted; both inclusive bounds (`0.0`, `1.0`) accepted; `> 1.0` rejected; `< 0.0` rejected; `NaN` rejected (it compares false against `RangeInclusive::contains`); `None` rejected with the "needs ebook_fraction" message.
  - `DeclareSyncPoint::validate()` — `Audio` arm: positive seconds accepted; `0.0` accepted (the `>= 0.0` floor is inclusive); negative rejected; `NaN` rejected; `None` rejected with the "needs audio_seconds" message.
  - `DeclareSyncPoint::validate()` — dispatch: one test pinning that only the *declaring* surface's half is checked, so an out-of-range value in the other format's field is ignored (the counterpart half comes from the server's stored row).
  - `ConfirmCrossFormatLink::validate()` — `Sequence` mode without a primary accepted; `Narrations` without a primary rejected; `Narrations` with a primary accepted; an `audio_order` of distinct ids accepted; an `audio_order` repeating an id rejected.
- 17 new tests, all named per rule 05's `fn_under_test_does_X_when_Y` convention.

## Test plan
- [x] `cargo fmt` — clean, no reformatting of the new file.
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — PASS, no warnings.
- [x] `cargo test -p omnibus-shared` — PASS: 335 passed, 0 failed (was 318 before; +17).
- [x] `cargo test -p omnibus-shared cross_format` — all 17 new tests listed and green.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- No bug was found in either `validate()` body; every test asserts current behaviour.
- Two behaviours worth naming, since they're intentional-looking but previously unasserted and now pinned by tests: `NaN` is rejected by both float checks purely as a side effect of IEEE comparison semantics (no explicit `is_nan()` guard), and an empty `audio_order` passes the duplicate check (`Iterator::all` on an empty iterator is vacuously true). If either should change, these tests will say so loudly.
- No `db` crate clippy run was needed: `cross_format.rs` stays a file with a sibling `cross_format/` test directory, so no module path changed and nothing outside `shared` is affected.
