### PR TITLE
refactor: batch tag and genre override inserts (#2008)

### DIFF
--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -16,6 +16,27 @@ use sqlx::{QueryBuilder, SqliteConnection};
 /// reason as `resolve_entity_aliases` in `crate::entity_alias`.
 const INSERT_CHUNK: usize = 500;
 
+/// The single-column vocabulary tables an override materializes rows in.
+///
+/// A closed enum rather than a `&str` so the table name — the one part of
+/// [`insert_vocabulary_rows`]'s statement that can't be a bind — is chosen
+/// from this file at compile time and can't be routed in from a call site.
+#[derive(Clone, Copy)]
+enum VocabularyTable {
+    Tags,
+    Genres,
+}
+
+impl VocabularyTable {
+    /// The SQL identifier this variant names.
+    fn as_sql(self) -> &'static str {
+        match self {
+            Self::Tags => "tags",
+            Self::Genres => "genres",
+        }
+    }
+}
+
 /// When an override sets a series name, ensure a `series` row and
 /// `books_series_link` exist so the browse index and detail-page breadcrumb
 /// resolve. Without this, override-only series are invisible to
@@ -68,7 +89,7 @@ pub(super) async fn materialize_tag_rows(
     let Some(subjects) = overrides.subjects.as_ref() else {
         return Ok(());
     };
-    insert_vocabulary_rows(conn, "tags", subjects).await
+    insert_vocabulary_rows(conn, VocabularyTable::Tags, subjects).await
 }
 
 /// When an override sets a genres list, ensure a `genres` row exists for
@@ -89,22 +110,23 @@ pub(super) async fn materialize_genre_rows(
     let Some(genres) = overrides.genres.as_ref() else {
         return Ok(());
     };
-    insert_vocabulary_rows(conn, "genres", genres).await
+    insert_vocabulary_rows(conn, VocabularyTable::Genres, genres).await
 }
 
 /// `INSERT OR IGNORE` every name in `names` into a single-column vocabulary
 /// table (`tags` / `genres`), one multi-row statement per
 /// [`INSERT_CHUNK`]-sized chunk instead of one statement per name.
 ///
