### PR TITLE
fix: compose apply_book_title_override's write and log into one transaction

### DIFF
--- a/db/src/cleanup/apply.rs
+++ b/db/src/cleanup/apply.rs
@@ -10,7 +10,7 @@ use omnibus_shared::{CleanupAction, CleanupKind, MetadataOverrides};
 use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use crate::metadata_overrides::{
-    get_metadata_overrides, rebuild_fts_for_book, upsert_one_in_tx, MetadataOverridesError,
+    get_metadata_overrides_exec, rebuild_fts_for_book, upsert_one_in_tx, MetadataOverridesError,
 };
 use crate::sync::upsert_fts;
 use crate::taxonomy::{delete_orphan_taxonomy, resolve_or_insert_tag};
@@ -437,13 +437,15 @@ pub async fn apply_tag_split(
 /// rename composes with every other override field and reverts cleanly.
 ///
 /// Like the other primitives, this runs in one `BEGIN IMMEDIATE`
-/// transaction: it composes [`upsert_one_in_tx`] (the tx-scoped body behind
-/// the pool-level [`crate::metadata_overrides::upsert_metadata_overrides`])
-/// with the `cleanup_log` INSERT, so the override write and the log row
-/// land together or not at all — no window where a successful rename has
-/// no undo record. The `books_fts` rebuild still runs best-effort after
-/// commit, matching every other override-write caller: a stale FTS row is
-/// recoverable and far less consequential than a stale series/tag link.
+/// transaction: the previous-overrides snapshot is read through that same
+/// transaction (not the pool), then it composes [`upsert_one_in_tx`] (the
+/// tx-scoped body behind the pool-level
+/// [`crate::metadata_overrides::upsert_metadata_overrides`]) with the
+/// `cleanup_log` INSERT — so the snapshot read, the override write, and the
+/// log row all agree with each other and land together or not at all. The
+/// `books_fts` rebuild still runs best-effort after commit, matching every
+/// other override-write caller: a stale FTS row is recoverable and far less
+/// consequential than a stale series/tag link.
 ///
 /// Takes a required `applied_by` (unlike the other primitives'
 /// `Option<i64>`) because the metadata-overrides write requires a real user
@@ -456,8 +458,14 @@ pub async fn apply_book_title_override(
     suggestion_id: Option<i64>,
     applied_by: i64,
 ) -> Result<i64, CleanupApplyError> {
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+
+    // Read the snapshot through this same transaction, not the pool, so a
+    // concurrent writer can't commit an override change between the read
+    // and this transaction's start — which would log a stale snapshot and
+    // make undo restore the wrong prior state.
     let (previous_overrides, previous_has_cover_override) =
-        match get_metadata_overrides(pool, book_uuid).await? {
+        match get_metadata_overrides_exec(&mut *tx, book_uuid).await? {
             Some((ov, has_cover)) => (Some(serde_json::to_string(&ov)?), has_cover),
             None => (None, false),
         };
@@ -468,7 +476,6 @@ pub async fn apply_book_title_override(
     };
     new_overrides.title = Some(proposed_title.to_string());
 
-    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
     upsert_one_in_tx(
         &mut tx,
         book_uuid,

--- a/db/src/cleanup/apply.rs
+++ b/db/src/cleanup/apply.rs
@@ -1,8 +1,8 @@
 //! Transactional apply primitives for the library-cleanup surface: execute
 //! an accepted `dedup_suggestions` row (or a direct on-page action) against
 //! the schema, snapshotting enough state into `cleanup_log` for
-//! [`super::undo::undo`] to reverse it exactly. Every primitive but
-//! [`apply_book_title_override`] runs in one `BEGIN IMMEDIATE` transaction.
+//! [`super::undo::undo`] to reverse it exactly. Every primitive runs in one
+//! `BEGIN IMMEDIATE` transaction.
 
 use std::collections::HashSet;
 
@@ -10,7 +10,7 @@ use omnibus_shared::{CleanupAction, CleanupKind, MetadataOverrides};
 use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use crate::metadata_overrides::{
-    get_metadata_overrides, upsert_metadata_overrides, MetadataOverridesError,
+    get_metadata_overrides, rebuild_fts_for_book, upsert_one_in_tx, MetadataOverridesError,
 };
 use crate::sync::upsert_fts;
 use crate::taxonomy::{delete_orphan_taxonomy, resolve_or_insert_tag};
@@ -433,22 +433,20 @@ pub async fn apply_tag_split(
 // ---------------------------------------------------------------------------
 
 /// Adopt `proposed_title` for `book_uuid` by routing through the existing
-/// [`upsert_metadata_overrides`] door — never touching `books.title`
-/// directly, so the rename composes with every other override field and
-/// reverts cleanly.
+/// metadata-overrides door — never touching `books.title` directly, so the
+/// rename composes with every other override field and reverts cleanly.
 ///
-/// Unlike the other primitives, this is **not** a single all-or-nothing
-/// transaction: `upsert_metadata_overrides` owns its own `BEGIN IMMEDIATE`
-/// transaction and can't be composed into ours. The pre-rename overrides
-/// blob is still read strictly before the mutating call (which is what
-/// undo needs), and the `cleanup_log` row is written only *after* the
-/// mutation commits — so a crash between the read and the mutate leaves no
-/// log row (nothing to undo, matching reality), and the only residual gap
-/// is a crash between a successful mutate and the log INSERT, which loses
-/// undo-ability for that one rename without corrupting any state.
+/// Like the other primitives, this runs in one `BEGIN IMMEDIATE`
+/// transaction: it composes [`upsert_one_in_tx`] (the tx-scoped body behind
+/// the pool-level [`crate::metadata_overrides::upsert_metadata_overrides`])
+/// with the `cleanup_log` INSERT, so the override write and the log row
+/// land together or not at all — no window where a successful rename has
+/// no undo record. The `books_fts` rebuild still runs best-effort after
+/// commit, matching every other override-write caller: a stale FTS row is
+/// recoverable and far less consequential than a stale series/tag link.
 ///
 /// Takes a required `applied_by` (unlike the other primitives'
-/// `Option<i64>`) because `upsert_metadata_overrides` requires a real user
+/// `Option<i64>`) because the metadata-overrides write requires a real user
 /// id to attribute the write to, and [`super::undo::undo`] reuses that same
 /// id to attribute the restore.
 pub async fn apply_book_title_override(
@@ -470,8 +468,9 @@ pub async fn apply_book_title_override(
     };
     new_overrides.title = Some(proposed_title.to_string());
 
-    upsert_metadata_overrides(
-        pool,
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    upsert_one_in_tx(
+        &mut tx,
         book_uuid,
         &new_overrides,
         previous_has_cover_override,
@@ -484,17 +483,22 @@ pub async fn apply_book_title_override(
         previous_overrides,
         previous_has_cover_override,
     };
-    let log_id: i64 = sqlx::query_scalar(
-        "INSERT INTO cleanup_log (suggestion_id, kind, action, snapshot_json, applied_by)
-         VALUES (?, ?, ?, ?, ?) RETURNING id",
+    let log_id = write_cleanup_log(
+        &mut tx,
+        suggestion_id,
+        CleanupKind::BookTitle,
+        CleanupAction::Rename,
+        &snapshot,
+        Some(applied_by),
     )
-    .bind(suggestion_id)
-    .bind(CleanupKind::BookTitle.as_str())
-    .bind(CleanupAction::Rename.as_str())
-    .bind(serde_json::to_string(&snapshot)?)
-    .bind(applied_by)
-    .fetch_one(pool)
     .await?;
+
+    tx.commit().await?;
+
+    if let Err(e) = rebuild_fts_for_book(pool, book_uuid).await {
+        tracing::warn!(book_uuid, error = %e, "books_fts rebuild after title override apply failed");
+    }
+
     Ok(log_id)
 }
 

--- a/db/src/cleanup/apply/tests.rs
+++ b/db/src/cleanup/apply/tests.rs
@@ -9,7 +9,7 @@ use omnibus_shared::MetadataOverrides;
 
 use super::super::undo::undo;
 use super::*;
-use crate::metadata_overrides::upsert_metadata_overrides;
+use crate::metadata_overrides::{get_metadata_overrides, upsert_metadata_overrides};
 use crate::pool::init_db;
 
 // ---------------------------------------------------------------------------

--- a/db/src/cleanup/apply/tests.rs
+++ b/db/src/cleanup/apply/tests.rs
@@ -9,6 +9,7 @@ use omnibus_shared::MetadataOverrides;
 
 use super::super::undo::undo;
 use super::*;
+use crate::metadata_overrides::upsert_metadata_overrides;
 use crate::pool::init_db;
 
 // ---------------------------------------------------------------------------
@@ -557,6 +558,54 @@ async fn apply_book_title_override_preserves_other_override_fields_and_undo_rest
     assert_eq!(
         restored.description.as_deref(),
         Some("An existing description.")
+    );
+}
+
+/// Composed-transaction proof: force the `cleanup_log` INSERT to fail
+/// *after* the override write has already run, by naming a `suggestion_id`
+/// with no matching `dedup_suggestions` row (`cleanup_log.suggestion_id`
+/// carries an FK, and the pool enables `PRAGMA foreign_keys = ON`). Before
+/// this fix, the override write committed on its own `BEGIN IMMEDIATE` and
+/// only the log INSERT failed, leaving an unloggable rename in place. Now
+/// both writes share one transaction, so the FK failure rolls the override
+/// write back too — the book keeps its pre-call state and nothing is
+/// left half-applied.
+#[tokio::test]
+async fn apply_book_title_override_rolls_back_the_override_write_when_the_log_insert_fails() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let user = seed_user(&pool).await;
+    let book = insert_book(&pool, lib, "book-1", "Maas, Sarah J - Throne of Glass").await;
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let bogus_suggestion_id = 999_999;
+    let err = apply_book_title_override(
+        &pool,
+        &uuid,
+        "Throne of Glass",
+        Some(bogus_suggestion_id),
+        user,
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, CleanupApplyError::Db(_)));
+
+    assert!(
+        get_metadata_overrides(&pool, &uuid)
+            .await
+            .unwrap()
+            .is_none(),
+        "the override write must not survive a failed cleanup_log INSERT \
+         in the same transaction"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM cleanup_log").await,
+        0,
+        "the failed INSERT itself must leave no row behind either"
     );
 }
 

--- a/db/src/metadata_overrides/mod.rs
+++ b/db/src/metadata_overrides/mod.rs
@@ -19,8 +19,8 @@ mod upsert;
 mod tests;
 
 pub(crate) use upsert::{
-    apply_overrides, backfill_override_norm_columns, delete_one_in_tx, load_overrides_bulk,
-    upsert_one_in_tx,
+    apply_overrides, backfill_override_norm_columns, delete_one_in_tx, get_metadata_overrides_exec,
+    load_overrides_bulk, upsert_one_in_tx,
 };
 pub use upsert::{
     bulk_merge_metadata_overrides, clear_cover_override, delete_metadata_overrides,

--- a/db/src/metadata_overrides/upsert/mod.rs
+++ b/db/src/metadata_overrides/upsert/mod.rs
@@ -299,11 +299,26 @@ pub async fn get_metadata_overrides(
     pool: &SqlitePool,
     book_uuid: &str,
 ) -> Result<Option<(MetadataOverrides, bool)>, MetadataOverridesError> {
+    get_metadata_overrides_exec(pool, book_uuid).await
+}
+
+/// Executor-generic body of [`get_metadata_overrides`], so a caller that
+/// already holds an open transaction (e.g. [`crate::cleanup::apply::apply_book_title_override`])
+/// can read the current overrides through that same transaction instead of
+/// racing it against a separate pool-level read taken before the
+/// transaction started.
+pub(crate) async fn get_metadata_overrides_exec<'e, E>(
+    executor: E,
+    book_uuid: &str,
+) -> Result<Option<(MetadataOverrides, bool)>, MetadataOverridesError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let row: Option<(String, i64)> = sqlx::query_as(
         "SELECT overrides, has_cover_override FROM metadata_overrides WHERE book_uuid = ?",
     )
     .bind(book_uuid)
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
 
     match row {


### PR DESCRIPTION
## Summary
- Closes #2032
- `apply_book_title_override` (`db/src/cleanup/apply.rs`) previously wrote its `metadata_overrides` mutation through the pool-level `upsert_metadata_overrides` (its own `BEGIN IMMEDIATE`), then wrote the `cleanup_log` row as a *separate* statement after that transaction had already committed. A crash between the two left a successful rename with no undo record — the residual gap the doc comment called out but didn't close.
- Fixed by using `upsert_one_in_tx` — the `pub(crate)` tx-scoped body already sitting behind `upsert_metadata_overrides`, and already documented as designed for exactly this join — inside `apply_book_title_override`'s own `BEGIN IMMEDIATE`, composed with the `cleanup_log` INSERT (via the shared `write_cleanup_log` helper the other primitives use) into one transaction. Both writes now land together or not at all, matching the shape of `apply_merge`/`apply_tag_split`/`apply_delete_author`. The best-effort `books_fts` rebuild still runs post-commit, matching every other override-write caller.
- No public signature changed and no other caller of `upsert_metadata_overrides` was touched — it stays available for its other ~15 call sites (server handlers + test helpers across the workspace).
- Updated the module-level and function-level doc comments to remove the now-resolved "not a single all-or-nothing transaction" caveat.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2032 cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2032 cargo test -p omnibus-db` — PASS for every test this change touches (all `cleanup::apply::tests::*`, 2203/2204 total in the crate). The one crate-wide failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing, unrelated environment gap — it needs the binary audiobook fixtures pulled via `just fixtures`, which this sandbox can't run (no `nix`/network egress for the release asset). It does not touch any file this PR changes.
- [x] Added `apply_book_title_override_rolls_back_the_override_write_when_the_log_insert_fails` — forces the `cleanup_log` INSERT to fail (a `suggestion_id` with no matching `dedup_suggestions` row, tripping its `ON DELETE SET NULL` FK under the pool's `PRAGMA foreign_keys = ON`) *after* the override write has already run, and asserts the whole transaction rolled back — proving the composed-transaction property this issue asked for.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Resolution path taken: the real fix (composing into one transaction), not the doc-comment-pointer fallback — `upsert_one_in_tx` already existed and was already documented as built for this exact join, so no larger refactor was needed.
- `db/src/cleanup/undo.rs`'s undo path already composed its own claim + restore into one transaction via `upsert_one_in_tx`/`delete_one_in_tx` before this change (see the existing `undo_concurrent_calls_on_a_rename_race_to_exactly_one_success` test) — this PR brings the apply side to the same standard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9dW7FkCd9yTR2KBuXGAzX)_