### PR TITLE
refactor: order import blocks and prefix test names with fn under test (#2055)

### DIFF
--- a/db/src/journals/markdown/tests.rs
+++ b/db/src/journals/markdown/tests.rs
@@ -26,13 +26,13 @@ fn render_strips_script_tags() {
 }
 
 #[test]
-fn strips_event_handler_attributes() {
+fn render_strips_event_handler_attributes() {
     let html = render("<a href=\"#\" onclick=\"steal()\">link</a>");
     assert!(!html.contains("onclick"), "handlers stripped: {html}");
 }
 
 #[test]
-fn wraps_spoiler_markers_in_keyboard_reachable_buttons() {
+fn render_wraps_spoiler_markers_in_keyboard_reachable_buttons() {
     // The spoiler wrapper is a real button so keyboard/screen-reader users
     // can reveal it. `type="button"` keeps it out of any surrounding form
     // (composer submits happen via a distinct Publish button), and
@@ -46,14 +46,14 @@ fn wraps_spoiler_markers_in_keyboard_reachable_buttons() {
 }
 
 #[test]
-fn spoiler_inner_text_is_markdown_processed() {
+fn render_processes_markdown_inside_spoiler_text() {
     let html = render("||the **butler** did it||");
     assert!(html.contains("class=\"spoiler\""), "got: {html}");
     assert!(html.contains("<strong>butler</strong>"), "got: {html}");
 }
 
 #[test]
-fn unterminated_spoiler_marker_is_left_literal() {
+fn render_leaves_unterminated_spoiler_marker_literal() {
     let html = render("a lone ||marker here");
     assert!(!html.contains("class=\"spoiler\""), "got: {html}");
     assert!(!html.contains("<button"), "no button emitted: {html}");
@@ -61,7 +61,7 @@ fn unterminated_spoiler_marker_is_left_literal() {
 }
 
 #[test]
-fn renders_task_list_checkboxes() {
+fn render_emits_task_list_checkboxes() {
     let html = render("- [x] done\n- [ ] todo");
     // A checked + an unchecked disabled checkbox survive sanitization.
     assert!(html.contains("type=\"checkbox\""), "got: {html}");
@@ -70,7 +70,7 @@ fn renders_task_list_checkboxes() {
 }
 
 #[test]
-fn strips_non_checkbox_input_element_entirely() {
+fn render_strips_non_checkbox_input_element_entirely() {
     // ammonia would keep the allowlisted `input` tag while stripping its
     // disallowed attributes, leaving a bare `<input>` (a text field by
     // default). The whole element — not just its attributes — must go.
@@ -81,7 +81,7 @@ fn strips_non_checkbox_input_element_entirely() {
 }
 
 #[test]
-fn strips_button_and_bare_inputs_entirely() {
+fn render_strips_button_and_bare_inputs_entirely() {
     // Non-checkbox inputs of any flavour, including an attribute-less one and
     // an *interactive* (non-disabled) checkbox, must not survive — each
     // degrades to a bare/enabled `<input>` under ammonia. Only the disabled
@@ -118,7 +118,7 @@ fn drop_non_checkbox_inputs_matches_real_attribute_tokens() {
 }
 
 #[test]
-fn renders_lone_image_as_captioned_figure() {
+fn render_wraps_lone_image_as_captioned_figure() {
     let html = render("![A sunset over the bay](/api/journals/images/abc.png)");
     assert!(
         html.contains("<figure class=\"journal-figure\">"),
@@ -135,14 +135,14 @@ fn renders_lone_image_as_captioned_figure() {
 }
 
 #[test]
-fn lone_image_without_alt_gets_no_figcaption() {
+fn render_omits_figcaption_for_lone_image_without_alt() {
     let html = render("![](/api/journals/images/abc.png)");
     assert!(html.contains("<figure"), "got: {html}");
     assert!(!html.contains("<figcaption>"), "got: {html}");
 }
 
 #[test]
-fn inline_image_amid_text_stays_unwrapped() {
+fn render_leaves_inline_image_amid_text_unwrapped() {
     let html = render("before ![tiny](/api/journals/images/abc.png) after");
     assert!(html.contains("<img"), "got: {html}");
     assert!(
@@ -152,7 +152,7 @@ fn inline_image_amid_text_stays_unwrapped() {
 }
 
 #[test]
-fn strips_images_with_offsite_or_off_prefix_src() {
+fn render_strips_images_with_offsite_or_off_prefix_src() {
     for md in [
         "![x](https://evil.example/track.png)",
         "![x](/covers/1.png)",
@@ -168,7 +168,7 @@ fn strips_images_with_offsite_or_off_prefix_src() {
 }
 
 #[test]
-fn hand_authored_figure_cannot_carry_the_journal_figure_class() {
+fn render_strips_journal_figure_class_from_hand_authored_figure() {
     // ammonia's defaults keep bare `<figure>`/`<figcaption>` (harmless
     // semantic markup), but the styled class only comes from our own
     // `wrap_figures` pass — a hand-authored one is stripped.
@@ -177,7 +177,7 @@ fn hand_authored_figure_cannot_carry_the_journal_figure_class() {
 }
 
 #[test]
-fn disallows_arbitrary_span_classes() {
+fn render_disallows_arbitrary_span_classes() {
     // Since spoilers no longer use `<span>`, the sanitizer no longer
     // allowlists any class on it: `<span>` itself remains under ammonia's
     // default tag list, but its `class` attribute (and thus a hand-authored
@@ -188,7 +188,7 @@ fn disallows_arbitrary_span_classes() {
 }
 
 #[test]
-fn disallows_arbitrary_button_classes_and_attrs() {
+fn render_disallows_arbitrary_button_classes_and_attrs() {
     // Only the spoiler wrapper's exact shape (`class="spoiler"`,
     // `type="button"`, `aria-expanded` ∈ {true,false}) is allowlisted; any
     // other class, an off-list `type`, or a spoofed `aria-expanded` value

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -314,12 +314,12 @@ find.
 like `search_books_finds_by_title_and_ranks_by_bm25`,
 `list_books_populates_formats_from_book_files`.
 
-**Anti-pattern.** [db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
-has a name like `strips_event_handler_attributes` that elides the
-function-under-test convention entirely — it tests `render`, the
-function whose behavior it's checking, but the name doesn't say so.
-Compare `render_emits_del_for_strikethrough` a few lines above in the
-same file, which correctly prefixes with the function it tests.
+**Anti-pattern.** A name like `strips_event_handler_attributes` elides
+the function-under-test convention entirely — it says what happened but
+not what did it. `render_strips_event_handler_attributes` is the same
+test named as a spec, and it is the shape every test in
+[db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
+now takes.
 
 ---
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -317,9 +317,9 @@ like `search_books_finds_by_title_and_ranks_by_bm25`,
 **Anti-pattern.** A name like `strips_event_handler_attributes` elides
 the function-under-test convention entirely — it says what happened but
 not what did it. `render_strips_event_handler_attributes` is the same
-test named as a spec, and it is the shape every test in
+test named as a spec. Every test in
 [db/src/journals/markdown/tests.rs](../db/src/journals/markdown/tests.rs)
-now takes.
+now leads with the function it exercises.
 
 ---
 

--- a/frontend/src/components/bottom_nav.rs
+++ b/frontend/src/components/bottom_nav.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn library_tab_lights_across_library_section() {
+    fn is_active_lights_library_tab_across_library_section() {
         assert!(is_active(&Route::Landing {}, TabKind::Library));
         assert!(is_active(&Route::Shelves {}, TabKind::Library));
         assert!(is_active(&Route::ShelfDetail { id: 3 }, TabKind::Library));
@@ -179,13 +179,13 @@ mod tests {
     }
 
     #[test]
-    fn authors_tab_lights_on_its_details() {
+    fn is_active_lights_authors_tab_on_author_details() {
         assert!(is_active(&Route::AuthorsIndex {}, TabKind::Authors));
         assert!(is_active(&Route::AuthorDetail { id: 1 }, TabKind::Authors));
     }
 
     #[test]
-    fn series_routes_light_no_tab_since_series_left_the_bar() {
+    fn is_active_lights_no_tab_for_series_routes() {
         // Series is no longer a bottom tab; its routes must not light any tab.
         for tab in [
             TabKind::Library,
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn you_tab_lights_across_account_section() {
+    fn is_active_lights_you_tab_across_account_section() {
         assert!(is_active(&Route::Account {}, TabKind::You));
         assert!(is_active(&Route::Settings { section: None }, TabKind::You));
         assert!(is_active(&Route::AddBooks {}, TabKind::You));
@@ -208,14 +208,14 @@ mod tests {
     }
 
     #[test]
-    fn stats_tab_lights_only_on_the_stats_route() {
+    fn is_active_lights_stats_tab_only_on_the_stats_route() {
         assert!(is_active(&Route::Stats {}, TabKind::Stats));
         assert!(!is_active(&Route::Landing {}, TabKind::Stats));
         assert!(!is_active(&Route::Stats {}, TabKind::Library));
     }
 
     #[test]
-    fn tabs_are_mutually_exclusive_on_landing() {
+    fn is_active_makes_tabs_mutually_exclusive_on_landing() {
         let here = Route::Landing {};
         assert!(is_active(&here, TabKind::Library));
         assert!(!is_active(&here, TabKind::Authors));
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn account_route_lights_only_the_you_tab() {
+    fn is_active_lights_only_the_you_tab_on_the_account_route() {
         let here = Route::Account {};
         assert!(!is_active(&here, TabKind::Library));
         assert!(!is_active(&here, TabKind::Authors));

--- a/frontend/src/components/bottom_nav.rs
+++ b/frontend/src/components/bottom_nav.rs
@@ -179,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn is_active_lights_authors_tab_on_author_details() {
+    fn is_active_lights_authors_tab_across_authors_section() {
         assert!(is_active(&Route::AuthorsIndex {}, TabKind::Authors));
         assert!(is_active(&Route::AuthorDetail { id: 1 }, TabKind::Authors));
     }

--- a/server/src/backend/routes.rs
+++ b/server/src/backend/routes.rs
@@ -10,13 +10,14 @@ use axum::{
     Router,
 };
 
+use crate::rate_limit::{rate_limit_by_ip, RateLimiter};
+
 use super::{
     account, admin_health, admin_sessions, audiobooks, author_photos, authors, bookmarks, covers,
     cross_format, ebooks, genres, highlights, journals, kindle, metadata, overrides, physical,
     profile, progress, ratings, read_status, scan, search, series, settings, shelves, stats,
     suggestions, summary, tags, uploads, users, AppState,
 };
-use crate::rate_limit::{rate_limit_by_ip, RateLimiter};
 
 /// Health check, settings, ebooks, and audiobook playback routes.
 pub(super) fn content_routes() -> Router<AppState> {

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -4,16 +4,17 @@
 //! `X-Forwarded-For` via `OMNIBUS_TRUST_FORWARDED_FOR=1`). Mounted
 //! per-router in `server/src/main.rs`.
 
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use axum::{
     extract::{ConnectInfo, Request, State},
     http::{self, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 /// Default window for the auth-endpoint limiter.


### PR DESCRIPTION
## Summary
- `server/src/rate_limit.rs` — moved the `std::` block ahead of the external-crate block and merged the stranded `tokio::sync::Mutex` into the same block as `axum`, per `.claude/rules/05-rust-style.md` § Mechanics.
- `server/src/backend/routes.rs` — put `use crate::rate_limit::{…}` before `use super::{…}`, separated by a blank line, so the `crate::` and `super::` blocks read in the rule's order.
- `db/src/journals/markdown/tests.rs` — every test exercising `render` is now prefixed with it (18 tests; the file's one `drop_non_checkbox_inputs` test was already correctly named). Went file-wide rather than just the 8 names the issue lists.
- `frontend/src/components/bottom_nav.rs` — all 7 tests for the `is_active` helper renamed to `is_active_*` spec style.
- `docs/style-guide.md` — refreshed the § Naming anti-pattern, which cited `strips_event_handler_attributes` by name as a live example in a file this PR makes fully compliant. Kept the same before/after teaching point, now framed as a name rather than a citation (rule 98).

Pure rename/reorder. No behavior change, no test logic touched, none added or removed.

Closes #2055

## Test plan
- [x] `cargo fmt` — PASS (no reformatting of the reordered blocks)
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db journals` — PASS (43 passed, 0 failed; all 18 `markdown::tests` green under their new names)
- [x] `cargo test -p omnibus-frontend --features server bottom_nav` — PASS (7 passed, 0 failed)
- [x] `cargo test -p omnibus` — 868 passed, 2 failed; both failures are pre-existing and unrelated (see Notes)

## Notes
> [!NOTE]
> `cargo test -p omnibus` reports two failures — `backend::uploads::tests::commit_rejects_read_only_library_with_400` and `…::audiobook_commit_rejects_read_only_library_with_400`. Both fail identically on a clean checkout of this branch's merge base with the changes stashed, so they are not introduced here. They look environmental: the tests make a directory read-only via `chmod` and assert a 400, which does not hold when the test process runs as uid 0. Nothing in this PR touches `backend::uploads`.

> [!NOTE]
> `just lint` / `just test` were not run — this environment has no Nix. The equivalent `cargo fmt`/`clippy`/`test` invocations above were run directly against the affected crates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmMuZvBbXPyLmMpmtLu3u)_