### PR TITLE
fix: batch undo_split's per-(book,atom) queries

### DIFF
--- a/db/src/cleanup/apply/tests.rs
+++ b/db/src/cleanup/apply/tests.rs
@@ -879,3 +879,127 @@ async fn apply_tag_split_links_every_book_in_a_larger_linked_set() {
         );
     }
 }
+
+/// `undo_split` used to resolve and delete each `(book, atom)` pair one at
+/// a time, so a real regression would delete every row naming an atom id
+/// rather than only the ones the split itself created. A book that links an
+/// atom independently — after the split, never part of `snap.links` — must
+/// survive the undo untouched.
+#[tokio::test]
+async fn undo_split_removes_only_the_splits_own_atom_links_leaving_unrelated_links_intact() {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let book_a = insert_book(&pool, lib, "book-a", "Title A").await;
+    let book_b = insert_book(&pool, lib, "book-b", "Title B").await;
+    let source = insert_tag(&pool, "scifi;fantasy").await;
+    link_tag(&pool, book_a, source).await;
+    link_tag(&pool, book_b, source).await;
+
+    let atoms = vec!["scifi".to_string(), "fantasy".to_string()];
+    let log_id = apply_tag_split(&pool, source, ";", &atoms, None, None)
+        .await
+        .unwrap();
+
+    // A third book links "scifi" independently, after the split — outside
+    // `snap.links`, so this row must survive the undo below.
+    let book_c = insert_book(&pool, lib, "book-c", "Title C").await;
+    let scifi_id: i64 = sqlx::query_scalar("SELECT id FROM tags WHERE name = 'scifi'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    link_tag(&pool, book_c, scifi_id).await;
+
+    undo(&pool, log_id).await.unwrap();
+
+    for &book in &[book_a, book_b] {
+        assert_eq!(
+            count_rows(
+                &pool,
+                &format!("SELECT COUNT(*) FROM books_tags_link WHERE book = {book}")
+            )
+            .await,
+            1,
+            "book must hold only the recreated source tag after undo"
+        );
+    }
+    assert_eq!(
+        count_rows(
+            &pool,
+            &format!("SELECT COUNT(*) FROM books_tags_link WHERE book = {book_c}")
+        )
+        .await,
+        1,
+        "book_c's independent scifi link must survive the undo"
+    );
+    assert_eq!(
+        count_rows(&pool, "SELECT COUNT(*) FROM tags WHERE name = 'scifi'").await,
+        1,
+        "scifi itself must survive since book_c still references it"
+    );
+}
+
+/// Counts `tracing` events sqlx emits (target `"sqlx::query"`, one per
+/// executed statement) while installed as the default subscriber. Mirrors
+/// the `QueryCounter` pattern in `db/src/epub_rewrite/tests.rs` and
+/// `db/src/cross_format/tests.rs`; every `Subscriber` method besides
+/// `event` is a no-op.
+struct QueryCounter(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+impl tracing::Subscriber for QueryCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.target() == "sqlx::query"
+    }
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        if event.metadata().target() == "sqlx::query" {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// The query count `undo(log_id)` issues to reverse a tag split whose
+/// source was linked to `book_count` books before the split, split into two
+/// atoms.
+async fn undo_split_query_count(book_count: usize) -> usize {
+    let pool = new_pool().await;
+    let lib = seed_root(&pool).await;
+    let source = insert_tag(&pool, "scifi;fantasy").await;
+    for i in 0..book_count {
+        let book = insert_book(&pool, lib, &format!("book-{i}"), &format!("Title {i}")).await;
+        link_tag(&pool, book, source).await;
+    }
+
+    let atoms = vec!["scifi".to_string(), "fantasy".to_string()];
+    let log_id = apply_tag_split(&pool, source, ";", &atoms, None, None)
+        .await
+        .unwrap();
+
+    let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let guard = tracing::subscriber::set_default(QueryCounter(count.clone()));
+    undo(&pool, log_id).await.unwrap();
+    drop(guard);
+    count.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// The naive replay this test guards against issued one `lookup_tag_id` +
+/// conditional `delete_link` per `(book, atom)` pair, so its query count
+/// scaled with `books × atoms`. The batched replacement resolves atoms and
+/// applies the link insert/delete as one statement per chunk, so as long as
+/// both book counts stay under one chunk (`SPLIT_UNDO_CHUNK` = 450) the
+/// query count must be identical regardless of how many books were linked.
+#[tokio::test]
+async fn undo_split_query_count_does_not_grow_with_linked_book_count() {
+    let few = undo_split_query_count(2).await;
+    let many = undo_split_query_count(200).await;
+    assert_eq!(
+        few, many,
+        "undo_split's query count must not grow with the number of linked \
+         books: {few} queries for 2 books vs {many} for 200"
+    );
+}

--- a/db/src/cleanup/entity_ops.rs
+++ b/db/src/cleanup/entity_ops.rs
@@ -271,15 +271,107 @@ pub(super) async fn recreate_entity(
         .await
 }
 
-/// Look up a tag's current id by name, for undoing a split's per-atom links.
-pub(super) async fn lookup_tag_id(
+/// Bind-parameter budget shared by the batched split-undo helpers below.
+/// [`delete_links_bulk`] chunks *two* `IN (...)` lists in the same
+/// statement, so this is sized to leave headroom for both — a chunk of
+/// each stays comfortably under SQLite's ~999-parameter cap even when both
+/// lists are large.
+const SPLIT_UNDO_CHUNK: usize = 450;
+
+/// Resolve every name in `names` to its current `tags.id` in chunked `IN
+/// (...)` queries — the batched replacement for a per-atom lookup-then-
+/// delete loop, used by [`super::undo::undo_split`] to resolve every split
+/// atom to an id in a handful of round trips instead of one per atom. A
+/// name with no live row (e.g. already reaped by an intervening
+/// [`crate::taxonomy::delete_orphan_taxonomy`]) is silently absent from the
+/// result, matching the original per-name `Option` guard it replaces.
+pub(super) async fn lookup_tag_ids(
     tx: &mut Transaction<'_, Sqlite>,
-    name: &str,
-) -> Result<Option<i64>, sqlx::Error> {
-    sqlx::query_scalar("SELECT id FROM tags WHERE name = ? COLLATE NOCASE")
-        .bind(name)
-        .fetch_optional(&mut **tx)
-        .await
+    names: &[String],
+) -> Result<Vec<i64>, sqlx::Error> {
+    let mut ids = Vec::with_capacity(names.len());
+    for chunk in names.chunks(SPLIT_UNDO_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("SELECT id FROM tags WHERE name COLLATE NOCASE IN ({placeholders})");
+        let mut q = sqlx::query_scalar::<_, i64>(&sql);
+        for name in chunk {
+            q = q.bind(name);
+        }
+        ids.extend(q.fetch_all(&mut **tx).await?);
+    }
+    Ok(ids)
+}
+
+/// Bulk counterpart of [`insert_link`] for entities with no `position`
+/// column (tags): one `(book, entity_id)` row per id in `book_ids`, as
+/// chunked multi-row `INSERT OR IGNORE` statements rather than one query
+/// per book.
+pub(super) async fn insert_links_bulk(
+    tx: &mut Transaction<'_, Sqlite>,
+    entity: MergeEntity,
+    entity_id: i64,
+    book_ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    debug_assert!(
+        !entity.has_position(),
+        "insert_links_bulk has no position-column support"
+    );
+    for chunk in book_ids.chunks(SPLIT_UNDO_CHUNK / 2) {
+        let placeholders = vec!["(?, ?)"; chunk.len()].join(", ");
+        let sql = format!(
+            "INSERT OR IGNORE INTO {} (book, {}) VALUES {placeholders}",
+            entity.link_table(),
+            entity.link_col()
+        );
+        let mut q = sqlx::query(&sql);
+        for &book_id in chunk {
+            q = q.bind(book_id).bind(entity_id);
+        }
+        q.execute(&mut **tx).await?;
+    }
+    Ok(())
+}
+
+/// Bulk counterpart of [`delete_link`]: delete every `(book, entity_id)`
+/// link row where `book` is in `book_ids` and `entity_id` is in
+/// `entity_ids` — used by [`super::undo::undo_split`] to remove exactly the
+/// per-book atom links a split added, without the O(books × atoms)
+/// lookup-then-delete the naive replay used. Both lists are chunked (not
+/// just `book_ids`) so the statement stays bounded even in the pathological
+/// case of a split with many atoms, though in practice `entity_ids` is a
+/// handful and this degenerates to one outer iteration.
+pub(super) async fn delete_links_bulk(
+    tx: &mut Transaction<'_, Sqlite>,
+    entity: MergeEntity,
+    book_ids: &[i64],
+    entity_ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    for entity_chunk in entity_ids.chunks(SPLIT_UNDO_CHUNK) {
+        let entity_placeholders = std::iter::repeat_n("?", entity_chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        for book_chunk in book_ids.chunks(SPLIT_UNDO_CHUNK) {
+            let book_placeholders = std::iter::repeat_n("?", book_chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "DELETE FROM {t} WHERE book IN ({book_placeholders}) AND {c} IN ({entity_placeholders})",
+                t = entity.link_table(),
+                c = entity.link_col()
+            );
+            let mut q = sqlx::query(&sql);
+            for &book_id in book_chunk {
+                q = q.bind(book_id);
+            }
+            for &entity_id in entity_chunk {
+                q = q.bind(entity_id);
+            }
+            q.execute(&mut **tx).await?;
+        }
+    }
+    Ok(())
 }
 
 /// Record that `alias_name` (a name a merge just absorbed) now resolves to

--- a/db/src/cleanup/undo.rs
+++ b/db/src/cleanup/undo.rs
@@ -8,13 +8,14 @@ use std::collections::HashSet;
 use omnibus_shared::{CleanupAction, CleanupKind};
 use sqlx::{Sqlite, SqlitePool, Transaction};
 
-use crate::sync::upsert_fts;
+use crate::sync::upsert_fts_batch;
 use crate::taxonomy::delete_orphan_taxonomy;
 
 use super::apply::CleanupApplyError;
 use super::entity_ops::{
-    clear_sort, delete_entity_alias, delete_link, insert_link, lookup_tag_id, recreate_entity,
-    restore_canonical_photo, restore_entity_alias, write_photo,
+    clear_sort, delete_entity_alias, delete_link, delete_links_bulk, insert_link,
+    insert_links_bulk, lookup_tag_ids, recreate_entity, restore_canonical_photo,
+    restore_entity_alias, write_photo,
 };
 use super::snapshot::{DeleteAuthorSnapshot, MergeSnapshot, RenameSnapshot, SplitSnapshot};
 use super::MergeEntity;
@@ -219,9 +220,8 @@ async fn undo_merge(
             .await?;
     }
 
-    for book_id in touched {
-        upsert_fts(tx, book_id).await?;
-    }
+    let touched: Vec<i64> = touched.into_iter().collect();
+    upsert_fts_batch(tx, &touched).await?;
     Ok(())
 }
 
@@ -230,6 +230,14 @@ async fn undo_merge(
 /// that pre-existed independently, or gained other links since, is left
 /// alone — only [`crate::taxonomy::delete_orphan_taxonomy`] can still reap
 /// it if it's now unreferenced).
+///
+/// Batched, not one query per `(book, atom)` pair: [`lookup_tag_ids`]
+/// resolves every atom name to an id in one pass, [`insert_links_bulk`]
+/// restores every book's link to the recreated source tag in one pass, and
+/// [`delete_links_bulk`] removes every atom link the split added in one
+/// pass — O(books + atoms) round trips instead of the O(books × atoms) the
+/// naive per-pair replay ran (mirrors `apply_tag_split`'s own set-based
+/// shape in `apply.rs`).
 async fn undo_split(
     tx: &mut Transaction<'_, Sqlite>,
     snapshot_json: &str,
@@ -237,19 +245,14 @@ async fn undo_split(
     let snap: SplitSnapshot = serde_json::from_str(snapshot_json)?;
 
     let new_id = recreate_entity(tx, MergeEntity::Tag, &snap.source_name, None).await?;
-    for &book_id in &snap.links {
-        insert_link(tx, MergeEntity::Tag, book_id, new_id, None).await?;
-        for atom in &snap.atoms {
-            if let Some(atom_id) = lookup_tag_id(tx, atom).await? {
-                delete_link(tx, MergeEntity::Tag, book_id, atom_id).await?;
-            }
-        }
-    }
+    insert_links_bulk(tx, MergeEntity::Tag, new_id, &snap.links).await?;
+
+    let atom_ids = lookup_tag_ids(tx, &snap.atoms).await?;
+    delete_links_bulk(tx, MergeEntity::Tag, &snap.links, &atom_ids).await?;
+
     delete_orphan_taxonomy(tx).await?;
 
-    for &book_id in &snap.links {
-        upsert_fts(tx, book_id).await?;
-    }
+    upsert_fts_batch(tx, &snap.links).await?;
     Ok(())
 }
 
@@ -274,8 +277,7 @@ async fn undo_delete_author(
         .execute(&mut **tx)
         .await?;
 
-    for link in &snap.links {
-        upsert_fts(tx, link.book_id).await?;
-    }
+    let book_ids: Vec<i64> = snap.links.iter().map(|link| link.book_id).collect();
+    upsert_fts_batch(tx, &book_ids).await?;
     Ok(())
 }

--- a/db/src/sync.rs
+++ b/db/src/sync.rs
@@ -18,12 +18,12 @@ pub(crate) use audiobooks::insert_chapters;
 pub use audiobooks::{sync_audiobooks, sync_audiobooks_with_progress, AudiobookSyncPlan};
 pub use books::{replace_books, sync_books, sync_books_with_progress, MovedFile, SyncPlan};
 
-// The single `books_fts` door. `upsert_fts` / `delete_fts` are
-// `pub(crate)` for the in-tx write sites (sync / merge / undo /
-// metadata_overrides); `rebuild_all_fts` is `pub` for the worker task +
-// admin endpoint that repair the whole index.
+// The single `books_fts` door. `upsert_fts` / `upsert_fts_batch` /
+// `delete_fts` are `pub(crate)` for the in-tx write sites (sync / merge /
+// undo / metadata_overrides); `rebuild_all_fts` is `pub` for the worker
+// task + admin endpoint that repair the whole index.
 pub use fts::rebuild_all_fts;
-pub(crate) use fts::{delete_fts, upsert_fts};
+pub(crate) use fts::{delete_fts, upsert_fts, upsert_fts_batch};
 
 /// Push a post-commit cover triple onto `covers`, allocating only when the book actually has a cover.
 pub(crate) fn push_cover(

--- a/db/src/sync/fts.rs
+++ b/db/src/sync/fts.rs
@@ -13,6 +13,10 @@ use std::sync::OnceLock;
 use anyhow::Context;
 use sqlx::{SqliteConnection, SqlitePool};
 
+/// Rows per chunk for [`upsert_fts_batch`]'s two `IN (...)` lists — one bind
+/// per book id per list, comfortably under SQLite's ~999-parameter cap.
+const UPSERT_BATCH_CHUNK: usize = 450;
+
 /// The `SELECT` projection shared by the per-book upsert and the
 /// whole-table rebuild: same columns, same correlated subqueries for the
 /// taxonomy joins and the ISBN lookup. Kept as one constant so the two
@@ -68,6 +72,44 @@ pub(crate) async fn upsert_fts(
         )
     });
     sqlx::query(sql).bind(book_id).execute(&mut *conn).await?;
+    Ok(())
+}
+
+/// The many-books counterpart of [`upsert_fts`]: delete-then-insert the
+/// `books_fts` rows for every id in `book_ids`, two DML statements per
+/// chunk of [`UPSERT_BATCH_CHUNK`] rather than 2N statements for N books.
+/// For a caller that already knows its whole affected-book set up front
+/// (a merge/split undo replaying a snapshot) this replaces a per-book
+/// `upsert_fts` loop; duplicate ids in `book_ids` are harmless — the
+/// `INSERT ... SELECT ... WHERE b.id IN (...)` reads one row per distinct
+/// book regardless of how many times its id appears in the bound list.
+pub(crate) async fn upsert_fts_batch(
+    conn: &mut SqliteConnection,
+    book_ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    for chunk in book_ids.chunks(UPSERT_BATCH_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let del_sql = format!("DELETE FROM books_fts WHERE rowid IN ({placeholders})");
+        let mut del_q = sqlx::query(&del_sql);
+        for &id in chunk {
+            del_q = del_q.bind(id);
+        }
+        del_q.execute(&mut *conn).await?;
+
+        let ins_sql = format!(
+            "INSERT INTO books_fts(rowid, title, authors, series, tags, description, isbn)
+             {FTS_SELECT_FROM_BOOKS}
+             WHERE b.id IN ({placeholders})"
+        );
+        let mut ins_q = sqlx::query(&ins_sql);
+        for &id in chunk {
+            ins_q = ins_q.bind(id);
+        }
+        ins_q.execute(&mut *conn).await?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Closes #2031
- `db/src/cleanup/undo.rs`'s `undo_split` resolved each split atom and deleted its per-book link one query at a time — O(books × atoms) round trips, the same fan-out shape `apply_tag_split` (in `db/src/cleanup/apply.rs`) was rewritten to avoid. Replaced it with a batched shape: `lookup_tag_ids` resolves every atom name to an id in one/few chunked `SELECT ... WHERE name IN (...)` queries, `insert_links_bulk` restores every book's link to the recreated source tag as chunked multi-row `INSERT OR IGNORE`, and `delete_links_bulk` removes every atom link the split added as chunked set-based `DELETE ... WHERE book IN (...) AND tag IN (...)` — all new helpers in `db/src/cleanup/entity_ops.rs`, chunked at 450 rows/list to stay under SQLite's ~999-bind-parameter cap (mirrors the existing `IN (...)` chunking pattern in `db/src/entity_alias.rs` / `db/src/author_photos_data.rs`).
- Also batched the per-book `upsert_fts` loops in `undo_split`, `undo_merge`, and `undo_delete_author` (flagged in the issue as supporting evidence) via a new `upsert_fts_batch` helper in `db/src/sync/fts.rs` — two DML statements per chunk instead of 2N for N books.

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (2205 lib tests + all integration binaries, 0 failed)
- Added `undo_split_removes_only_the_splits_own_atom_links_leaving_unrelated_links_intact` — a correctness regression test proving the batched `DELETE` is scoped per-book, not global per-atom-id (a book that links an atom independently, outside the split's own snapshot, must survive the undo).
- Added `undo_split_query_count_does_not_grow_with_linked_book_count` — a `tracing`-subscriber query-count test (mirrors the `QueryCounter` pattern already used in `db/src/cross_format/tests.rs` / `db/src/epub_rewrite/tests.rs`) asserting `undo(log_id)`'s SQL statement count for 2 linked books equals that for 200 — the naive per-`(book, atom)` replay this replaces would have scaled with the product.
- Existing `apply_tag_split_links_every_book_in_a_larger_linked_set` (25 books × 3 atoms, apply + undo round trip) continues to pass, confirming no behavior regression at a multi-book, multi-atom scale.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Scope matches the issue exactly: only `undo_split`'s main loop (the primary finding) and the three `upsert_fts` loops it flagged as supporting evidence. `apply.rs`'s own per-book `upsert_fts` loops (already O(books), not O(books × atoms)) were left untouched — out of scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9dW7FkCd9yTR2KBuXGAzX)_