### PR TITLE
refactor: reconcile deny.toml advisory ignores and skip-tree (#2054)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -90,7 +90,7 @@ ignore = [
     # (`cargo update -p memmap2`; patched in >= 0.9.11), which needs no change
     # to the Dioxus pin. See Cargo.lock.
     { id = "RUSTSEC-2024-0429", reason = "glib 0.18.5 VariantStrIter unsoundness — mobile/desktop only via wry→gtk→glib (patched in glib 0.20, forced by upstream gtk-rs 0.18 pin under wry); not reachable in the server build" },
-    { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 unsoundness — aliased mutable reference when a custom `log` logger calls rand::rng()/thread_rng() and ThreadRng reseeds mid-log; build-dependency only via phf_generator 0.8 (ammonia/html5ever codegen under wry), never links into any runtime binary and that logger-reseed path is not exercised in a build script" },
+    { id = "RUSTSEC-2026-0097", reason = "rand 0.7.3 unsoundness — aliased mutable reference when a custom `log` logger calls rand::rng()/thread_rng() and ThreadRng reseeds mid-log; build-dependency only via phf_generator 0.8, pulled in by kuchikiki (wry's bundled HTML/CSS engine, an old html5ever/cssparser codegen path), not ammonia — ammonia is a direct omnibus-db dependency but sits on a separate, newer markup5ever lineage that uses phf_generator 0.13 (fastrand-backed, no rand at all); never links into any runtime binary and that logger-reseed path is not exercised in a build script" },
 
     # ---- Unsound (informational) advisory reachable in the DEFAULT (server)
     # build — unlike the two mobile/desktop-confined entries just above, `lru`
@@ -263,9 +263,14 @@ skip = [
     { name = "convert_case", version = "0.8.0" },
 
     # --- rand 0.7 / 0.8 (build-dep only) + 0.9 (websocket) ---
-    # phf_generator (build dep of ammonia→html5ever) uses rand 0.7 and 0.8
-    # via two separate phf_generator versions on the codegen path — never
-    # links into the runtime binary. rand 0.9 is the runtime copy pulled by
+    # phf_generator uses rand 0.7 and 0.8 via two separate phf_generator
+    # versions on the codegen path, both pulled in transitively by kuchikiki
+    # (wry's bundled HTML/CSS engine, on an old html5ever/cssparser
+    # lineage) — NOT by `ammonia` (a direct omnibus-db dependency), which
+    # sits on its own newer markup5ever chain using phf_generator 0.13
+    # (fastrand-backed, no rand at all; verified with `cargo tree -i
+    # rand@0.7.3`/`@0.8.6` and `cargo tree -p omnibus-db`, issue #2054).
+    # Never links into the runtime binary. rand 0.9 is the runtime copy pulled by
     # tungstenite (masking-key RNG) across all three websocket versions;
     # blocked by the same Dioxus/Axum websocket split as tungstenite above.
     { name = "rand", version = "0.7.3" },
@@ -368,13 +373,17 @@ skip = [
 # default-build packages with `cargo tree -p omnibus` and
 # `cargo tree -p omnibus-frontend` (see #1276). None of these link into the
 # shipped `omnibus` server binary — they exist only under the native shell.
-# Exceptions: `rustc-hash`, `libloading`, `png`, and `windows-sys`/
-# `windows-targets` also duplicate via a path that reaches the default
-# (non-mobile) build directly — not through wry or tao — so skip-tree alone
-# doesn't collapse them; they're each an explicit `skip` entry above instead
-# (see docs/dependency-audit.md's rustc-hash row for the original case,
-# issue #2054 for the other three). Collapsing the rest requires
-# upstream wry/tao to migrate off gtk-rs 0.18 / bitflags 1 etc., which is
+# Exceptions: `rustc-hash`, `libloading`, `png`, and `windows-sys` also
+# duplicate via a path that reaches the default (non-mobile) build directly
+# — not through wry or tao — so skip-tree alone doesn't collapse them;
+# they're each an explicit `skip` entry above instead (see
+# docs/dependency-audit.md's rustc-hash row for the original case, issue
+# #2054 for the other three). `windows-targets` (windows-sys's own
+# dependency) has no matching `skip` entry because `cargo deny check bans`
+# does not flag it at all — its several Cargo.lock versions never surface as
+# a duplicate, presumably pruned by cargo-deny's own graph resolution the
+# same way `rsa` is (see the advisories section above). Collapsing the rest
+# requires upstream wry/tao to migrate off gtk-rs 0.18 / bitflags 1 etc., which is
 # gated on the Dioxus pin (see [patch.crates-io] in root Cargo.toml). We skip
 # the whole subtree rather than enumerate ~40 leaf crates that all share this
 # single root cause. Revisit when Dioxus upgrades wry/tao.

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,18 @@
 [advisories]
 version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
+# cargo-deny's own default for "unsound" (informational) advisories is
+# `Scope::Workspace` — it only evaluates them against our own workspace
+# crates, never their transitive dependencies. `unmaintained` already
+# defaults to `Scope::All`; without this override every `informational =
+# "unsound"` advisory below (glib, rand, lru) is silently never matched
+# against anything, so its `ignore` entry perpetually warns
+# `advisory-not-detected` regardless of whether the crate/version is
+# actually present. Verified via `cargo deny -L debug check advisories`:
+# with the default Workspace scope none of the three even get a
+# match/ignore trace; with `unsound = "all"` all three resolve and are
+# correctly suppressed by their `ignore` entries below (issue #2054).
+unsound = "all"
 # Yanked crates surface as warnings, not errors. Currently accepted:
 # `spin 0.9.8` (yanked, no advisory) — transitive via `flume` (sqlx-sqlite)
 # and `multer` (axum); collapses when either upstream drops it. See
@@ -21,12 +33,21 @@ yanked = "warn"
 # "sound" = no known exploitable vulnerability; "best-effort" also pulls in
 # unmaintained / notice advisories.
 ignore = [
-    # rsa "Marvin Attack" timing sidechannel. `rsa` enters Cargo.lock only via
-    # `sqlx-mysql`; this project uses sqlx with the sqlite backend only, so
-    # `rsa` is never compiled into any target (`cargo tree -i rsa --target all`
-    # is empty). No fixed `rsa` release exists yet — revisit when one ships.
-    # Keep in sync with the `--ignore` flag on the cargo-audit step in rust.yml.
-    { id = "RUSTSEC-2023-0071", reason = "rsa is lock-only via the unused sqlx-mysql backend; never compiled (sqlite-only), so not reachable" },
+    # ---- rsa "Marvin Attack" timing sidechannel (RUSTSEC-2023-0071) is
+    # deliberately NOT listed here, unlike every other entry in this block.
+    # `rsa` enters Cargo.lock only via `sqlx-mysql` (this project uses sqlx
+    # with the sqlite backend only), and unlike the informational advisories
+    # above, "vulnerability"-category advisories have no configurable scope
+    # to relax — the gap here is cargo-deny's own crate-graph resolution,
+    # which prunes `rsa` as genuinely unreachable for any built target
+    # (`cargo deny -L debug check advisories` logs `filtered rsa 0.9.10`;
+    # confirmed independently with `cargo tree -i rsa --target all`, which
+    # is empty even with `--workspace`). An `ignore` entry here can never
+    # match, so it would sit as permanent `advisory-not-detected` noise. The
+    # real exemption lives on the `--ignore RUSTSEC-2023-0071` flag on the
+    # cargo-audit step in rust.yml, which scans the raw Cargo.lock and does
+    # find it. No fixed `rsa` release exists yet — revisit when one ships,
+    # and keep the two tools' exemptions in sync until then.
 
     # ---- Unmaintained (informational) advisories pulled in by the Dioxus
     # desktop/mobile native shell tree (wry/tao → gtk-rs/webkit2gtk on Linux,
@@ -251,6 +272,56 @@ skip = [
     { name = "rand", version = "0.8.6" },
     { name = "rand", version = "0.9.4" },
 
+    # --- libloading (native shell vs Dioxus hot-patch machinery) ---
+    # 0.7.4 from libappindicator-sys (→ libappindicator → tray-icon →
+    # dioxus-desktop, native shell only, Linux tray icon support). 0.8.9 from
+    # `subsecond` (→ dioxus-core → dioxus), which IS in the default build —
+    # not purely a wry/tao-tree duplicate, so the skip-tree below doesn't
+    # collapse it. Internal impl detail either way (issue #2054).
+    { name = "libloading", version = "0.7.4" },
+    { name = "libloading", version = "0.8.9" },
+
+    # --- png (native shell tray icon vs cover/thumbnail decoding) ---
+    # 0.17.16 from muda/tray-icon (→ dioxus-desktop, native shell only).
+    # 0.18.1 from `image` (→ omnibus-db directly, default build — cover art
+    # and thumbnail decoding). Same "listed as a skip-tree example but not
+    # actually collapsed" gap as libloading: the default-build copy reaches
+    # the tree through `image`, not through wry/tao (issue #2054).
+    { name = "png", version = "0.17.16" },
+    { name = "png", version = "0.18.1" },
+
+    # --- rustc-hash (both versions reach the default build) ---
+    # 1.1.0 from sledgehammer_utils (→ dioxus-interpreter-js → BOTH
+    # dioxus-desktop and dioxus-server — the latter IS the default server
+    # build). 2.1.2 from dioxus-core directly. Neither copy is confined to
+    # the wry/tao native-shell subtree, so the skip-tree below deliberately
+    # excludes this crate (see docs/dependency-audit.md's rustc-hash row);
+    # explicit skip is the correct mechanism here (issue #2054).
+    { name = "rustc-hash", version = "1.1.0" },
+    { name = "rustc-hash", version = "2.1.2" },
+
+    # --- windows-sys (four-way split, all windows-target-conditional) ---
+    # `cargo deny` resolves the crate graph across every target (like
+    # `cargo tree --target all`), so these Windows-only (`cfg(windows)`)
+    # copies show up even though this project ships Linux/container-only.
+    # Each version straddles BOTH the native shell and the default build,
+    # so none can be absorbed by the wry/tao skip-tree alone:
+    #   0.52.0 — errno→rustix (native shell: x11rb/global-hotkey; dev-only:
+    #            tempfile) AND ring/rustls-webpki + signal-hook-registry→
+    #            tokio (default build, TLS + async runtime).
+    #   0.59.0 — dirs-sys + global-hotkey (native shell) AND nu-ansi-term→
+    #            tracing-subscriber (default build, Windows console color).
+    #   0.60.2 — muda/tray-icon (native shell) AND socket2→hyper-util/
+    #            lettre/tokio (default build).
+    #   0.61.2 — mio→tokio (default build) AND rfd + schannel→native-tls→
+    #            tungstenite (native shell) AND rustls-native-certs→
+    #            rustls-platform-verifier→reqwest (default build).
+    # Confirmed via `cargo deny -L debug check bans` (issue #2054).
+    { name = "windows-sys", version = "0.52.0" },
+    { name = "windows-sys", version = "0.59.0" },
+    { name = "windows-sys", version = "0.60.2" },
+    { name = "windows-sys", version = "0.61.2" },
+
     # --- webpki-roots ---
     # 0.26 from sqlx-core; 1.0 from hyper-rustls (reqwest).
     # Collapses when sqlx bumps its rustls deps.
@@ -293,14 +364,16 @@ skip = [
 # on Linux, muda/tray-icon, plus the windows-* and core-foundation/core-graphics
 # platform crates). These are old pinned versions carried by the native webview
 # stack (e.g. bitflags 1, derive_more 0.99, heck 0.4, html5ever/markup5ever,
-# string_cache, jni, png, raw-window-handle, siphasher, the
-# windows-sys/windows-targets family). Spot-checked against the default-build
-# packages with `cargo tree -p omnibus` and `cargo tree -p omnibus-frontend`
-# (see #1276). None of these link into the shipped `omnibus` server binary —
-# they exist only under the native shell.
-# Exception: `rustc-hash` also duplicates via `dioxus-core` in the default
-# (non-mobile) build, so it's deliberately left off this list — see
-# docs/dependency-audit.md's rustc-hash row. Collapsing the rest requires
+# string_cache, jni, raw-window-handle, siphasher). Spot-checked against the
+# default-build packages with `cargo tree -p omnibus` and
+# `cargo tree -p omnibus-frontend` (see #1276). None of these link into the
+# shipped `omnibus` server binary — they exist only under the native shell.
+# Exceptions: `rustc-hash`, `libloading`, `png`, and `windows-sys`/
+# `windows-targets` also duplicate via a path that reaches the default
+# (non-mobile) build directly — not through wry or tao — so skip-tree alone
+# doesn't collapse them; they're each an explicit `skip` entry above instead
+# (see docs/dependency-audit.md's rustc-hash row for the original case,
+# issue #2054 for the other three). Collapsing the rest requires
 # upstream wry/tao to migrate off gtk-rs 0.18 / bitflags 1 etc., which is
 # gated on the Dioxus pin (see [patch.crates-io] in root Cargo.toml). We skip
 # the whole subtree rather than enumerate ~40 leaf crates that all share this

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,6 +1,6 @@
 # Dependency Audit — Cargo.lock Duplicate Families
 
-Last updated: 2026-08-09 (issue #1767; previously issues #1710, #1621, #1529, #1530, #1100, #1268, #1147, #643).
+Last updated: 2026-08-20 (issue #2054; previously issues #1767, #1710, #1621, #1529, #1530, #1100, #1268, #1147, #643).
 
 Run `cargo tree -d` and inspect the output any time Dioxus or Axum are bumped.
 The `deny.toml` `[bans]` section has matching `skip` entries for all accepted
@@ -22,6 +22,8 @@ this list.
 | `hashlink` | 0.9.1, 0.10.0 | 0.9.1 via `rusqlite 0.32.1` (`omnibus-frontend`'s mobile-offline SQLite store); 0.10.0 via `sqlx-core 0.8.6` | **blocked by upstream** | Downstream instance of the same `rusqlite`/`sqlx` `libsqlite3-sys` coupling already documented for issue #1529 (see Policy section below) — the two crates simply vendor different `hashlink` minors alongside their independent `libsqlite3-sys` pins. Collapses only when that coordinated `rusqlite`/`sqlx` bump happens. |
 | `convert_case` | 0.4.0, 0.8.0, 0.10.0 | 0.4 from `derive_more 0.99.20` (proc-macro path, transitive via Dioxus desktop/mobile shells); 0.8 from Dioxus proc-macro crates (`dioxus-core-macro`, `dioxus-html-internal-macro`, `dioxus-stores-macro`); 0.10 from `derive_more-impl` (pulled by `dioxus-fullstack`) | **blocked by upstream** | Pure proc-macro dependency; not in any runtime binary image. |
 | `rand` | 0.7.3, 0.8.6, 0.9.4 | 0.7 from `phf_generator 0.8.0` (build dep of `ammonia` → `html5ever` chain); 0.8 from a separate `phf_generator` path; 0.9 from `rand_core@0.9` (via tungstenite) | **blocked by upstream** | The 0.7 and 0.8 copies are build-only (`phf_codegen` / `string_cache_codegen`) and never link into the runtime binary. |
+| `libloading` | 0.7.4, 0.8.9 | 0.7.4 via `libappindicator-sys` → `libappindicator` → `tray-icon` (native shell only); 0.8.9 via `subsecond` → `dioxus-core` → `dioxus` directly (default build) | **blocked by upstream** | Not confined to the `wry`/`tao` native-shell subtree — the 0.8.9 copy reaches `omnibus`/`omnibus-frontend` through `dioxus-core` regardless of platform, same shape as the `rustc-hash` row below. Collapses when `tray-icon`'s `libappindicator` pin catches up to `libloading 0.8`. |
+| `png` | 0.17.16, 0.18.1 | 0.17.16 via `muda`/`tray-icon` (native shell only, tray icon rendering); 0.18.1 via `image` → `omnibus-db` directly (default build, cover/thumbnail decoding) | **blocked by upstream** | Same "not confined to wry/tao" shape as `libloading` above. Collapses when `tray-icon`'s `muda` pin catches up to `png 0.18`. |
 | `webpki-roots` | 0.26.11, 1.0.7 | 0.26 from `sqlx-core`; 1.0.7 from `hyper-rustls` (reqwest) | **blocked by upstream** | sqlx-core pins 0.26; reqwest/hyper-rustls have moved to 1.x. Collapses when sqlx bumps its rustls deps. |
 | `axum-extra` | 0.10.3, 0.12.6 | 0.10.3 via `dioxus-fullstack` 0.7.9 (the git-pinned Dioxus tag); 0.12.6 via our own `omnibus` server crate directly | **blocked by upstream** | Mirrors the `tower-http` split below: the Dioxus git pin hasn't caught up to the `axum-extra` version our server crate uses. Collapses on the next Dioxus bump. |
 | `tower-http` | 0.6.11, 0.7.0 | 0.6.11 via `dioxus-fullstack`/`dioxus-server` 0.7.9 and transitively via **both** `reqwest` 0.12.28 and 0.13.4 (each vendors its own `tower-http` dependency); 0.7.0 via our own `omnibus` server crate directly | **blocked by upstream** | Not purely a Dioxus-version-lag issue like `axum-extra` above — `reqwest` 0.13.4 (our own workspace-pinned version, not just the older `dioxus-fullstack` copy) also depends directly on `tower-http 0.6.11` (see `Cargo.lock`'s `reqwest 0.13.4` dependency block). So a Dioxus bump alone won't collapse this: it persists until `reqwest` itself upgrades to `tower-http 0.7`, or our own server crate's direct `tower-http` dep is downgraded to 0.6.11 to match. |
@@ -30,7 +32,8 @@ this list.
 | `gloo-timers` | 0.3.0, 0.4.0 | 0.3.0 via `dioxus-web` 0.7.9 (the git-pinned Dioxus tag); 0.4.0 via `omnibus-frontend`'s own direct pin (`frontend/Cargo.toml`, behind the `web` feature) | **blocked by upstream** | Same root cause as the `gloo-net` row above. Resolves automatically once Dioxus publishes a crates.io release matching the git tag, tracked by #522. |
 | `gloo-utils` | 0.2.0, 0.3.0 | 0.2.0 transitively via `gloo-net 0.6.0`; 0.3.0 transitively via `gloo-net 0.7.0` | **blocked by upstream** | Follows the `gloo-net` split one level down and collapses in lockstep with it. Resolves automatically once Dioxus publishes a crates.io release matching the git tag, tracked by #522. |
 | `digest` | 0.10.7 (×2) | Both consumers are `sha1` (axum/tungstenite) + `blake2`/`sha2` (argon2/sqlx) | N/A — same version | `cargo tree -d` shows two entry paths to the same version (different consumers). No actual duplicate in the lockfile. |
-| `rustc-hash` | 1.1.0, 2.1.2 | 1.1.0 via `sledgehammer_utils` (pulled in by `dioxus-interpreter-js`, which both `dioxus-web` and `dioxus-server` depend on); 2.1.2 as a direct dependency of `dioxus-core` | **blocked by upstream** | Verified with `cargo tree -i rustc-hash@1.1.0` / `@2.1.2` (not assumed): both versions are reachable from the default, non-mobile build via `dioxus-core`/`dioxus-server`/`dioxus-web`, which `omnibus` and `omnibus-frontend` depend on directly — i.e. **inside** the shipped web/WASM bundle, not confined to the `wry`/`tao` mobile native-shell subtree (despite that subtree's skip-tree comment in `deny.toml` also naming `rustc-hash` among its duplicates — the mobile subtree apparently resolves to one of these same two versions rather than introducing a third). Collapses when Dioxus unifies its internal `rustc-hash` pin. |
+| `rustc-hash` | 1.1.0, 2.1.2 | 1.1.0 via `sledgehammer_utils` (pulled in by `dioxus-interpreter-js`, which both `dioxus-web` and `dioxus-server` depend on); 2.1.2 as a direct dependency of `dioxus-core` | **blocked by upstream** | Verified with `cargo tree -i rustc-hash@1.1.0` / `@2.1.2` (not assumed): both versions are reachable from the default, non-mobile build via `dioxus-core`/`dioxus-server`/`dioxus-web`, which `omnibus` and `omnibus-frontend` depend on directly — i.e. **inside** the shipped web/WASM bundle, not confined to the `wry`/`tao` mobile native-shell subtree (despite that subtree's skip-tree comment in `deny.toml` also naming `rustc-hash` among its duplicates — the mobile subtree apparently resolves to one of these same two versions rather than introducing a third). Collapses when Dioxus unifies its internal `rustc-hash` pin. As of issue #2054 this row finally has the matching `deny.toml` `skip` entries the Policy section below promises — a prior gap: the row existed here but `bans` had nothing suppressing it. |
+| `windows-sys` | 0.52.0, 0.59.0, 0.60.2, 0.61.2 | Four independent chains, each straddling both the native shell and the default build (`cfg(windows)`-gated, so `cargo deny`'s all-target resolution surfaces them even though this project ships Linux/container-only): 0.52.0 via `errno`→`rustix` (native shell) **and** `ring`/`rustls-webpki` + `signal-hook-registry`→`tokio` (default build); 0.59.0 via `dirs-sys`/`global-hotkey` (native shell) **and** `nu-ansi-term`→`tracing-subscriber` (default build); 0.60.2 via `muda`/`tray-icon` (native shell) **and** `socket2`→`hyper-util`/`lettre`/`tokio` (default build); 0.61.2 via `rfd`/`schannel`→`native-tls`→`tungstenite` (native shell) **and** `mio`→`tokio` + `rustls-native-certs`→`rustls-platform-verifier`→`reqwest` (default build) | **blocked by upstream** | Not confined to `wry`/`tao` — the default-build paths run through `tokio`/`rustls`/`tracing-subscriber`, core dependencies of the shipped server. Windows target support in those crates is out of this project's control. |
 | `bytes`, `futures-*`, `num-traits`, `tokio`, `manganis-core`, `log`, `fastrand`, `sqlx-sqlite` | (shown ×2 each) | Multiple downstream consumers | N/A — same version | Same pattern as `digest`: one version, multiple reverse-dependency entry points in the `cargo tree -d` output. Not true duplicates. |
 
 ## First-party skew resolved in this PR
@@ -46,6 +49,44 @@ this list.
   `catch_unwind` plus a panicking `Drop` on a cached key during a pop, which
   `dioxus-server`'s internal use does not trigger. `deny.toml` ignores it
   with a matching comment. Revisit when Dioxus bumps `lru` to >= 0.18.2.
+- `glib 0.18.5` — RUSTSEC-2024-0429 (unsound: `VariantStrIter` iterator
+  impls). Reaches the production graph via `wry`/`tao` → `gtk-rs`; patched
+  in glib 0.20, forced to 0.18 by the upstream gtk-rs pin under `wry`.
+  `deny.toml` ignores it with a matching comment.
+- `rand 0.7.3` — RUSTSEC-2026-0097 (unsound: aliased mutable reference when
+  a custom `log` logger calls `rand::rng()`/`thread_rng()` mid-log).
+  Build-dependency only, via `phf_generator 0.8` (`ammonia`/`html5ever`
+  codegen under `wry`) — never links into any runtime binary, and that
+  logger-reseed path isn't exercised in a build script. `deny.toml` ignores
+  it with a matching comment.
+- **`unsound` scope gap (issue #2054):** all three entries above sat as
+  permanently-unmatched `deny.toml` `ignore` entries — `cargo deny check
+  advisories` reported `advisory-not-detected` for every one, not because
+  the crate/version was wrong, but because cargo-deny's own `[advisories]
+  unsound` setting defaults to `Scope::Workspace` (only our own workspace
+  crates), unlike `unmaintained`'s default of `Scope::All`. A transitive
+  `informational = "unsound"` advisory was therefore never evaluated at
+  all. Fixed by setting `unsound = "all"` in `deny.toml`, verified with
+  `cargo deny -L debug check advisories` before/after (see the comment
+  above `unsound = "all"` in `deny.toml` for the exact trace). `cargo
+  audit` was never affected by this gap — it scans the raw `Cargo.lock`
+  directly and always found these three (as warnings, not errors, since
+  none carry a `vulnerability` category).
+- **`rsa 0.9.10` / RUSTSEC-2023-0071 — deliberately not in `deny.toml`**
+  (issue #2054): unlike the three above, this advisory has no `informational`
+  category (it's a true `vulnerability`), so the `unsound`-scope fix above
+  doesn't apply — and there's no configurable scope for vulnerability-class
+  advisories to relax. The actual gap is that cargo-deny's own crate-graph
+  resolution prunes `rsa` as unreachable for any built target before the
+  advisories check ever runs (`cargo deny -L debug check advisories` logs
+  `filtered rsa 0.9.10`; independently confirmed with `cargo tree -i rsa
+  --target all`, empty even with `--workspace`). An `ignore` entry for it in
+  `deny.toml` can therefore never match anything and would sit as permanent
+  `advisory-not-detected` noise, so it was removed rather than kept stale.
+  `rsa` is real, present, and unpatched per `cargo audit` (which does not
+  do this pruning) — its exemption lives on the `--ignore RUSTSEC-2023-0071`
+  flag on the cargo-audit step in `rust.yml`, which is the tool that
+  actually encounters it.
 
 ## Yanked crates
 

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -21,7 +21,7 @@ this list.
 | `foldhash` | 0.1.5, 0.2.0 | 0.1.5 via `hashbrown 0.15.5` (sqlx-core/hashlink path); 0.2.0 via `hashbrown 0.16.1` (dioxus-server's `lru`/`metrics-util` path) | **accepted intentionally** | One copy per `hashbrown` minor — both are internal impl details of `hashbrown`, same root cause as the `hashbrown` row above. Classified separately, though: the `deny.toml` skips for both `foldhash` versions are already in place, unlike `hashbrown`'s still-open four-way spread. Already carries a `deny.toml` skip + comment. |
 | `hashlink` | 0.9.1, 0.10.0 | 0.9.1 via `rusqlite 0.32.1` (`omnibus-frontend`'s mobile-offline SQLite store); 0.10.0 via `sqlx-core 0.8.6` | **blocked by upstream** | Downstream instance of the same `rusqlite`/`sqlx` `libsqlite3-sys` coupling already documented for issue #1529 (see Policy section below) — the two crates simply vendor different `hashlink` minors alongside their independent `libsqlite3-sys` pins. Collapses only when that coordinated `rusqlite`/`sqlx` bump happens. |
 | `convert_case` | 0.4.0, 0.8.0, 0.10.0 | 0.4 from `derive_more 0.99.20` (proc-macro path, transitive via Dioxus desktop/mobile shells); 0.8 from Dioxus proc-macro crates (`dioxus-core-macro`, `dioxus-html-internal-macro`, `dioxus-stores-macro`); 0.10 from `derive_more-impl` (pulled by `dioxus-fullstack`) | **blocked by upstream** | Pure proc-macro dependency; not in any runtime binary image. |
-| `rand` | 0.7.3, 0.8.6, 0.9.4 | 0.7 from `phf_generator 0.8.0` (build dep of `ammonia` → `html5ever` chain); 0.8 from a separate `phf_generator` path; 0.9 from `rand_core@0.9` (via tungstenite) | **blocked by upstream** | The 0.7 and 0.8 copies are build-only (`phf_codegen` / `string_cache_codegen`) and never link into the runtime binary. |
+| `rand` | 0.7.3, 0.8.6, 0.9.4 | 0.7 and 0.8 both from `phf_generator` build-dep chains rooted in `kuchikiki` (wry's bundled HTML/CSS engine, on an old html5ever/cssparser lineage) → `wry` — **not** `ammonia`, which is a direct `omnibus-db` dependency but sits on a separate, newer `markup5ever` lineage using `phf_generator 0.13` (fastrand-backed, no `rand` at all); 0.9 from `rand_core@0.9` (via tungstenite) | **blocked by upstream** | Verified with `cargo tree -i rand@0.7.3` / `@0.8.6` and `cargo tree -p omnibus-db` (issue #2054): both build-dep copies terminate at `wry`, confined to the native shell. The 0.7 and 0.8 copies are build-only (`phf_codegen` / `string_cache_codegen`) and never link into the runtime binary. |
 | `libloading` | 0.7.4, 0.8.9 | 0.7.4 via `libappindicator-sys` → `libappindicator` → `tray-icon` (native shell only); 0.8.9 via `subsecond` → `dioxus-core` → `dioxus` directly (default build) | **blocked by upstream** | Not confined to the `wry`/`tao` native-shell subtree — the 0.8.9 copy reaches `omnibus`/`omnibus-frontend` through `dioxus-core` regardless of platform, same shape as the `rustc-hash` row below. Collapses when `tray-icon`'s `libappindicator` pin catches up to `libloading 0.8`. |
 | `png` | 0.17.16, 0.18.1 | 0.17.16 via `muda`/`tray-icon` (native shell only, tray icon rendering); 0.18.1 via `image` → `omnibus-db` directly (default build, cover/thumbnail decoding) | **blocked by upstream** | Same "not confined to wry/tao" shape as `libloading` above. Collapses when `tray-icon`'s `muda` pin catches up to `png 0.18`. |
 | `webpki-roots` | 0.26.11, 1.0.7 | 0.26 from `sqlx-core`; 1.0.7 from `hyper-rustls` (reqwest) | **blocked by upstream** | sqlx-core pins 0.26; reqwest/hyper-rustls have moved to 1.x. Collapses when sqlx bumps its rustls deps. |
@@ -55,8 +55,12 @@ this list.
   `deny.toml` ignores it with a matching comment.
 - `rand 0.7.3` — RUSTSEC-2026-0097 (unsound: aliased mutable reference when
   a custom `log` logger calls `rand::rng()`/`thread_rng()` mid-log).
-  Build-dependency only, via `phf_generator 0.8` (`ammonia`/`html5ever`
-  codegen under `wry`) — never links into any runtime binary, and that
+  Build-dependency only, via `phf_generator 0.8` pulled in by `kuchikiki`
+  (wry's bundled HTML/CSS engine, an old html5ever/cssparser codegen path)
+  — genuinely confined to `wry`, but *not* via `ammonia`: `ammonia` is a
+  direct `omnibus-db` dependency, but sits on a separate, newer
+  `markup5ever` lineage that uses `phf_generator 0.13` (fastrand-backed, no
+  `rand` involved at all). Never links into any runtime binary, and that
   logger-reseed path isn't exercised in a build script. `deny.toml` ignores
   it with a matching comment.
 - **`unsound` scope gap (issue #2054):** all three entries above sat as


### PR DESCRIPTION
## Summary
- Closes #2054
- Fix two `cargo deny check advisories sources bans` hygiene gaps in `deny.toml`:
  1. **Four stale `[advisories.ignore]` entries** (`RUSTSEC-2023-0071` rsa, `RUSTSEC-2024-0429` glib, `RUSTSEC-2026-0097` rand 0.7.3, `RUSTSEC-2026-0253` lru) all warned `advisory-not-detected` even though `cargo audit` finds all four present in `Cargo.lock`. Root-caused via `cargo deny -L debug check advisories`: cargo-deny's `[advisories] unsound` scope defaults to `Scope::Workspace` (only our own workspace crates), unlike `unmaintained`'s `Scope::All` default — so every `informational = "unsound"` advisory (glib, rand, lru) was structurally never evaluated against a transitive dependency, regardless of version. Setting `unsound = "all"` fixes matching for those three (verified: no longer reported as unmatched). The fourth, rsa, is a true `vulnerability`-category advisory with no configurable scope to relax — it's genuinely pruned from cargo-deny's own resolved graph as unreachable (`filtered rsa 0.9.10` in debug output; independently confirmed with `cargo tree -i rsa --target all`, empty even with `--workspace`), so an `ignore` entry for it can never match and was removed; its real exemption already lives on the `--ignore RUSTSEC-2023-0071` flag on the cargo-audit step in `rust.yml` (unchanged), which scans the raw lockfile directly and does find it.
  2. **Four duplicate-version `bans` warnings** (`libloading`, `png`, `rustc-hash`, `windows-sys`) escaped the `skip-tree = [wry, tao]` block because each has a copy that reaches the default (non-mobile) build through a path that does *not* run through `wry`/`tao` (e.g. `image` → `omnibus-db` for `png`, `dioxus-core` directly for `rustc-hash`/`libloading`, `tokio`/`rustls`/`tracing-subscriber` for the Windows-target-conditional `windows-sys`). Added explicit `skip` entries with source-chain comments for all four, matching the file's existing pattern for other straddling crates (`hashbrown`, `getrandom`). Also corrected the skip-tree block's own comment, which listed `png` and the `windows-sys`/`windows-targets` family as things it covers when it didn't fully absorb them.
- Updated `docs/dependency-audit.md`'s duplicate-family table (new rows for `libloading`, `png`, `windows-sys`; updated `rustc-hash` note) and its "Accepted advisories" section (added `glib`/`rand` entries, explained the `unsound` scope fix, and documented why `rsa` is deliberately absent from `deny.toml`).

## Test plan
- [x] `cargo deny check advisories sources bans` (after fix) — `bans ok, sources ok`; `advisories` still reports `FAILED`, but only for a pre-existing, unrelated advisory that surfaced independently of this issue: `RUSTSEC-2026-0258` (h2 unbounded empty DATA frames, published 2026-08-17, low severity, not in scope for #2054 — no ignore/fix attempted here per the issue's scope and the "stay surgical" instruction) plus the already-accepted `spin` yanked warning. No `advisory-not-detected` warnings remain, and zero bans duplicate-version warnings remain (down from the 4 in the issue).
- [x] `cargo deny check bans -s` — `bans ok: 0 errors, 0 warnings, 505 notes` (was 4 warnings before the fix).
- [x] `cargo deny check licenses` — `licenses ok` (unaffected sanity check).
- [x] `cargo audit` (v0.22.2, fresh advisory-db clone) — confirms `rsa`, `glib`, `rand 0.7.3`, `lru` are all genuinely present in `Cargo.lock` at the advisory-affected versions (2 vulnerabilities: `h2` + `rsa`; 16 allowed warnings including the 3 unsound ones), matching the issue's claim and grounding the `deny.toml` fix.
- [x] Manually verified reachability claims used in the new comments: `cargo tree -i rsa --target all` / `cargo tree --workspace -i rsa --target all` → empty (rsa genuinely unreachable); `cargo tree --workspace -i rand@0.7.3 --target all` / `-i glib --target all` → reachable via `omnibus`/`omnibus-frontend` (default build), confirming the `unsound = "all"` fix is the correct root cause rather than a version mismatch.

Neither `cargo-deny` nor `cargo-audit` were pre-installed in the sandbox; both were installed via `cargo install --locked` (network access to `index.crates.io` and `raw.githubusercontent.com` was available through the proxy's allowlist) so all of the above is real tool output, not a manual best-effort analysis.

## Version
- [x] **Patch** — the default; left unlabeled (docs/config hygiene fix, no functional or release-relevant behavior change).

## Notes
- Per task instructions: no release labels applied, and no assignee/label set on the PR — the `create_pull_request` MCP tool's schema doesn't expose either parameter, so both are skipped as explicitly permitted.
- `RUSTSEC-2026-0258` (h2, low severity, patched in h2 >= 0.4.16) is a new, unrelated finding surfaced by the same `cargo deny check advisories` run. It postdates this issue's filing and isn't mentioned in #2054's scope, so it was deliberately left untouched here (a `cargo update -p h2` lockfile-only bump would be the fix) — flagging it in case a follow-up issue is wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWPCGpP97RdK5wbP619ss5)_