### PR TITLE
refactor: group over-threshold Dioxus component props into cohesive structs (#2044)

### DIFF
--- a/frontend/src/pages/book_detail/body.rs
+++ b/frontend/src/pages/book_detail/body.rs
@@ -34,17 +34,29 @@ pub(super) struct BdAuthorCluster {
     pub author_books: Vec<EbookMetadata>,
 }
 
+/// The book this body renders: durable uuid, effective title, and the accent
+/// color its saved-passage cards inherit.
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct BdBodyBook {
+    pub uuid: String,
+    pub title: String,
+    pub accent: Option<String>,
+}
+
 /// Main column: public journal feed, saved passages, from-the-same-hand fan,
 /// and the "Readers also enjoyed" suggestions strip.
 #[component]
 pub(super) fn BdBodyMain(
-    uuid: String,
-    title: String,
+    book: BdBodyBook,
     author: BdAuthorCluster,
-    accent: Option<String>,
     suggestions: Option<SuggestionsResponse>,
     ctx: BdPageCtx,
 ) -> Element {
+    let BdBodyBook {
+        uuid,
+        title,
+        accent,
+    } = book;
     rsx! {
         div { class: "bd-body-main",
             BdJournalSection { uuid: uuid.clone() }
@@ -315,16 +327,28 @@ fn SuggestionsConnectCard(is_admin: bool) -> Element {
     }
 }
 
+/// The rail's file-details facts: effective title, the joined authors line, and
+/// the series name (`None` for a standalone).
+#[derive(Clone, PartialEq, Props)]
+pub(super) struct BdRailFacts {
+    pub title: String,
+    pub authors_line: String,
+    pub series: Option<String>,
+}
+
 /// Sticky rail: file-details card, series/standalone card, reading-insights card.
 #[component]
 pub(super) fn BdRailSection(
     b: EbookMetadata,
-    title: String,
-    authors_line: String,
-    series: Option<String>,
+    facts: BdRailFacts,
     merge_button: Option<Element>,
     delete_button: Option<Element>,
 ) -> Element {
+    let BdRailFacts {
+        title,
+        authors_line,
+        series,
+    } = facts;
     let uuid = b.unique_identifier.clone().unwrap_or_default();
     rsx! {
         aside { class: "bd-rail",

--- a/frontend/src/pages/book_detail/file_picker.rs
+++ b/frontend/src/pages/book_detail/file_picker.rs
@@ -76,16 +76,28 @@ fn file_picker_item_meta(file: &BookFileInfo, kind: FilePickerKind) -> Option<St
     }
 }
 
+/// How the picker's trigger presents itself: its label, the button classes it
+/// wears, and the testid the single-file (plain link) form carries.
+#[derive(Clone, PartialEq)]
+pub(super) struct FilePickerChrome {
+    pub label: String,
+    pub button_class: String,
+    pub single_testid: String,
+}
+
 /// Read/listen action that expands into a file picker when multiple files match.
 #[component]
 pub(super) fn BdFilePickerMenu(
     uuid: String,
     kind: FilePickerKind,
     files: Vec<BookFileInfo>,
-    label: String,
-    button_class: String,
-    single_testid: String,
+    chrome: FilePickerChrome,
 ) -> Element {
+    let FilePickerChrome {
+        label,
+        button_class,
+        single_testid,
+    } = chrome;
     let prefix = kind.route_prefix();
     if files.len() < 2 {
         let href = format!("/{prefix}/{uuid}");
@@ -263,9 +275,11 @@ mod tests {
                 uuid: "book-a".to_string(),
                 kind: FilePickerKind::Listen,
                 files: vec![file("MP3", 1, 0), file("MP3", 2, 1)],
-                label: "Start listening".to_string(),
-                button_class: "btn primary lg".to_string(),
-                single_testid: "start-listening".to_string(),
+                chrome: FilePickerChrome {
+                    label: "Start listening".to_string(),
+                    button_class: "btn primary lg".to_string(),
+                    single_testid: "start-listening".to_string(),
+                },
             }
         });
 

--- a/frontend/src/pages/book_detail/hero.rs
+++ b/frontend/src/pages/book_detail/hero.rs
@@ -12,7 +12,7 @@ use crate::components::{BookActionMeta, FetchSummaryButton};
 use crate::{data, use_server_url, Route};
 
 use super::export_menu::{BdExportContext, BdExportMenu};
-use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerKind};
+use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerChrome, FilePickerKind};
 use super::immersive::BdImmersiveButton;
 use super::physical::{BdBookIdentity, BdWishlistRailSlot};
 use super::rating::BdRatingWidget;
@@ -57,11 +57,14 @@ fn BdWishlistBadge() -> Element {
     }
 }
 
-/// Breadcrumb trail + title-column kicker text, grouped to keep [`BdHeroSection`] under the 5-prop guideline.
+/// The hero's header text — breadcrumb trail, title-column kicker, and the
+/// effective (override-merged) title — grouped to keep [`BdHeroSection`] under
+/// the 5-prop guideline.
 #[derive(Clone, PartialEq)]
 pub(super) struct BdHeroChrome {
     pub kicker: String,
     pub crumbs: Vec<BdCrumbItem>,
+    pub title: String,
 }
 
 /// Hero section: breadcrumb, cover + format badges + tags, title + CTAs, and
@@ -69,7 +72,6 @@ pub(super) struct BdHeroChrome {
 #[component]
 pub(super) fn BdHeroSection(
     b: EbookMetadata,
-    title: String,
     chrome: BdHeroChrome,
     avail: Availability,
     phys: PhysSignals,
@@ -77,7 +79,11 @@ pub(super) fn BdHeroSection(
     /// below the CTA row — empty for single-format books.
     sync_panel: Element,
 ) -> Element {
-    let BdHeroChrome { kicker, crumbs } = chrome;
+    let BdHeroChrome {
+        kicker,
+        crumbs,
+        title,
+    } = chrome;
     let uuid = b.unique_identifier.clone().unwrap_or_default();
     let on_wishlist = phys.wishlist.read().is_some();
     rsx! {
@@ -292,9 +298,11 @@ fn BdCtaRow(has_ebook: bool, has_audio: bool, has_comic: bool, meta: BookActionM
                     uuid: uuid.clone(),
                     kind: FilePickerKind::Read,
                     files: epub_files.clone(),
-                    label: "Start reading",
-                    button_class: "btn primary lg",
-                    single_testid: "start-reading",
+                    chrome: FilePickerChrome {
+                        label: "Start reading".to_string(),
+                        button_class: "btn primary lg".to_string(),
+                        single_testid: "start-reading".to_string(),
+                    },
                 }
             } else if has_comic {
                 // CBZ books open the comic pager. A book carrying both an
@@ -314,9 +322,11 @@ fn BdCtaRow(has_ebook: bool, has_audio: bool, has_comic: bool, meta: BookActionM
                             uuid: uuid.clone(),
                             kind: FilePickerKind::Listen,
                             files: audio_files.clone(),
-                            label: "Start listening",
-                            button_class: "btn primary lg",
-                            single_testid: "start-listening",
+                            chrome: FilePickerChrome {
+                                label: "Start listening".to_string(),
+                                button_class: "btn primary lg".to_string(),
+                                single_testid: "start-listening".to_string(),
+                            },
                         }
                     };
                     #[cfg(feature = "mobile")]
@@ -334,9 +344,11 @@ fn BdCtaRow(has_ebook: bool, has_audio: bool, has_comic: bool, meta: BookActionM
                             uuid: uuid.clone(),
                             kind: FilePickerKind::Listen,
                             files: audio_files.clone(),
-                            label: "Listen",
-                            button_class: "btn lg",
-                            single_testid: "listen-secondary",
+                            chrome: FilePickerChrome {
+                                label: "Listen".to_string(),
+                                button_class: "btn lg".to_string(),
+                                single_testid: "listen-secondary".to_string(),
+                            },
                         }
                     };
                     #[cfg(feature = "mobile")]

--- a/frontend/src/pages/book_detail/mobile.rs
+++ b/frontend/src/pages/book_detail/mobile.rs
@@ -20,7 +20,7 @@ use super::discovery::{
     cover_src, list_count_label, same_hand_author_label, same_hand_title, same_hand_year,
     suggestion_cover_book, SuggestionsSpinner,
 };
-use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerKind};
+use super::file_picker::{is_audio_book_file, BdFilePickerMenu, FilePickerChrome, FilePickerKind};
 use super::immersive::BdImmersiveButton;
 use super::journal::BdJournalSection;
 use super::rating::BdRatingWidget;
@@ -292,9 +292,11 @@ fn title_and_cta_section(
                     uuid: uuid.to_string(),
                     kind: FilePickerKind::Read,
                     files: epub_files.to_vec(),
-                    label: "Read",
-                    button_class: "btn primary lg",
-                    single_testid: "start-reading",
+                    chrome: FilePickerChrome {
+                        label: "Read".to_string(),
+                        button_class: "btn primary lg".to_string(),
+                        single_testid: "start-reading".to_string(),
+                    },
                 }
             } else if has_comic {
                 Link {
@@ -309,9 +311,11 @@ fn title_and_cta_section(
                     uuid: uuid.to_string(),
                     kind: FilePickerKind::Listen,
                     files: audio_files.to_vec(),
-                    label: "Listen",
-                    button_class: "btn lg",
-                    single_testid: "start-listening",
+                    chrome: FilePickerChrome {
+                        label: "Listen".to_string(),
+                        button_class: "btn lg".to_string(),
+                        single_testid: "start-listening".to_string(),
+                    },
                 }
             }
             // Immersive Read is a dual-format-only action, so gate it on both.

--- a/frontend/src/pages/book_detail/view.rs
+++ b/frontend/src/pages/book_detail/view.rs
@@ -15,7 +15,7 @@ use omnibus_shared::{EbookMetadata, SuggestionsResponse};
 use crate::Route;
 
 #[cfg(not(feature = "mobile"))]
-use super::body::{BdAuthorCluster, BdBodyMain, BdPageCtx, BdRailSection};
+use super::body::{BdAuthorCluster, BdBodyBook, BdBodyMain, BdPageCtx, BdRailFacts, BdRailSection};
 #[cfg(not(feature = "mobile"))]
 use super::hero::{self, BdHeroSection};
 #[cfg(feature = "mobile")]
@@ -271,8 +271,7 @@ pub(super) fn render_loaded(
         div { class: "bd-root", style: "{accent_style}",
             BdHeroSection {
                 b: b.clone(),
-                title: title.clone(),
-                chrome: hero::BdHeroChrome { kicker, crumbs },
+                chrome: hero::BdHeroChrome { kicker, crumbs, title: title.clone() },
                 avail: hero::Availability {
                     has_ebook,
                     has_audio,
@@ -289,18 +288,14 @@ pub(super) fn render_loaded(
             }
             section { class: "bd-body-grid",
                 BdBodyMain {
-                    uuid: uuid.clone(),
-                    title: title.clone(),
+                    book: BdBodyBook { uuid: uuid.clone(), title: title.clone(), accent },
                     author: BdAuthorCluster { primary_author, author_id, author_books },
-                    accent,
                     suggestions,
                     ctx: BdPageCtx { server_url, is_admin },
                 }
                 BdRailSection {
                     b,
-                    title,
-                    authors_line,
-                    series,
+                    facts: BdRailFacts { title, authors_line, series },
                     merge_button,
                     delete_button,
                 }

--- a/frontend/src/pages/check_in/mod.rs
+++ b/frontend/src/pages/check_in/mod.rs
@@ -28,7 +28,8 @@ use link::LinkExistingScreen;
 use lookup::LookupScreen;
 use scan::ScanScreen;
 use screens::{
-    ChooseScreen, CloseMatchScreen, ConfirmScreen, ResolvingScreen, SuccessScreen, UnresolvedScreen,
+    ChooseAction, ChooseScreen, CloseMatchScreen, ConfirmScreen, ResolvingScreen, SuccessScreen,
+    UnresolvedScreen,
 };
 
 /// Whether the check-in overlay is open. Provided at [`crate::App`] scope so
@@ -502,14 +503,19 @@ fn choose_stage(
         online: online.clone(),
     };
     let isbn = online.isbn13.clone();
+    let on_own_it = handlers.on_own_it;
+    let on_wishlist = handlers.on_wishlist;
+    let on_link = go_to_link(state, isbn, origin);
     rsx! {
         ChooseScreen {
             online,
             state,
-            on_own_it: handlers.on_own_it,
-            on_wishlist: handlers.on_wishlist,
-            on_link: go_to_link(state, isbn, origin),
-            on_restart,
+            on_action: EventHandler::new(move |action: ChooseAction| match action {
+                ChooseAction::OwnIt(meta) => on_own_it.call(meta),
+                ChooseAction::Wishlist(req) => on_wishlist.call(req),
+                ChooseAction::Link => on_link.call(()),
+                ChooseAction::Restart => on_restart.call(()),
+            }),
         }
     }
 }

--- a/frontend/src/pages/check_in/screens.rs
+++ b/frontend/src/pages/check_in/screens.rs
@@ -191,16 +191,23 @@ pub(super) fn LibraryPickOption(
     }
 }
 
+/// What the 3c chooser's four buttons ask [`super::CheckInPage`] to do, each
+/// carrying exactly the payload its transport needs.
+#[derive(Clone, PartialEq)]
+pub(super) enum ChooseAction {
+    OwnIt(ExternalBookMeta),
+    Wishlist(WishlistAddRequest),
+    Link,
+    Restart,
+}
+
 /// 3c — resolved online but absent from the library: own it, link it to a
 /// book already on the shelf, wishlist it, or start over.
 #[component]
 pub(super) fn ChooseScreen(
     online: ExternalBookMeta,
     state: FlowState,
-    on_own_it: EventHandler<ExternalBookMeta>,
-    on_wishlist: EventHandler<WishlistAddRequest>,
-    on_link: EventHandler<()>,
-    on_restart: EventHandler<()>,
+    on_action: EventHandler<ChooseAction>,
 ) -> Element {
     let busy = state.busy;
     let own_meta = online.clone();
@@ -216,7 +223,7 @@ pub(super) fn ChooseScreen(
                     class: "btn primary",
                     disabled: busy(),
                     "data-testid": "check-in-own-it",
-                    onclick: move |_| on_own_it.call(own_meta.clone()),
+                    onclick: move |_| on_action.call(ChooseAction::OwnIt(own_meta.clone())),
                     "I own it \u{2014} add to my collection"
                 }
                 // A provider record can carry a placeholder title that shares
@@ -228,7 +235,7 @@ pub(super) fn ChooseScreen(
                     class: "btn ghost",
                     disabled: busy(),
                     "data-testid": "check-in-link-existing",
-                    onclick: move |_| on_link.call(()),
+                    onclick: move |_| on_action.call(ChooseAction::Link),
                     "I already have this book"
                 }
                 button {
@@ -236,7 +243,7 @@ pub(super) fn ChooseScreen(
                     class: "btn ghost",
                     disabled: busy(),
                     "data-testid": "check-in-wishlist",
-                    onclick: move |_| on_wishlist.call(wishlist_request_for(&wish_meta)),
+                    onclick: move |_| on_action.call(ChooseAction::Wishlist(wishlist_request_for(&wish_meta))),
                     "Add to my wishlist"
                 }
                 button {
@@ -244,7 +251,7 @@ pub(super) fn ChooseScreen(
                     class: "btn ghost",
                     disabled: busy(),
                     "data-testid": "check-in-restart",
-                    onclick: move |_| on_restart.call(()),
+                    onclick: move |_| on_action.call(ChooseAction::Restart),
                     "Not the right book?"
                 }
             }

--- a/frontend/src/pages/landing/sections.rs
+++ b/frontend/src/pages/landing/sections.rs
@@ -217,9 +217,11 @@ pub(super) fn LandingContent(props: LandingContentProps) -> Element {
                     books,
                     prefs,
                     ctx,
-                    on_sort: EventHandler::new(on_sort),
-                    on_load_more,
-                    on_clear_filters,
+                    handlers: LandingBooksHandlers {
+                        on_sort: EventHandler::new(on_sort),
+                        on_load_more,
+                        on_clear_filters,
+                    },
                 }
             }
         }
@@ -244,6 +246,15 @@ fn build_sort_handler(
     }
 }
 
+/// Handlers the book area dispatches: a sort-column click, the load-more
+/// sentinel, and the filtered-empty "clear filters" escape.
+#[derive(Clone, PartialEq)]
+pub(super) struct LandingBooksHandlers {
+    pub on_sort: EventHandler<SortKey>,
+    pub on_load_more: EventHandler<()>,
+    pub on_clear_filters: EventHandler<()>,
+}
+
 /// The loading / table-or-grid / empty / filtered-empty states for the main
 /// book area, and the load-more pagination sentinel.
 #[component]
@@ -251,10 +262,13 @@ fn LandingBooksArea(
     books: BooksView,
     prefs: ViewPrefs,
     ctx: BookTableContext,
-    on_sort: EventHandler<SortKey>,
-    on_load_more: EventHandler<()>,
-    on_clear_filters: EventHandler<()>,
+    handlers: LandingBooksHandlers,
 ) -> Element {
+    let LandingBooksHandlers {
+        on_sort,
+        on_load_more,
+        on_clear_filters,
+    } = handlers;
     let BooksView {
         is_loading,
         visible_books,

--- a/frontend/src/pages/reader/drawer_shell.rs
+++ b/frontend/src/pages/reader/drawer_shell.rs
@@ -22,6 +22,9 @@ pub(super) fn ReaderScrim(onclick: EventHandler<MouseEvent>) -> Element {
 /// sections. `extra_class` appends additional drawer classes (the search
 /// panel's `rd-search-drawer`, which lets the phone breakpoint take it
 /// full-screen).
+// Deliberately left at six props: four of them (`head`, `actions`, `children`,
+// `on_close`) are slot/handler idioms a struct can't carry without losing the
+// rsx slot syntax, so grouping would only bundle the two chrome strings.
 #[component]
 pub(super) fn ReaderDrawerShell(
     testid: String,

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -133,7 +133,7 @@ fn SelectionSwatches(
 }
 
 /// One of the popover's four non-highlight actions, carrying exactly the
-/// payload [`SelectionActions`]' matching handler takes.
+/// payload the matching handler on [`SelectionActions`] takes.
 #[derive(Clone, PartialEq)]
 enum SelectionButtonAction {
     Note { cfi: String, text: String },

--- a/frontend/src/pages/reader/selection.rs
+++ b/frontend/src/pages/reader/selection.rs
@@ -78,10 +78,12 @@ pub(crate) fn SelectionPopover(anchor: SelectionAnchor, actions: SelectionAction
                 SelectionActionButtons {
                     cfi: sel_cfi,
                     text: sel_text,
-                    on_note,
-                    on_copy,
-                    on_quote,
-                    on_share,
+                    on_action: EventHandler::new(move |action: SelectionButtonAction| match action {
+                        SelectionButtonAction::Note { cfi, text } => on_note.call((cfi, text)),
+                        SelectionButtonAction::Copy { text } => on_copy.call(text),
+                        SelectionButtonAction::Quote { cfi, text } => on_quote.call((cfi, text)),
+                        SelectionButtonAction::Share { text } => on_share.call(text),
+                    }),
                 }
             }
         }
@@ -130,15 +132,22 @@ fn SelectionSwatches(
     }
 }
 
+/// One of the popover's four non-highlight actions, carrying exactly the
+/// payload [`SelectionActions`]' matching handler takes.
+#[derive(Clone, PartialEq)]
+enum SelectionButtonAction {
+    Note { cfi: String, text: String },
+    Copy { text: String },
+    Quote { cfi: String, text: String },
+    Share { text: String },
+}
+
 /// The Note / Copy / Quote / Share action buttons.
 #[component]
 fn SelectionActionButtons(
     cfi: String,
     text: String,
-    on_note: EventHandler<(String, String)>,
-    on_copy: EventHandler<String>,
-    on_quote: EventHandler<(String, String)>,
-    on_share: EventHandler<String>,
+    on_action: EventHandler<SelectionButtonAction>,
 ) -> Element {
     rsx! {
         button {
@@ -148,7 +157,7 @@ fn SelectionActionButtons(
             onclick: {
                 let cfi = cfi.clone();
                 let text = text.clone();
-                move |_| on_note.call((cfi.clone(), text.clone()))
+                move |_| on_action.call(SelectionButtonAction::Note { cfi: cfi.clone(), text: text.clone() })
             },
             svg {
                 width: "15", height: "15", view_box: "0 0 24 24",
@@ -164,7 +173,7 @@ fn SelectionActionButtons(
             "data-testid": "selection-copy",
             onclick: {
                 let text = text.clone();
-                move |_| on_copy.call(text.clone())
+                move |_| on_action.call(SelectionButtonAction::Copy { text: text.clone() })
             },
             svg {
                 width: "15", height: "15", view_box: "0 0 24 24",
@@ -184,7 +193,7 @@ fn SelectionActionButtons(
             onclick: {
                 let cfi = cfi.clone();
                 let text = text.clone();
-                move |_| on_quote.call((cfi.clone(), text.clone()))
+                move |_| on_action.call(SelectionButtonAction::Quote { cfi: cfi.clone(), text: text.clone() })
             },
             svg {
                 width: "15", height: "15", view_box: "0 0 24 24",
@@ -199,7 +208,7 @@ fn SelectionActionButtons(
             "data-testid": "selection-share",
             onclick: {
                 let text = text.clone();
-                move |_| on_share.call(text.clone())
+                move |_| on_action.call(SelectionButtonAction::Share { text: text.clone() })
             },
             svg {
                 width: "15", height: "15", view_box: "0 0 24 24",


### PR DESCRIPTION
## Summary
- Re-ran the prop-count check on all eight components named in #2044 — every one still exceeded the ~5-prop threshold, so none of this was already fixed.
- Seven now take a grouped prop; the eighth (`ReaderDrawerShell`) is left as-is with a one-line rationale comment, which the issue's acceptance criteria explicitly allow and #2010 set the precedent for.
- Two shapes used, both already in the tree: a cohesive context/value struct (the `ctx: BdPageCtx` / `chrome: BdHeroChrome` / `avail: Availability` pattern) and the `on_action: EventHandler<SomeActionEnum>` consolidation #2010 used for `UserRow`.
- No behavior or rendered-markup change: every edit is a prop signature, a call site, or a comment. No rsx element, attribute, `id`, `data-testid`, `role`, `class`, or text string moved.
- Closes #2044

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` (default members) — PASS
- [x] `cargo test -p omnibus-frontend --features server` — PASS (852 passed, 0 failed)

## Notes

### Per-component verdicts

| Component | Verdict | Reason |
|---|---|---|
| `book_detail/hero.rs` — `BdHeroSection` | consolidated: effective `title` folded into the existing `BdHeroChrome` (→ 5 props) | Breadcrumbs, kicker, and the override-merged title are one thing — the hero's header text — and the struct was already there for exactly this purpose. |
| `book_detail/body.rs` — `BdBodyMain` | consolidated into `BdBodyBook { uuid, title, accent }` (→ 4 props) | The three loose props are all facets of *which book this body is about*; `author`/`suggestions`/`ctx` are genuinely separate concerns. |
| `book_detail/body.rs` — `BdRailSection` | consolidated into `BdRailFacts { title, authors_line, series }` (→ 4 props) | Those three are exactly the rows of the "File details" card. The two `Option<Element>` button slots stay separate — bundling slots costs more clarity than it buys. |
| `book_detail/file_picker.rs` — `BdFilePickerMenu` | consolidated into `FilePickerChrome { label, button_class, single_testid }` (→ 4 props) | Cleanly splits *what the picker opens* (`uuid`, `kind`, `files`) from *how its trigger presents*. |
| `check_in/screens.rs` — `ChooseScreen` | consolidated into `on_action: EventHandler<ChooseAction>` (→ 3 props) | Four mutually-exclusive answers to one question; the enum names the decision the screen actually makes and each variant carries just its own payload. |
| `landing/sections.rs` — `LandingBooksArea` | consolidated into `LandingBooksHandlers` (→ 4 props) | Mirrors the `LandingContentHandlers` struct sitting a few lines above it in the same file. |
| `reader/selection.rs` — `SelectionActionButtons` | consolidated into `on_action: EventHandler<SelectionButtonAction>` (→ 3 props) | The shape the issue suggested. `SelectionPopover` keeps its four named handlers on `SelectionActions` and dispatches in one `match`, so the public surface is unchanged. |
| `reader/drawer_shell.rs` — `ReaderDrawerShell` | **left as-is** (rationale comment added in-file) | Four of the six props (`head`, `actions`, `children`, `on_close`) are Dioxus slot/handler idioms that can't move into a struct without losing rsx slot syntax at all four call sites. That leaves only `testid` + `extra_class` to bundle — a two-field struct that makes every call site longer and nothing clearer. |

### Markup is a frozen contract
Playwright specs assert against these roles/labels/testids and the suite isn't runnable in this environment, so the markup was held byte-identical on purpose. The diff contains no changes inside any rsx element — only prop lists, struct literals at call sites, and one comment. Rule 07 also holds: no component body is cfg-gated, no hook is declared conditionally, no hook order changed, and no element type is swapped inside a conditional.

### Coordination with in-flight PRs
Per the overlap with #1997 (inline genre/tag editors in the book-detail hero) and #2065 (async-action/toast dedupe), the edits in `book_detail/hero.rs` and `book_detail/body.rs` were kept surgical — nothing was reflowed, reordered, or reformatted. The hero changes are confined to the `BdHeroChrome` definition, one destructure, and the four `BdFilePickerMenu` call sites inside `BdCtaRow`; the cover column and tag/genre lists are untouched.

>[!NOTE]
> **Lanes not runnable locally.** This was verified with plain `cargo` outside the Nix shell, so `clippy (frontend-mobile)`, `clippy (frontend-web)` (wasm32), `clippy (mobile)`, and the Playwright E2E suites were not run here — CI is the check for those. The dead-code risk those lanes catch was considered: `FilePickerChrome` lives in `file_picker.rs`, which is compiled on **both** targets and consumed by `hero.rs` (web) and `mobile.rs` (mobile); `BdBodyBook`/`BdRailFacts`/the new `BdHeroChrome` field live in `cfg(not(feature = "mobile"))` modules and are used there; `ChooseAction`, `LandingBooksHandlers`, and `SelectionButtonAction` live in unconditionally-compiled modules. Nothing added is used on only one target.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmMuZvBbXPyLmMpmtLu3u)_