### PR TITLE
refactor: cover zero-coverage utility modules and untested thiserror variants (#2053)

### DIFF
--- a/db/src/cross_format/tests.rs
+++ b/db/src/cross_format/tests.rs
@@ -152,6 +152,14 @@ async fn upsert_link_returns_book_not_found_for_unknown_uuid() {
 }
 
 #[tokio::test]
+async fn get_link_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = get_link(&pool, 1, "some-uuid").await;
+    assert!(matches!(err, Err(CrossFormatError::Sqlx(_))));
+}
+
+#[tokio::test]
 async fn link_is_stale_flips_when_the_audio_file_set_changes() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "alice").await;

--- a/db/src/http_client.rs
+++ b/db/src/http_client.rs
@@ -22,3 +22,21 @@ pub(crate) fn default_user_agent() -> String {
         env!("CARGO_PKG_VERSION")
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_client_succeeds_with_a_default_user_agent() {
+        let client = build_client(&default_user_agent());
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn default_user_agent_names_the_crate_and_repo() {
+        let ua = default_user_agent();
+        assert!(ua.starts_with("omnibus/"));
+        assert!(ua.contains("github.com/sloansa/omnibus"));
+    }
+}

--- a/db/src/kobo_devices.rs
+++ b/db/src/kobo_devices.rs
@@ -7,7 +7,7 @@
 use serde::Serialize;
 use sqlx::{Row, SqlitePool};
 
-use crate::auth::generate_token;
+use crate::auth::{generate_token, AuthResult};
 
 /// Column list shared by every row-returning query, matched by [`row_to_device`].
 const COLS: &str =
@@ -57,7 +57,18 @@ pub async fn create_device(
     user_id: i64,
     name: &str,
 ) -> Result<KoboDevice, KoboDeviceError> {
-    let token = generate_token().map_err(|e| KoboDeviceError::Token(e.to_string()))?;
+    create_device_with_token(pool, user_id, name, generate_token).await
+}
+
+/// `create_device` with the token generator passed in, so a test can inject a
+/// forced failure without depending on the OS CSPRNG actually erroring.
+async fn create_device_with_token(
+    pool: &SqlitePool,
+    user_id: i64,
+    name: &str,
+    token_fn: impl FnOnce() -> AuthResult<String>,
+) -> Result<KoboDevice, KoboDeviceError> {
+    let token = token_fn().map_err(|e| KoboDeviceError::Token(e.to_string()))?;
     let row = sqlx::query(&format!(
         "INSERT INTO kobo_devices (user_id, token, name)
          VALUES (?, ?, ?)

--- a/db/src/kobo_devices/tests.rs
+++ b/db/src/kobo_devices/tests.rs
@@ -44,6 +44,26 @@ async fn create_device_propagates_db_error_when_pool_is_closed() {
 }
 
 #[tokio::test]
+async fn create_device_surfaces_a_token_error_when_generation_fails() {
+    // generate_token()'s real failure mode is a CSPRNG error, which isn't
+    // forceable from a test — inject a failing generator through the
+    // private seam instead to exercise the `.map_err` branch.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool, "reader").await;
+
+    let err = create_device_with_token(&pool, user, "Kobo", || {
+        Err(crate::auth::AuthError::Crypto(
+            "forced CSPRNG failure for test".to_string(),
+        ))
+    })
+    .await;
+    assert!(
+        matches!(err, Err(KoboDeviceError::Token(msg)) if msg.contains("forced CSPRNG failure"))
+    );
+    assert!(list_devices(&pool, user).await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn create_device_mints_unique_tokens_per_device() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let user = seed_user(&pool, "reader").await;

--- a/server/src/http_errors.rs
+++ b/server/src/http_errors.rs
@@ -12,3 +12,20 @@ pub(crate) fn internal<E: std::fmt::Display>(context: &'static str, e: E) -> Res
     tracing::error!(error = %e, context = context, "internal server error");
     (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn internal_returns_a_generic_500_without_leaking_the_error() {
+        let res = internal("book lookup", "connection refused: 10.0.0.5:5432");
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert_eq!(text, "internal server error");
+        assert!(!text.contains("10.0.0.5"));
+    }
+}

--- a/server/src/logging.rs
+++ b/server/src/logging.rs
@@ -6,6 +6,9 @@
 
 mod error_ring_layer;
 
+#[cfg(test)]
+mod tests;
+
 use error_ring_layer::ErrorRingLayer;
 
 /// Install the global tracing subscriber. Must run before `dioxus::serve`,
@@ -21,17 +24,9 @@ use error_ring_layer::ErrorRingLayer;
 /// `None` when the log directory can't be created — stderr logging still comes
 /// up so the server isn't blocked on a read-only volume.
 pub fn init_tracing() -> Option<tracing_appender::non_blocking::WorkerGuard> {
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    use tracing_subscriber::{fmt, prelude::*};
 
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|err| {
-        // try_from_default_env also errs when RUST_LOG is simply unset — only an
-        // actually-set-but-unparsable value deserves a warning. eprintln because
-        // no subscriber exists yet to carry the event.
-        if std::env::var_os("RUST_LOG").is_some() {
-            eprintln!("invalid RUST_LOG ({err}); falling back to default log filter");
-        }
-        EnvFilter::new("info,omnibus=debug")
-    });
+    let filter = resolve_env_filter();
 
     // Build the rolling-file JSON layer, or fall back to stderr-only if the
     // directory can't be created. `Option<Layer>` is itself a `Layer` (None =
@@ -39,20 +34,9 @@ pub fn init_tracing() -> Option<tracing_appender::non_blocking::WorkerGuard> {
     // owned by `omnibus_db::logs` so the log viewer reads exactly where we
     // write.
     let dir = omnibus_db::logs::log_dir();
-    let (file_layer, guard) = match std::fs::create_dir_all(&dir) {
-        Ok(()) => {
-            let appender = tracing_appender::rolling::daily(&dir, "omnibus.log");
-            let (writer, guard) = tracing_appender::non_blocking(appender);
-            let layer = fmt::layer().json().with_writer(writer);
-            (Some(layer), Some(guard))
-        }
-        Err(err) => {
-            eprintln!(
-                "could not create log dir {}: {err}; on-disk JSON logging disabled",
-                dir.display()
-            );
-            (None, None)
-        }
+    let (file_layer, guard) = match build_file_writer(&dir) {
+        Some((writer, guard)) => (Some(fmt::layer().json().with_writer(writer)), Some(guard)),
+        None => (None, None),
     };
 
     // try_init over init: a second subscriber (e.g. in tests) is a no-op, not a
@@ -69,4 +53,44 @@ pub fn init_tracing() -> Option<tracing_appender::non_blocking::WorkerGuard> {
         .ok();
 
     guard
+}
+
+/// Resolve `RUST_LOG` into an `EnvFilter`, falling back to
+/// `"info,omnibus=debug"` when unset or unparsable (a warning is only
+/// printed for the unparsable case — an unset var is the expected default
+/// path). Split out from `init_tracing` so the fallback logic is testable
+/// without installing a global subscriber.
+fn resolve_env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|err| {
+        // eprintln because no subscriber exists yet to carry the event.
+        if std::env::var_os("RUST_LOG").is_some() {
+            eprintln!("invalid RUST_LOG ({err}); falling back to default log filter");
+        }
+        tracing_subscriber::EnvFilter::new("info,omnibus=debug")
+    })
+}
+
+/// Build the daily-rolling JSON file writer for `dir`, or `None` if the
+/// directory can't be created (e.g. a read-only volume). Split out from
+/// `init_tracing` so the dir-creation failure branch is testable without
+/// installing a global subscriber.
+fn build_file_writer(
+    dir: &std::path::Path,
+) -> Option<(
+    tracing_appender::non_blocking::NonBlocking,
+    tracing_appender::non_blocking::WorkerGuard,
+)> {
+    match std::fs::create_dir_all(dir) {
+        Ok(()) => {
+            let appender = tracing_appender::rolling::daily(dir, "omnibus.log");
+            Some(tracing_appender::non_blocking(appender))
+        }
+        Err(err) => {
+            eprintln!(
+                "could not create log dir {}: {err}; on-disk JSON logging disabled",
+                dir.display()
+            );
+            None
+        }
+    }
 }

--- a/server/src/logging/tests.rs
+++ b/server/src/logging/tests.rs
@@ -1,0 +1,65 @@
+//! Unit tests for `logging`'s two extracted-for-testability helpers:
+//! `resolve_env_filter` (the `RUST_LOG` fallback, unset and unparsable) and
+//! `build_file_writer` (the log-dir-creation failure branch). Neither helper
+//! touches the global tracing registry, so — unlike `init_tracing` itself —
+//! these tests can't race `error_ring_layer`'s tests over the process-wide
+//! subscriber slot and its shared ring buffer.
+
+use omnibus_db::test_support::EnvVarGuard;
+
+use super::*;
+
+/// `EnvFilter::to_string()` reorders directives, so assert on presence of
+/// each half rather than the exact joined string.
+fn is_the_default_filter(filter: &tracing_subscriber::EnvFilter) -> bool {
+    let s = filter.to_string();
+    s.contains("info") && s.contains("omnibus=debug")
+}
+
+#[test]
+fn resolve_env_filter_falls_back_to_the_default_directives_when_rust_log_is_unset() {
+    let _env = EnvVarGuard::set("RUST_LOG", None);
+    let filter = resolve_env_filter();
+    assert!(is_the_default_filter(&filter));
+}
+
+#[test]
+fn resolve_env_filter_falls_back_to_the_default_directives_when_rust_log_is_unparsable() {
+    // A directive's level (after `=`) must be a known level keyword or a
+    // number — an arbitrary word there is what actually fails to parse
+    // (tracing's grammar otherwise treats a bare word as a target with an
+    // implicit TRACE level, so most "garbage" strings parse successfully).
+    let _env = EnvVarGuard::set("RUST_LOG", Some("omnibus=not_a_real_level"));
+    // Must not panic on the unparsable value — it falls back to the same
+    // default as the unset case.
+    let filter = resolve_env_filter();
+    assert!(is_the_default_filter(&filter));
+}
+
+#[test]
+fn resolve_env_filter_uses_rust_log_when_set_to_a_valid_directive() {
+    let _env = EnvVarGuard::set("RUST_LOG", Some("debug"));
+    let filter = resolve_env_filter();
+    assert_eq!(filter.to_string(), "debug");
+}
+
+#[test]
+fn build_file_writer_returns_some_when_the_dir_is_writable() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(build_file_writer(dir.path()).is_some());
+}
+
+#[test]
+fn build_file_writer_returns_none_when_the_dir_cannot_be_created() {
+    let parent = tempfile::tempdir().unwrap();
+    // A regular file where a directory component is expected: create_dir_all
+    // fails with ENOTDIR rather than silently succeeding.
+    let blocker = parent.path().join("blocker-file");
+    std::fs::write(&blocker, b"not a directory").unwrap();
+    let unusable_dir = blocker.join("logs");
+
+    assert!(
+        build_file_writer(&unusable_dir).is_none(),
+        "an uncreatable log dir must disable file logging, not panic"
+    );
+}

--- a/shared/src/kobo.rs
+++ b/shared/src/kobo.rs
@@ -28,3 +28,43 @@ pub fn kobo_device_name_invalid(name: &str) -> bool {
     let trimmed = name.trim();
     trimmed.is_empty() || trimmed.len() > KOBO_DEVICE_NAME_MAX_LEN
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kobo_device_name_invalid_accepts_a_reasonable_label() {
+        assert!(!kobo_device_name_invalid("Kobo Clara"));
+    }
+
+    #[test]
+    fn kobo_device_name_invalid_rejects_an_empty_name() {
+        assert!(kobo_device_name_invalid(""));
+    }
+
+    #[test]
+    fn kobo_device_name_invalid_rejects_a_whitespace_only_name() {
+        assert!(kobo_device_name_invalid("   \t\n  "));
+    }
+
+    #[test]
+    fn kobo_device_name_invalid_rejects_a_name_over_the_max_length() {
+        let name = "x".repeat(KOBO_DEVICE_NAME_MAX_LEN + 1);
+        assert!(kobo_device_name_invalid(&name));
+    }
+
+    #[test]
+    fn kobo_device_name_invalid_accepts_a_name_exactly_at_the_max_length() {
+        let name = "x".repeat(KOBO_DEVICE_NAME_MAX_LEN);
+        assert!(!kobo_device_name_invalid(&name));
+    }
+
+    #[test]
+    fn kobo_device_name_invalid_trims_surrounding_whitespace_before_checking_length() {
+        // Padding that would push the raw length over the cap should not
+        // matter once trimmed.
+        let padded = format!("  {}  ", "x".repeat(KOBO_DEVICE_NAME_MAX_LEN));
+        assert!(!kobo_device_name_invalid(&padded));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #2053

- Adds tests for four previously zero-coverage utility modules:
  - `db::http_client::{build_client, default_user_agent}`
  - `server::logging::init_tracing` (RUST_LOG fallback + log-dir-creation failure)
  - `server::http_errors::internal`
  - `shared::kobo::kobo_device_name_invalid`
- Adds the missing `thiserror` variant tests:
  - `CrossFormatError::Sqlx` — new "propagates db error when pool is closed" test in `db/src/cross_format/tests.rs`
  - `KoboDeviceError::Token` — new test forcing the token-generation-failure branch of `create_device`
  - `ShelfError::Sqlx` was **already covered on `main`** (`get_shelf_propagates_db_error_when_pool_is_closed`, `shelf_exclusive_hidden_uuids_propagates_db_error_when_pool_is_closed`) — no change needed there.
- `server::logging::init_tracing` is split into two pure helpers, `resolve_env_filter` and `build_file_writer`, so its two interesting branches are testable without installing the real global tracing subscriber. Calling the real `init_tracing()` from a test races `error_ring_layer`'s own tests over the process-wide `ErrorRingLayer` slot and its shared ring buffer (observed as an intermittent `index out of bounds` panic in an unrelated `error_ring_layer` test while developing this); the extracted helpers touch no global state.
- `db::kobo_devices::create_device` gains a small private `create_device_with_token` seam (an injectable token generator) so a test can force the token-generation-failure branch without depending on the OS CSPRNG actually erroring.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — clean (server crate; package name is `omnibus`, not `omnibus-server`)
- [x] `cargo clippy -p omnibus-shared --all-targets -- -D warnings` — clean
- [x] `cargo test -p omnibus-db` — 2270 passed, 0 failed
- [x] `cargo test -p omnibus-shared` — 348 passed, 0 failed (includes 6 new `kobo::tests::*`)
- [x] `cargo test -p omnibus` — 874 passed, 2 failed; both pre-existing and unrelated (`backend::uploads::tests::{commit,audiobook_commit}_rejects_read_only_library_with_400` fail only because tests run as `root` in this sandbox, which bypasses the `chmod 0555` permission check the tests rely on — reproduces identically on a clean checkout of this branch's base with no changes)

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- No new modules/dependencies/env vars — no `docs/architecture.md` or `.claude/rules/` updates needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HWPCGpP97RdK5wbP619ss5)_