### PR TITLE
[OMNI-2077] Add Ignored-Author Alias Conversion and Relink Pass

### DIFF
--- a/db/src/cleanup.rs
+++ b/db/src/cleanup.rs
@@ -15,6 +15,7 @@ use sqlx::SqlitePool;
 use crate::normalize::normalize_author;
 
 mod apply;
+mod blocklist;
 mod entity_ops;
 mod review;
 mod snapshot;
@@ -27,6 +28,7 @@ pub use apply::{
     apply_book_title_override, apply_delete_author, apply_merge_authors, apply_merge_series,
     apply_merge_tags, apply_tag_split, CleanupApplyError,
 };
+pub use blocklist::{apply_alias_ignored_author, list_ignored_authors, remove_ignored_author};
 pub use review::{
     decide_suggestion, review_counts, review_queue, CleanupStoreError, REVIEW_QUEUE_MAX,
 };

--- a/db/src/cleanup/blocklist.rs
+++ b/db/src/cleanup/blocklist.rs
@@ -1,0 +1,119 @@
+//! Management surface for the `ignored_authors` blocklist the delete-author
+//! flows write: list the entries, convert one into an `entity_aliases`
+//! mapping (the recovery path for a duplicate spelling deleted as junk), or
+//! remove one outright. The convert is a `cleanup_log`-backed primitive so
+//! [`super::undo::undo`] can reverse it exactly.
+
+use omnibus_shared::{CleanupAction, CleanupKind, IgnoredAuthor};
+use sqlx::SqlitePool;
+
+use super::apply::CleanupApplyError;
+use super::entity_ops::{
+    fetch_entity_alias, fetch_name_sort, write_cleanup_log, write_entity_alias,
+};
+use super::snapshot::{AliasIgnoredSnapshot, AliasSnapshot};
+use super::MergeEntity;
+
+#[cfg(test)]
+mod tests;
+
+/// Every `ignored_authors` entry, alphabetical by name, for the Settings
+/// blocklist list.
+pub async fn list_ignored_authors(
+    pool: &SqlitePool,
+) -> Result<Vec<IgnoredAuthor>, CleanupApplyError> {
+    let rows: Vec<(String, i64)> =
+        sqlx::query_as("SELECT name, ignored_at FROM ignored_authors ORDER BY name")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(name, ignored_at)| IgnoredAuthor { name, ignored_at })
+        .collect())
+}
+
+/// Convert the `ignored_authors` entry for `name` into an author
+/// `entity_aliases` row pointing at `canonical_id`, so future reindexes
+/// resolve the spelling to the canonical author instead of silently skipping
+/// it. Errs [`CleanupApplyError::InvalidRequest`] when `name` is not
+/// blocklisted and [`CleanupApplyError::NotFound`] when `canonical_id` names
+/// no author. Logged in `cleanup_log` (kind Author, action Alias) and
+/// undoable.
+///
+/// Only the *future* mapping is written here — books already indexed while
+/// the name was blocklisted keep their missing link until a relink pass
+/// re-parses them (`crate::worker::Task::RelinkAuthorless`); callers that
+/// want the repair post that task after this returns.
+pub async fn apply_alias_ignored_author(
+    pool: &SqlitePool,
+    name: &str,
+    canonical_id: i64,
+    applied_by: Option<i64>,
+) -> Result<i64, CleanupApplyError> {
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+
+    // NOCASE lookup matching the column's own collation, but snapshot the
+    // stored casing so undo restores the row exactly as it was.
+    let row: Option<(String, i64)> =
+        sqlx::query_as("SELECT name, ignored_at FROM ignored_authors WHERE name = ?")
+            .bind(name)
+            .fetch_optional(&mut *tx)
+            .await?;
+    let Some((stored_name, ignored_at)) = row else {
+        return Err(CleanupApplyError::InvalidRequest(format!(
+            "author name is not blocklisted: {name}"
+        )));
+    };
+    fetch_name_sort(&mut tx, MergeEntity::Author, canonical_id)
+        .await?
+        .ok_or(CleanupApplyError::NotFound(canonical_id))?;
+
+    let previous_alias = fetch_entity_alias(&mut tx, CleanupKind::Author, &stored_name)
+        .await?
+        .map(|(canonical_id, created_at)| AliasSnapshot {
+            canonical_id,
+            created_at,
+        });
+
+    sqlx::query("DELETE FROM ignored_authors WHERE name = ?")
+        .bind(&stored_name)
+        .execute(&mut *tx)
+        .await?;
+    write_entity_alias(&mut tx, CleanupKind::Author, &stored_name, canonical_id).await?;
+
+    let snapshot = AliasIgnoredSnapshot {
+        name: stored_name,
+        ignored_at,
+        previous_alias,
+    };
+    let log_id = write_cleanup_log(
+        &mut tx,
+        None,
+        CleanupKind::Author,
+        CleanupAction::Alias,
+        &snapshot,
+        applied_by,
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(log_id)
+}
+
+/// Remove the `ignored_authors` entry for `name` outright, so future
+/// reindexes may recreate the author from file metadata again. Errs
+/// [`CleanupApplyError::InvalidRequest`] when `name` is not blocklisted.
+/// Not logged: unlike the convert, the removed row is fully described by its
+/// name and re-blocklisting is one delete-author away.
+pub async fn remove_ignored_author(pool: &SqlitePool, name: &str) -> Result<(), CleanupApplyError> {
+    let result = sqlx::query("DELETE FROM ignored_authors WHERE name = ?")
+        .bind(name)
+        .execute(pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(CleanupApplyError::InvalidRequest(format!(
+            "author name is not blocklisted: {name}"
+        )));
+    }
+    Ok(())
+}

--- a/db/src/cleanup/blocklist/tests.rs
+++ b/db/src/cleanup/blocklist/tests.rs
@@ -1,0 +1,168 @@
+//! Coverage for the `ignored_authors` blocklist management surface: listing,
+//! the convert-to-alias primitive (happy + per-variant errors + undo
+//! round-trip), and the plain remove. All tests run against
+//! `sqlite::memory:` per [`crate::pool::init_db`].
+
+use sqlx::SqlitePool;
+
+use super::super::apply::CleanupApplyError;
+use super::super::undo::undo;
+use super::*;
+use crate::pool::init_db;
+
+async fn new_pool() -> SqlitePool {
+    init_db("sqlite::memory:").await.unwrap()
+}
+
+async fn insert_author(pool: &SqlitePool, name: &str) -> i64 {
+    sqlx::query_scalar("INSERT INTO authors (name) VALUES (?) RETURNING id")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+async fn insert_ignored(pool: &SqlitePool, name: &str, ignored_at: i64) {
+    sqlx::query("INSERT INTO ignored_authors (name, ignored_at) VALUES (?, ?)")
+        .bind(name)
+        .bind(ignored_at)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn fetch_alias(pool: &SqlitePool, name: &str) -> Option<(i64, i64)> {
+    sqlx::query_as(
+        "SELECT canonical_id, created_at FROM entity_aliases
+          WHERE kind = 'author' AND alias_name = ?",
+    )
+    .bind(name)
+    .fetch_optional(pool)
+    .await
+    .unwrap()
+}
+
+async fn fetch_ignored(pool: &SqlitePool, name: &str) -> Option<i64> {
+    sqlx::query_scalar("SELECT ignored_at FROM ignored_authors WHERE name = ?")
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn list_ignored_authors_returns_entries_alphabetically() {
+    let pool = new_pool().await;
+    insert_ignored(&pool, "Weir, Andy", 200).await;
+    insert_ignored(&pool, "Smashwords, Inc.", 100).await;
+
+    let entries = list_ignored_authors(&pool).await.unwrap();
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, ["Smashwords, Inc.", "Weir, Andy"]);
+    assert_eq!(entries[0].ignored_at, 100);
+}
+
+#[tokio::test]
+async fn apply_alias_ignored_author_moves_entry_into_entity_aliases_and_logs() {
+    let pool = new_pool().await;
+    let canonical = insert_author(&pool, "Andy Weir").await;
+    insert_ignored(&pool, "Weir, Andy", 123).await;
+
+    let admin: i64 = sqlx::query_scalar(
+        "INSERT INTO users (username, password_hash, is_admin) VALUES ('admin', 'x', 1) RETURNING id",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let log_id = apply_alias_ignored_author(&pool, "Weir, Andy", canonical, Some(admin))
+        .await
+        .unwrap();
+    assert!(log_id > 0);
+
+    assert_eq!(fetch_ignored(&pool, "Weir, Andy").await, None);
+    let (alias_canonical, _) = fetch_alias(&pool, "Weir, Andy").await.unwrap();
+    assert_eq!(alias_canonical, canonical);
+}
+
+#[tokio::test]
+async fn apply_alias_ignored_author_rejects_name_not_on_the_blocklist() {
+    let pool = new_pool().await;
+    let canonical = insert_author(&pool, "Andy Weir").await;
+
+    let err = apply_alias_ignored_author(&pool, "Weir, Andy", canonical, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CleanupApplyError::InvalidRequest(_)));
+}
+
+#[tokio::test]
+async fn apply_alias_ignored_author_rejects_unknown_canonical_author() {
+    let pool = new_pool().await;
+    insert_ignored(&pool, "Weir, Andy", 123).await;
+
+    let err = apply_alias_ignored_author(&pool, "Weir, Andy", 999, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CleanupApplyError::NotFound(999)));
+}
+
+#[tokio::test]
+async fn undo_alias_ignored_author_restores_the_blocklist_row_and_removes_the_alias() {
+    let pool = new_pool().await;
+    let canonical = insert_author(&pool, "Andy Weir").await;
+    insert_ignored(&pool, "Weir, Andy", 123).await;
+
+    let log_id = apply_alias_ignored_author(&pool, "Weir, Andy", canonical, None)
+        .await
+        .unwrap();
+    undo(&pool, log_id).await.unwrap();
+
+    assert_eq!(fetch_ignored(&pool, "Weir, Andy").await, Some(123));
+    assert_eq!(fetch_alias(&pool, "Weir, Andy").await, None);
+}
+
+#[tokio::test]
+async fn undo_alias_ignored_author_restores_a_pre_existing_alias_mapping() {
+    let pool = new_pool().await;
+    let earlier = insert_author(&pool, "A. Weir").await;
+    let canonical = insert_author(&pool, "Andy Weir").await;
+    sqlx::query(
+        "INSERT INTO entity_aliases (kind, alias_name, canonical_id, created_at)
+         VALUES ('author', 'Weir, Andy', ?, 55)",
+    )
+    .bind(earlier)
+    .execute(&pool)
+    .await
+    .unwrap();
+    insert_ignored(&pool, "Weir, Andy", 123).await;
+
+    let log_id = apply_alias_ignored_author(&pool, "Weir, Andy", canonical, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        fetch_alias(&pool, "Weir, Andy").await,
+        Some((canonical, fetch_alias(&pool, "Weir, Andy").await.unwrap().1))
+    );
+
+    undo(&pool, log_id).await.unwrap();
+    assert_eq!(fetch_alias(&pool, "Weir, Andy").await, Some((earlier, 55)));
+    assert_eq!(fetch_ignored(&pool, "Weir, Andy").await, Some(123));
+}
+
+#[tokio::test]
+async fn remove_ignored_author_deletes_the_entry() {
+    let pool = new_pool().await;
+    insert_ignored(&pool, "Smashwords, Inc.", 100).await;
+
+    remove_ignored_author(&pool, "Smashwords, Inc.")
+        .await
+        .unwrap();
+    assert_eq!(fetch_ignored(&pool, "Smashwords, Inc.").await, None);
+}
+
+#[tokio::test]
+async fn remove_ignored_author_rejects_name_not_on_the_blocklist() {
+    let pool = new_pool().await;
+    let err = remove_ignored_author(&pool, "Nobody").await.unwrap_err();
+    assert!(matches!(err, CleanupApplyError::InvalidRequest(_)));
+}

--- a/db/src/cleanup/snapshot.rs
+++ b/db/src/cleanup/snapshot.rs
@@ -122,3 +122,14 @@ pub(super) struct DeleteAuthorSnapshot {
     pub links: Vec<BookLink>,
     pub photo: Option<PhotoSnapshot>,
 }
+
+/// Pre-conversion state for `apply_alias_ignored_author`: the blocklist row
+/// it removed and whatever `entity_aliases` row its write overwrote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct AliasIgnoredSnapshot {
+    pub name: String,
+    /// The removed row's original `ignored_at`, restored verbatim on undo.
+    pub ignored_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_alias: Option<AliasSnapshot>,
+}

--- a/db/src/cleanup/undo.rs
+++ b/db/src/cleanup/undo.rs
@@ -17,7 +17,9 @@ use super::entity_ops::{
     insert_links_bulk, lookup_tag_ids, recreate_entity, restore_canonical_photo,
     restore_entity_alias, write_photo,
 };
-use super::snapshot::{DeleteAuthorSnapshot, MergeSnapshot, RenameSnapshot, SplitSnapshot};
+use super::snapshot::{
+    AliasIgnoredSnapshot, DeleteAuthorSnapshot, MergeSnapshot, RenameSnapshot, SplitSnapshot,
+};
 use super::MergeEntity;
 
 /// Reverse a previously-applied cleanup log entry, restoring the
@@ -78,6 +80,9 @@ pub async fn undo(pool: &SqlitePool, log_id: i64) -> Result<(), CleanupApplyErro
         (CleanupKind::Tag, CleanupAction::Split) => undo_split(&mut tx, &row.snapshot_json).await?,
         (CleanupKind::Author, CleanupAction::Delete) => {
             undo_delete_author(&mut tx, &row.snapshot_json).await?
+        }
+        (CleanupKind::Author, CleanupAction::Alias) => {
+            undo_alias_ignored_author(&mut tx, &row.snapshot_json).await?
         }
         (CleanupKind::BookTitle, CleanupAction::Rename) => {
             fts_rebuild_uuid = undo_rename(&mut tx, &row.snapshot_json, row.applied_by).await?;
@@ -279,5 +284,37 @@ async fn undo_delete_author(
 
     let book_ids: Vec<i64> = snap.links.iter().map(|link| link.book_id).collect();
     upsert_fts_batch(tx, &book_ids).await?;
+    Ok(())
+}
+
+/// Undo `apply_alias_ignored_author`: put the `ignored_authors` row back
+/// with its original `ignored_at`, and restore the `entity_aliases` row to
+/// whatever it held before the conversion — or delete it, if nothing did.
+async fn undo_alias_ignored_author(
+    tx: &mut Transaction<'_, Sqlite>,
+    snapshot_json: &str,
+) -> Result<(), CleanupApplyError> {
+    let snap: AliasIgnoredSnapshot = serde_json::from_str(snapshot_json)?;
+
+    // OR REPLACE: a delete-author of the same name run since the conversion
+    // may have re-blocklisted it; the restored original timestamp wins.
+    sqlx::query("INSERT OR REPLACE INTO ignored_authors (name, ignored_at) VALUES (?, ?)")
+        .bind(&snap.name)
+        .bind(snap.ignored_at)
+        .execute(&mut **tx)
+        .await?;
+    match &snap.previous_alias {
+        Some(prev) => {
+            restore_entity_alias(
+                tx,
+                CleanupKind::Author,
+                &snap.name,
+                prev.canonical_id,
+                prev.created_at,
+            )
+            .await?
+        }
+        None => delete_entity_alias(tx, CleanupKind::Author, &snap.name).await?,
+    }
     Ok(())
 }

--- a/db/src/indexer/audiobooks.rs
+++ b/db/src/indexer/audiobooks.rs
@@ -10,8 +10,9 @@ use crate::{audiobook, books, sync};
 
 use super::{
     check_mass_missing, diff_library, diff_tallies, enumeration_is_trustworthy,
-    gc_missing_files_best_effort, report_parse_progress, report_sync_progress, root_display_name,
-    ReindexDiff, ReindexStats, ScanUpdate, PHASE_WALKING,
+    gc_missing_files_best_effort, promote_authorless_unchanged, report_parse_progress,
+    report_sync_progress, root_display_name, ReindexDiff, ReindexOptions, ReindexStats, ScanUpdate,
+    PHASE_WALKING,
 };
 
 /// Audiobook-library sibling of [`super::reindex`]. Groups audio files by
@@ -101,6 +102,7 @@ struct AudiobookDiffPhase {
 async fn diff_audiobook_library_for_reindex(
     pool: &SqlitePool,
     library_path: &str,
+    options: ReindexOptions,
 ) -> anyhow::Result<AudiobookDiffPhase> {
     let (groups, signals) = stat_and_group_audiobooks(library_path).await?;
 
@@ -132,7 +134,11 @@ async fn diff_audiobook_library_for_reindex(
              skipping the removal pass; no books marked missing (issue #819)"
         );
     }
-    let diff = diff_library(&groups_as_stat, &db_rows, &library_root, trustworthy);
+    let mut diff = diff_library(&groups_as_stat, &db_rows, &library_root, trustworthy);
+    if options.relink_authorless {
+        promote_authorless_unchanged(pool, &mut diff, &groups_as_stat, &db_rows, &library_root)
+            .await?;
+    }
     let removed_count = diff.removed.len();
     let moved_count = diff.moved.len();
     check_mass_missing(removed_count, db_file_backed)?;
@@ -201,10 +207,23 @@ pub async fn reindex_audiobooks_with_progress(
     library_path: &str,
     on_progress: impl FnMut(ScanUpdate) + Send + 'static,
 ) -> anyhow::Result<ReindexStats> {
+    reindex_audiobooks_with_options(pool, library_path, ReindexOptions::default(), on_progress)
+        .await
+}
+
+/// [`reindex_audiobooks_with_progress`] variant taking [`ReindexOptions`] —
+/// currently just the authorless relink pass posted by the blocklist
+/// recovery flow.
+pub async fn reindex_audiobooks_with_options(
+    pool: &SqlitePool,
+    library_path: &str,
+    options: ReindexOptions,
+    on_progress: impl FnMut(ScanUpdate) + Send + 'static,
+) -> anyhow::Result<ReindexStats> {
     let mut on_progress = on_progress;
     on_progress(ScanUpdate::phase(PHASE_WALKING));
 
-    let phase_a = diff_audiobook_library_for_reindex(pool, library_path).await?;
+    let phase_a = diff_audiobook_library_for_reindex(pool, library_path, options).await?;
 
     // Phase B: parse only the New and Changed groups.
     let (new_groups, changed_groups) = select_parse_groups(phase_a.groups, &phase_a.diff);

--- a/db/src/indexer/ebooks.rs
+++ b/db/src/indexer/ebooks.rs
@@ -10,8 +10,9 @@ use crate::{books, ebook, sync};
 
 use super::{
     check_mass_missing, diff_library, diff_tallies, enumeration_is_trustworthy,
-    gc_missing_files_best_effort, report_parse_progress, report_sync_progress, root_display_name,
-    ReindexDiff, ReindexStats, ScanUpdate, PHASE_WALKING,
+    gc_missing_files_best_effort, promote_authorless_unchanged, report_parse_progress,
+    report_sync_progress, root_display_name, ReindexDiff, ReindexOptions, ReindexStats, ScanUpdate,
+    PHASE_WALKING,
 };
 
 /// Scan `library_path`, diff against the existing index, and apply only
@@ -48,6 +49,7 @@ struct EbookDiffPhase {
 async fn diff_ebook_library_for_reindex(
     pool: &SqlitePool,
     library_path: &str,
+    options: ReindexOptions,
 ) -> anyhow::Result<EbookDiffPhase> {
     let path_for_scan = library_path.to_owned();
     let library_key_for_scan = library_path.to_owned();
@@ -83,7 +85,11 @@ async fn diff_ebook_library_for_reindex(
              skipping the removal pass; no books marked missing (issue #819)"
         );
     }
-    let diff = diff_library(&stat.entries, &db_rows, &library_root, trustworthy);
+    let mut diff = diff_library(&stat.entries, &db_rows, &library_root, trustworthy);
+    if options.relink_authorless {
+        promote_authorless_unchanged(pool, &mut diff, &stat.entries, &db_rows, &library_root)
+            .await?;
+    }
     let removed_count = diff.removed.len();
     let moved_count = diff.moved.len();
     // Moved files never entered `removed`, so a reorganization — however
@@ -131,10 +137,21 @@ pub async fn reindex_with_progress(
     library_path: &str,
     on_progress: impl FnMut(ScanUpdate) + Send + 'static,
 ) -> anyhow::Result<ReindexStats> {
+    reindex_with_options(pool, library_path, ReindexOptions::default(), on_progress).await
+}
+
+/// [`reindex_with_progress`] variant taking [`ReindexOptions`] — currently
+/// just the authorless relink pass posted by the blocklist recovery flow.
+pub async fn reindex_with_options(
+    pool: &SqlitePool,
+    library_path: &str,
+    options: ReindexOptions,
+    on_progress: impl FnMut(ScanUpdate) + Send + 'static,
+) -> anyhow::Result<ReindexStats> {
     let mut on_progress = on_progress;
     on_progress(ScanUpdate::phase(PHASE_WALKING));
 
-    let mut phase_a = diff_ebook_library_for_reindex(pool, library_path).await?;
+    let mut phase_a = diff_ebook_library_for_reindex(pool, library_path, options).await?;
 
     // Parse Phase B only for the buckets that need it. `diff.removed`/
     // `.backfill` are read again below, but `.new`/`.changed` are not, so

--- a/db/src/indexer/mod.rs
+++ b/db/src/indexer/mod.rs
@@ -15,12 +15,14 @@ mod backfill;
 mod ebooks;
 mod progress;
 
-pub use audiobooks::{reindex_audiobooks, reindex_audiobooks_with_progress};
+pub use audiobooks::{
+    reindex_audiobooks, reindex_audiobooks_with_options, reindex_audiobooks_with_progress,
+};
 pub(crate) use backfill::{
     backfill_chapters, backfill_epub_structure, backfill_page_counts, backfill_thumbs,
     backfill_word_counts,
 };
-pub use ebooks::{reindex, reindex_with_progress};
+pub use ebooks::{reindex, reindex_with_options, reindex_with_progress};
 pub(crate) use progress::{
     diff_tallies, display_item, report_parse_progress, report_sync_progress, root_display_name,
 };
@@ -231,6 +233,95 @@ pub async fn is_stale(pool: &SqlitePool, library_path: &str) -> Result<bool, Ind
 /// unit-testable without depending on a readable wall clock.
 fn is_stale_decision(last: i64, now: i64) -> bool {
     now - last >= REFRESH_AFTER_SECS
+}
+
+/// Behavior switches for a reindex pass beyond the default incremental diff.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReindexOptions {
+    /// Re-parse Unchanged files whose book has no author link left. The
+    /// repair pass for books orphaned while their author's name sat on the
+    /// `ignored_authors` blocklist: the normal diff never re-parses an
+    /// Unchanged file, so removing a blocklist entry (or aliasing it) can
+    /// only take effect on books whose files happen to change — this
+    /// promotes the orphaned ones through the ordinary Changed path instead.
+    pub relink_authorless: bool,
+}
+
+/// Move every Unchanged entry whose book has no `books_authors_link` row
+/// into Changed, so Phase B re-parses it and the writer re-derives its
+/// author links against the current blocklist + `entity_aliases` state.
+/// Only primary rows (`books.uuid`) are promoted — a merged/attached file's
+/// metadata is owned by its primary book, and the attached-file Changed path
+/// never rewrites book metadata.
+async fn promote_authorless_unchanged(
+    pool: &SqlitePool,
+    diff: &mut ReindexDiff,
+    disk: &[ebook::StatEntry],
+    db_rows: &[books::IndexedRow],
+    library_root: &Path,
+) -> Result<(), sqlx::Error> {
+    if diff.unchanged.is_empty() {
+        return Ok(());
+    }
+    let authorless = authorless_uuids(pool, &diff.unchanged).await?;
+    if authorless.is_empty() {
+        return Ok(());
+    }
+
+    let row_by_uuid: std::collections::HashMap<&str, &books::IndexedRow> =
+        db_rows.iter().map(|r| (r.uuid.as_str(), r)).collect();
+    let entry_by_scan_key: std::collections::HashMap<&str, &ebook::StatEntry> =
+        disk.iter().map(|e| (e.scan_key.as_str(), e)).collect();
+
+    let mut kept = Vec::with_capacity(diff.unchanged.len());
+    let mut promoted = Vec::new();
+    for uuid in diff.unchanged.drain(..) {
+        let entry = authorless.contains(&uuid).then(|| {
+            row_by_uuid
+                .get(uuid.as_str())
+                .and_then(|row| entry_by_scan_key.get(row.scan_key.as_str()))
+        });
+        match entry.flatten() {
+            Some(entry) => promoted.push(parse_target(entry, library_root)),
+            None => kept.push(uuid),
+        }
+    }
+    if !promoted.is_empty() {
+        tracing::info!(
+            promoted = promoted.len(),
+            "reindex: re-parsing unchanged files for authorless books (relink pass)"
+        );
+    }
+    diff.unchanged = kept;
+    diff.changed.extend(promoted);
+    // Restore the deterministic order sort_buckets established.
+    diff.changed.sort_by(|a, b| a.filename.cmp(&b.filename));
+    Ok(())
+}
+
+/// The subset of `uuids` naming a `books` row with no author link. Merged
+/// uuids (attach-ledger stand-ins) never match, by design. Chunked at 500 to
+/// stay under SQLite's bound-parameter cap.
+async fn authorless_uuids(
+    pool: &SqlitePool,
+    uuids: &[String],
+) -> Result<std::collections::HashSet<String>, sqlx::Error> {
+    let mut out = std::collections::HashSet::new();
+    for chunk in uuids.chunks(500) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT b.uuid FROM books b WHERE b.uuid IN ({placeholders})
+               AND NOT EXISTS (SELECT 1 FROM books_authors_link l WHERE l.book = b.id)"
+        );
+        let mut q = sqlx::query_scalar::<_, String>(&sql);
+        for uuid in chunk {
+            q = q.bind(uuid);
+        }
+        out.extend(q.fetch_all(pool).await?);
+    }
+    Ok(out)
 }
 
 /// Result of [`diff_library`]. Each bucket is what the writer should do

--- a/db/src/indexer/tests.rs
+++ b/db/src/indexer/tests.rs
@@ -2780,3 +2780,176 @@ async fn reindex_surfaces_a_malformed_cbz_as_an_error_row_without_aborting() {
 
     let _ = std::fs::remove_dir_all(&lib);
 }
+
+// ---------------------------------------------------------------------------
+// Authorless relink pass (`ReindexOptions::relink_authorless`)
+// ---------------------------------------------------------------------------
+
+/// A real, parseable EPUB whose OPF names `creator`, written at
+/// `library_path/filename` so a reindex both stats and parses it.
+fn write_epub_with_creator(library_path: &str, filename: &str, title: &str, creator: &str) {
+    let container: &[u8] = br#"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+</container>"#;
+    let chapter = r#"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c1</title></head><body><p>Hello.</p></body></html>"#;
+    let opf = format!(
+        r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="pub-id">relink-test</dc:identifier>
+    <dc:title>{title}</dc:title>
+    <dc:creator>{creator}</dc:creator>
+  </metadata>
+  <manifest><item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine><itemref idref="c1"/></spine>
+</package>"#
+    );
+    let zip = build_stored_zip(&[
+        ("mimetype", b"application/epub+zip"),
+        ("META-INF/container.xml", container),
+        ("content.opf", opf.as_bytes()),
+        ("c1.xhtml", chapter.as_bytes()),
+    ]);
+    let abs = std::path::Path::new(library_path).join(filename);
+    if let Some(parent) = abs.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&abs, zip).unwrap();
+}
+
+async fn author_links_for_scan_key(pool: &SqlitePool, scan_key: &str) -> Vec<(i64, String)> {
+    sqlx::query_as(
+        "SELECT a.id, a.name FROM books b
+           JOIN books_authors_link l ON l.book = b.id
+           JOIN authors a ON a.id = l.author
+          WHERE b.scan_key = ? ORDER BY l.position",
+    )
+    .bind(scan_key)
+    .fetch_all(pool)
+    .await
+    .unwrap()
+}
+
+/// End-to-end blocklist recovery: a book indexed while its author's spelling
+/// sat on `ignored_authors` has no author link, a plain rescan never
+/// re-parses its Unchanged file, and the relink pass promotes it through
+/// Changed — where the `entity_aliases` row written by the blocklist
+/// conversion resolves the spelling to the canonical author instead of
+/// resurrecting it.
+#[tokio::test]
+async fn relink_pass_relinks_authorless_book_to_canonical_via_alias() {
+    let _covers = CoversTempDir::new("relink-alias");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib = make_test_dir("relink-alias-lib");
+    let lib_path = lib.to_string_lossy().into_owned();
+
+    write_epub_with_creator(
+        &lib_path,
+        "hail-mary.epub",
+        "Project Hail Mary",
+        "Weir, Andy",
+    );
+    sqlx::query("INSERT INTO ignored_authors (name) VALUES ('Weir, Andy')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    reindex(&pool, &lib_path).await.unwrap();
+    assert_eq!(
+        author_links_for_scan_key(&pool, "hail-mary.epub").await,
+        vec![],
+        "the blocklisted creator must be skipped on first index"
+    );
+
+    let canonical: i64 =
+        sqlx::query_scalar("INSERT INTO authors (name) VALUES ('Andy Weir') RETURNING id")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    crate::cleanup::apply_alias_ignored_author(&pool, "Weir, Andy", canonical, None)
+        .await
+        .unwrap();
+
+    // A plain rescan classifies the file Unchanged and heals nothing.
+    reindex(&pool, &lib_path).await.unwrap();
+    assert_eq!(
+        author_links_for_scan_key(&pool, "hail-mary.epub").await,
+        vec![],
+        "a plain rescan must not re-parse an Unchanged file"
+    );
+
+    reindex_with_options(
+        &pool,
+        &lib_path,
+        ReindexOptions {
+            relink_authorless: true,
+        },
+        |_| {},
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        author_links_for_scan_key(&pool, "hail-mary.epub").await,
+        vec![(canonical, "Andy Weir".to_string())],
+        "the relink pass must resolve the aliased spelling to the canonical author"
+    );
+    let weir_rows = count_rows(
+        &pool,
+        "SELECT COUNT(*) FROM authors WHERE name = 'Weir, Andy'",
+    )
+    .await;
+    assert_eq!(weir_rows, 0, "the aliased spelling must not be resurrected");
+
+    let _ = std::fs::remove_dir_all(&lib);
+}
+
+/// The promotion itself is surgical: only an authorless book's Unchanged
+/// entry moves to Changed; a book that still has its author links stays put.
+#[tokio::test]
+async fn promote_authorless_unchanged_moves_only_authorless_books() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let lib_path = "/relink-lib";
+
+    let authored = indexed(
+        "authored.epub",
+        Some("Authored"),
+        &["Kept Author"],
+        &[],
+        None,
+        None,
+    );
+    let orphaned = indexed("orphaned.epub", Some("Orphaned"), &[], &[], None, None);
+    sync_books(
+        &pool,
+        lib_path,
+        SyncPlan {
+            new_books: vec![authored, orphaned],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let db_rows = list_indexed_rows_for_formats(&pool, lib_path, crate::ebook::EBOOK_FORMATS)
+        .await
+        .unwrap();
+    let disk: Vec<StatEntry> = db_rows
+        .iter()
+        .map(|r| entry(&r.scan_key, &r.scan_key, r.mtime_epoch, r.size_bytes))
+        .collect();
+    let mut diff = ReindexDiff {
+        unchanged: db_rows.iter().map(|r| r.uuid.clone()).collect(),
+        ..Default::default()
+    };
+
+    promote_authorless_unchanged(&pool, &mut diff, &disk, &db_rows, Path::new(lib_path))
+        .await
+        .unwrap();
+
+    let authored_uuid = uuid_by_scan_key(&pool, "authored.epub").await;
+    assert_eq!(diff.unchanged, vec![authored_uuid]);
+    let changed: Vec<&str> = diff.changed.iter().map(|t| t.filename.as_str()).collect();
+    assert_eq!(changed, ["orphaned.epub"]);
+}

--- a/db/src/sync/authors/tests.rs
+++ b/db/src/sync/authors/tests.rs
@@ -113,3 +113,46 @@ async fn insert_author_links_resolves_a_merged_away_name_to_its_canonical_id() {
         "AC1: the book must link to the surviving canonical author"
     );
 }
+
+#[tokio::test]
+async fn insert_author_links_skips_a_name_that_is_both_blocklisted_and_aliased() {
+    // Precedence contract: the `ignored_authors` filter runs before alias
+    // resolution, so a name carrying both a blocklist entry and an alias is
+    // skipped outright. The blocklist recovery flow relies on this — a
+    // convert-to-alias must *remove* the blocklist row, not merely add the
+    // alias, or nothing changes at reindex time.
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let book_id = seed_book(&pool).await;
+
+    let canonical_id: i64 =
+        sqlx::query_scalar("INSERT INTO authors (name) VALUES ('Andy Weir') RETURNING id")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    sqlx::query(
+        "INSERT INTO entity_aliases (kind, alias_name, canonical_id) \
+         VALUES ('author', 'Weir, Andy', ?)",
+    )
+    .bind(canonical_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO ignored_authors (name) VALUES ('Weir, Andy')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let m = metadata_with_creator("Weir, Andy");
+    let author_aliases = HashMap::from([("Weir, Andy".to_string(), canonical_id)]);
+    let mut tx = pool.begin().await.unwrap();
+    insert_author_links(&mut tx, book_id, &m, &author_aliases)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        linked_author_ids(&pool, book_id).await,
+        Vec::<i64>::new(),
+        "the blocklist must win over the alias while both exist"
+    );
+}

--- a/db/src/worker/handlers.rs
+++ b/db/src/worker/handlers.rs
@@ -205,6 +205,13 @@ impl Worker {
                 "cleanup detection",
                 run_cleanup_detection(&self.pool, kind).await,
             ),
+            Task::RelinkAuthorless {
+                library_path,
+                audiobooks,
+            } => {
+                self.handle_relink_authorless(library_path, audiobooks, id)
+                    .await
+            }
             Task::GenerateThumbs {
                 book_id,
                 last_modified_epoch,
@@ -500,6 +507,60 @@ impl Worker {
                 TaskOutcome::Ok(warning.map(TaskSuccessDetail::GhostFiles))
             }
             Err(e) => sanitized_err("library scan", e),
+        }
+    }
+
+    /// `Task::RelinkAuthorless`: rerun one library's reindex with the
+    /// authorless relink pass on, so books orphaned by a blocklisted author
+    /// name re-parse and re-link against the current blocklist +
+    /// `entity_aliases` state. Posts the same follow-up backfills as the
+    /// corresponding scan handler — the promoted books go through the
+    /// ordinary Changed path, which cascades the same derived rows a real
+    /// file change would.
+    async fn handle_relink_authorless(
+        self: &Arc<Self>,
+        library_path: String,
+        audiobooks: bool,
+        id: TaskId,
+    ) -> TaskOutcome {
+        let worker = self.clone();
+        let on_progress = move |u: crate::indexer::ScanUpdate| {
+            worker.report_progress_update(id, u.processed, u.total, u.detail);
+        };
+        let options = crate::indexer::ReindexOptions {
+            relink_authorless: true,
+        };
+        let result = if audiobooks {
+            crate::indexer::reindex_audiobooks_with_options(
+                &self.pool,
+                &library_path,
+                options,
+                on_progress,
+            )
+            .await
+        } else {
+            crate::indexer::reindex_with_options(&self.pool, &library_path, options, on_progress)
+                .await
+        };
+        match result {
+            Ok(_) => {
+                if audiobooks {
+                    self.post(Task::BackfillChapters { library_path });
+                } else {
+                    self.post(Task::BackfillWordCounts {
+                        library_path: library_path.clone(),
+                    });
+                    self.post(Task::BackfillPageCounts {
+                        library_path: library_path.clone(),
+                    });
+                    self.post(Task::BackfillEpubStructure {
+                        library_path: library_path.clone(),
+                    });
+                    self.post(Task::BackfillThumbs { library_path });
+                }
+                TaskOutcome::Ok(None)
+            }
+            Err(e) => sanitized_err("author relink pass", e),
         }
     }
 

--- a/db/src/worker/types.rs
+++ b/db/src/worker/types.rs
@@ -169,6 +169,19 @@ pub enum Task {
     /// reads a handful of already-indexed tables, it doesn't walk the
     /// filesystem).
     DetectCleanup { kind: Option<CleanupKind> },
+    /// Author-relink repair pass: rerun the library reindex with
+    /// `ReindexOptions::relink_authorless`, so Unchanged files whose book
+    /// lost every author link (a name deleted onto the `ignored_authors`
+    /// blocklist) are re-parsed and re-linked against the current blocklist
+    /// and `entity_aliases` state. Posted by the blocklist recovery flow after
+    /// a convert/remove. `audiobooks` picks which pipeline runs; the
+    /// resource key matches the corresponding scan's so a relink and a scan
+    /// of the same library serialize, and it consumes the scan semaphore
+    /// like the scans it wraps.
+    RelinkAuthorless {
+        library_path: String,
+        audiobooks: bool,
+    },
     /// Test-only synthetic task: sleeps `latency_ms` and invokes the
     /// optional `on_run` / `on_done` hooks, with `resource` and
     /// `route_through_scan_sem` letting a test exercise the keyed mutex and
@@ -211,6 +224,14 @@ impl Task {
             Task::SendToKindle { .. } => Some("smtp".into()),
             Task::RewriteAllEpubs => Some("rewrite-all-epubs".into()),
             Task::DetectCleanup { .. } => Some("cleanup".into()),
+            Task::RelinkAuthorless {
+                library_path,
+                audiobooks,
+            } => Some(if *audiobooks {
+                format!("audiobooks:{library_path}")
+            } else {
+                library_path.clone()
+            }),
             #[cfg(test)]
             Task::Test { resource, .. } => resource.clone(),
         }
@@ -236,6 +257,7 @@ impl Task {
             Task::SendToKindle { .. } => false,
             Task::RewriteAllEpubs => false,
             Task::DetectCleanup { .. } => false,
+            Task::RelinkAuthorless { .. } => true,
             #[cfg(test)]
             Task::Test {
                 route_through_scan_sem,
@@ -281,6 +303,7 @@ impl Task {
             Task::SendToKindle { .. } => "send_to_kindle",
             Task::RewriteAllEpubs => "rewrite_all_epubs",
             Task::DetectCleanup { .. } => "detect_cleanup",
+            Task::RelinkAuthorless { .. } => "relink_authorless",
             #[cfg(test)]
             Task::Test { .. } => "test",
         }
@@ -333,6 +356,8 @@ impl Task {
             // dedicated progress widget, mirroring BackfillWordCounts/
             // BackfillPageCounts above.
             Task::DetectCleanup { .. } => TaskKind::Scan,
+            // A relink is a scoped rescan — reuse the scan progress widget.
+            Task::RelinkAuthorless { .. } => TaskKind::Scan,
             #[cfg(test)]
             Task::Test { .. } => TaskKind::Scan,
         }

--- a/shared/src/cleanup.rs
+++ b/shared/src/cleanup.rs
@@ -62,6 +62,9 @@ pub enum CleanupAction {
     Rename,
     /// Remove an entity outright (e.g. an orphaned tag).
     Delete,
+    /// Convert an `ignored_authors` blocklist entry into an
+    /// `entity_aliases` mapping onto a canonical entity.
+    Alias,
 }
 
 impl CleanupAction {
@@ -72,6 +75,7 @@ impl CleanupAction {
             Self::Split => "split",
             Self::Rename => "rename",
             Self::Delete => "delete",
+            Self::Alias => "alias",
         }
     }
 
@@ -83,6 +87,7 @@ impl CleanupAction {
             "split" => Self::Split,
             "rename" => Self::Rename,
             "delete" => Self::Delete,
+            "alias" => Self::Alias,
             _ => return None,
         })
     }
@@ -158,4 +163,14 @@ pub struct SuggestionCard {
     pub photo_url: Option<String>,
     /// Unix seconds the suggestion was detected.
     pub created_at: i64,
+}
+
+/// One `ignored_authors` blocklist entry, for the Settings blocklist
+/// management list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IgnoredAuthor {
+    /// The blocklisted name, exactly as stored.
+    pub name: String,
+    /// Unix seconds the name was blocklisted.
+    pub ignored_at: i64,
 }

--- a/shared/src/cleanup/tests.rs
+++ b/shared/src/cleanup/tests.rs
@@ -34,6 +34,7 @@ fn cleanup_action_round_trips_through_str_tokens() {
         CleanupAction::Split,
         CleanupAction::Rename,
         CleanupAction::Delete,
+        CleanupAction::Alias,
     ] {
         assert_eq!(CleanupAction::from_str(a.as_str()), Some(a));
     }
@@ -106,4 +107,15 @@ fn suggestion_card_round_trips_through_json_with_optional_fields_present_and_abs
     let json = serde_json::to_string(&without_optionals).unwrap();
     let back: SuggestionCard = serde_json::from_str(&json).unwrap();
     assert_eq!(back, without_optionals);
+}
+
+#[test]
+fn ignored_author_round_trips_through_json() {
+    let entry = IgnoredAuthor {
+        name: "Weir, Andy".into(),
+        ignored_at: 1_700_000_000,
+    };
+    let json = serde_json::to_string(&entry).unwrap();
+    let back: IgnoredAuthor = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, entry);
 }


### PR DESCRIPTION
## Summary
- `db::cleanup::blocklist`: list `ignored_authors`, convert an entry into an author `entity_aliases` mapping (logged as `(Author, Alias)` in `cleanup_log`, undoable, restores the original `ignored_at`), or remove it outright.
- `ReindexOptions::relink_authorless` + worker `Task::RelinkAuthorless`: promotes Unchanged files of author-less books through the ordinary Changed sync path so they re-link against the current blocklist and alias state — a plain rescan never re-parses an Unchanged file, so blocklist recovery needs this pass.
- `shared`: `CleanupAction::Alias` token and the `IgnoredAuthor` wire type.
- First half of a two-PR stack; the RPC surface and UI land in `OMNI-2077/delete-as-duplicate-alias-2`.

Part of #2077

## Test plan
- [x] `cargo nextest run -p omnibus-db -p omnibus-shared` — 2648 passed (blocklist convert/remove/undo round-trips, blocklist-vs-alias precedence, end-to-end relink via alias, promotion scoping).
- [x] `cargo clippy -p omnibus-db -p omnibus-shared --all-targets` + `cargo fmt` clean.

## Version
- [ ] **Minor**
- [x] **Patch**
- [ ] **No release**

## Notes
- The relink task shares the matching scan's resource key and the scan semaphore, so a relink and a rescan of the same library serialize.