### PR TITLE
fix: batch cross-format audio_marks queries, dedupe alignment_view calls (#2019)

### DIFF
--- a/db/src/cross_format/alignment.rs
+++ b/db/src/cross_format/alignment.rs
@@ -106,8 +106,11 @@ async fn anchor_preview(
     let Some(timeline) = audio_timeline(pool, book_id, &preview).await? else {
         return Ok(AnchorPreview::default());
     };
+    // Computed once and threaded into `anchor_map_from_marks` below, rather
+    // than letting `anchor_map` recompute the same batched fetch.
+    let audio = anchors::audio_marks(pool, &timeline).await?;
     let mut out = AnchorPreview {
-        audio_chapter_marks: anchors::usable_audio_marks(pool, &timeline).await?,
+        audio_chapter_marks: anchors::usable_audio_mark_count(&audio),
         ..AnchorPreview::default()
     };
     let Some((ebook_file_id, _)) = crate::book_file_with_id(pool, book_id, "EPUB").await? else {
@@ -115,7 +118,8 @@ async fn anchor_preview(
     };
     // User anchors fold in exactly as the jump path does, so the preview's
     // threads and interpolation are the pairs the mapping will really use.
-    let chapter_map = anchors::anchor_map(pool, ebook_file_id, &timeline).await?;
+    let chapter_map =
+        anchors::anchor_map_from_marks(pool, ebook_file_id, &timeline, &audio).await?;
     let user = preview_user_anchors(raw_link, &timeline);
     let stats = chapter_map.as_ref().map(|m| (m.matched, m.ebook_chapters));
     if let Some(merged) = anchors::merge_user_anchors(&user, chapter_map) {

--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -6,7 +6,7 @@
 
 use sqlx::SqlitePool;
 
-use super::{AudioTimeline, CrossFormatError};
+use super::{AudioTimeline, CrossFormatError, TimelineFile};
 
 /// One matched anchor: the same narrative point as a fraction through the
 /// ebook text and through the audio timeline. `(0,0)` and `(1,1)` endpoints
@@ -60,7 +60,7 @@ fn strip_track_prefix(raw: &str) -> &str {
 /// An audio-side anchor candidate: a title-ish label plus its start as a
 /// fraction of the timeline.
 #[derive(Debug, Clone)]
-struct AudioMark {
+pub(super) struct AudioMark {
     key: Option<String>,
     chapter_no: Option<u32>,
     synthetic: bool,
@@ -175,11 +175,26 @@ fn word_number(word: &str) -> Option<u32> {
 
 /// Build the anchor map for a linked book, or `None` when no trustworthy
 /// anchoring exists. `ebook_file_id` is the served EPUB's `book_files` row
-/// (spine stats + chapters live under it).
+/// (spine stats + chapters live under it). Computes the audio marks itself —
+/// callers that already hold them (because they also need
+/// [`usable_audio_mark_count`]) should call [`anchor_map_from_marks`]
+/// instead, to avoid a redundant `audio_marks` fetch.
 pub(super) async fn anchor_map(
     pool: &SqlitePool,
     ebook_file_id: i64,
     timeline: &AudioTimeline,
+) -> Result<Option<AnchorMap>, CrossFormatError> {
+    let audio = audio_marks(pool, timeline).await?;
+    anchor_map_from_marks(pool, ebook_file_id, timeline, &audio).await
+}
+
+/// Same as [`anchor_map`], but takes pre-computed audio marks rather than
+/// fetching them again.
+pub(super) async fn anchor_map_from_marks(
+    pool: &SqlitePool,
+    ebook_file_id: i64,
+    timeline: &AudioTimeline,
+    audio: &[AudioMark],
 ) -> Result<Option<AnchorMap>, CrossFormatError> {
     let stats = crate::epub_structure::get_spine_stats(pool, ebook_file_id).await?;
     let total_chars: i64 = stats
@@ -201,7 +216,6 @@ pub(super) async fn anchor_map(
         return Ok(None);
     }
 
-    let audio = audio_marks(pool, timeline).await?;
     if audio.is_empty() {
         return Ok(None);
     }
@@ -224,9 +238,9 @@ pub(super) async fn anchor_map(
     // clear none of them and fall through to an honest refusal.
     let mut chosen: Option<Vec<Anchor>> = None;
     for rung in [
-        match_by_title(&text, &audio),
-        match_by_chapter_number(&text, &audio),
-        match_by_title_prefix(&text, &audio),
+        match_by_title(&text, audio),
+        match_by_chapter_number(&text, audio),
+        match_by_title_prefix(&text, audio),
     ] {
         let m = monotonic(rung);
         if passes(&m) {
@@ -334,64 +348,101 @@ fn match_by_title_prefix(text: &[TextMark], audio: &[AudioMark]) -> Vec<Anchor> 
     anchors
 }
 
-/// How many usable (titled, non-synthetic) audio marks the timeline
-/// carries — lets the modal distinguish "no marks in the audio" from
-/// "marks exist but couldn't be aligned".
-pub(super) async fn usable_audio_marks(
-    pool: &SqlitePool,
-    timeline: &AudioTimeline,
-) -> Result<i64, CrossFormatError> {
-    Ok(audio_marks(pool, timeline)
-        .await?
+/// How many usable (titled, non-synthetic) audio marks a mark set carries —
+/// lets the modal distinguish "no marks in the audio" from "marks exist but
+/// couldn't be aligned". Pure and synchronous: callers that already hold the
+/// marks (they came from [`audio_marks`]) don't pay for another fetch.
+pub(super) fn usable_audio_mark_count(audio: &[AudioMark]) -> i64 {
+    audio
         .iter()
         .filter(|a| !a.synthetic && a.key.is_some())
-        .count() as i64)
+        .count() as i64
 }
 
-/// Audio anchor candidates across the timeline: real chapter marks carry
-/// their titles; a file whose chapters are all synthetic falls back to its
-/// parts' filename stems (the per-chapter MP3 folder shape), which carry
-/// the real chapter names when anything does.
-async fn audio_marks(
+/// Audio anchor candidates across the whole timeline, in one batched round
+/// trip per lookup kind: real chapter marks carry their titles; a file whose
+/// chapters are all synthetic falls back to its parts' filename stems (the
+/// per-chapter MP3 folder shape), which carry the real chapter names when
+/// anything does.
+pub(super) async fn audio_marks(
     pool: &SqlitePool,
     timeline: &AudioTimeline,
 ) -> Result<Vec<AudioMark>, CrossFormatError> {
+    let ids: Vec<i64> = timeline.files.iter().map(|f| f.book_file_id).collect();
+    let chapters_by_file = crate::hls::get_chapters_bulk(pool, &ids).await?;
+
+    let fallback_ids: Vec<i64> = timeline
+        .files
+        .iter()
+        .filter(|f| synthetic_only(chapters_by_file.get(&f.book_file_id)))
+        .map(|f| f.book_file_id)
+        .collect();
+    let parts_by_file = crate::hls::get_parts_bulk(pool, &fallback_ids).await?;
+
     let mut marks = Vec::new();
     for file in &timeline.files {
-        let chapters = crate::hls::get_chapters(pool, file.book_file_id).await?;
-        let all_synthetic =
-            !chapters.is_empty() && chapters.iter().all(|c| is_synthetic_title(&c.title));
-        if all_synthetic {
-            let parts = crate::hls::get_parts(pool, file.book_file_id).await?;
-            let mut start = 0.0f64;
-            for part in &parts {
-                let stem = part
-                    .filename
-                    .rsplit('/')
-                    .next()
-                    .and_then(|name| name.rsplit_once('.').map(|(s, _)| s).or(Some(name)))
-                    .unwrap_or(&part.filename);
-                marks.push(AudioMark {
-                    key: title_key(stem),
-                    chapter_no: chapter_number(stem),
-                    synthetic: false,
-                    frac: ((file.start_seconds + start) / timeline.total_seconds).clamp(0.0, 1.0),
-                });
-                start += part.duration_seconds.max(0.0);
-            }
+        let chapters = chapters_by_file.get(&file.book_file_id);
+        if synthetic_only(chapters) {
+            let parts = parts_by_file
+                .get(&file.book_file_id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            marks.extend(part_marks(file, parts, timeline.total_seconds));
         } else {
-            for c in &chapters {
-                marks.push(AudioMark {
-                    key: title_key(&c.title),
-                    chapter_no: chapter_number(&c.title),
-                    synthetic: is_synthetic_title(&c.title),
-                    frac: ((file.start_seconds + c.start_seconds) / timeline.total_seconds)
-                        .clamp(0.0, 1.0),
-                });
-            }
+            let chapters = chapters.map(Vec::as_slice).unwrap_or(&[]);
+            marks.extend(chapter_marks(file, chapters, timeline.total_seconds));
         }
     }
     Ok(marks)
+}
+
+/// Whether a file's chapters are all synthetic ("Part 1", "Part 2", …) —
+/// the signal to fall back to filename-stem marks instead.
+fn synthetic_only(chapters: Option<&Vec<omnibus_shared::ChapterInfo>>) -> bool {
+    chapters.is_some_and(|c| !c.is_empty() && c.iter().all(|c| is_synthetic_title(&c.title)))
+}
+
+/// Marks built from a file's real chapter titles.
+fn chapter_marks(
+    file: &TimelineFile,
+    chapters: &[omnibus_shared::ChapterInfo],
+    total_seconds: f64,
+) -> Vec<AudioMark> {
+    chapters
+        .iter()
+        .map(|c| AudioMark {
+            key: title_key(&c.title),
+            chapter_no: chapter_number(&c.title),
+            synthetic: is_synthetic_title(&c.title),
+            frac: ((file.start_seconds + c.start_seconds) / total_seconds).clamp(0.0, 1.0),
+        })
+        .collect()
+}
+
+/// Marks built from a synthetic-only file's part filename stems.
+fn part_marks(
+    file: &TimelineFile,
+    parts: &[crate::hls::HlsPart],
+    total_seconds: f64,
+) -> Vec<AudioMark> {
+    let mut out = Vec::with_capacity(parts.len());
+    let mut start = 0.0f64;
+    for part in parts {
+        let stem = part
+            .filename
+            .rsplit('/')
+            .next()
+            .and_then(|name| name.rsplit_once('.').map(|(s, _)| s).or(Some(name)))
+            .unwrap_or(&part.filename);
+        out.push(AudioMark {
+            key: title_key(stem),
+            chapter_no: chapter_number(stem),
+            synthetic: false,
+            frac: ((file.start_seconds + start) / total_seconds).clamp(0.0, 1.0),
+        });
+        start += part.duration_seconds.max(0.0);
+    }
+    out
 }
 
 /// Ordered title matching: walk both mark lists front to back, pairing

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1794,6 +1794,67 @@ async fn alignment_view_serves_the_anchor_pairs_the_jump_uses() {
     );
 }
 
+// --- #2019: audio_marks batching + alignment_view's single audio_marks fetch ---
+
+/// Counts `tracing` events sqlx emits (target `"sqlx::query"`, one per
+/// executed statement) while installed as the default subscriber. Mirrors
+/// the `QueryCounter` pattern in `db/src/epub_rewrite/tests.rs`; every
+/// `Subscriber` method besides `event` is a no-op.
+struct QueryCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+impl tracing::Subscriber for QueryCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.target() == "sqlx::query"
+    }
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        if event.metadata().target() == "sqlx::query" {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// The query count `alignment_view` issues against a fresh in-memory pool
+/// seeded with `file_count` sequence-mode audio files (no per-file
+/// chapters — the old per-file `hls::get_chapters`/`get_parts` loop still
+/// issued one round trip per file even when every result came back empty).
+async fn alignment_view_query_count(file_count: usize) -> usize {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "reader").await;
+    let durations: Vec<f64> = vec![300.0; file_count];
+    let (_, uuid, _) = seed_dual_book(&pool, &durations).await;
+
+    let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let guard = tracing::subscriber::set_default(QueryCounter(count.clone()));
+    alignment_view(&pool, user, &uuid).await.unwrap();
+    drop(guard);
+    count.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[tokio::test]
+async fn alignment_view_issues_a_query_count_independent_of_audio_file_count() {
+    // `audio_marks` used to issue one (or two) `hls` queries per timeline
+    // file, and `alignment_view` computed it twice over (once via
+    // `usable_audio_marks`, once inside `anchor_map`) — a sequence-mode
+    // book laid out as one file per chapter meant dozens of round trips
+    // per modal open. Both are batched and deduped now, so the query count
+    // must not grow with the file count.
+    let few = alignment_view_query_count(2).await;
+    let many = alignment_view_query_count(40).await;
+    assert_eq!(
+        few, many,
+        "alignment_view's query count must not grow with the number of \
+         audio files in the timeline: {few} queries for 2 files vs {many} \
+         for 40"
+    );
+}
+
 #[test]
 fn interpolate_extends_the_measured_slope_past_two_or_more_anchors() {
     use super::anchors::{interpolate, Anchor};

--- a/db/src/hls/mod.rs
+++ b/db/src/hls/mod.rs
@@ -21,7 +21,8 @@ pub use fs::{
 };
 pub use manifest::{build_manifest, ffmpeg_progress_fraction, parse_ffmpeg_progress_us};
 pub use query::{
-    count_audio_files, get_chapters, get_parts, resolve_audiobook, resolve_audiobook_file,
+    count_audio_files, get_chapters, get_chapters_bulk, get_parts, get_parts_bulk,
+    resolve_audiobook, resolve_audiobook_file,
 };
 pub use transcode::{evict_if_over_cap, transcode_book, used_bytes};
 

--- a/db/src/hls/query.rs
+++ b/db/src/hls/query.rs
@@ -3,9 +3,15 @@
 //! the per-file `book_file_parts` + `file_chapters` lookups the manifest
 //! builder and status handler depend on.
 
+use std::collections::HashMap;
+
 use sqlx::SqlitePool;
 
 use super::{HlsError, HlsPart, ResolvedAudiobook};
+
+/// SQLite's default bound-parameter cap is 999; chunking well under it
+/// keeps a single `IN (...)` query safe regardless of build-time overrides.
+const BULK_CHUNK_SIZE: usize = 500;
 
 /// Resolve a book `uuid` to the ids and library path needed by the HLS
 /// handlers. When `file_id` is `Some`, resolve that specific `book_files`
@@ -128,4 +134,76 @@ pub async fn get_chapters(
             },
         )
         .collect())
+}
+
+/// Fetch ordered `book_file_parts` for every id in `book_file_ids` in one
+/// round trip (chunked under SQLite's bind cap), grouped by `book_file_id`.
+/// A file with no rows in the map has no parts.
+pub async fn get_parts_bulk(
+    pool: &SqlitePool,
+    book_file_ids: &[i64],
+) -> Result<HashMap<i64, Vec<HlsPart>>, HlsError> {
+    let mut map: HashMap<i64, Vec<HlsPart>> = HashMap::new();
+    for chunk in book_file_ids.chunks(BULK_CHUNK_SIZE) {
+        let placeholders = vec!["?"; chunk.len()].join(", ");
+        let sql = format!(
+            "SELECT book_file_id, ordinal, filename, duration_seconds \
+             FROM book_file_parts \
+             WHERE book_file_id IN ({placeholders}) \
+             ORDER BY book_file_id, ordinal"
+        );
+        let mut q = sqlx::query_as::<_, (i64, i64, String, f64)>(&sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        for (book_file_id, ordinal, filename, duration_seconds) in q.fetch_all(pool).await? {
+            map.entry(book_file_id).or_default().push(HlsPart {
+                ordinal,
+                filename,
+                duration_seconds,
+            });
+        }
+    }
+    Ok(map)
+}
+
+/// Fetch chapter markers for every id in `book_file_ids` in one round trip
+/// (chunked under SQLite's bind cap), grouped by `book_file_id`. Returns
+/// only rows actually found in `file_chapters` — an id with no chapters (or
+/// not present in `book_files` at all) is simply absent from the returned
+/// map. Unlike [`get_chapters`]'s single-id query, which always returns a
+/// `Vec` (possibly empty) for the one id it's given, a caller here must
+/// treat a missing key as "no chapters", not panic or assume the id was
+/// invalid.
+pub async fn get_chapters_bulk(
+    pool: &SqlitePool,
+    book_file_ids: &[i64],
+) -> Result<HashMap<i64, Vec<omnibus_shared::ChapterInfo>>, HlsError> {
+    let mut map: HashMap<i64, Vec<omnibus_shared::ChapterInfo>> = HashMap::new();
+    for chunk in book_file_ids.chunks(BULK_CHUNK_SIZE) {
+        let placeholders = vec!["?"; chunk.len()].join(", ");
+        let sql = format!(
+            "SELECT book_file_id, ordinal, title, start_seconds, duration_seconds \
+             FROM file_chapters \
+             WHERE book_file_id IN ({placeholders}) \
+             ORDER BY book_file_id, ordinal"
+        );
+        let mut q = sqlx::query_as::<_, (i64, i64, String, f64, f64)>(&sql);
+        for id in chunk {
+            q = q.bind(id);
+        }
+        for (book_file_id, ordinal, title, start_seconds, duration_seconds) in
+            q.fetch_all(pool).await?
+        {
+            map.entry(book_file_id)
+                .or_default()
+                .push(omnibus_shared::ChapterInfo {
+                    ordinal,
+                    title,
+                    start_seconds,
+                    duration_seconds,
+                });
+        }
+    }
+    Ok(map)
 }


### PR DESCRIPTION
## Summary
- Closes #2019
- `audio_marks` (Cross-Format Progress Sync) issued one `hls::get_chapters` query per audio file in a book's timeline, plus a conditional `hls::get_parts` query per file, inside a `for file in &timeline.files` loop — and `alignment_view` called into it twice per invocation (once via `usable_audio_marks`, once inside `anchor_map`). For a sequence-mode audiobook laid out as one file per chapter, a single `alignment_view` call issued 40-80 round trips instead of 2.
- Added `get_chapters_bulk`/`get_parts_bulk` to `db::hls`, mirroring `bulk_chapter_starts`'s chunked single-query-per-lookup shape (chunked under SQLite's bind cap), and rewrote `audio_marks` to consume them in one batched round trip per lookup kind instead of looping per file.
- Split `anchor_map` into a thin wrapper plus `anchor_map_from_marks`, which takes pre-computed audio marks. `alignment_view` now computes `audio_marks` once and threads the same `Vec` into both the usable-mark count (now a pure sync `usable_audio_mark_count` helper) and the anchor match, instead of `anchor_map` recomputing it.
- `resume_candidate`'s independent pass through `anchor_map` is left as-is per the issue's implementer notes — it's a separate request and is now itself O(1) queries thanks to the batched `audio_marks`.

## Test plan
- [x] `cargo fmt -p omnibus-db --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (2202 passed, 1 failed; the one failure, `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`, is a pre-existing, unrelated failure caused by a missing binary test fixture in this sandbox — `just fixtures` isn't runnable here — and does not touch any file changed in this PR)
- [x] Added `alignment_view_issues_a_query_count_independent_of_audio_file_count` to `db/src/cross_format/tests.rs`, using the `QueryCounter` `tracing::Subscriber` pattern from `db/src/epub_rewrite/tests.rs`, asserting `alignment_view`'s query count is identical for a 2-file and a 40-file timeline — PASS
- [x] All 46 tests in `db/src/cross_format/tests.rs` — PASS

## Version
- [x] **Patch** — the default; leaving unlabeled.

## Notes
- No schema change; no migration needed.
- Requesting the `tech-debt` label be applied (I don't have label-write access via this PR-creation path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeeNrowRhEQ8xN4gfMvD1y)_