### PR TITLE
fix: add rsx keys to alignment_modal/lanes.rs's 4 dynamic lists

### DIFF
--- a/frontend/src/components/alignment_modal/lanes.rs
+++ b/frontend/src/components/alignment_modal/lanes.rs
@@ -216,6 +216,7 @@ pub(super) fn render_lanes(
                 for (i, ch) in ebook_chapters.iter().enumerate() {
                     if i % text_step == 0 {
                         div {
+                            key: "{ch.title}-{ch.percent}",
                             class: "al-tick",
                             title: "{ch.title}",
                             style: "left: {ch.percent}%",
@@ -239,6 +240,7 @@ pub(super) fn render_lanes(
                     preserve_aspect_ratio: "none",
                     for (t, a) in view.anchor_pairs.iter() {
                         line {
+                            key: "{t}-{a}",
                             x1: "{t * 1000.0}",
                             y1: "0",
                             x2: "{a * 1000.0}",
@@ -260,6 +262,7 @@ pub(super) fn render_lanes(
             div { class: "al-lane al-lane-audio",
                 for f in files.iter() {
                     div {
+                        key: "{f.book_file_id}",
                         class: "al-seg",
                         style: format!(
                             "flex-grow: {}",
@@ -275,7 +278,7 @@ pub(super) fn render_lanes(
                     }
                     for (i, t) in audio_ticks.iter().enumerate() {
                         if i % audio_step == 0 {
-                            div { class: "al-tick", style: "left: {t * 100.0}%" }
+                            div { key: "{i}", class: "al-tick", style: "left: {t * 100.0}%" }
                         }
                     }
                     if let Some(f) = listen_frac {


### PR DESCRIPTION
## Summary
- Closes #2030
- Adds a `key:` attribute to each of the 4 unkeyed dynamic `for` loops in `frontend/src/components/alignment_modal/lanes.rs` (chapter ticks, connector-line anchor pairs, audio-file segments, audio-lane ticks), so Dioxus can diff each list by stable identity instead of position.
- Highest-priority loop (audio-file segments, `for f in files.iter()`) is keyed on `f.book_file_id` — the reorderable collection the issue called out as the real risk. The other three are keyed per the issue's suggested approach: chapter ticks on `{ch.title}-{ch.percent}`, connector-line anchor pairs on `{t}-{a}` (recomputed wholesale each render, so this is index-equivalent), and audio-lane ticks on their loop index.
- No behavior or markup change — `key:` is purely a diffing-identity hint (see `.claude/rules/07-hydration.md`); this does not touch SSR/hydration parity.
- Scoped strictly to `lanes.rs` to avoid a merge conflict with the concurrent #2020 PR, which touches `choice.rs` in the same directory.

## Test plan
- [x] `cargo fmt` — clean, no diff beyond the intended change
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2030 cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `CARGO_TARGET_DIR=/tmp/omnibus-target-2030 cargo test -p omnibus-frontend --features server` — PASS, 837 passed; 0 failed (includes `lanes.rs`'s existing unit tests, unmodified and still passing)

## Version
- [x] **Patch** — the default; left unlabeled per template (no `minor version` / `no release` label needed for this tech-debt fix).

## Notes
- Pure diffing-identity fix; no rendered markup changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9dW7FkCd9yTR2KBuXGAzX)_