### PR TITLE
fix: bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2820,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5261,7 +5261,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5760,7 +5760,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5819,7 +5819,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6239,7 +6239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6723,7 +6723,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- The `security` job (`cargo audit`) is failing on **every** open PR, and because
  `🔒 Cargo Audit Required` gates on it, nothing can currently reach a green
  required-check set. The advisory is not introduced by any of those PRs — it is
  present on `main` today.
- `h2 0.4.14`, pulled in transitively via `hyper`, carries
  **RUSTSEC-2026-0258** — h2 unbounded empty DATA frames
  ([GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)).
- Lockfile-only bump to `h2 0.4.16`, which is semver-compatible, so no manifest
  change is needed and no crate's dependency requirements move.

Opened as its own PR rather than folded into a feature branch: it is the shared
blocker for every other open PR, and duplicating the same `Cargo.lock` edit
across several branches would guarantee conflicts between them.

## Test plan
- [x] `cargo update -p h2 --precise 0.4.16` — `h2 v0.4.14 -> v0.4.16`
- [x] `cargo check -p omnibus -p omnibus-db -p omnibus-shared -p omnibus-frontend --all-targets` — PASS (clean)
- [x] `cargo test -p omnibus` — 856 passed, 2 failed. Both failures are
      `backend::uploads::tests::commit_rejects_read_only_library_with_400` and
      `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`,
      which are environmental to the container this ran in (it executes as uid 0,
      so the `chmod 0o555` those tests rely on to force `PermissionDenied` has no
      effect). They are unrelated to h2 and pass on a normal non-root runner.
- [x] CI's own `cargo audit` job is the real acceptance check for this one.

## Notes
- `cargo update` also re-resolved a handful of `windows-sys` version selections
  in the lockfile (0.52.0/0.60.2 → 0.59.0/0.61.2 on various edges). That churn
  appears even with `--precise` and is pre-existing lockfile drift being
  normalized; all of it is Windows-only crates, which this project does not
  build for. Happy to strip it back to a single-package diff if you'd prefer.
- No manifest (`Cargo.toml`) change, so nothing downstream needs a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LH5phhKRKdvqkkCbsLC6n)_