### PR TITLE
fix: add missing key: to heatmap month/legend loops (#2045)

### DIFF
--- a/frontend/src/pages/stats/heatmap.rs
+++ b/frontend/src/pages/stats/heatmap.rs
@@ -189,13 +189,13 @@ pub(super) fn HeatmapCard(summary: StatsSummary) -> Element {
             }
             div { class: "st-hm-months", aria_hidden: "true",
                 for m in months {
-                    span { {m} }
+                    span { key: "{m}", {m} }
                 }
             }
             div { class: "st-hm-legend", aria_hidden: "true",
                 span { class: "mono", "less" }
                 for level in 0..5 {
-                    div { class: "st-hm-cell st-hm-{level}" }
+                    div { key: "{level}", class: "st-hm-cell st-hm-{level}" }
                 }
                 span { class: "mono", "more" }
             }


### PR DESCRIPTION
## Summary
- Closes #2045
- Adds a stable `key:` attribute to the two `rsx!` `for` loops in `frontend/src/pages/stats/heatmap.rs` that were missing it (trailing-year month labels row, keyed on the month string; less/more legend swatches, keyed on the level index) — bringing them in line with the other 149 keyed loops in the codebase, including the `cells` loop a few lines above in the same component.
- Pure markup change — no behavior change; `key:` only affects Dioxus's list diffing.

## Test plan
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — PASS, no warnings
- [x] `cargo test -p omnibus-frontend --features server` — PASS, 802 passed; 0 failed (including the 5 existing `pages::stats::heatmap::tests::*` tests)

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- No test changes were needed — this is a pure `key:` attribute addition with no observable behavior change, and the existing heatmap unit tests (day-math, intensity buckets, month labels, cell building) already cover the component's logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWPCGpP97RdK5wbP619ss5)_