### PR TITLE
docs: point indexer citations at the split module directory (#1961)

### DIFF
--- a/.claude/rules/05-rust-style.md
+++ b/.claude/rules/05-rust-style.md
@@ -56,7 +56,7 @@ covered by [04-playwright.md](04-playwright.md).
   (`anyhow::bail!("scan of {path} failed: {msg}")`). The right fit when
   the source is a foreign system (filesystem, parser, network) and the
   caller just propagates. Example: `reindex` in
-  [db/src/indexer.rs](../../db/src/indexer.rs).
+  [db/src/indexer/ebooks.rs](../../db/src/indexer/ebooks.rs).
 - **Coarse variants.** Group by failure mode and let the
   `#[error("...")]` message carry the detail. One
   `PasswordInvalid(String)` beats `PasswordTooShort` /

--- a/.claude/rules/98-keep-skills-fresh.md
+++ b/.claude/rules/98-keep-skills-fresh.md
@@ -6,7 +6,7 @@ When touching any of the following areas, re-read the matching skill and update 
 
 | Code area | Skill to re-check |
 |---|---|
-| `server/src/backend.rs`, `server/src/backend/conditional.rs`, `server/src/main.rs`, `frontend/src/rpc/`, `frontend/src/data.rs`, `db/src/books/`, `db/src/settings/`, `db/src/scanner.rs`, `db/src/ebook.rs`, `db/src/indexer.rs`, `db/src/library_layout.rs`, `db/src/worker.rs`, `db/migrations/`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
+| `server/src/backend.rs`, `server/src/backend/conditional.rs`, `server/src/main.rs`, `frontend/src/rpc/`, `frontend/src/data.rs`, `db/src/books/`, `db/src/settings/`, `db/src/scanner.rs`, `db/src/ebook.rs`, `db/src/indexer/`, `db/src/library_layout.rs`, `db/src/worker.rs`, `db/migrations/`, `shared/src/lib.rs` | [add-backend-route](../skills/add-backend-route/SKILL.md) |
 | `ui_tests/playwright/tests/fixtures/`, `ui_tests/playwright/tests/utils/`, selector conventions | [add-playwright-flow](../skills/add-playwright-flow/SKILL.md) |
 | `server/src/backend.rs` (`_health`), `server/src/auth/{boot.rs,gate.rs,handlers.rs}`, `scripts/dev-server-up.sh`, `justfile` (`dev-up`), `.env.example`, `ui_tests/playwright/playwright.config.ts` (baseURL) | [ui-validate](../skills/ui-validate/SKILL.md) |
 
@@ -14,4 +14,4 @@ If a skill no longer has a corresponding code area (the pattern was removed), de
 
 A skill is "stale" if: the file paths it references no longer exist, the function/module names it names have been renamed, or the steps it prescribes would no longer produce a working result, or if the underlying assumptions it relies on have changed.
 
-The same applies to **file:line citations** in the rules, skills, and [docs/style-guide.md](../../docs/style-guide.md): a bare `path/to/file.rs:NN` anchor rots the moment the cited file is edited or split. Prefer function-name anchors (e.g. "`reindex` in `db/src/indexer.rs`"); when you touch a file that other docs cite by line, refresh those citations in the same change.
+The same applies to **file:line citations** in the rules, skills, and [docs/style-guide.md](../../docs/style-guide.md): a bare `path/to/file.rs:NN` anchor rots the moment the cited file is edited or split. Prefer function-name anchors (e.g. "`reindex` in `db/src/indexer/ebooks.rs`"); when you touch a file that other docs cite by line, refresh those citations in the same change.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -183,7 +183,7 @@ differently. `AuthError` was once over-granular but has since been
 coarsened to the shape below — see "Coarse variants".
 
 **Pattern (unpredictable).** `reindex` in
-[db/src/indexer.rs](../db/src/indexer.rs):
+[db/src/indexer/ebooks.rs](../db/src/indexer/ebooks.rs):
 
 ```rust
 pub async fn reindex(pool: &SqlitePool, library_path: &str) -> anyhow::Result<ReindexStats> {


### PR DESCRIPTION
## Summary
- Closes #1961
- `db/src/indexer.rs` was split into `db/src/indexer/{mod,ebooks,audiobooks,backfill,progress,tests}.rs`, leaving stale citations behind — three dead markdown links and one skill-freshness trigger-table row.
- `.claude/rules/05-rust-style.md` § Errors — the `anyhow` worked example cites `reindex`, so its link now points at `db/src/indexer/ebooks.rs`, where `reindex` actually lives (`db/src/indexer/ebooks.rs:28`).
- `.claude/rules/98-keep-skills-fresh.md` § trigger table — the `add-backend-route` row now reads `db/src/indexer/` (directory reference, matching how the table already lists `db/src/settings/` and `db/src/books/`).
- `.claude/rules/98-keep-skills-fresh.md` § "file:line citations" — the worked example for "prefer function-name anchors" now reads ``"`reindex` in `db/src/indexer/ebooks.rs`"``. This was the one that stung most: a dead link inside the rule whose whole purpose is catching citation rot.
- `docs/style-guide.md` § Errors — a **fourth** instance the issue didn't list, same `reindex` example in long form, fixed the same way.

## Test plan
- [x] `grep -rn "db/src/indexer\.rs" .claude/ docs/ CLAUDE.md AGENTS.md README.md` — returns nothing (exit 1). This is the issue's final acceptance criterion.
- [x] `grep -rn "pub async fn reindex" db/src/indexer/` → `db/src/indexer/ebooks.rs:28`, confirming the new link target is where `reindex` really is rather than assuming `mod.rs`.
- [x] `ls db/src/indexer/ebooks.rs` — every rewritten link resolves; relative depth checked for both `.claude/rules/` (`../../`) and `docs/` (`../`).
- [x] `git diff --stat` — 3 files, 4 insertions, 4 deletions; docs-only, no code touched.
- [x] Both rule files remain under the ~200-line cap (133 and 17 lines).

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The issue described the rule-05 instance as living in the "Function shape" section's "Resolved anti-pattern" example. It doesn't — it's in the **Errors** section as the `anyhow` example. The fix targets `ebooks.rs` (where `reindex` is) rather than the `mod.rs` the issue suggested, since every one of these four citations is anchored on that function.
- Scope held to `db/src/indexer.rs` citations only; no other stale path in these files was touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDwS33VhPGY3wkoRvdXN1p)_