### PR TITLE
refactor: coarsen the cleanup error enums where callers do not branch, refresh the style-guide example (#2051)

### DIFF
--- a/db/src/cleanup/apply.rs
+++ b/db/src/cleanup/apply.rs
@@ -40,12 +40,11 @@ pub enum CleanupApplyError {
     Overrides(#[from] MetadataOverridesError),
     #[error("entity not found: {0}")]
     NotFound(i64),
-    #[error("merge source and canonical are the same entity: {0}")]
-    CanonicalIsSource(i64),
-    #[error("merge requires at least one source entity")]
-    EmptySources,
-    #[error("tag split requires at least two atoms")]
-    TooFewAtoms,
+    /// A caller's arguments fail a primitive's own precondition. Coarse on
+    /// purpose: no caller branches on *which* precondition, every one of them
+    /// is rendered as this sentence.
+    #[error("{0}")]
+    InvalidRequest(String),
     #[error("cleanup log entry not found: {0}")]
     LogNotFound(i64),
     #[error("cleanup was already undone")]
@@ -136,10 +135,14 @@ async fn apply_merge(
     applied_by: Option<i64>,
 ) -> Result<i64, CleanupApplyError> {
     if source_ids.is_empty() {
-        return Err(CleanupApplyError::EmptySources);
+        return Err(CleanupApplyError::InvalidRequest(
+            "merge requires at least one source entity".to_string(),
+        ));
     }
     if source_ids.contains(&canonical_id) {
-        return Err(CleanupApplyError::CanonicalIsSource(canonical_id));
+        return Err(CleanupApplyError::InvalidRequest(format!(
+            "merge source and canonical are the same entity: {canonical_id}"
+        )));
     }
 
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
@@ -381,7 +384,9 @@ pub async fn apply_tag_split(
     applied_by: Option<i64>,
 ) -> Result<i64, CleanupApplyError> {
     if atoms.len() < 2 {
-        return Err(CleanupApplyError::TooFewAtoms);
+        return Err(CleanupApplyError::InvalidRequest(
+            "tag split requires at least two atoms".to_string(),
+        ));
     }
 
     let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;

--- a/db/src/cleanup/apply/tests.rs
+++ b/db/src/cleanup/apply/tests.rs
@@ -325,7 +325,10 @@ async fn apply_merge_authors_returns_empty_sources_for_an_empty_list() {
     let err = apply_merge_authors(&pool, &[], canonical, None, None)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupApplyError::EmptySources));
+    assert!(
+        matches!(err, CleanupApplyError::InvalidRequest(ref m) if m == "merge requires at least one source entity"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -335,7 +338,10 @@ async fn apply_merge_authors_returns_canonical_is_source_when_they_collide() {
     let err = apply_merge_authors(&pool, &[a], a, None, None)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupApplyError::CanonicalIsSource(id) if id == a));
+    assert!(
+        matches!(err, CleanupApplyError::InvalidRequest(ref m) if m == &format!("merge source and canonical are the same entity: {a}")),
+        "unexpected error: {err}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -480,7 +486,10 @@ async fn apply_tag_split_returns_too_few_atoms_for_a_single_atom_list() {
     let err = apply_tag_split(&pool, source, ";", &["solo".to_string()], None, None)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupApplyError::TooFewAtoms));
+    assert!(
+        matches!(err, CleanupApplyError::InvalidRequest(ref m) if m == "tag split requires at least two atoms"),
+        "unexpected error: {err}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/db/src/cleanup/review.rs
+++ b/db/src/cleanup/review.rs
@@ -21,9 +21,10 @@ mod tests;
 /// minutes of review while keeping the per-card hydration queries bounded.
 pub const REVIEW_QUEUE_MAX: i64 = 50;
 
-/// Errors from the review queue. The first three are internal faults (a DB
-/// failure, or a stored row this build can't decode); [`Self::Refused`] is the
-/// sentence a caller renders verbatim.
+/// Errors from the review queue. [`Self::Db`], [`Self::Payload`] and
+/// [`Self::UnknownToken`] are internal faults — a DB failure, a stored row this
+/// build can't decode, and a token that names no known suggestion;
+/// [`Self::Refused`] is the sentence a caller renders verbatim.
 #[derive(Debug, thiserror::Error)]
 pub enum CleanupStoreError {
     #[error(transparent)]

--- a/db/src/cleanup/review.rs
+++ b/db/src/cleanup/review.rs
@@ -22,8 +22,8 @@ mod tests;
 pub const REVIEW_QUEUE_MAX: i64 = 50;
 
 /// Errors from the review queue. The first three are internal faults (a DB
-/// failure, or a stored row this build can't decode); the rest are decisions
-/// a caller can render verbatim.
+/// failure, or a stored row this build can't decode); [`Self::Refused`] is the
+/// sentence a caller renders verbatim.
 #[derive(Debug, thiserror::Error)]
 pub enum CleanupStoreError {
     #[error(transparent)]
@@ -32,14 +32,10 @@ pub enum CleanupStoreError {
     Payload(#[from] serde_json::Error),
     #[error("unrecognized cleanup token: {0}")]
     UnknownToken(String),
-    #[error("decision must be accepted or rejected")]
-    NotADecision,
-    #[error("suggestion not found")]
-    NotFound,
-    #[error("suggestion has already been reviewed")]
-    AlreadyReviewed,
-    #[error("this suggestion cannot be applied automatically")]
-    Unsupported,
+    /// The review action can't proceed and the reason is safe to show. Coarse
+    /// on purpose: no caller branches on which reason, they all render it.
+    #[error("{0}")]
+    Refused(String),
     #[error(transparent)]
     Apply(#[from] CleanupApplyError),
 }
@@ -142,13 +138,17 @@ pub async fn decide_suggestion(
     admin_id: i64,
 ) -> Result<(), CleanupStoreError> {
     if decision == Decision::Pending {
-        return Err(CleanupStoreError::NotADecision);
+        return Err(CleanupStoreError::Refused(
+            "decision must be accepted or rejected".to_string(),
+        ));
     }
     let row = load_suggestion(pool, id)
         .await?
-        .ok_or(CleanupStoreError::NotFound)?;
+        .ok_or_else(|| CleanupStoreError::Refused("suggestion not found".to_string()))?;
     if row.decision != Decision::Pending {
-        return Err(CleanupStoreError::AlreadyReviewed);
+        return Err(CleanupStoreError::Refused(
+            "suggestion has already been reviewed".to_string(),
+        ));
     }
     if decision == Decision::Accepted {
         apply_suggestion(pool, &row, admin_id).await?;
@@ -369,7 +369,11 @@ async fn apply_suggestion(
         (CleanupKind::Author, CleanupAction::Delete, CleanupPayload::Delete { entity_id, .. }) => {
             apply_delete_author(pool, *entity_id, id, by).await?
         }
-        _ => return Err(CleanupStoreError::Unsupported),
+        _ => {
+            return Err(CleanupStoreError::Refused(
+                "this suggestion cannot be applied automatically".to_string(),
+            ))
+        }
     };
     Ok(())
 }

--- a/db/src/cleanup/review/tests.rs
+++ b/db/src/cleanup/review/tests.rs
@@ -347,7 +347,10 @@ async fn decide_suggestion_refuses_a_pending_decision() {
     let err = decide_suggestion(&pool, 1, Decision::Pending, 1)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupStoreError::NotADecision));
+    assert!(
+        matches!(err, CleanupStoreError::Refused(ref m) if m == "decision must be accepted or rejected"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -356,7 +359,10 @@ async fn decide_suggestion_reports_not_found_for_an_unknown_id() {
     let err = decide_suggestion(&pool, 4242, Decision::Accepted, 1)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupStoreError::NotFound));
+    assert!(
+        matches!(err, CleanupStoreError::Refused(ref m) if m == "suggestion not found"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -373,7 +379,10 @@ async fn decide_suggestion_refuses_a_row_that_was_already_reviewed() {
     let err = decide_suggestion(&pool, id, Decision::Accepted, 1)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupStoreError::AlreadyReviewed));
+    assert!(
+        matches!(err, CleanupStoreError::Refused(ref m) if m == "suggestion has already been reviewed"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]
@@ -399,7 +408,10 @@ async fn decide_suggestion_reports_unsupported_for_a_kind_action_pair_with_no_pr
     let err = decide_suggestion(&pool, id, Decision::Accepted, 1)
         .await
         .unwrap_err();
-    assert!(matches!(err, CleanupStoreError::Unsupported));
+    assert!(
+        matches!(err, CleanupStoreError::Refused(ref m) if m == "this suggestion cannot be applied automatically"),
+        "unexpected error: {err}"
+    );
     // And the row stays pending, so the card comes back on the next pass.
     assert_eq!(stored_decision(&pool, id).await, "pending");
 }

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -180,7 +180,7 @@ updating — `anyhow` with a `with_context(...)` message is honest.
 correctly chooses `thiserror`: login, registration, and session
 validation each have a finite set of outcomes a UI renders
 differently. `AuthError` was once over-granular but has since been
-coarsened to the shape below — see "Coarse variants".
+coarsened — see "Coarse variants".
 
 **Pattern (unpredictable).** `reindex` in
 [db/src/indexer/ebooks.rs](../db/src/indexer/ebooks.rs):
@@ -202,33 +202,65 @@ propagates. The format string carries the detail.
 `PasswordTooShort { min }` / `PasswordTooLong { max }` /
 `PasswordCommon` unless the caller actually branches on them.
 
-**Anti-pattern (since fixed).** `db/src/auth.rs`'s `AuthError` once had
-14 variants — three password rules, four username rules — even though
-the login UI renders the same "invalid username or password" for every
-credential failure and the registration form shows the `#[error]` text
-directly. It has since collapsed to ~8 coarse variants
-(`InvalidCredentials`, `Validation(String)`, `UsernameTaken`,
-`SessionNotFound`, `AccountLocked`, `RegistrationDisabled`, transparent
-`Db`, …), with the message doing the work — matching the Pattern below.
+**The test is a call-site audit, not a variant count.** `rg` the enum
+name, find every `match` / `if let` on it plus any `From` /
+`IntoResponse` mapping, and ask of each variant: does some caller give
+it its own HTTP status, its own user-facing sentence, or its own
+control flow? A variant that does earns its place however many
+neighbours it has. A variant that lands in the same catch-all arm as
+three others does not.
 
-**Pattern.** Three to five variants, each genuinely different in how
-the caller handles them:
+**Anti-pattern (since fixed).** `AuthError` in
+[db/src/auth.rs](../db/src/auth.rs) once had 14 variants — three
+password rules, four username rules — even though the login UI renders
+the same "invalid username or password" for every credential failure
+and the registration form shows the `#[error]` text directly. The seven
+input rules collapsed into one `Validation(String)`, with the message
+doing the work.
+
+**Pattern (growth that earns it).** `AuthError` has since grown back to
+11 variants, and the audit vindicates every one:
+`auth_error_to_response` in
+`server/src/auth/handlers.rs` matches all 11 exhaustively and hands out
+six distinct statuses (401 `InvalidCredentials`, 429 + `Retry-After`
+`AccountLocked`, 409 `UsernameTaken` / `LastAdmin`, 404 `UserNotFound` /
+`DeviceNotFound`, 400 `Validation`, 403 `RegistrationDisabled`, 401
+`SessionNotFound`), with `Internal` and `Crypto` the two 500s that
+differ in their log context and in the `From` impl each exists to carry.
+Growth is not the smell; an unbranched variant is.
+
+**Pattern (coarsening that pays).** `CleanupStoreError` in
+[db/src/cleanup/review.rs](../db/src/cleanup/review.rs) is the same rule
+applied in the other direction. Its callers are `map_store_error` /
+`map_apply_error` in `frontend/src/rpc/cleanup.rs`, which branch on
+exactly one thing — is this an internal fault to log and genericize, or
+a sentence safe to show the admin? So the four review refusals that used
+to be their own unit variants are one message-carrying variant, while
+the three internal faults stay split because that branch reads them:
 
 ```rust
 #[derive(Debug, thiserror::Error)]
-pub enum AuthError {
-    #[error("invalid credentials")]
-    InvalidCredentials,
-    #[error("account is temporarily locked")]
-    AccountLocked { until_unix: i64 },
-    #[error("{0}")]
-    Validation(String),          // password/username rules, etc.
-    #[error("session not found or expired")]
-    SessionNotFound,
+pub enum CleanupStoreError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    #[error("malformed cleanup suggestion payload: {0}")]
+    Payload(#[from] serde_json::Error),
+    #[error("unrecognized cleanup token: {0}")]
+    UnknownToken(String),
+    /// Not found / already reviewed / not a decision / unsupported —
+    /// every caller renders the sentence, so they are one variant.
+    #[error("{0}")]
+    Refused(String),
+    #[error(transparent)]
+    Apply(#[from] CleanupApplyError),
 }
 ```
+
+Note what is *not* coarsened: `NotFound(i64)` and `LogNotFound(i64)` in
+the sibling `CleanupApplyError` stay separate because each is raised
+from several primitives and names a different row, and `AlreadyUndone`
+stays because it is an idempotency outcome the concurrency tests assert
+on by variant, not an error message.
 
 ### Never leak `sqlx::Error`
 

--- a/frontend/src/rpc/cleanup.rs
+++ b/frontend/src/rpc/cleanup.rs
@@ -73,9 +73,10 @@ pub async fn rpc_cleanup_delete_entity(kind: CleanupKind, entity_id: i64) -> Res
     )
 }
 
-/// Map a `CleanupStoreError` to a client-facing error. The three internal
-/// faults (DB, an undecodable stored row) are logged and genericized; a
-/// refusal already carries a safe, specific sentence.
+/// Map a `CleanupStoreError` to a client-facing error. The internal faults
+/// (`Db`, `Payload`, `UnknownToken`) are logged and genericized — an unknown
+/// token must not echo the token back; a refusal already carries a safe,
+/// specific sentence.
 #[cfg(feature = "server")]
 fn map_store_error(context: &'static str, e: db::cleanup::CleanupStoreError) -> ServerFnError {
     use db::cleanup::CleanupStoreError as E;

--- a/frontend/src/rpc/cleanup.rs
+++ b/frontend/src/rpc/cleanup.rs
@@ -74,15 +74,15 @@ pub async fn rpc_cleanup_delete_entity(kind: CleanupKind, entity_id: i64) -> Res
 }
 
 /// Map a `CleanupStoreError` to a client-facing error. The three internal
-/// faults (DB, an undecodable stored row) are logged and genericized; the
-/// review decisions already carry a safe, specific sentence.
+/// faults (DB, an undecodable stored row) are logged and genericized; a
+/// refusal already carries a safe, specific sentence.
 #[cfg(feature = "server")]
 fn map_store_error(context: &'static str, e: db::cleanup::CleanupStoreError) -> ServerFnError {
     use db::cleanup::CleanupStoreError as E;
     match e {
         E::Db(_) | E::Payload(_) | E::UnknownToken(_) => internal_rpc_error(context, e),
         E::Apply(inner) => map_apply_error(context, inner),
-        other => ServerFnError::new(other.to_string()),
+        E::Refused(msg) => ServerFnError::new(msg),
     }
 }
 

--- a/frontend/src/rpc/cleanup/tests.rs
+++ b/frontend/src/rpc/cleanup/tests.rs
@@ -21,21 +21,13 @@ fn map_store_error_genericizes_an_internal_fault() {
 
 #[test]
 fn map_store_error_passes_a_review_decision_through_verbatim() {
-    for (e, expected) in [
-        (CleanupStoreError::NotFound, "suggestion not found"),
-        (
-            CleanupStoreError::AlreadyReviewed,
-            "suggestion has already been reviewed",
-        ),
-        (
-            CleanupStoreError::NotADecision,
-            "decision must be accepted or rejected",
-        ),
-        (
-            CleanupStoreError::Unsupported,
-            "this suggestion cannot be applied automatically",
-        ),
+    for expected in [
+        "suggestion not found",
+        "suggestion has already been reviewed",
+        "decision must be accepted or rejected",
+        "this suggestion cannot be applied automatically",
     ] {
+        let e = CleanupStoreError::Refused(expected.to_string());
         assert!(map_store_error("ctx", e).to_string().contains(expected));
     }
 }


### PR DESCRIPTION
## Summary

- Audited every call site of `CleanupApplyError` (10 variants) and `CleanupStoreError` (8 variants). The only consumers outside `db::cleanup` are `map_apply_error` / `map_store_error` in `frontend/src/rpc/cleanup.rs`; the server crate has no cleanup routes at all. Those two functions branch on exactly one distinction — internal fault (log + genericize) vs. a sentence safe to render to the admin.
- Coarsened **only** the variants the audit proves render identically to every caller: three argument guards in `CleanupApplyError` → `InvalidRequest(String)` (10 → 8), and four review refusals in `CleanupStoreError` → `Refused(String)` (8 → 5). Full per-variant table in Notes.
- Behaviour-preserving at the API surface: every `#[error("…")]` string is reproduced verbatim at the construction site, so the same input still produces the same message and the same status.
- `map_store_error`'s catch-all `other =>` arm is now an explicit `E::Refused(msg) =>` arm, so the match is exhaustive and a future variant is a compile error rather than a message that silently leaks to the client.
- Refreshed `docs/style-guide.md`'s "Coarse variants" worked example, which was stale in three ways: it claimed `AuthError` sat at ~8 variants (it has 11), listed a `#[error(transparent)] Db(#[from] sqlx::Error)` variant that does not exist and would contradict the "Never leak `sqlx::Error`" section right below it, and headlined the pattern as "three to five variants". The refreshed section shows both directions of the rule and cites by type/function name per `.claude/rules/98-keep-skills-fresh.md`.

Closes #2051

## Test plan

Run from the worktree with `CARGO_TARGET_DIR` set:

- `cargo fmt` — PASS (`cargo fmt --check` clean)
- `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- `cargo test -p omnibus-db` — PASS (2265 passed, 1 pre-existing failure, see below)
- `cargo test -p omnibus` — PASS (868 passed, 2 pre-existing failures, see below)
- `cargo test -p omnibus-frontend --features server rpc::cleanup` — PASS (4/4)

Pre-existing failures in this container, unrelated to this change and failing identically on a clean merge base:

- `backend::uploads::tests::commit_rejects_read_only_library_with_400`
- `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`
  (container runs as uid 0, so a chmod-read-only dir is still writable)
- `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`
  (public-domain fixtures are not in git and `just fixtures` needs nix)

## Notes

### Call-site audit

The audit surface is small and complete: `rg CleanupApplyError|CleanupStoreError` across `db/`, `server/`, `frontend/`, `shared/`. There is **no** `server/src/backend/cleanup*.rs` — the suggested-approach guess in the issue — so there is no `IntoResponse` / status mapping anywhere. Every external consumer goes through the two mappers in `frontend/src/rpc/cleanup.rs`:

```rust
fn map_store_error(context, e) -> ServerFnError {
    match e {
        E::Db(_) | E::Payload(_) | E::UnknownToken(_) => internal_rpc_error(context, e),
        E::Apply(inner) => map_apply_error(context, inner),
        other => ServerFnError::new(other.to_string()),   // ← the catch-all
    }
}

fn map_apply_error(context, e) -> ServerFnError {
    match e {
        Db(inner) | Snapshot(inner) => internal_rpc_error(context, inner),
        other => ServerFnError::new(other.to_string()),   // ← the catch-all
    }
}
```

`internal_rpc_error` logs and returns the literal `"internal server error"`, so anything on the left of that branch has its message suppressed; anything in the catch-all has its message shown. That single distinction is the only branch in the system.

#### `CleanupApplyError` — 10 → 8

| Variant | Branched on where | Verdict |
|---|---|---|
| `Db(#[from] sqlx::Error)` | `map_apply_error` → `internal_rpc_error` (message suppressed) | **kept** — the one real branch reads it |
| `Snapshot(#[from] serde_json::Error)` | `map_apply_error` → `internal_rpc_error` | **kept** — same branch |
| `Overrides(#[from] MetadataOverridesError)` | nowhere (falls in catch-all) | **kept** — carries a distinct `#[from]` source; `?` in `apply_book_title_override` needs it, and it is a wrapper not a precondition |
| `NotFound(i64)` | nowhere | **kept** — raised from 4 sites across `snapshot_canonical`, `move_source_links`, `apply_tag_split`, `apply_delete_author`; reused and id-carrying, not a single-use guard |
| `CanonicalIsSource(i64)` | nowhere | **merged** → `InvalidRequest` (single use, `apply_merge`) |
| `EmptySources` | nowhere | **merged** → `InvalidRequest` (single use, `apply_merge`) |
| `TooFewAtoms` | nowhere | **merged** → `InvalidRequest` (single use, `apply_tag_split`) |
| `LogNotFound(i64)` | nowhere | **kept** — raised from 4 sites in `undo`; the undo-side sibling of `NotFound`, id-carrying |
| `AlreadyUndone` | `db/src/cleanup/apply/tests.rs` concurrency tests match it by variant to assert "every racing undo resolves to success or `AlreadyUndone`, nothing else" | **kept** — an idempotency *outcome*, not an error message; collapsing it would weaken that invariant into a string compare |
| `MissingActor` | nowhere | **kept** — different failure mode from the three merged guards (a stored `cleanup_log` row missing its actor id, i.e. corrupt state, not a bad argument). It has no honest home; folding it into `InvalidRequest` would misfile it. Flagging it as the one judgment call I would happily reverse. |

The three merged variants share one mode — *the caller's arguments fail a primitive's own precondition* — and are each used exactly once. Preserved text: `"merge requires at least one source entity"`, `"merge source and canonical are the same entity: {id}"`, `"tag split requires at least two atoms"`.

#### `CleanupStoreError` — 8 → 5

| Variant | Branched on where | Verdict |
|---|---|---|
| `Db(#[from] sqlx::Error)` | `map_store_error` → `internal_rpc_error` | **kept** |
| `Payload(#[from] serde_json::Error)` | `map_store_error` → `internal_rpc_error` | **kept** |
| `UnknownToken(String)` | `map_store_error` → `internal_rpc_error` | **kept — load-bearing.** It sits on the *internal-fault* side of the only branch. Merging it with the refusals would flip its message from `"internal server error"` to `"unrecognized cleanup token: publisher"`, i.e. an actual behaviour change. |
| `Apply(#[from] CleanupApplyError)` | `map_store_error` → delegates to `map_apply_error` | **kept** — distinct control flow |
| `NotADecision` | nowhere | **merged** → `Refused` |
| `NotFound` | nowhere | **merged** → `Refused` |
| `AlreadyReviewed` | nowhere | **merged** → `Refused` |
| `Unsupported` | nowhere | **merged** → `Refused` |

Corroborating evidence beyond the mapper: the enum's own pre-existing doc comment already grouped them — *"the first three are internal faults …; the rest are decisions a caller can render verbatim."* The four were one group in prose before they were one variant in code. Each is constructed exactly once, in `decide_suggestion` or `apply_suggestion`.

**For the maintainer to decide:** merging `NotFound` is the most aggressive call here. Today nothing branches on it, but it is the one variant a future REST endpoint would plausibly want to map to 404 rather than a generic error. If you would rather keep that door open, say so and I will split it back out — everything else in the table is uncontentious.

### Tests

No coverage was deleted; the assertions were re-pointed onto the merged variants and now check the user-visible sentence, which is a slightly stronger assertion of the behaviour-preservation claim than matching a variant name was:

- `db/src/cleanup/apply/tests.rs` — 3 assertions (`EmptySources`, `CanonicalIsSource`, `TooFewAtoms`)
- `db/src/cleanup/review/tests.rs` — 4 assertions (`NotADecision`, `NotFound`, `AlreadyReviewed`, `Unsupported`)
- `frontend/src/rpc/cleanup/tests.rs` — `map_store_error_passes_a_review_decision_through_verbatim` now loops the four sentences through `Refused`, keeping all four cases

The `AlreadyUndone` concurrency tests are untouched, which is the point of keeping that variant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmMuZvBbXPyLmMpmtLu3u)_