### PR TITLE
fix: cover the 5 untested cross-format handler DB-failure paths (#2018)

### DIFF
--- a/server/src/backend/cross_format/tests.rs
+++ b/server/src/backend/cross_format/tests.rs
@@ -151,6 +151,101 @@ async fn api_cross_format_resume_500s_when_the_db_is_gone() {
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
+/// An authed user plus a seeded dual-format book, with the link table
+/// dropped so every cross-format query fails at the DB layer; returns
+/// `(app, token, book uuid)`.
+async fn fixture_with_no_link_table() -> (axum::Router, String, String) {
+    let (app, _state, pool) = fixture().await;
+    let user = auth_test_support::create_user(&pool, "alice").await;
+    let token = auth_test_support::bearer_token(&pool, user.id).await;
+    let (book_id, uuid) = seed_book_with_uuid(&pool, "/lib", "Dual").await;
+    attach_audio(&pool, book_id).await;
+    sqlx::query("DROP TABLE cross_format_links")
+        .execute(&pool)
+        .await
+        .unwrap();
+    (app, token, uuid)
+}
+
+#[tokio::test]
+async fn api_get_alignment_500s_when_the_db_is_gone() {
+    let (app, token, uuid) = fixture_with_no_link_table().await;
+    let res = app
+        .oneshot(get_with_bearer(
+            &format!("/api/books/{uuid}/alignment"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn api_post_cross_format_link_500s_when_the_db_is_gone() {
+    let (app, token, uuid) = fixture_with_no_link_table().await;
+    // A body that clears `validate()` — the DB is only reached past it.
+    let res = app
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/cross-format-link"),
+            &token,
+            &serde_json::json!({ "book_uuid": "ignored", "mode": "sequence" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn api_delete_cross_format_link_500s_when_the_db_is_gone() {
+    let (app, token, uuid) = fixture_with_no_link_table().await;
+    let res = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri(format!("/api/books/{uuid}/cross-format-link"))
+                .method("DELETE")
+                .header(axum::http::header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn api_post_sync_point_500s_when_the_db_is_gone() {
+    let (app, token, uuid) = fixture_with_no_link_table().await;
+    // Audio-with-seconds clears `validate()`, so the declaration reaches
+    // the link read rather than short-circuiting on a 422.
+    let res = app
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/sync-point"),
+            &token,
+            &serde_json::json!({
+                "book_uuid": "ignored",
+                "format": "audio",
+                "audio_seconds": 300.0,
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn api_post_cross_format_follow_500s_when_the_db_is_gone() {
+    let (app, token, uuid) = fixture_with_no_link_table().await;
+    let res = app
+        .oneshot(post_json_with_bearer(
+            &format!("/api/books/{uuid}/cross-format-follow"),
+            &token,
+            &serde_json::json!({ "enabled": true }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 #[tokio::test]
 async fn api_alignment_and_link_lifecycle_round_trips() {
     let (app, _state, pool) = fixture().await;

--- a/server/src/backend/cross_format/tests.rs
+++ b/server/src/backend/cross_format/tests.rs
@@ -151,9 +151,8 @@ async fn api_cross_format_resume_500s_when_the_db_is_gone() {
     assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
-/// An authed user plus a seeded dual-format book, with the link table
-/// dropped so every cross-format query fails at the DB layer; returns
-/// `(app, token, book uuid)`.
+/// Authed user + dual-format book with `cross_format_links` dropped, so every
+/// cross-format query fails at the DB layer.
 async fn fixture_with_no_link_table() -> (axum::Router, String, String) {
     let (app, _state, pool) = fixture().await;
     let user = auth_test_support::create_user(&pool, "alice").await;
@@ -215,8 +214,7 @@ async fn api_delete_cross_format_link_500s_when_the_db_is_gone() {
 #[tokio::test]
 async fn api_post_sync_point_500s_when_the_db_is_gone() {
     let (app, token, uuid) = fixture_with_no_link_table().await;
-    // Audio-with-seconds clears `validate()`, so the declaration reaches
-    // the link read rather than short-circuiting on a 422.
+    // Audio-with-seconds clears `validate()`, so this reaches the link read.
     let res = app
         .oneshot(post_json_with_bearer(
             &format!("/api/books/{uuid}/sync-point"),


### PR DESCRIPTION
## Summary
Closes #2018

- `server/src/backend/cross_format.rs` has six handlers, but only
  `get_cross_format_resume` had a test for its 5xx/DB-failure path — the other
  five (including the link confirm/unlink, sync-point declare, and follow-toggle
  write paths) shipped with 200/4xx coverage only, so nothing verified that a DB
  failure degrades to a clean 500 rather than a panic or an inconsistent
  response.
- Adds a DB-failure-path test for each of `get_alignment`,
  `post_cross_format_link`, `delete_cross_format_link`, `post_sync_point`, and
  `post_cross_format_follow`, following the existing
  `api_cross_format_resume_500s_when_the_db_is_gone` pattern.
- The five share a module-local `fixture_with_no_link_table()` helper that
  composes the existing `test_support` fixtures (authed user + seeded
  dual-format book) and then drops `cross_format_links`, so each handler's
  first DB query fails and the `error_response` mapping is exercised on its
  `Sqlx` arm.
- `post_cross_format_link` and `post_sync_point` validate their body before
  touching the DB, so their tests send a body that clears `validate()`
  (`mode: "sequence"` / `format: "audio"` with `audio_seconds`) and still
  reaches the query rather than short-circuiting on a 422.
- Tests only — no production code changed.

## Test plan
- [x] `cargo fmt` — PASS (no diff)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS (clean)
- [x] `cargo test -p omnibus cross_format` — PASS (15 passed, 0 failed; the 5
      new tests green)
- [x] `cargo test -p omnibus` — 861 passed, 2 failed. The two failures are
      `backend::uploads::tests::commit_rejects_read_only_library_with_400` and
      `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`,
      both **pre-existing and environmental**: they `chmod 0o555` a temp library
      to force a `PermissionDenied`, and the build sandbox runs as uid 0, which
      ignores the write bit. Verified they fail identically on the unmodified
      tree (`git stash` + rerun) — unrelated to this change.

## Notes
- **Scope:** this PR delivers only the first acceptance criterion — the five
  REST-handler DB-failure tests in `server/src/backend/cross_format/tests.rs`.
  The issue's second acceptance criterion (a db-level test for
  `declare_sync_point`'s auto-create-then-fail branch, in
  `db/src/cross_format/tests.rs`) is **delivered by the companion PR for #2017**,
  which owns that file. Please confirm both are merged before closing #2018.
- No production code change was needed for any of the five tests, matching the
  issue's suggested approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LH5phhKRKdvqkkCbsLC6n)_