### PR TITLE
[OMNI-2072] Drop bkp-role contributors from the creator merge

### DIFF
--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -203,6 +203,16 @@ fn collect_contributors<R: std::io::Read + std::io::Seek>(
                 .refinement("role")
                 .map(|r| r.value.clone())
                 .or_else(|| lookup_refinement(&m.refined, "role"));
+            // `bkp` (MARC "book producer") is the role conversion tools stamp
+            // their generator string with (Calibre: `calibre (X.Y.Z) [http…]`).
+            // It names production tooling, not a person — drop it here so the
+            // stamp never reaches `books_authors_link` (#2072).
+            if role
+                .as_deref()
+                .is_some_and(|r| r.eq_ignore_ascii_case("bkp"))
+            {
+                return None;
+            }
             let file_as = m
                 .refinement("file-as")
                 .map(|r| r.value.clone())

--- a/db/src/ebook/parse.rs
+++ b/db/src/ebook/parse.rs
@@ -203,8 +203,8 @@ fn collect_contributors<R: std::io::Read + std::io::Seek>(
                 .refinement("role")
                 .map(|r| r.value.clone())
                 .or_else(|| lookup_refinement(&m.refined, "role"));
-            // `bkp` (MARC "book producer") is the role conversion tools stamp
-            // their generator string with (Calibre: `calibre (X.Y.Z) [http…]`).
+            // Conversion tools mark their generator string with the `bkp`
+            // (MARC "book producer") role (Calibre: `calibre (X.Y.Z) [http…]`).
             // It names production tooling, not a person — drop it here so the
             // stamp never reaches `books_authors_link` (#2072).
             if role

--- a/db/src/ebook/parse/tests.rs
+++ b/db/src/ebook/parse/tests.rs
@@ -175,6 +175,37 @@ fn collect_contributors_filters_by_key_and_skips_blank_names() {
     assert!(contributors[0].file_as.is_none());
 }
 
+#[test]
+fn collect_contributors_drops_bkp_role_conversion_tool_stamp() {
+    // Calibre stamps its generator string as a `bkp` (book producer)
+    // contributor; it must never surface as an author. Legacy EPUB2
+    // attribute form, the shape Calibre actually writes.
+    let doc = doc_from_opf(&opf_package(
+        "2.0",
+        r#"    <dc:contributor opf:role="bkp">calibre (2.80.0) [https://calibre-ebook.com]</dc:contributor>
+<dc:contributor opf:role="trl">Ken Liu</dc:contributor>"#,
+    ));
+    let contributors = collect_contributors(&doc, "contributor");
+    assert_eq!(contributors.len(), 1);
+    assert_eq!(contributors[0].name, "Ken Liu");
+    assert_eq!(contributors[0].role.as_deref(), Some("trl"));
+}
+
+#[test]
+fn collect_contributors_drops_bkp_role_from_epub3_refinement() {
+    let doc = doc_from_opf(&opf_package(
+        "3.0",
+        r##"    <dc:creator>Cixin Liu</dc:creator>
+<dc:contributor id="bkp">calibre (7.3.0) [https://calibre-ebook.com]</dc:contributor>
+<meta refines="#bkp" property="role">bkp</meta>"##,
+    ));
+    assert_eq!(collect_contributors(&doc, "contributor").len(), 0);
+    // The real creator is untouched by the filter.
+    let creators = collect_contributors(&doc, "creator");
+    assert_eq!(creators.len(), 1);
+    assert_eq!(creators[0].name, "Cixin Liu");
+}
+
 // --- collect_series ----------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- Calibre stamps its generator string as a `bkp` (book producer) `dc:contributor`; the creator+contributor merge ingested it as an author row, one per Calibre version.
- `collect_contributors` now drops entries whose role is `bkp` (case-insensitive, both EPUB3 refinement and legacy `opf:role` forms); authorial roles still merge per #174.

Closes #2072

## Test plan
- [x] Two new unit tests (legacy-attribute and EPUB3-refinement `bkp` shapes, each proving a real creator/contributor survives).
- [x] Full `cargo test -p omnibus-db`: 2277 passed, 0 failed.
- [x] `cargo fmt` + `cargo clippy -p omnibus-db --all-targets` clean.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Existing bogus rows heal via the cleanup delete tool (which blocklists the name); the live library's `ignored_authors` already holds ~25 Calibre version strings — this fix ends that whack-a-mole.