### PR TITLE
docs: add CHANGELOG.md (#2034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**How this file is maintained:** [`.github/workflows/release.yml`](.github/workflows/release.yml)
+cuts an automated GitHub release (and version tag) on every merge to `main` —
+a patch bump by default, a minor bump with the `minor version` label, and no
+release at all for a docs/CI-only PR or one labeled `no release`. That gives
+every release a tag and generated release notes, but not every one of those
+automated releases is worth a line here. This file is a curated, human-written
+summary of user-facing changes, updated as part of notable PRs rather than
+generated from the release automation. It was started retroactively and does
+not attempt to reconstruct the project's full release history — only the most
+recent releases are recorded below; everything earlier is available via the
+[GitHub releases page](https://github.com/seamus-sloan/omnibus/releases) and
+`git log`.
+
+## [Unreleased]
+
+## [0.22.10] - 2026-08-18
+
+### Fixed
+
+- Bumped the `h2` dependency to 0.4.16 to address RUSTSEC-2026-0258 (#2026)
+
+## [0.22.9] - 2026-08-18
+
+### Fixed
+
+- Batched cross-format `audio_marks` queries and deduplicated `alignment_view`
+  calls (#2019, #2023)
+
+[Unreleased]: https://github.com/seamus-sloan/omnibus/compare/v0.22.10...HEAD
+[0.22.10]: https://github.com/seamus-sloan/omnibus/compare/v0.22.9...v0.22.10
+[0.22.9]: https://github.com/seamus-sloan/omnibus/releases/tag/v0.22.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **How this file is maintained:** [`.github/workflows/release.yml`](.github/workflows/release.yml)
 cuts an automated GitHub release (and version tag) on every merge to `main` —
 a patch bump by default, a minor bump with the `minor version` label, and no
-release at all for a docs/CI-only PR or one labeled `no release`. That gives
+release for a PR labeled `no release`. An unlabeled PR that only touches
+docs/CI files also skips the release — but an explicit `patch version` or
+`minor version` label always wins and still cuts one, even for a docs/CI-only
+PR. That gives
 every release a tag and generated release notes, but not every one of those
 automated releases is worth a line here. This file is a curated, human-written
 summary of user-facing changes, updated as part of notable PRs rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Full crate descriptions, per-crate module maps, request flow diagrams, and mobil
 
 This repo is developed with [Jujutsu (`jj`)](https://jj-vcs.github.io/jj/) over the Git backend, and changes land as GitHub pull requests — one PR per change, conventional-commit titles (`feat:` / `fix:` / `chore:` / `docs:`).
 
+- User-facing changes worth calling out get a line in [CHANGELOG.md](CHANGELOG.md) (Keep a Changelog format) under `[Unreleased]`, alongside the PR that makes them — curated separately from, and more sparingly than, the automated per-merge release tags `release.yml` cuts.
 - **Never amend or rewrite an already-pushed commit.** `jj` auto-snapshots the working copy into the current change on every command, so editing files while `@` sits on a pushed bookmark silently rewrites published history into a force-push. Run `jj new <bookmark>` to start a fresh change *before* editing — even when the working copy is clean.
 - Routine flow: `jj git fetch` to sync; `jj bookmark create <name>` for a branch; `jj describe -m "…"` to set the message; `jj bookmark move <name> --to @` then `jj git push`.
 - The dev tooling assumes `jj` — `scripts/dev-server-up.sh` identity-checks the workspace root so sibling `jj` workspaces don't collide on a port.


### PR DESCRIPTION
## Summary
- Closes #2034
- Adds `CHANGELOG.md` at the repo root, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format: an empty `[Unreleased]` section ready for future entries, plus populated entries for the two most recent release tags (`v0.22.10`, `v0.22.9`) sourced from their actual release notes. Per the issue's own "Notes for the implementer," this is the minimal resolution — starting the file now rather than backfilling the full release history.
- Adds a one-line pointer in `CLAUDE.md`'s "Version control" section noting that user-facing changes get a line in `CHANGELOG.md` under `[Unreleased]`, and how that's distinct from the automated per-merge release tags `.github/workflows/release.yml` already cuts.
- Deliberately leaves `.github/workflows/release.yml` untouched — no auto-generation from the changelog, no wiring into the release pipeline. That's out of scope for this minimal resolution and risks breaking a working release flow.

## Test plan
- N/A — docs-only change.

## Version
This PR only touches `CHANGELOG.md` and `CLAUDE.md` (both `.md`), so per the release workflow's existing docs/CI-only check it will automatically skip cutting a release — no version label needed.

## Notes
- No changes to any Rust, workflow, or config files. `cargo fmt --check` confirmed clean (no `.rs` files touched).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9dW7FkCd9yTR2KBuXGAzX)_