-/// `table` is a caller-supplied literal, never user input — it is the one
-/// part of the statement that isn't a bind. Names are trimmed, blanks
+/// `table` is a [`VocabularyTable`], not a string — the one part of the
+/// statement that isn't a bind therefore can't carry user input. Names are
+/// trimmed, blanks
 /// dropped, and duplicates collapsed case-insensitively to match the
 /// `UNIQUE COLLATE NOCASE` column the insert lands on, so a list naming the
 /// same tag twice stays one row (as it did per-statement) and can't make a
 /// single batch conflict with itself.
 async fn insert_vocabulary_rows(
     conn: &mut SqliteConnection,
-    table: &str,
+    table: VocabularyTable,
     names: &[String],
 ) -> Result<(), sqlx::Error> {
     let mut seen: HashSet<String> = HashSet::new();
@@ -117,7 +139,7 @@ async fn insert_vocabulary_rows(
 
     for chunk in names.chunks(INSERT_CHUNK) {
         let mut qb = QueryBuilder::new("INSERT OR IGNORE INTO ");
-        qb.push(table);
+        qb.push(table.as_sql());
         qb.push(" (name) ");
         qb.push_values(chunk, |mut b, name| {
             b.push_bind(*name);

--- a/db/src/metadata_overrides/links.rs
+++ b/db/src/metadata_overrides/links.rs
@@ -5,8 +5,16 @@
 //! author override path replaces its m2m list at read time via
 //! `apply_overrides` and doesn't need a helper here.
 
+use std::collections::HashSet;
+
 use omnibus_shared::MetadataOverrides;
-use sqlx::SqliteConnection;
+use sqlx::{QueryBuilder, SqliteConnection};
+
+/// Names bound per batched insert. SQLite's default bound-parameter cap is
+/// 999 (32766 on newer builds) and a subjects/genres list is user-supplied,
+/// so the batch is chunked rather than trusted to stay small — same size and
+/// reason as `resolve_entity_aliases` in `crate::entity_alias`.
+const INSERT_CHUNK: usize = 500;
 
 /// When an override sets a series name, ensure a `series` row and
 /// `books_series_link` exist so the browse index and detail-page breadcrumb
@@ -60,13 +68,7 @@ pub(super) async fn materialize_tag_rows(
     let Some(subjects) = overrides.subjects.as_ref() else {
         return Ok(());
     };
-    for tag in subjects.iter().map(|s| s.trim()).filter(|s| !s.is_empty()) {
-        sqlx::query("INSERT OR IGNORE INTO tags (name) VALUES (?)")
-            .bind(tag)
-            .execute(&mut *conn)
-            .await?;
-    }
-    Ok(())
+    insert_vocabulary_rows(conn, "tags", subjects).await
 }
 
 /// When an override sets a genres list, ensure a `genres` row exists for
@@ -87,11 +89,40 @@ pub(super) async fn materialize_genre_rows(
     let Some(genres) = overrides.genres.as_ref() else {
         return Ok(());
     };
-    for genre in genres.iter().map(|s| s.trim()).filter(|s| !s.is_empty()) {
-        sqlx::query("INSERT OR IGNORE INTO genres (name) VALUES (?)")
-            .bind(genre)
-            .execute(&mut *conn)
-            .await?;
+    insert_vocabulary_rows(conn, "genres", genres).await
+}
+
+/// `INSERT OR IGNORE` every name in `names` into a single-column vocabulary
+/// table (`tags` / `genres`), one multi-row statement per
+/// [`INSERT_CHUNK`]-sized chunk instead of one statement per name.
+///
+/// `table` is a caller-supplied literal, never user input — it is the one
+/// part of the statement that isn't a bind. Names are trimmed, blanks
+/// dropped, and duplicates collapsed case-insensitively to match the
+/// `UNIQUE COLLATE NOCASE` column the insert lands on, so a list naming the
+/// same tag twice stays one row (as it did per-statement) and can't make a
+/// single batch conflict with itself.
+async fn insert_vocabulary_rows(
+    conn: &mut SqliteConnection,
+    table: &str,
+    names: &[String],
+) -> Result<(), sqlx::Error> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let names: Vec<&str> = names
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .filter(|s| seen.insert(s.to_ascii_lowercase()))
+        .collect();
+
+    for chunk in names.chunks(INSERT_CHUNK) {
+        let mut qb = QueryBuilder::new("INSERT OR IGNORE INTO ");
+        qb.push(table);
+        qb.push(" (name) ");
+        qb.push_values(chunk, |mut b, name| {
+            b.push_bind(*name);
+        });
+        qb.build().execute(&mut *conn).await?;
     }
     Ok(())
 }

--- a/db/src/metadata_overrides/tests.rs
+++ b/db/src/metadata_overrides/tests.rs
@@ -2547,3 +2547,117 @@ async fn bulk_merge_metadata_overrides_rejects_a_genre_delta_past_the_per_book_c
             if u == uuid && max == MetadataOverrides::MAX_GENRES
     ));
 }
+
+// -----------------------------------------------------------------
+// Batched tag / genre vocabulary materialization
+// -----------------------------------------------------------------
+
+/// A name list deliberately past SQLite's 999 bound-parameter cap, so an
+/// unchunked single-statement insert would error instead of inserting.
+fn oversized_name_list(prefix: &str) -> Vec<String> {
+    (0..1_500).map(|i| format!("{prefix}-{i}")).collect()
+}
+
+#[tokio::test]
+async fn materialize_tag_rows_inserts_every_name_when_the_list_exceeds_the_sqlite_bind_cap() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let names = oversized_name_list("tag");
+    let ov = MetadataOverrides {
+        subjects: Some(names.clone()),
+        ..Default::default()
+    };
+    let mut conn = pool.acquire().await.unwrap();
+
+    super::links::materialize_tag_rows(&mut conn, &ov)
+        .await
+        .unwrap();
+    // Re-running must stay a no-op: `INSERT OR IGNORE` survives batching.
+    super::links::materialize_tag_rows(&mut conn, &ov)
+        .await
+        .unwrap();
+    drop(conn);
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count,
+        names.len() as i64,
+        "every name in an over-the-cap list should be materialized exactly once"
+    );
+    assert_eq!(tag_row_count(&pool, "tag-1499").await, 1);
+}
+
+#[tokio::test]
+async fn materialize_genre_rows_inserts_every_name_when_the_list_exceeds_the_sqlite_bind_cap() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let names = oversized_name_list("genre");
+    let ov = MetadataOverrides {
+        genres: Some(names.clone()),
+        ..Default::default()
+    };
+    let mut conn = pool.acquire().await.unwrap();
+
+    super::links::materialize_genre_rows(&mut conn, &ov)
+        .await
+        .unwrap();
+    super::links::materialize_genre_rows(&mut conn, &ov)
+        .await
+        .unwrap();
+    drop(conn);
+
+    assert_eq!(genre_row_names(&pool).await.len(), names.len());
+}
+
+#[tokio::test]
+async fn upsert_metadata_overrides_materializes_each_tag_and_genre_once_when_names_repeat() {
+    let _covers = CoversTempDir::new("batched_vocab");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user_id = crate::auth::create_user(&pool, "admin", "securepassword1")
+        .await
+        .unwrap()
+        .id;
+    let (uuid, _) = seed_one_book_with_tags(&pool, &[]).await;
+
+    // Repeats, casing variants, padding and blanks in one save — the batch
+    // must collapse them exactly as the old per-name statements did.
+    let ov = MetadataOverrides {
+        subjects: Some(vec![
+            "Space Opera".into(),
+            " Space Opera ".into(),
+            "space opera".into(),
+            "  ".into(),
+            "Hard SF".into(),
+        ]),
+        genres: Some(vec![
+            "Horror".into(),
+            "horror".into(),
+            "Noir".into(),
+            "".into(),
+        ]),
+        ..Default::default()
+    };
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+
+    assert_eq!(tag_row_count(&pool, "Space Opera").await, 1);
+    assert_eq!(tag_row_count(&pool, "Hard SF").await, 1);
+    let tag_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tags")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        tag_count, 2,
+        "blank and duplicate subjects never materialize"
+    );
+    assert_eq!(genre_row_names(&pool).await, vec!["Horror", "Noir"]);
+
+    // Re-saving the same lists changes nothing.
+    upsert_metadata_overrides(&pool, &uuid, &ov, false, user_id)
+        .await
+        .unwrap();
+    assert_eq!(tag_row_count(&pool, "Space Opera").await, 1);
+    assert_eq!(genre_row_names(&pool).await, vec!["Horror", "Noir"]);
+}

