### PR TITLE
fix: correct iOS EPUB reader rotation drift (#2081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ recent releases are recorded below; everything earlier is available via the
 
 ## [Unreleased]
 
+### Fixed
+
+- Rotating the device and back in the iOS EPUB reader no longer drifts off
+  the page the reader was actually on: a rotation's re-pagination now goes
+  through the same correction (and echo tagging) a boot restore does, so it
+  writes no position and never moves the restore anchor. Added an explicit
+  single/two-page reader setting on iOS, matching web (#2081)
+
 ## [0.22.10] - 2026-08-18
 
 ### Fixed

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -18,7 +18,7 @@
  * Public surface: window.OmnibusReader
  *   init(elementId, fileUrl, opts)  opts = { cfi?, fontSize?, theme?,
  *                                           fontFamily?, lineHeight?,
- *                                           maxWidth?, justify?,
+ *                                           maxWidth?, justify?, spread?,
  *                                           allowScriptedContent?,
  *                                           locationsKey? }
  *   next()                          queued/coalesced — see the paging-turn
@@ -33,6 +33,9 @@
  *   setLineHeight(value)
  *   setMargins(maxWidth)
  *   setJustify(on)
+ *   setSpread(mode)                 "none" (single column) or "auto"
+ *                                   (epub.js pairs columns once the stage
+ *                                   crosses its minSpreadWidth)
  *   addAnnotation(cfiRange, color)
  *   removeAnnotation(cfiRange)
  *   clearAnnotations()
@@ -93,6 +96,19 @@
   // emission re-states the restored position and is tagged `echo` so the
   // host renders it without persisting it (see emitRelocate).
   var restoreEchoPending = false;
+  // True from the first resize-driven "resized" event of a rotation/resize
+  // burst until the corrected redisplay that follows it has been reported —
+  // mutes every relocate in between (issue #2081, finding 1 & 2). A
+  // rotation re-paginates but is not reading movement: epub.js's own
+  // window-resize handler and installStageResizeWatch's ResizeObserver
+  // each re-display the pre-resize CFI through a plain, uncorrected
+  // `rendition.display()`, so left unmuted the host would see one or two
+  // relocates that both land off the actual page (no nudgeToTarget
+  // correction) and both look like real movement (no echo tag).
+  var resizeSettling = false;
+  var resizeCorrectionTimer = null;
+  var resizeCorrectionTarget = null;
+  var RESIZE_CORRECTION_DEBOUNCE_MS = 200;
   var tocFlat = [];
   var currentTheme = "dark";
   // Whether the section iframe runs scripts. Only then can we await the
@@ -145,6 +161,12 @@
       clearTimeout(stageResizeTimer);
       stageResizeTimer = null;
     }
+    if (resizeCorrectionTimer) {
+      clearTimeout(resizeCorrectionTimer);
+      resizeCorrectionTimer = null;
+    }
+    resizeSettling = false;
+    resizeCorrectionTarget = null;
     if (annotationRepaintTimer) {
       clearTimeout(annotationRepaintTimer);
       annotationRepaintTimer = null;
@@ -596,6 +618,20 @@
       }, 400);
     });
 
