### PR TITLE
fix: make declare_sync_point's auto-link and anchor one transaction (#2017)

### DIFF
--- a/db/src/cross_format/declare.rs
+++ b/db/src/cross_format/declare.rs
@@ -8,10 +8,10 @@ use sqlx::SqlitePool;
 
 use crate::{progress, resolve_book_id_by_uuid, resolve_canonical_book_uuid};
 
-use super::link::{delete_link, get_link, upsert_link};
+use super::link::get_link;
 use super::mapping::{
     audio_files, audio_fraction, audio_timeline, epub_source_fraction, fraction_for_cfi,
-    link_is_stale, AudioTimeline,
+    link_is_stale, snapshot_json, AudioTimeline,
 };
 use super::{CrossFormatError, CrossFormatLink};
 
@@ -40,46 +40,85 @@ pub async fn declare_sync_point(
         .await?
         .ok_or(CrossFormatError::BookNotFound)?;
 
+    // Resolved in memory first, so every refusal below precedes any write.
     let (link, created_here) = match get_link(pool, user_id, &book_uuid).await? {
         Some(link) => (link, false),
-        None => {
-            if audio_files(pool, book_id).await?.len() != 1 {
-                return Err(CrossFormatError::LinkRequired);
-            }
-            let link = upsert_link(
-                pool,
-                user_id,
-                &book_uuid,
-                CrossFormatLinkMode::Sequence,
-                None,
-            )
-            .await?;
-            (link, true)
-        }
+        None => (auto_sequence_link(pool, book_id).await?, true),
     };
-    // A declaration that fails past this point must not leave behind the
-    // link this call just auto-created — the UI reported failure, and a
-    // silently-confirmed follow link would start moving positions the
-    // user never agreed to sync. Best-effort compensation, not a
-    // transaction: the link insert has value only alongside its anchor.
-    let result = declare_against_link(pool, user_id, book_id, &book_uuid, &link, decl).await;
-    if created_here && result.is_err() {
-        let _ = delete_link(pool, user_id, &book_uuid).await;
+    let (text_frac, audio_global) =
+        declared_pair(pool, user_id, book_id, &book_uuid, &link, decl).await?;
+
+    // One transaction, mirroring `confirm_link`: a link left behind without
+    // its anchor carries `follow = 1` and syncs positions the caller was
+    // told the declaration never recorded.
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    if created_here {
+        insert_auto_link(&mut tx, user_id, &book_uuid, &link.audio_snapshot).await?;
     }
-    result
+    store_anchor(&mut tx, user_id, &book_uuid, &link, text_frac, audio_global).await?;
+    tx.commit().await?;
+
+    get_link(pool, user_id, &book_uuid)
+        .await?
+        .ok_or(CrossFormatError::BookNotFound)
 }
 
-/// The declaration proper, against an existing (or just-created) link —
-/// split from [`declare_sync_point`] so a failure there can compensate by
-/// removing a link it auto-created.
-async fn declare_against_link(
+/// The link a single-audio-file book is auto-confirmed with, built in
+/// memory so the declaration resolves against it before anything is
+/// written. A multi-file book refuses with [`CrossFormatError::LinkRequired`].
+async fn auto_sequence_link(
+    pool: &SqlitePool,
+    book_id: i64,
+) -> Result<CrossFormatLink, CrossFormatError> {
+    let files = audio_files(pool, book_id).await?;
+    if files.len() != 1 {
+        return Err(CrossFormatError::LinkRequired);
+    }
+    Ok(CrossFormatLink {
+        mode: CrossFormatLinkMode::Sequence,
+        primary_book_file_id: None,
+        audio_snapshot: snapshot_json(&files),
+        // Placeholder — the INSERT stamps the value the caller reads back.
+        confirmed_at: 0,
+        follow: true,
+        user_anchors: Vec::new(),
+    })
+}
+
+/// Write the auto-confirmed sequence link inside the declaration's
+/// transaction. Plain INSERT on purpose: a racing confirm trips the unique
+/// constraint and rolls the declaration back, rather than filing this
+/// anchor against an alignment it was never measured on.
+async fn insert_auto_link(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    user_id: i64,
+    book_uuid: &str,
+    audio_snapshot: &str,
+) -> Result<(), CrossFormatError> {
+    sqlx::query(
+        "INSERT INTO cross_format_links
+            (user_id, book_uuid, mode, primary_book_file_id, audio_snapshot, confirmed_at, follow)
+         VALUES (?, ?, 'sequence', NULL, ?, CAST(strftime('%s','now') AS INTEGER), 1)",
+    )
+    .bind(user_id)
+    .bind(book_uuid)
+    .bind(audio_snapshot)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Resolve the declared pair — `(text fraction, audio global seconds)` —
+/// against the link the anchor will be stored on. Read-only by design:
+/// [`declare_sync_point`] runs it before opening its write transaction.
+async fn declared_pair(
     pool: &SqlitePool,
     user_id: i64,
     book_id: i64,
     book_uuid: &str,
     link: &CrossFormatLink,
     decl: &omnibus_shared::cross_format::DeclareSyncPoint,
-) -> Result<CrossFormatLink, CrossFormatError> {
+) -> Result<(f64, f64), CrossFormatError> {
     if link_is_stale(pool, book_id, link).await? {
         return Err(CrossFormatError::AudioSetMismatch);
     }
@@ -87,16 +126,14 @@ async fn declare_against_link(
         .await?
         .ok_or(CrossFormatError::LinkRequired)?;
 
-    let (text_frac, audio_global) = match decl.format {
+    match decl.format {
         ProgressFormat::Epub => {
-            ebook_declared_pair(pool, user_id, book_id, book_uuid, &timeline, decl).await?
+            ebook_declared_pair(pool, user_id, book_id, book_uuid, &timeline, decl).await
         }
         ProgressFormat::Audio => {
-            audio_declared_pair(pool, user_id, book_id, book_uuid, &timeline, decl).await?
+            audio_declared_pair(pool, user_id, book_id, book_uuid, &timeline, decl).await
         }
-    };
-
-    store_anchor(pool, user_id, book_uuid, link, text_frac, audio_global).await
+    }
 }
 
 /// A declaration made from the reader: the CFI (or client fraction) names
@@ -166,15 +203,16 @@ async fn audio_declared_pair(
 }
 
 /// Fold the declared pair into the link's stored anchors (replacing a
-/// re-declaration of the same spot) and turn follow mode on.
+/// re-declaration of the same spot) and turn follow mode on, inside the
+/// caller's transaction.
 async fn store_anchor(
-    pool: &SqlitePool,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     user_id: i64,
     book_uuid: &str,
     link: &CrossFormatLink,
     text_frac: f64,
     audio_global: f64,
-) -> Result<CrossFormatLink, CrossFormatError> {
+) -> Result<(), CrossFormatError> {
     let mut anchors: Vec<(f64, f64)> = link
         .user_anchors
         .iter()
@@ -192,9 +230,7 @@ async fn store_anchor(
     .bind(&json)
     .bind(user_id)
     .bind(book_uuid)
-    .execute(pool)
+    .execute(&mut **tx)
     .await?;
-    get_link(pool, user_id, book_uuid)
-        .await?
-        .ok_or(CrossFormatError::BookNotFound)
+    Ok(())
 }

--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -1552,6 +1552,24 @@ async fn declare_sync_point_refuses_what_it_cannot_pair() {
 }
 
 #[tokio::test]
+async fn declare_sync_point_leaves_no_auto_created_link_when_the_pair_cannot_be_resolved() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "alice").await;
+    // Single audio file reaches the auto-confirm branch; nothing read yet
+    // leaves it with no counterpart to pair.
+    let (_, uuid, _) = seed_dual_book(&pool, &[1_000.0]).await;
+    assert!(get_link(&pool, user, &uuid).await.unwrap().is_none());
+
+    let err = declare_sync_point(&pool, user, &declare_audio(&uuid, None, 500.0))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CrossFormatError::CounterpartMissing));
+
+    // A link left behind would follow with no anchor the user declared.
+    assert!(get_link(&pool, user, &uuid).await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn reconfirm_keeps_follow_and_clears_anchors_only_when_the_audio_set_changed() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "alice").await;


### PR DESCRIPTION
## Summary
Closes #2017

`declare_sync_point` auto-creates a `cross_format_links` row for a single-audio-file
book with no link yet, then recorded the anchor as a second, separate write. When the
anchor step failed it "compensated" with `let _ = delete_link(...)` — a discarded
`Result` on a live write path. If that delete itself failed, the book was left with an
active link carrying `follow = 1` and empty `user_anchors`, so every resume surface
(continue hero, book detail, reader, player) started following the counterpart format's
position with no user consent and no error record.

The fix mirrors what the sibling `confirm_link` already does one file over, and goes one
step further by moving every refusal ahead of the first write:

- `declare_against_link` is split into `declared_pair` (read-only: staleness check,
  timeline build, counterpart lookup) and the writes. The auto-confirmed sequence link is
  now built **in memory** first (`auto_sequence_link`), so `LinkRequired`,
  `AudioSetMismatch`, and `CounterpartMissing` all return before a single row exists.
- The two remaining writes — the auto-created link row and the anchor `UPDATE` that
  justifies it — run inside one `pool.begin_with("BEGIN IMMEDIATE")` transaction, the same
  shape `confirm_link` uses. A failure at any point rolls both back, so nothing partial
  lands and the compensating delete is gone entirely (along with the `delete_link` /
  `upsert_link` imports in `declare.rs`).
- `store_anchor` and the new `insert_auto_link` take
  `&mut sqlx::Transaction<'_, sqlx::Sqlite>`, following the `apply_audio_order_tx`
  convention in `order.rs`. `insert_auto_link` is a plain `INSERT` on purpose: a racing
  confirm that landed a row since the read trips the unique constraint and rolls the whole
  declaration back, rather than filing this anchor against an alignment it was never
  measured on.

No behaviour change on the success path — the returned link, its anchors, the
replace-nearby slack, and follow-on are all identical.

New test `declare_sync_point_leaves_no_auto_created_link_when_the_pair_cannot_be_resolved`
covers the previously untested compensation path: a single-audio-file dual-format book
with no link and no counterpart reading position, asserting both the `CounterpartMissing`
error and that `get_link` still returns `None` afterward. Every pre-existing
`CounterpartMissing` test pre-linked via `upsert_link`, sidestepping the auto-create
branch entirely.

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test -p omnibus-db` — 2203 passed, 1 failed. The single failure is
  `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`,
  which panics with the suite's own "audiobook fixture … missing — run `just fixtures`"
  message. `test_data/audiobooks/public_domain/` is absent in the container this ran in
  and `just` is unavailable there, so it is environmental and untouched by this change.
- [x] `cargo test -p omnibus-db --lib cross_format::` — PASS (47 passed, 0 failed),
  including the five `declare_sync_point_*` tests and the new one.

## Notes
- Acceptance criterion 1 (the transactional fix) is satisfied, so criterion 2 (the
  `tracing::warn!` fallback) is moot — there is no compensating `delete_link` call left to
  log.
- This PR also carries the **db-level** acceptance criterion listed on the companion issue
  #2018, since that test belongs in `db/src/cross_format/tests.rs`. The five REST-handler
  DB-failure tests for #2018 are in #2025.
- Scope stayed inside `db/src/cross_format/{declare.rs,tests.rs}`. Threading a transaction
  through the `mapping.rs` read helpers (`link_is_stale`, `audio_timeline`,
  `epub_source_fraction`, `fraction_for_cfi`) turned out to be unnecessary once the reads
  were hoisted ahead of the writes — they are pure reads and gain nothing from holding the
  write lock, which also keeps the `BEGIN IMMEDIATE` window as short as possible.
- `auto_sequence_link` builds its `CrossFormatLink` with `confirmed_at: 0` as a
  placeholder; the `INSERT` stamps the real value and the committed row is re-read via
  `get_link` before returning, so the placeholder is never observable to a caller.
- `cargo audit` will fail on this branch until #2026 merges — `h2 0.4.14` carries
  RUSTSEC-2026-0258 on `main` today, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LH5phhKRKdvqkkCbsLC6n)_