--- a/db/src/series_normalize.rs
+++ b/db/src/series_normalize.rs
@@ -93,6 +93,9 @@ async fn merge_series_row(
     // is never touched. Scoped to `source_book_ids` (not "every book on
     // `target_id`") so a canonical row with pre-existing, unrelated books
     // that happen to have no index of their own is never stamped.
+    //
+    // Left per-book rather than batched into an `id IN (...)`: boot-only and
+    // idempotent (one `backfill_embedded_series_index` pass at `init_db`).
     if let Some(idx_val) = parse_series_index(embedded_idx) {
         for book_id in source_book_ids {
             sqlx::query("UPDATE books SET series_index = ? WHERE id = ? AND series_index IS NULL")


### PR DESCRIPTION
## Summary
- Batch the per-item `INSERT OR IGNORE` loops in `db/src/metadata_overrides/links.rs`: `materialize_tag_rows` and `materialize_genre_rows` now delegate to one shared `insert_vocabulary_rows` helper that builds a single multi-row insert with `sqlx::QueryBuilder::push_values` instead of one statement per tag/genre. This is the live book-edit path (every override save), not a boot-only backfill.
- **Chunked at 500 names per statement** (`INSERT_CHUNK`). Subjects/genres lists are user-supplied, and SQLite's default bound-parameter cap is 999 (32766 only on newer builds), so an unbounded `push_values` could overflow it. 500 mirrors the existing precedent in `resolve_entity_aliases` (`db/src/entity_alias.rs`), which chunks its `IN (...)` lookups at the same size for the same reason.
- Behavior is unchanged: same `INSERT OR IGNORE` semantics, same trimming and empty-name filtering, same `&mut *conn` usage inside the caller's transaction. Names are additionally deduplicated case-insensitively before binding, matching the `UNIQUE COLLATE NOCASE` column the insert lands on — a repeated name in one list stays one row (as it did when each was its own statement) and can't make a single batch conflict with itself.
- `merge_series_row` in `db/src/series_normalize.rs`: **took the leave-as-is option** — its per-book `UPDATE` loop now carries a one-line comment noting it is boot-only (one `backfill_embedded_series_index` pass at `init_db`) and idempotent, per the acceptance criteria's escape hatch.
- Adds three tests in `db/src/metadata_overrides/tests.rs` asserting observable outcomes rather than SQL text: an end-to-end multi-tag/multi-genre save with repeats, casing variants, padding and blanks materializes each name exactly once and is idempotent on re-save; and a 1,500-name list (past the 999 bind cap) succeeds for both tags and genres rather than erroring.

Closes #2008

## Test plan
- [x] `cargo fmt --check` — PASS (clean)
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — 2201 passed, 1 failed. The single failure is the pre-existing, environment-only `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, which panics with `run just fixtures` because the public-domain fixture set isn't downloaded in this sandbox. Unrelated to this diff (no audiobook code touched).
- [x] `cargo test -p omnibus-db metadata_overrides::tests` — PASS (66 passed, 0 failed), including the three new tests and the existing `materializes_tag_links_for_new_tags` / `materializes_a_genres_row_per_entry` coverage.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.

## Notes
- The table name is the only non-bound part of the generated statement; it is a caller-supplied literal (`"tags"` / `"genres"`), never user input. Every name is a bind.
- Deduplication uses ASCII case folding (`to_ascii_lowercase`), matching SQLite's builtin `NOCASE` collation — the same fold `resolve_entity_aliases` relies on with `eq_ignore_ascii_case`.
- No migration, no schema change, no API surface change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDwS33VhPGY3wkoRvdXN1p)_