### PR TITLE
[OMNI-2073] Fix single-file audiobook path-fallback directory offsets

### DIFF
--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -180,8 +180,13 @@ struct BookLevel {
 
 /// Parse a single [`super::AudiobookGroup`] into an [`IndexedAudiobook`].
 fn parse_one_group(group: super::AudiobookGroup, library_root: &Path) -> IndexedAudiobook {
+    // Single-file groups (m4b/m4a) carry the file's own relative path as
+    // `group_path`; mp3 folder groups carry their parent directory. The
+    // path-derived metadata fallback needs to know which shape it is
+    // looking at, so the directory offsets line up either way.
+    let single_file = group.parts.len() == 1 && group.parts[0].filename == group.group_path;
     let (parts_work, first_cover) = extract_tags_and_metadata(&group, library_root);
-    let (book_level, parts) = build_parts_list(parts_work, &group.group_path);
+    let (book_level, parts) = build_parts_list(parts_work, &group.group_path, single_file);
     let chapters = apply_chapters(&parts, library_root, &group.format);
 
     let accent = first_cover
@@ -301,6 +306,7 @@ fn extract_tags_and_metadata(
 fn build_parts_list(
     mut parts_work: Vec<PartWork>,
     group_path: &str,
+    single_file: bool,
 ) -> (BookLevel, Vec<AudiobookPart>) {
     parts_work.sort_by(|a, b| {
         a.sort_track
@@ -308,19 +314,19 @@ fn build_parts_list(
             .then_with(|| a.filename.cmp(&b.filename))
     });
 
-    // Derive book-level metadata from the sorted parts. Title falls back
-    // to the album tag, then to the group path's leaf — every m4b/m4a is
-    // one-file-per-group post-fix, so the leaf reads as the file stem
-    // (or for an mp3 folder group, the folder name).
+    // Derive book-level metadata from the sorted parts: album tag first,
+    // artist tag first, then the path-derived fallback for whatever the
+    // tags left empty.
+    let (fallback_title, fallback_creator) = path_fallback(group_path, single_file);
     let title = parts_work
         .iter()
         .find_map(|p| p.meta.album.clone())
-        .unwrap_or_else(|| leaf_name(group_path));
+        .unwrap_or(fallback_title);
 
     let creator_name = parts_work
         .iter()
         .find_map(|p| p.meta.artist.clone())
-        .or_else(|| parent_name(group_path));
+        .or(fallback_creator);
 
     let total_secs: f64 = parts_work.iter().map(|p| p.duration_seconds).sum();
     let description = if total_secs > 0.0 {
@@ -401,6 +407,58 @@ fn offset_chapters(
         .collect()
 }
 
+/// Path-derived `(title, creator)` fallback for groups whose tags carry
+/// neither. An mp3 folder group's `group_path` *is* the title directory, so
+/// leaf = title and parent = creator. A single-file group's `group_path` is
+/// the file itself, one level deeper — under the standard
+/// `<Author>/<Title>/<file>` layout the title is the parent directory and
+/// the creator its grandparent (#2073). Shallower single-file layouts
+/// degrade: `<Author>/<file>` takes parent as creator and the file stem
+/// (minus any duplicated `<creator> - ` prefix) as title; a bare `<file>`
+/// keeps the stem with no creator.
+fn path_fallback(group_path: &str, single_file: bool) -> (String, Option<String>) {
+    if !single_file {
+        return (leaf_name(group_path), parent_name(group_path));
+    }
+    let path = Path::new(group_path);
+    let parent = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty());
+    let grandparent = path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty());
+    match (parent, grandparent) {
+        (Some(title_dir), Some(author_dir)) => {
+            (title_dir.to_string(), Some(author_dir.to_string()))
+        }
+        (Some(author_dir), None) => {
+            let creator = author_dir.to_string();
+            let title = strip_creator_prefix(&leaf_name(group_path), &creator);
+            (title, Some(creator))
+        }
+        _ => (leaf_name(group_path), None),
+    }
+}
+
+/// Strip a leading `"<creator> - "` from a filename-derived title so
+/// `Author - Title.m4b` shapes don't duplicate the author into the title.
+/// Case-insensitive on the creator; a title that is *only* the prefix is
+/// left untouched rather than emptied.
+fn strip_creator_prefix(title: &str, creator: &str) -> String {
+    title
+        .get(..creator.len())
+        .filter(|head| head.eq_ignore_ascii_case(creator))
+        .and_then(|_| title.get(creator.len()..))
+        .and_then(|rest| rest.strip_prefix(" - "))
+        .filter(|rest| !rest.trim().is_empty())
+        .map_or_else(|| title.to_string(), |rest| rest.trim_start().to_string())
+}
+
 /// Leaf directory name or file stem from a group path (title fallback).
 fn leaf_name(group_path: &str) -> String {
     PathBuf::from(group_path)
@@ -459,7 +517,7 @@ pub fn parse_audiobook_targets(targets: Vec<AudiobookParseTarget>) -> Vec<super:
 #[cfg(test)]
 mod tests {
     use super::super::chapters::RawChapter;
-    use super::offset_chapters;
+    use super::{offset_chapters, path_fallback, strip_creator_prefix};
 
     #[test]
     fn offset_chapters_shifts_start_and_end_by_offset() {
@@ -482,5 +540,53 @@ mod tests {
         assert_eq!(shifted[0].end_ms, 11_000);
         assert_eq!(shifted[1].start_ms, 11_000);
         assert_eq!(shifted[1].end_ms, 12_500);
+    }
+
+    #[test]
+    fn path_fallback_single_file_reads_title_from_parent_and_creator_from_grandparent() {
+        let (title, creator) = path_fallback(
+            "Logan Karlie/Dream by the Shadows/Logan Karlie - Dream by the Shadows.m4b",
+            true,
+        );
+        assert_eq!(title, "Dream by the Shadows");
+        assert_eq!(creator.as_deref(), Some("Logan Karlie"));
+    }
+
+    #[test]
+    fn path_fallback_single_file_at_depth_two_takes_parent_as_creator_and_strips_prefix() {
+        let (title, creator) = path_fallback("Andy Weir/Andy Weir - Project Hail Mary.m4b", true);
+        assert_eq!(title, "Project Hail Mary");
+        assert_eq!(creator.as_deref(), Some("Andy Weir"));
+    }
+
+    #[test]
+    fn path_fallback_single_file_at_root_keeps_stem_with_no_creator() {
+        let (title, creator) = path_fallback("Dracula Pt1.m4b", true);
+        assert_eq!(title, "Dracula Pt1");
+        assert_eq!(creator, None);
+    }
+
+    #[test]
+    fn path_fallback_folder_group_keeps_leaf_title_and_parent_creator() {
+        let (title, creator) = path_fallback("Bram Stoker/Dracula", false);
+        assert_eq!(title, "Dracula");
+        assert_eq!(creator.as_deref(), Some("Bram Stoker"));
+    }
+
+    #[test]
+    fn strip_creator_prefix_is_case_insensitive_and_keeps_unrelated_titles() {
+        assert_eq!(
+            strip_creator_prefix("andy weir - Project Hail Mary", "Andy Weir"),
+            "Project Hail Mary"
+        );
+        assert_eq!(
+            strip_creator_prefix("Project Hail Mary", "Andy Weir"),
+            "Project Hail Mary"
+        );
+        // A title that is only the prefix is left untouched rather than emptied.
+        assert_eq!(
+            strip_creator_prefix("Andy Weir - ", "Andy Weir"),
+            "Andy Weir - "
+        );
     }
 }

--- a/db/src/audiobook/parse.rs
+++ b/db/src/audiobook/parse.rs
@@ -447,7 +447,7 @@ fn path_fallback(group_path: &str, single_file: bool) -> (String, Option<String>
 
 /// Strip a leading `"<creator> - "` from a filename-derived title so
 /// `Author - Title.m4b` shapes don't duplicate the author into the title.
-/// Case-insensitive on the creator; a title that is *only* the prefix is
+/// ASCII-case-insensitive on the creator; a title that is *only* the prefix is
 /// left untouched rather than emptied.
 fn strip_creator_prefix(title: &str, creator: &str) -> String {
     title

--- a/db/src/audiobook/tests.rs
+++ b/db/src/audiobook/tests.rs
@@ -155,6 +155,49 @@ fn parse_groups_emits_one_book_per_m4b_even_when_stems_share_a_base() {
 }
 
 #[test]
+fn parse_groups_untagged_m4b_derives_title_from_parent_dir_and_creator_from_grandparent() {
+    // #2073 repro: an untagged single-file m4b under the standard
+    // `<Author>/<Title>/<file>` layout. Junk bytes drive the tag read to
+    // its warn-and-default path, so the path fallback decides everything —
+    // it must read the title from the parent dir and the creator from the
+    // grandparent, not (as before) the stem and the title dir.
+    let dir = make_test_dir("m4b_nested_fallback");
+    let book_dir = dir.join("Logan Karlie").join("Dream by the Shadows");
+    fs::create_dir_all(&book_dir).unwrap();
+    fs::write(
+        book_dir.join("Logan Karlie - Dream by the Shadows.m4b"),
+        b"junk",
+    )
+    .unwrap();
+    let stat = stat_audiobook_library(dir.to_str(), dir.to_str().unwrap());
+    let groups = group_into_books(stat.entries, dir.to_str().unwrap());
+    let books = parse_groups(groups, &dir);
+    fs::remove_dir_all(&dir).unwrap();
+    assert_eq!(books.len(), 1);
+    assert_eq!(books[0].title, "Dream by the Shadows");
+    assert_eq!(books[0].creator_name.as_deref(), Some("Logan Karlie"));
+}
+
+#[test]
+fn parse_groups_untagged_m4b_at_depth_two_takes_parent_as_creator_and_strips_title_prefix() {
+    let dir = make_test_dir("m4b_depth2_fallback");
+    let author_dir = dir.join("Andy Weir");
+    fs::create_dir_all(&author_dir).unwrap();
+    fs::write(
+        author_dir.join("Andy Weir - Project Hail Mary.m4b"),
+        b"junk",
+    )
+    .unwrap();
+    let stat = stat_audiobook_library(dir.to_str(), dir.to_str().unwrap());
+    let groups = group_into_books(stat.entries, dir.to_str().unwrap());
+    let books = parse_groups(groups, &dir);
+    fs::remove_dir_all(&dir).unwrap();
+    assert_eq!(books.len(), 1);
+    assert_eq!(books[0].title, "Project Hail Mary");
+    assert_eq!(books[0].creator_name.as_deref(), Some("Andy Weir"));
+}
+
+#[test]
 fn build_indexed_book_surfaces_error_for_undecodable_audio() {
     // `build_indexed_book` propagates the lofty decode/container failure as
     // an `anyhow::Error` — the direct-propagation counterpart to


### PR DESCRIPTION
## Summary
- Untagged single-file M4B/M4A books derived title from the file stem and author from the *title* directory — `group_path` is the file path for single-file groups, one level deeper than the mp3 folder groups the fallback was written for.
- `build_parts_list` now takes the group shape and `path_fallback` applies the right offsets: `<Author>/<Title>/<file>` → title = parent, creator = grandparent; `<Author>/<file>` → creator = parent, title = stem minus a duplicated `<creator> - ` prefix; bare files and mp3 folder groups are unchanged.
- Correct fallback strings also let cross-format auto-attach (normalized title+author) fire for untagged audiobooks instead of splitting them from their EPUBs.

Closes #2073

## Test plan
- [x] Five pure-fn tests (each layout depth, folder-group branch, prefix stripping) + two end-to-end `parse_groups` tests on nested untagged files, including the verbatim repro path.
- [x] Full `cargo test -p omnibus-db`: 2282 passed, 0 failed.
- [x] `cargo fmt` + `cargo clippy -p omnibus-db --all-targets` clean.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Tag-supplied metadata always wins; the fallback only fills fields the tags left empty, so tagged libraries index exactly as before.