+    // epub.js's Rendition.onResized emits this, then immediately issues its
+    // own plain, uncorrected `display(e || this.location.start.cfi)` — the
+    // pre-resize position, at the moment this fires, since `location` isn't
+    // re-measured until that display resolves. Anchor the correction on the
+    // same fallback so it targets the same pre-resize page epub.js does.
+    rendition.on("resized", function (size, cfiOverride) {
+      var target =
+        cfiOverride ||
+        (rendition && rendition.location && rendition.location.start
+          ? rendition.location.start.cfi
+          : null);
+      scheduleResizeCorrection(target);
+    });
+
     rendition.on("selected", function (cfiRange, contents) {
       if (typeof window.__omnibusOnSelection !== "function") return;
       if (!contents || !contents.window) return;
@@ -653,7 +689,7 @@
   // when it arrives through the debounced relocated handler, so the flag
   // is consumed here rather than trusted to the call sites.
   function emitRelocate(location, isEcho) {
-    if (!restoreSettled) return;
+    if (!restoreSettled || resizeSettling) return;
     var echo = !!isEcho;
     if (restoreEchoPending) {
       restoreEchoPending = false;
@@ -1937,6 +1973,81 @@
       /* CFI compare is best effort */
     }
     return Promise.resolve();
+  }
+
+  // The corrected, echo-tagged counterpart to epub.js's own resize-driven
+  // re-display (issue #2081, findings 1 & 2). `resizeSettling` mutes every
+  // relocate — including the raw, uncorrected ones epub.js's own onResized
+  // fires straight through `rendition.display()` — from the first "resized"
+  // event of a burst until this fires once, reporting the settled, nudged
+  // landing as a single echo. A rotation re-paginates but is not reading
+  // movement: `!data.echo` is what already keeps `build_relocate_callback`
+  // (frontend/src/pages/reader/interop.rs) from persisting it.
+  function finishResizeCorrection(r) {
+    resizeSettling = false;
+    if (rendition !== r) return;
+    var loc = null;
+    try {
+      loc = rendition.currentLocation();
+    } catch (e) {
+      /* not ready */
+    }
+    if (loc && loc.start) {
+      emitRelocate(loc, true);
+    } else if (rendition.location) {
+      emitRelocate(rendition.location, true);
+    }
+  }
+
+  // Re-display the pre-resize target through the same settle-then-redisplay
+  // and nudgeToTarget correction the boot restore gets, rather than trusting
+  // epub.js's own plain `display()`. Mirrors the boot-restore chain in
+  // init() rather than calling displaySettled(), which does not nudge.
+  function runResizeCorrection() {
+    resizeCorrectionTimer = null;
+    var target = resizeCorrectionTarget;
+    resizeCorrectionTarget = null;
+    var r = rendition;
+    if (!target || !r) {
+      resizeSettling = false;
+      return;
+    }
+    displayToken++;
+    var myToken = displayToken;
+    var current = function () {
+      return displayToken === myToken;
+    };
+    var reveal = beginSettleFade();
+    r.display(target)
+      .then(function () {
+        return redisplayWhenSettled(target, current);
+      })
+      .then(function () {
+        if (current()) return nudgeToTarget(target);
+      })
+      .catch(function () {
+        /* keep whatever landed */
+      })
+      .then(function () {
+        reveal();
+        finishResizeCorrection(r);
+      });
+  }
+
+  // Coalesce the two racing resize paths (epub.js's own window-resize
+  // listener and installStageResizeWatch's container ResizeObserver) into
+  // one corrected redisplay per burst (AC4). Anchored to the FIRST target
+  // seen — not whichever raw, uncorrected redisplay happens to land last —
+  // so a mid-burst measurement can't walk the anchor away from the page the
+  // reader was actually on, and repeated rotations can't accumulate drift.
+  function scheduleResizeCorrection(target) {
+    if (!target || !rendition) return;
+    if (!resizeSettling) {
+      resizeSettling = true;
+      resizeCorrectionTarget = target;
+    }
+    if (resizeCorrectionTimer) clearTimeout(resizeCorrectionTimer);
+    resizeCorrectionTimer = setTimeout(runResizeCorrection, RESIZE_CORRECTION_DEBOUNCE_MS);
   }
 
   function display(target) {

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -768,6 +768,7 @@
     pendingJumpCfi = null;
     restoreEchoPending = false;
     displayToken++;
+    cancelResizeCorrection();
     if (turnInFlight) {
       turnPendingDir = dir;
       return;
@@ -872,6 +873,7 @@
     if (!rendition || !rendition.manager) return false;
     var manager = rendition.manager;
     if (!hasAdjacentSection(manager, dir)) return false;
+    cancelResizeCorrection();
     var release = beginSectionTurn();
     var runTurn = function () {
       return dir > 0 ? manager.next() : manager.prev();
@@ -1975,6 +1977,26 @@
     return Promise.resolve();
   }
 
+  // Drop any pending or in-flight resize correction and resume relocates
+  // immediately. A user-initiated turn (queueTurn, a swipe across a
+  // section) mid-burst is real reading movement: muting through the
+  // correction — or worse, letting a correction already in flight land
+  // afterward and stomp the turn's own relocate with a stale echo of the
+  // pre-resize target — leaves the page indicator, restore anchor, and
+  // persist trigger out of step with where the reader actually turned to
+  // (review finding on #2081). Bumping displayToken is what lets a
+  // correction chain already past this point (mid `display()`/settle,
+  // inside `current()`) notice it's stale and skip its landing.
+  function cancelResizeCorrection() {
+    displayToken++;
+    if (resizeCorrectionTimer) {
+      clearTimeout(resizeCorrectionTimer);
+      resizeCorrectionTimer = null;
+    }
+    resizeSettling = false;
+    resizeCorrectionTarget = null;
+  }
+
   // The corrected, echo-tagged counterpart to epub.js's own resize-driven
   // re-display (issue #2081, findings 1 & 2). `resizeSettling` mutes every
   // relocate — including the raw, uncorrected ones epub.js's own onResized
@@ -1983,7 +2005,11 @@
   // landing as a single echo. A rotation re-paginates but is not reading
   // movement: `!data.echo` is what already keeps `build_relocate_callback`
   // (frontend/src/pages/reader/interop.rs) from persisting it.
-  function finishResizeCorrection(r) {
+  function finishResizeCorrection(r, current) {
+    // Superseded by a user turn (cancelResizeCorrection) or a newer resize
+    // burst — that path already resumed relocates (or will report its own
+    // landing); this one has nothing current to say.
+    if (current && !current()) return;
     resizeSettling = false;
     if (rendition !== r) return;
     var loc = null;
@@ -2030,7 +2056,7 @@
       })
       .then(function () {
         reveal();
-        finishResizeCorrection(r);
+        finishResizeCorrection(r, current);
       });
   }
 

--- a/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
@@ -66,6 +66,12 @@ struct ReaderSettingsSheet: View {
                             selection: $controller.settings.margins
                         )
 
+                        PillSelector(
+                            options: ReaderSpread.allCases,
+                            label: \.label,
+                            selection: $controller.settings.spread
+                        )
+
                         Plate {
                             PlateRow(label: "Justify text", isFirst: true) {
                                 Toggle("", isOn: $controller.settings.justify)

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -201,13 +201,18 @@ struct ReaderView: View {
             }
         }
         .onChange(of: controller.location?.cfi) { old, _ in
-            // The boot restore's nil→CFI transition is an echo of the
-            // position the server already holds — persisting it stamps a
-            // fresh clock on an unmoved row and shadows a newer audiobook
-            // spot at the cross-format clock gate (the same #1972 class
-            // the web reader suppresses via echo-tagged relocates). Only
-            // CFI→CFI transitions are movement worth recording.
-            guard old != nil else { return }
+            // The boot restore's nil→CFI transition, and a rotation or
+            // resize's corrected re-pagination, are echoes of a position the
+            // reader already reported — persisting one stamps a fresh clock
+            // on an unmoved row and shadows a newer audiobook spot at the
+            // cross-format clock gate (the same #1972 class the web reader
+            // suppresses via echo-tagged relocates; issue #2081, AC2). `old
+            // != nil` alone only catches the boot case — a rotation is a
+            // genuine CFI→CFI transition — so `isMovement` (decoded from the
+            // glue's `echo` flag) is the one that actually matters; `old !=
+            // nil` stays as a defensive belt for a relocate that somehow
+            // arrives untagged.
+            guard old != nil, controller.location?.isMovement == true else { return }
             Task { await persist(force: false) }
         }
         .onChange(of: controller.location?.atEnd) { _, atEnd in

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -65,7 +65,7 @@ enum ReaderSpread: String, Codable, CaseIterable {
     var label: String {
         switch self {
         case .single: "Single Page"
-        case .double: "Two Page"
+        case .double: "Two Pages"
         }
     }
 }

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -45,6 +45,31 @@ enum ReaderMargins: String, Codable, CaseIterable {
     }
 }
 
+/// Single vs two-page layout. `OmnibusReader.init`'s `spread` option and
+/// `setSpread` take this literally: "none" forces a single column, "auto"
+/// lets epub.js pair columns once the stage crosses its `minSpreadWidth` —
+/// which a landscape phone or an iPad routinely does. Without an explicit
+/// value the reader silently inherited "auto" (issue #2081, finding 3);
+/// mirrors the web reader's `Spread` in
+/// `frontend/src/pages/reader/typography.rs`.
+enum ReaderSpread: String, Codable, CaseIterable {
+    case single, double
+
+    var css: String {
+        switch self {
+        case .single: "none"
+        case .double: "auto"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .single: "Single Page"
+        case .double: "Two Page"
+        }
+    }
+}
+
 struct ReaderSettings: Codable, Equatable {
     var fontSize: Int = 19
     var fontFamily: String = "serif"
@@ -53,6 +78,9 @@ struct ReaderSettings: Codable, Equatable {
     var justify: Bool = true
     /// epub.js theme token — matches the four `themes.register` names.
     var theme: String = "dark"
+    /// Matches epub.js's own default ("auto") so a reader upgrading from a
+    /// build that never sent `spread` sees no change in behavior.
+    var spread: ReaderSpread = .double
 
     static let storageKey = "omnibus.readerSettings"
 
@@ -98,6 +126,15 @@ struct RelocateData: Codable {
     /// Pages between here and the end of the current chapter; 0 when unknown
     /// (locations still generating) or already on the chapter's last page.
     var chapterPagesLeft: Int = 0
+    /// True when the glue is re-stating a position it already reported — a
+    /// boot restore settling, or a rotation/resize's corrected re-pagination
+    /// — rather than reporting real reading movement (issue #2081). Render
+    /// it like any relocate, but never persist it or move `restoreCFI`: an
+    /// echo write stamps a fresh clock on an unmoved position, which
+    /// out-orders a newer counterpart-format position at the cross-format
+    /// clock gate (the same #1972 class the web reader suppresses the same
+    /// way — `!data.echo` in `frontend/src/pages/reader/interop.rs`).
+    var echo: Bool = false
 
     /// `0...1` for the progress bar. Page numbers only exist once epub.js has
     /// finished its whole-book locations pass, so this is the reliable one.
@@ -106,6 +143,10 @@ struct RelocateData: Codable {
     var hasPageNumbers: Bool { totalPages > 0 }
 
     var chapterName: String? { chapterTitle.nilIfBlank }
+
+    /// Whether this position is worth persisting or worth moving the
+    /// restore anchor for — real reading movement, not an echo.
+    var isMovement: Bool { !echo }
 }
 
 /// A box on the page, in web-view coordinates — the same space the reader's
@@ -435,6 +476,9 @@ final class ReaderController: NSObject {
         if settings.justify != old.justify {
             run("OmnibusReader.setJustify(\(settings.justify))")
         }
+        if settings.spread != old.spread {
+            run("OmnibusReader.setSpread(\(settings.spread.css.jsQuoted))")
+        }
     }
 
     fileprivate func run(_ script: String) {
@@ -458,6 +502,7 @@ final class ReaderController: NSObject {
             "lineHeight": settings.lineHeight,
             "maxWidth": settings.margins.css,
             "justify": settings.justify,
+            "spread": settings.spread.css,
             // Without allow-scripts on the section iframe WebKit dispatches no
             // events into it — selection and gestures are dead on iOS.
             "allowScriptedContent": true,
@@ -514,8 +559,12 @@ final class ReaderController: NSObject {
             location = decoded
             // Where a reboot of the page picks up. Relocates are muted until a
             // restore has settled, so this only ever moves to a position the
-            // reader was actually shown.
-            if let cfi = decoded.cfi?.nilIfBlank { restoreCFI = cfi }
+            // reader was actually shown. An echo (a rotation's corrected
+            // re-pagination, or the restore settling) doesn't count: moving
+            // the anchor for one would reboot the page onto a position that
+            // is, for a rotation, a spread short of the page the reader was
+            // actually shown (issue #2081, AC3).
+            if decoded.isMovement, let cfi = decoded.cfi?.nilIfBlank { restoreCFI = cfi }
 
         case "toc":
             guard let payload, let data = payload.data(using: .utf8),

--- a/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
+++ b/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
@@ -98,6 +98,13 @@
   var resizeSettling = false;
   var resizeCorrectionTimer = null;
   var resizeCorrectionTarget = null;
+  // Bumped by cancelResizeCorrection() and by each runResizeCorrection()
+  // invocation, so a superseded correction chain (a user turn mid-burst, or
+  // a second resize burst starting before the first settled) can tell it's
+  // stale and skip its landing rather than stomping a newer relocate with a
+  // stale echo. iOS's glue has no shared displayToken to reuse for this the
+  // way the web copy does.
+  var resizeCorrectionGen = 0;
   var RESIZE_CORRECTION_DEBOUNCE_MS = 200;
   var tocFlat = [];
   var currentTheme = "dark";
@@ -566,11 +573,13 @@
 
   function next() {
     if (!rendition) return;
+    cancelResizeCorrection();
     return rendition.next();
   }
 
   function prev() {
     if (!rendition) return;
+    cancelResizeCorrection();
     return rendition.prev();
   }
 
@@ -663,6 +672,7 @@
     if (!rendition || !rendition.manager) return false;
     var manager = rendition.manager;
     if (!hasAdjacentSection(manager, dir)) return false;
+    cancelResizeCorrection();
     var release = beginSectionTurn();
     var runTurn = function () {
       return dir > 0 ? manager.next() : manager.prev();
@@ -2349,6 +2359,26 @@
     return Promise.resolve();
   }
 
+  // Drop any pending or in-flight resize correction and resume relocates
+  // immediately. A user-initiated turn (next/prev, a swipe across a
+  // section) mid-burst is real reading movement: muting through the
+  // correction — or worse, letting a correction already in flight land
+  // afterward and stomp the turn's own relocate with a stale echo of the
+  // pre-resize target — leaves the page indicator, restore anchor, and
+  // persist trigger out of step with where the reader actually turned to
+  // (review finding on #2081). Bumping the generation is what lets a
+  // correction chain already past this point (mid `display()`/settle)
+  // notice it's stale and skip its landing instead.
+  function cancelResizeCorrection() {
+    resizeCorrectionGen++;
+    if (resizeCorrectionTimer) {
+      clearTimeout(resizeCorrectionTimer);
+      resizeCorrectionTimer = null;
+    }
+    resizeSettling = false;
+    resizeCorrectionTarget = null;
+  }
+
   // The corrected, echo-tagged counterpart to epub.js's own resize-driven
   // re-display (issue #2081). `resizeSettling` mutes every relocate —
   // including the raw, uncorrected ones epub.js's own onResized fires
@@ -2357,7 +2387,11 @@
   // landing as a single echo. `RelocateData.isMovement` in
   // ReaderWebView.swift is what keeps the host from persisting it or
   // moving `restoreCFI`.
-  function finishResizeCorrection(r) {
+  function finishResizeCorrection(r, gen) {
+    // Superseded by a user turn (cancelResizeCorrection) or a newer resize
+    // burst — that path already resumed relocates (or will report its own
+    // landing); this one has nothing current to say.
+    if (gen !== resizeCorrectionGen) return;
     resizeSettling = false;
     if (rendition !== r) return;
     var loc = null;
@@ -2386,20 +2420,22 @@
       resizeSettling = false;
       return;
     }
+    resizeCorrectionGen++;
+    var gen = resizeCorrectionGen;
     var reveal = beginSettleFade();
     r.display(target)
       .then(function () {
         return redisplayWhenSettled(target);
       })
       .then(function () {
-        return nudgeToTarget(target);
+        if (gen === resizeCorrectionGen) return nudgeToTarget(target);
       })
       .catch(function () {
         /* keep whatever landed */
       })
       .then(function () {
         reveal();
-        finishResizeCorrection(r);
+        finishResizeCorrection(r, gen);
       });
   }
 

--- a/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
+++ b/omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js
@@ -18,7 +18,7 @@
  * Public surface: window.OmnibusReader
  *   init(elementId, fileUrl, opts)  opts = { cfi?, fontSize?, theme?,
  *                                           fontFamily?, lineHeight?,
- *                                           maxWidth?, justify?,
+ *                                           maxWidth?, justify?, spread?,
  *                                           allowScriptedContent?,
  *                                           locationsKey? }
  *   next()
@@ -29,6 +29,9 @@
  *   setLineHeight(value)
  *   setMargins(maxWidth)
  *   setJustify(on)
+ *   setSpread(mode)                 "none" (single column) or "auto"
+ *                                   (epub.js pairs columns once the stage
+ *                                   crosses its minSpreadWidth)
  *   addAnnotation(cfiRange, color)
  *   removeAnnotation(cfiRange)
  *   clearAnnotations()
@@ -79,6 +82,23 @@
   // so the first-pass landing (a page or two off until fonts/theme reflow) is
   // never persisted as reading progress.
   var restoreSettled = true;
+  // True from a CFI restore until its first post-settle emission — that
+  // emission re-states the restored position and is tagged `echo` so the
+  // host renders it without persisting it or moving `restoreCFI` (see
+  // emitRelocate; mirrors frontend/assets/vendor/epub-reader-glue.js).
+  var restoreEchoPending = false;
+  // True from the first resize-driven "resized" event of a rotation/resize
+  // burst until the corrected redisplay that follows it has been reported —
+  // mutes every relocate in between (issue #2081). A rotation re-paginates
+  // but is not reading movement: epub.js's own window-resize handler and
+  // installStageResizeWatch's ResizeObserver each re-display the pre-resize
+  // CFI through a plain, uncorrected `rendition.display()`, so left unmuted
+  // the host would see relocates that both land off the actual page (no
+  // nudgeToTarget correction) and both look like real movement (no echo).
+  var resizeSettling = false;
+  var resizeCorrectionTimer = null;
+  var resizeCorrectionTarget = null;
+  var RESIZE_CORRECTION_DEBOUNCE_MS = 200;
   var tocFlat = [];
   var currentTheme = "dark";
   // Reading typography, tracked because the highlight geometry depends on it
@@ -121,6 +141,12 @@
       clearTimeout(stageResizeTimer);
       stageResizeTimer = null;
     }
+    if (resizeCorrectionTimer) {
+      clearTimeout(resizeCorrectionTimer);
+      resizeCorrectionTimer = null;
+    }
+    resizeSettling = false;
+    resizeCorrectionTarget = null;
     if (stageResizeObserver) {
       try {
         stageResizeObserver.disconnect();
@@ -380,9 +406,10 @@
         // Re-emit now that each entry can carry its page and percent.
         emitToc();
         // Re-emit current location now that locations are resolved so the
-        // Rust side gets real page numbers on first load.
+        // Rust side gets real page numbers on first load. An echo: it
+        // re-states the position, it doesn't report movement.
         if (rendition && rendition.location) {
-          emitRelocate(rendition.location);
+          emitRelocate(rendition.location, true);
         }
       })
       .catch(function () {
@@ -401,6 +428,7 @@
     // saved progress paint (and report ready) immediately.
     var initialCfi = opts.cfi || null;
     restoreSettled = !initialCfi;
+    restoreEchoPending = !!initialCfi;
     rendition.display(initialCfi || undefined).then(
       function () {
         if (!initialCfi) {
@@ -462,6 +490,20 @@
       }, 400);
     });
 
+    // epub.js's Rendition.onResized emits this, then immediately issues its
+    // own plain, uncorrected `display(e || this.location.start.cfi)` — the
+    // pre-resize position, at the moment this fires, since `location` isn't
+    // re-measured until that display resolves. Anchor the correction on the
+    // same fallback so it targets the same pre-resize page epub.js does.
+    rendition.on("resized", function (size, cfiOverride) {
+      var target =
+        cfiOverride ||
+        (rendition && rendition.location && rendition.location.start
+          ? rendition.location.start.cfi
+          : null);
+      scheduleResizeCorrection(target);
+    });
+
     // A new section means new text nodes, so every block flattened off the
     // old ones is dead weight.
     rendition.on("rendered", dropFlatCache);
@@ -499,9 +541,24 @@
     });
   }
 
-  function emitRelocate(location) {
-    if (!restoreSettled) return;
+  // `isEcho` marks an emission that re-states a position the host already
+  // knows (the restore settle, a resize/rotation's corrected landing)
+  // rather than reporting movement. The host renders echoes but must not
+  // persist them or move `restoreCFI`: an echo write stamps a fresh clock
+  // on an unmoved position, which out-orders a newer counterpart-format
+  // position at the cross-format clock gate (see `RelocateData.isMovement`
+  // in ReaderWebView.swift). The first emission after a CFI restore is an
+  // echo even when it arrives through the debounced relocated handler, so
+  // the flag is consumed here rather than trusted to the call sites.
+  function emitRelocate(location, isEcho) {
+    if (!restoreSettled || resizeSettling) return;
+    var echo = !!isEcho;
+    if (restoreEchoPending) {
+      restoreEchoPending = false;
+      echo = true;
+    }
     var data = buildRelocateData(location);
+    data.echo = echo;
     if (data.cfi && typeof window.__omnibusOnRelocate === "function") {
       window.__omnibusOnRelocate(JSON.stringify(data));
     }
@@ -2290,6 +2347,76 @@
       /* CFI compare is best effort */
     }
     return Promise.resolve();
+  }
+
+  // The corrected, echo-tagged counterpart to epub.js's own resize-driven
+  // re-display (issue #2081). `resizeSettling` mutes every relocate —
+  // including the raw, uncorrected ones epub.js's own onResized fires
+  // straight through `rendition.display()` — from the first "resized"
+  // event of a burst until this fires once, reporting the settled, nudged
+  // landing as a single echo. `RelocateData.isMovement` in
+  // ReaderWebView.swift is what keeps the host from persisting it or
+  // moving `restoreCFI`.
+  function finishResizeCorrection(r) {
+    resizeSettling = false;
+    if (rendition !== r) return;
+    var loc = null;
+    try {
+      loc = rendition.currentLocation();
+    } catch (e) {
+      /* not ready */
+    }
+    if (loc && loc.start) {
+      emitRelocate(loc, true);
+    } else if (rendition.location) {
+      emitRelocate(rendition.location, true);
+    }
+  }
+
+  // Re-display the pre-resize target through the same settle-then-redisplay
+  // and nudgeToTarget correction the boot restore gets, rather than trusting
+  // epub.js's own plain `display()`. Mirrors the boot-restore chain in
+  // init() rather than calling displaySettled(), which does not nudge.
+  function runResizeCorrection() {
+    resizeCorrectionTimer = null;
+    var target = resizeCorrectionTarget;
+    resizeCorrectionTarget = null;
+    var r = rendition;
+    if (!target || !r) {
+      resizeSettling = false;
+      return;
+    }
+    var reveal = beginSettleFade();
+    r.display(target)
+      .then(function () {
+        return redisplayWhenSettled(target);
+      })
+      .then(function () {
+        return nudgeToTarget(target);
+      })
+      .catch(function () {
+        /* keep whatever landed */
+      })
+      .then(function () {
+        reveal();
+        finishResizeCorrection(r);
+      });
+  }
+
+  // Coalesce the two racing resize paths (epub.js's own window-resize
+  // listener and installStageResizeWatch's container ResizeObserver) into
+  // one corrected redisplay per burst. Anchored to the FIRST target seen —
+  // not whichever raw, uncorrected redisplay happens to land last — so a
+  // mid-burst measurement can't walk the anchor away from the page the
+  // reader was actually on, and repeated rotations can't accumulate drift.
+  function scheduleResizeCorrection(target) {
+    if (!target || !rendition) return;
+    if (!resizeSettling) {
+      resizeSettling = true;
+      resizeCorrectionTarget = target;
+    }
+    if (resizeCorrectionTimer) clearTimeout(resizeCorrectionTimer);
+    resizeCorrectionTimer = setTimeout(runResizeCorrection, RESIZE_CORRECTION_DEBOUNCE_MS);
   }
 
   function display(target) {

--- a/omnibus-ios/omnibusTests/ReaderEchoTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderEchoTests.swift
@@ -1,0 +1,109 @@
+//  ReaderEchoTests.swift
+//  What "echo" on a relocate means for persistence and the restore anchor.
+//
+//  A relocate that merely re-states a position the reader already reported —
+//  the boot restore settling, or a rotation/resize's corrected re-pagination
+//  (#2081) — carries `echo: true`. It must still reach the page (rendered
+//  like any relocate), but must never move `restoreCFI`: moving the anchor
+//  for a rotation would reboot the page onto a spread-short position the
+//  reader was never actually shown. `RelocateData.isMovement` is the same
+//  flag ReaderView's persist guard reads — a SwiftUI `onChange` closure
+//  isn't unit-testable in isolation, so the "not persisted" half is pinned
+//  at that guard's input rather than the write it skips.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+@MainActor
+private func openReader(at cfi: String?) -> ReaderController {
+    let controller = ReaderController()
+    controller.configure(
+        book: Book(
+            id: 1, filename: "hound.epub", title: "The Hound of the Baskervilles",
+            uniqueIdentifier: "book-uuid"
+        ),
+        startCFI: cfi,
+        highlights: []
+    )
+    // What the page announces on load, and what the glue reports once a
+    // restore has settled — the sequence every open goes through.
+    controller.handle(message: ["type": "hostReady"])
+    controller.handle(message: ["type": "status", "payload": "ready"])
+    return controller
+}
+
+/// A relocate as the glue posts it: `buildRelocateData`, JSON, over the
+/// bridge — with an explicit `echo` flag, as a rotation's corrected landing
+/// carries it.
+@MainActor
+private func relocate(_ controller: ReaderController, to cfi: String, echo: Bool = false) throws {
+    let data = RelocateData(
+        cfi: cfi, page: 212, totalPages: 661, pct: 32,
+        chapter: 7, totalChapters: 24, chapterTitle: "The Moor", chapterPagesLeft: 9,
+        echo: echo
+    )
+    let json = String(decoding: try JSONEncoder().encode(data), as: UTF8.self)
+    controller.handle(message: ["type": "relocate", "payload": json])
+}
+
+private let openedAt = "epubcfi(/6/14[chap07]!/4/2/2,/1:0,/1:1)"
+private let readTo = "epubcfi(/6/14[chap07]!/4/2/58,/1:0,/1:1)"
+// One column short of `readTo` — the exact shape of the drift finding 1
+// describes: a rotation's corrected redisplay lands the settled viewport a
+// spread away from the position it was asked to restate.
+private let rotatedTo = "epubcfi(/6/14[chap07]!/4/2/56,/1:0,/1:1)"
+
+@Suite("Reader relocate echo")
+@MainActor
+struct ReaderEchoTests {
+    @Test("a relocate with echo unset is movement")
+    func defaultRelocateIsMovement() {
+        let data = RelocateData(cfi: readTo)
+
+        #expect(data.echo == false)
+        #expect(data.isMovement)
+    }
+
+    @Test("a relocate tagged echo is not movement")
+    func echoTaggedRelocateIsNotMovement() {
+        let data = RelocateData(cfi: readTo, echo: true)
+
+        #expect(data.echo)
+        #expect(!data.isMovement)
+    }
+
+    /// The bug itself, at the restore anchor. A rotation's own corrected
+    /// redisplay reaches the page normally — the reader sees the settled
+    /// landing — but must not become where a reboot picks up.
+    @Test("an echoed relocate reaches the page but leaves the restore point standing")
+    func echoedRelocateDoesNotMoveTheRestorePoint() throws {
+        let controller = openReader(at: openedAt)
+        try relocate(controller, to: readTo)
+        #expect(controller.restoreCFI == readTo)
+
+        // A rotation's corrected re-pagination: the glue reports the settled
+        // landing tagged `echo: true`.
+        try relocate(controller, to: rotatedTo, echo: true)
+
+        // Rendered — the page indicator/footer follow it like any relocate.
+        #expect(controller.location?.cfi == rotatedTo)
+        #expect(controller.location?.echo == true)
+        // Not movement — a reboot still lands where the reader actually was
+        // before the rotation, not the drifted echo.
+        #expect(controller.restoreCFI == readTo)
+    }
+
+    @Test("a real page turn after an echo still moves the restore point")
+    func realMovementAfterAnEchoStillMovesTheRestorePoint() throws {
+        let controller = openReader(at: openedAt)
+        try relocate(controller, to: readTo)
+        try relocate(controller, to: rotatedTo, echo: true)
+
+        let turnedTo = "epubcfi(/6/16[chap08]!/4/2/2,/1:0,/1:1)"
+        try relocate(controller, to: turnedTo)
+
+        #expect(controller.restoreCFI == turnedTo)
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #2081
- **Finding 1 (drift on rotation).** Both resize paths — epub.js's own window-resize handler and `installStageResizeWatch`'s `ResizeObserver` — re-displayed the pre-resize CFI through epub.js's plain, uncorrected `rendition.display()`, never through `displaySettled`/`redisplayWhenSettled`/`nudgeToTarget`. Added a `resized` listener in both glue copies (`frontend/assets/vendor/epub-reader-glue.js` and iOS's diverged `omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js`) that mutes relocates for the burst, coalesces the two racing paths with a debounce anchored to the *first* pre-resize target seen, then runs the same settle-then-redisplay + `nudgeToTarget` correction the boot restore gets, and reports exactly one settled, echo-tagged relocate.
- **Finding 2 (rotation recorded as reading).** iOS's glue never had the web glue's `echo`/`restoreEchoPending` mechanism at all (a genuine, pre-existing divergence, not just missing a flag) — ported it in. `RelocateData` (`ReaderWebView.swift`) now decodes `echo` and exposes `isMovement`; iOS's persist guard (`ReaderView.swift`) and `restoreCFI` assignment (`ReaderWebView.swift`) are gated on it, on top of (not instead of) the existing `old != nil` boot guard, as a defensive belt. Web needed **no Rust changes** — `frontend/src/pages/reader/interop.rs` already gates persistence and the local restore save on `!data.echo`.
- **Finding 3 (missing spread option).** Both glue files already supported `opts.spread`/`setSpread(mode)` (undocumented — fixed the doc comments too); iOS just never called it. Added `ReaderSpread` (single/double, mirroring web's `Spread` in `frontend/src/pages/reader/typography.rs`) to `ReaderSettings`, threaded through `bootScript()`/`applySettings`, and added a `PillSelector` for it in `ReaderSettingsSheet` next to margins.
- Added `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `node --check` on both glue files — syntax OK (no JS toolchain lint beyond that is set up in this repo).
- [x] `cargo fmt --check -p omnibus-frontend` — not run; no `.rs` files were touched (web-side fix required no Rust changes, confirmed by reading `interop.rs`'s existing `!data.echo` gate).
- [x] Added `omnibus-ios/omnibusTests/ReaderEchoTests.swift` (AC6, unit half): pins `RelocateData.isMovement` for both `echo` states, and — via `ReaderController` — that an echo-tagged relocate is rendered (`location` updates) but leaves `restoreCFI` standing, while a real page turn after it still moves it.
- [ ] **NOTE:** iOS build/test (`just ios-build`, `just ios-test`) could not be run — this is a Linux cloud environment with no Xcode/simulator toolchain. Please confirm via CI's `ios-tests.yml`.
- [ ] **NOTE:** AC6's `omnibusUITests` rotation round-trip was **not added**. The existing UI suite (`omnibusUITests.swift`) is deliberately hermetic/offline and has no path to open the EPUB reader — no bundled fixture book, no demo/guest mode, no launch-arg hook analogous to `--uitest-reset` that reaches a book. Building one (a bundled fixture EPUB plus a new app-routing bypass in `omnibusApp.swift`/`AppState`) is a real feature addition I couldn't safely author or verify blind in this environment (no simulator, no compiler) — happy to follow up with it, or take direction on the intended hook, in a separate PR.

## Notes
- `omnibus-ios/omnibus/Reader/Web/epub-reader-glue.js` is a documented, intentional fork of the web copy (see `omnibus-ios/README.md`) — I ported the equivalent logic rather than copying the file over, per that note.
- Left `Op::SetKindleEmail`-style scope creep out: did not touch the locations-resolved re-emit's *pre-existing* lack of an echo tag on iOS beyond adding one consistent `true` there (it's now consistent with the boot restore's, which was already a genuine re-statement, not new behavior this PR needed to fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_013Ft42YbbrQg87eZpbW1brc)_