### PR TITLE
refactor: trim reindex-guard module doc, remove panicking index (#1986)

### DIFF
--- a/db/src/entity_alias.rs
+++ b/db/src/entity_alias.rs
@@ -1,10 +1,8 @@
-//! Reindex-resurrection guard (#964): shared read-side of the
-//! `entity_aliases` ledger that `cleanup::entity_ops::write_entity_alias`
-//! writes when a library-cleanup merge absorbs an author, series, or tag.
-//! Consulted by every taxonomy resolver *before* it mints a new row, so a
-//! later reindex re-parsing a file that still names the merged-away entity
-//! resolves back to the surviving canonical id instead of recreating the
-//! row the merge just removed.
+//! Shared read-side of the `entity_aliases` ledger that
+//! `cleanup::entity_ops::write_entity_alias` writes when a library-cleanup
+//! merge absorbs an author, series, or tag. Consulted by every taxonomy
+//! resolver before it mints a new row, so a later reindex resolves a
+//! merged-away entity back to its surviving canonical id.
 
 use std::collections::HashMap;
 

--- a/db/src/sync/authors.rs
+++ b/db/src/sync/authors.rs
@@ -188,14 +188,22 @@ async fn insert_direct_author_links(
     entries: &[(&str, i64)],
     aliased: &HashMap<String, i64>,
 ) -> Result<(), sqlx::Error> {
-    let rows = std::iter::repeat_n("(?, ?, ?)", entries.len())
+    // `.get()`, not indexing, so a name the caller's filter missed is dropped rather than panicking.
+    let resolved: Vec<(i64, i64)> = entries
+        .iter()
+        .filter_map(|(name, pos)| aliased.get(*name).map(|&author_id| (author_id, *pos)))
+        .collect();
+    if resolved.is_empty() {
+        return Ok(());
+    }
+    let rows = std::iter::repeat_n("(?, ?, ?)", resolved.len())
         .collect::<Vec<_>>()
         .join(", ");
     let sql =
         format!("INSERT OR IGNORE INTO books_authors_link (book, author, position) VALUES {rows}");
     let mut q = sqlx::query(&sql);
-    for (name, pos) in entries {
-        q = q.bind(book_id).bind(aliased[*name]).bind(*pos);
+    for (author_id, pos) in resolved {
+        q = q.bind(book_id).bind(author_id).bind(pos);
     }
     q.execute(&mut **tx).await?;
     Ok(())

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -4,7 +4,7 @@
 //! the rewrite-in-place and cross-format attach paths, and the
 //! post-commit cover materialization + missing-files marker helper.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use omnibus_shared::{CleanupKind, EbookMetadata};
 use sqlx::Transaction;
@@ -493,7 +493,7 @@ async fn insert_tag_links(
 async fn link_aliased_tags(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
-    aliased: &std::collections::HashMap<String, i64>,
+    aliased: &HashMap<String, i64>,
 ) -> Result<(), sqlx::Error> {
     if aliased.is_empty() {
         return Ok(());


### PR DESCRIPTION
## Summary
- Closes #1986
- Trims `db/src/entity_alias.rs`'s module doc to the 5-line cap (`.claude/rules/05-rust-style.md` § Comments & docs) and removes the `(#964)` issue-number reference.
- Replaces the panicking `aliased[*name]` `HashMap` index in `insert_direct_author_links` (`db/src/sync/authors.rs`) with a `filter_map` over `.get()`: ids are resolved up front, the `VALUES` placeholder count is built from the resolved rows (not the raw entry count), and an unresolved name is dropped rather than causing either a panic or a bind/placeholder mismatch. The pre-filter on `aliased.contains_key` in the caller is now a performance shortcut rather than a soundness requirement.
- Swaps the inline `std::collections::HashMap` path in `db/src/sync/books/shared.rs::link_aliased_tags` for the existing top-level `use` block (now `use std::collections::{HashMap, HashSet};`), matching the sibling `db/src/sync/authors.rs` convention.
- Distinct from #1985's N+1 finding (already has its own PR, #2003) — nothing in that path was touched.

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean, no warnings
- [x] `cargo test -p omnibus-db` — 2201 passed; 1 failed (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`), which is a pre-existing environment gap unrelated to this change — it panics on a missing binary audio fixture (`just fixtures` not runnable in this sandbox, no `nix`/`just` available). None of the three files touched by this PR are exercised by that test.

## Version
Unlabeled — defaults to a patch release (no functional/behavioral change, style-only refactor).

## Notes
- Line numbers in the original issue were approximate; re-located all three items by content against current `main` (post #2016/#2002/#2014/#2000, pre-#2003 — #1985's N+1 fix had not yet merged into `db/src/sync/authors.rs` at the time of this branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeeNrowRhEQ8xN4gfMvD1y)_