### PR TITLE
refactor: remove dead get_book_uuid API

### DIFF
--- a/db/src/metadata_overrides/mod.rs
+++ b/db/src/metadata_overrides/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use upsert::{
 };
 pub use upsert::{
     bulk_merge_metadata_overrides, clear_cover_override, delete_metadata_overrides,
-    delete_override_cover, get_book_uuid, get_metadata_overrides, merge_metadata_overrides,
+    delete_override_cover, get_metadata_overrides, merge_metadata_overrides,
     upsert_metadata_overrides, write_override_cover, MetadataOverridesError,
 };
 

--- a/db/src/metadata_overrides/upsert/cover.rs
+++ b/db/src/metadata_overrides/upsert/cover.rs
@@ -73,18 +73,6 @@ pub async fn clear_cover_override(
     Ok(())
 }
 
-/// Look up the UUID for a given `books.id`. Used by the override-save
-/// endpoints to bridge the id-based API with the uuid-keyed overrides table.
-pub async fn get_book_uuid(
-    pool: &SqlitePool,
-    book_id: i64,
-) -> Result<Option<String>, MetadataOverridesError> {
-    Ok(sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
-        .bind(book_id)
-        .fetch_optional(pool)
-        .await?)
-}
-
 /// Apply a `MetadataOverrides` to an `EbookMetadata`, mutating it in place,
 /// gated by whether `precedence` (the owning scan root's configured
 /// metadata-source order) ranks `OmnibusOverrides` above

--- a/db/src/metadata_overrides/upsert/mod.rs
+++ b/db/src/metadata_overrides/upsert/mod.rs
@@ -20,7 +20,7 @@ mod cover;
 mod merge;
 
 pub(crate) use cover::apply_overrides;
-pub use cover::{clear_cover_override, delete_override_cover, get_book_uuid, write_override_cover};
+pub use cover::{clear_cover_override, delete_override_cover, write_override_cover};
 pub use merge::{bulk_merge_metadata_overrides, merge_metadata_overrides};
 
 /// Errors returned by the metadata overrides data layer.


### PR DESCRIPTION
## Summary
- Closes #2033
- Removes `db::metadata_overrides::get_book_uuid` (defined in `db/src/metadata_overrides/upsert/cover.rs`), which had no remaining callers after the override-save endpoints were refactored to work directly off the uuid-keyed path — the only other references were two stale comments in `server/src/backend/overrides.rs` describing prior behavior, not live calls.
- Removes its re-exports from `db/src/metadata_overrides/upsert/mod.rs` and `db/src/metadata_overrides/mod.rs`. Its now-false doc comment ("Used by the override-save endpoints to bridge the id-based API with the uuid-keyed overrides table") goes with it.
- Left `db::books::get_book_uuid_by_scan_key` (an unrelated, still-live function) untouched.

## Test plan
- [x] `git grep -n "get_book_uuid(" -- '*.rs'` — confirmed no call sites remain (only the two stale comments, now unambiguous about referring to past behavior)
- [x] `cargo fmt` — clean, no diff
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2033 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS, no warnings
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2033 cargo test -p omnibus-db` — 2202 passed, 1 failed. The one failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing environment gap unrelated to this change — this worktree doesn't have the binary audiobook test fixtures downloaded (normally bootstrapped via `just fixtures`, which requires tooling not available in this sandbox), and the change here doesn't touch any audiobook/cover code.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled

## Notes
- Pure dead-code removal, no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9dW7FkCd9yTR2KBuXGAzX)_