### PR TITLE
refactor: consolidate props on 7 over-threshold Dioxus components (#2010)

### DIFF
--- a/frontend/src/components/confirm_modal.rs
+++ b/frontend/src/components/confirm_modal.rs
@@ -45,6 +45,9 @@ fn dismiss_unless_busy(busy: bool, on_dismiss: EventHandler<()>) {
 /// plus a leading grabber bar) — forcing one shape would change either
 /// caller's rendered markup, which is the one thing this refactor must not
 /// do.
+///
+/// 8 heterogeneous props left ungrouped: 16 call sites make a chrome struct
+/// not worth the churn.
 #[component]
 pub fn ConfirmModal(
     testid: String,

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -118,7 +118,6 @@ pub(super) fn BdHeroSection(
                     b: b.clone(),
                     title: title.clone(),
                     kicker: kicker.clone(),
-                    uuid: uuid.clone(),
                     avail,
                     sync_panel,
                 }
@@ -155,7 +154,6 @@ fn BdTitleCol(
     b: EbookMetadata,
     title: String,
     kicker: String,
-    uuid: String,
     avail: Availability,
     sync_panel: Element,
 ) -> Element {
@@ -164,6 +162,9 @@ fn BdTitleCol(
         has_audio,
         has_comic,
     } = avail;
+    // Re-derived from `b` rather than threaded as a prop — identical to how
+    // the caller (`BdHeroSection`) computes it, so no behavior changes.
+    let uuid = b.unique_identifier.clone().unwrap_or_default();
 
     // Local copy of the effective summary so a fetch-and-save can refresh the
     // shown description in place. Seeded identically on SSR and first WASM

--- a/frontend/src/pages/book_detail/journal/entry_card.rs
+++ b/frontend/src/pages/book_detail/journal/entry_card.rs
@@ -29,6 +29,16 @@ struct JournalEntryEditState {
     delete_confirm: Signal<bool>,
 }
 
+/// The identifying + editable fields of one entry — grouped so
+/// [`BdJournalEntryActions`] stays under the 5-prop threshold.
+#[derive(Clone, PartialEq)]
+struct JournalEntryContent {
+    server_url: String,
+    entry_id: i64,
+    body_for_edit: String,
+    entry_progress: Option<u8>,
+}
+
 /// Presentational fields for a journal entry card header (author identity,
 /// meta line, and the data an owner's Edit action needs to seed the form).
 #[derive(Clone, PartialEq)]
@@ -121,10 +131,12 @@ fn BdJournalEntryHeader(view: JournalEntryHeaderView, edit: JournalEntryEditStat
             BdJournalEntryByline { author_name, is_owner, is_draft, meta_line }
             if is_owner && !editing() {
                 BdJournalEntryActions {
-                    server_url,
-                    entry_id,
-                    body_for_edit,
-                    entry_progress,
+                    content: JournalEntryContent {
+                        server_url,
+                        entry_id,
+                        body_for_edit,
+                        entry_progress,
+                    },
                     is_draft,
                     edit,
                 }
@@ -168,13 +180,16 @@ fn BdJournalEntryByline(
 /// RPC only fires from the modal's own confirm button.
 #[component]
 fn BdJournalEntryActions(
-    server_url: String,
-    entry_id: i64,
-    body_for_edit: String,
-    entry_progress: Option<u8>,
+    content: JournalEntryContent,
     is_draft: bool,
     edit: JournalEntryEditState,
 ) -> Element {
+    let JournalEntryContent {
+        server_url,
+        entry_id,
+        body_for_edit,
+        entry_progress,
+    } = content;
     let JournalEntryEditState {
         mut editing,
         mut edit_body,
@@ -591,10 +606,12 @@ mod render_tests {
     fn ActionsHarness(delete_confirm: bool) -> Element {
         rsx! {
             BdJournalEntryActions {
-                server_url: "http://localhost".to_string(),
-                entry_id: 1,
-                body_for_edit: "body".to_string(),
-                entry_progress: None,
+                content: JournalEntryContent {
+                    server_url: "http://localhost".to_string(),
+                    entry_id: 1,
+                    body_for_edit: "body".to_string(),
+                    entry_progress: None,
+                },
                 is_draft: false,
                 edit: actions_state(delete_confirm),
             }

--- a/frontend/src/pages/book_detail/offline.rs
+++ b/frontend/src/pages/book_detail/offline.rs
@@ -8,6 +8,18 @@ use dioxus::prelude::*;
 use crate::offline::downloads::{self, DlFormat, DownloadStatus};
 use crate::use_server_url;
 
+/// One offline-download row's identity + current state — grouped to keep
+/// [`DlRow`] under the 5-prop threshold.
+#[derive(Clone, PartialEq)]
+struct DlRowData {
+    uuid: String,
+    title: String,
+    format_label: &'static str,
+    format: DlFormat,
+    status: DownloadStatus,
+    stale: bool,
+}
+
 /// The "Available offline" section. Rendered only on books with at least
 /// one downloadable format and only for users whose `can_download` bit is
 /// set (the default).
@@ -45,10 +57,11 @@ pub(super) fn BdOfflineSection(
         return rsx! {};
     }
     // Read the generation so registry bumps re-render this section. The
-    // per-row `status` is computed HERE and passed down as a prop: `DlRow`'s
-    // other props never change, so without a changing prop Dioxus would
-    // memoize the row and skip re-rendering it — the Download/Remove tap
-    // would appear to do nothing until the page remounted.
+    // per-row `status` is computed HERE and passed down inside `DlRowData`:
+    // `DlRow`'s other fields never change, so without a changing field
+    // Dioxus would memoize the row and skip re-rendering it — the
+    // Download/Remove tap would appear to do nothing until the page
+    // remounted.
     let _generation = generation();
 
     rsx! {
@@ -57,22 +70,26 @@ pub(super) fn BdOfflineSection(
             div { class: "m-dl-rows",
                 if has_ebook {
                     DlRow {
-                        uuid: uuid.clone(),
-                        title: title.clone(),
-                        format_label: "Ebook",
-                        format: DlFormat::Epub,
-                        status: downloads::status(&uuid, DlFormat::Epub),
-                        stale: downloads::is_marked_stale(&uuid, DlFormat::Epub),
+                        data: DlRowData {
+                            uuid: uuid.clone(),
+                            title: title.clone(),
+                            format_label: "Ebook",
+                            format: DlFormat::Epub,
+                            status: downloads::status(&uuid, DlFormat::Epub),
+                            stale: downloads::is_marked_stale(&uuid, DlFormat::Epub),
+                        },
                     }
                 }
                 if has_audio {
                     DlRow {
-                        uuid: uuid.clone(),
-                        title,
-                        format_label: "Audiobook",
-                        format: DlFormat::Audio,
-                        status: downloads::status(&uuid, DlFormat::Audio),
-                        stale: downloads::is_marked_stale(&uuid, DlFormat::Audio),
+                        data: DlRowData {
+                            uuid: uuid.clone(),
+                            title,
+                            format_label: "Audiobook",
+                            format: DlFormat::Audio,
+                            status: downloads::status(&uuid, DlFormat::Audio),
+                            stale: downloads::is_marked_stale(&uuid, DlFormat::Audio),
+                        },
                     }
                 }
             }
@@ -81,18 +98,19 @@ pub(super) fn BdOfflineSection(
 }
 
 /// One per-format row: status line on the left, the state's action on the
-/// right. `status` and `stale` arrive as props (not read from the registry
-/// here) so the row re-renders on every registry transition — see the
-/// memoization note in [`BdOfflineSection`].
+/// right. `status` and `stale` arrive inside `data` (not read from the
+/// registry here) so the row re-renders on every registry transition — see
+/// the memoization note in [`BdOfflineSection`].
 #[component]
-fn DlRow(
-    uuid: String,
-    title: String,
-    format_label: &'static str,
-    format: DlFormat,
-    status: DownloadStatus,
-    stale: bool,
-) -> Element {
+fn DlRow(data: DlRowData) -> Element {
+    let DlRowData {
+        uuid,
+        title,
+        format_label,
+        format,
+        status,
+        stale,
+    } = data;
     let server_url = use_server_url();
 
     let start = {

--- a/frontend/src/pages/settings/users/mod.rs
+++ b/frontend/src/pages/settings/users/mod.rs
@@ -25,6 +25,17 @@ enum Modal {
     Sessions(AdminUserRow),
 }
 
+/// One user-row action, unified so `UserRow`/`UsersTable` carry a single
+/// `on_action` handler instead of five separate `EventHandler`s each.
+#[derive(Clone, PartialEq)]
+enum UserRowAction {
+    Edit(AdminUserRow),
+    Delete(AdminUserRow),
+    Sessions(AdminUserRow),
+    Unlocked,
+    Error(String),
+}
+
 /// The Users section: header + table, with a reload counter the mutations bump.
 #[component]
 pub fn UsersSection() -> Element {
@@ -58,11 +69,16 @@ pub fn UsersSection() -> Element {
             UsersTable {
                 users: users(),
                 current_id,
-                on_edit: move |row| modal.set(Modal::Edit(row)),
-                on_delete: move |row| modal.set(Modal::Delete(row)),
-                on_sessions: move |row| modal.set(Modal::Sessions(row)),
-                on_unlocked: move |_| { action_error.set(None); reload.with_mut(|n| *n += 1); },
-                on_row_error: move |msg| action_error.set(Some(msg)),
+                on_action: move |action| match action {
+                    UserRowAction::Edit(row) => modal.set(Modal::Edit(row)),
+                    UserRowAction::Delete(row) => modal.set(Modal::Delete(row)),
+                    UserRowAction::Sessions(row) => modal.set(Modal::Sessions(row)),
+                    UserRowAction::Unlocked => {
+                        action_error.set(None);
+                        reload.with_mut(|n| *n += 1);
+                    }
+                    UserRowAction::Error(msg) => action_error.set(Some(msg)),
+                },
             }
         }
 
@@ -116,11 +132,7 @@ fn UsersHeader(on_new: EventHandler<MouseEvent>) -> Element {
 fn UsersTable(
     users: Vec<AdminUserRow>,
     current_id: Option<i64>,
-    on_edit: EventHandler<AdminUserRow>,
-    on_delete: EventHandler<AdminUserRow>,
-    on_sessions: EventHandler<AdminUserRow>,
-    on_unlocked: EventHandler<()>,
-    on_row_error: EventHandler<String>,
+    on_action: EventHandler<UserRowAction>,
 ) -> Element {
     rsx! {
         table { class: "users-table", "data-testid": "users-table",
@@ -143,11 +155,7 @@ fn UsersTable(
                                 key: "{id}",
                                 user: u,
                                 is_self: Some(id) == current_id,
-                                on_edit,
-                                on_delete,
-                                on_sessions,
-                                on_unlocked,
-                                on_error: on_row_error,
+                                on_action,
                             }
                         }
                     }
@@ -211,15 +219,7 @@ fn users_modals(
 /// One table row: identity, permission chips, Kindle, created date, lock
 /// status (with inline Unlock), and Edit / Delete / Sessions actions.
 #[component]
-fn UserRow(
-    user: AdminUserRow,
-    is_self: bool,
-    on_edit: EventHandler<AdminUserRow>,
-    on_delete: EventHandler<AdminUserRow>,
-    on_sessions: EventHandler<AdminUserRow>,
-    on_unlocked: EventHandler<()>,
-    on_error: EventHandler<String>,
-) -> Element {
+fn UserRow(user: AdminUserRow, is_self: bool, on_action: EventHandler<UserRowAction>) -> Element {
     let mut unlocking = use_signal(|| false);
     let uid = user.id;
     let kindle = user
@@ -237,8 +237,8 @@ fn UserRow(
             // banner instead of being swallowed (an admin must be able to tell
             // a still-locked account from a successful unlock).
             match data::unlock_user(uid).await {
-                Ok(()) => on_unlocked.call(()),
-                Err(e) => on_error.call(e),
+                Ok(()) => on_action.call(UserRowAction::Unlocked),
+                Err(e) => on_action.call(UserRowAction::Error(e)),
             }
             unlocking.set(false);
         });
@@ -277,21 +277,21 @@ fn UserRow(
                     r#type: "button",
                     class: "btn ghost sm",
                     "data-testid": "user-edit-{uid}",
-                    onclick: move |_| on_edit.call(edit_row.clone()),
+                    onclick: move |_| on_action.call(UserRowAction::Edit(edit_row.clone())),
                     "Edit"
                 }
                 button {
                     r#type: "button",
                     class: "btn ghost sm",
                     "data-testid": "user-sessions-{uid}",
-                    onclick: move |_| on_sessions.call(sessions_row.clone()),
+                    onclick: move |_| on_action.call(UserRowAction::Sessions(sessions_row.clone())),
                     "Sessions"
                 }
                 button {
                     r#type: "button",
                     class: "btn ghost sm users-danger",
                     "data-testid": "user-delete-{uid}",
-                    onclick: move |_| on_delete.call(delete_row.clone()),
+                    onclick: move |_| on_action.call(UserRowAction::Delete(delete_row.clone())),
                     "Delete"
                 }
             }


### PR DESCRIPTION
## Summary
- Closes #2010. Re-audited all 7 flagged components against current `main` (line numbers in the issue had drifted) and consolidated the six still over the 5-prop threshold; the seventh was already fixed.
- `UsersTable`/`UserRow` (`frontend/src/pages/settings/users/mod.rs`) now share one `on_action: EventHandler<UserRowAction>` in place of five separate handlers each, exactly the enum shape the issue suggested.
- `BdTitleCol` (`frontend/src/pages/book_detail/hero.rs`) drops the redundant `uuid` prop — it's re-derived from `b.unique_identifier` inside the component, identically to how the caller already computed it.
- `DlRow` (`frontend/src/pages/book_detail/offline.rs`) groups its six data props into one `DlRowData` struct.
- `BdJournalEntryActions` (`frontend/src/pages/book_detail/journal/entry_card.rs`) groups its four content fields into one `JournalEntryContent` struct.
- `ConfirmModal` (`frontend/src/components/confirm_modal.rs`) is left un-grouped with a one-line rationale comment: its 8 props are heterogeneous (styling strings, a busy flag, one handler, two content slots) rather than a cohesive `EventHandler` cluster, and it has 16 call sites, so folding them into a chrome struct would touch every caller for no readability gain.
- `SendToKoboButton` (`frontend/src/components/format_switcher/kobo.rs`) was already at 5 props on `main` — no change needed.
- No rendered-markup or behavior change anywhere: every `data-testid`, role, and visible label is untouched, and every consolidation either re-derives an already-identical value or repackages existing fields into a struct/enum the callers still populate the same way.

## Test plan
- [x] `cargo fmt -p omnibus-frontend` — PASS (no diff)
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS (0 warnings)
- [x] `cargo test -p omnibus-frontend --features server` — PASS (837 passed; 0 failed), including the `entry_card::render_tests` SSR-smoke coverage for `BdJournalEntryActions`'s delete-confirm flow, which was updated to call the new `content: JournalEntryContent { .. }` shape.
- [x] Read `ui_tests/playwright/tests/flows/users.spec.ts` and the book-detail flow specs for selectors touching the changed markup — all reference `data-testid`s (`users-table`, `user-edit-{uid}`, `user-delete-{uid}`, `user-sessions-{uid}`, `user-unlock-{uid}`, `journal-edit`, `journal-delete`, `journal-delete-modal`, `offline-row-*`, etc.) that render byte-identical in this PR; none were touched.
- Playwright itself was not run in this environment (no nix/pnpm available here).

## Version
Left unlabeled (defaults to **Patch**) — no release-cutting label applied.

## Notes
- Consolidated: `UsersTable`/`UserRow` (enum), `BdTitleCol` (dropped redundant prop), `DlRow` (struct), `BdJournalEntryActions` (struct).
- Left as-is with rationale: `ConfirmModal`.
- Already fixed on `main` before this PR: `SendToKoboButton` (5 props).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeeNrowRhEQ8xN4gfMvD1y)_