### PR TITLE
refactor: extract helpers from 6 long functions (#2042)

### DIFF
--- a/db/src/cross_format/anchors.rs
+++ b/db/src/cross_format/anchors.rs
@@ -196,14 +196,62 @@ pub(super) async fn anchor_map_from_marks(
     timeline: &AudioTimeline,
     audio: &[AudioMark],
 ) -> Result<Option<AnchorMap>, CrossFormatError> {
-    let stats = crate::epub_structure::get_spine_stats(pool, ebook_file_id).await?;
-    let total_chars: i64 = stats
-        .iter()
-        .fold(0i64, |acc, s| acc.saturating_add(s.visible_chars.max(0)));
+    let total_chars = compute_spine_char_totals(pool, ebook_file_id).await?;
     if total_chars <= 0 || timeline.total_seconds <= 0.0 {
         return Ok(None);
     }
-    let text: Vec<TextMark> = crate::epub_structure::get_chapters(pool, ebook_file_id)
+    let text = build_text_marks(pool, ebook_file_id, total_chars).await?;
+    if text.is_empty() || audio.is_empty() {
+        return Ok(None);
+    }
+
+    // The match bar scores against the *smaller* mark list: a nav padded
+    // with front matter (Cover, Copyright, Contents…) must not raise the
+    // bar past what the audio side could ever supply (#1894).
+    let usable_audio = usable_audio_mark_count(audio) as usize;
+    let denom = text.len().min(usable_audio.max(1));
+    let passes = |a: &[Anchor]| {
+        a.len() >= MIN_ANCHORS && (a.len() as f64) >= MIN_MATCH_FRACTION * denom as f64
+    };
+
+    // Rungs, most exact first; then positional count-alignment as a last
+    // resort. Junk encoder labels ("STORMLIGHT0501P01") clear none of them
+    // and fall through to an honest refusal.
+    let anchors = match try_match_rungs(&text, audio, passes) {
+        Some(a) => a,
+        None => match positional_fallback(&text, audio, passes) {
+            Some(a) => a,
+            None => return Ok(None),
+        },
+    };
+    Ok(Some(AnchorMap {
+        matched: anchors.len() as i64,
+        anchors,
+        ebook_chapters: text.len() as i64,
+    }))
+}
+
+/// Stage 1: total visible characters across the ebook's spine — the
+/// denominator for every text-side fraction. `0` (or an empty spine) is the
+/// caller's signal to refuse anchoring rather than divide by zero.
+async fn compute_spine_char_totals(
+    pool: &SqlitePool,
+    ebook_file_id: i64,
+) -> Result<i64, CrossFormatError> {
+    let stats = crate::epub_structure::get_spine_stats(pool, ebook_file_id).await?;
+    Ok(stats
+        .iter()
+        .fold(0i64, |acc, s| acc.saturating_add(s.visible_chars.max(0))))
+}
+
+/// Stage 2: the ebook-side anchor candidates, keyed and fractioned against
+/// the already-computed spine character total.
+async fn build_text_marks(
+    pool: &SqlitePool,
+    ebook_file_id: i64,
+    total_chars: i64,
+) -> Result<Vec<TextMark>, CrossFormatError> {
+    Ok(crate::epub_structure::get_chapters(pool, ebook_file_id)
         .await?
         .into_iter()
         .map(|c| TextMark {
@@ -211,69 +259,48 @@ pub(super) async fn anchor_map_from_marks(
             chapter_no: chapter_number(&c.title),
             frac: (c.start_chars.max(0) as f64 / total_chars as f64).clamp(0.0, 1.0),
         })
-        .collect();
-    if text.is_empty() {
-        return Ok(None);
-    }
+        .collect())
+}
 
-    if audio.is_empty() {
-        return Ok(None);
-    }
+/// Stage 4: try each matching rung, most exact first, filtered to a
+/// strictly-monotonic subsequence. Returns the first rung whose anchors
+/// clear `passes`.
+fn try_match_rungs(
+    text: &[TextMark],
+    audio: &[AudioMark],
+    passes: impl Fn(&[Anchor]) -> bool,
+) -> Option<Vec<Anchor>> {
+    [
+        match_by_title(text, audio),
+        match_by_chapter_number(text, audio),
+        match_by_title_prefix(text, audio),
+    ]
+    .into_iter()
+    .map(monotonic)
+    .find(|m| passes(m))
+}
 
-    // The match bar scores against the *smaller* mark list: a nav padded
-    // with front matter (Cover, Copyright, Contents…) must not raise the
-    // bar past what the audio side could ever supply (#1894).
-    let usable_audio = audio
-        .iter()
-        .filter(|a| !a.synthetic && a.key.is_some())
-        .count();
-    let denom = text.len().min(usable_audio.max(1));
-    let passes = |a: &[Anchor]| {
-        a.len() >= MIN_ANCHORS && (a.len() as f64) >= MIN_MATCH_FRACTION * denom as f64
-    };
-
-    // Rungs, most exact first; the first that clears the bar (after the
-    // monotonic filter, so the count reflects anchors the interpolation
-    // actually uses) wins. Junk encoder labels ("STORMLIGHT0501P01")
-    // clear none of them and fall through to an honest refusal.
-    let mut chosen: Option<Vec<Anchor>> = None;
-    for rung in [
-        match_by_title(&text, audio),
-        match_by_chapter_number(&text, audio),
-        match_by_title_prefix(&text, audio),
-    ] {
-        let m = monotonic(rung);
-        if passes(&m) {
-            chosen = Some(m);
-            break;
-        }
+/// Stage 5: positional count-alignment, when every rung above missed — the
+/// shape of a per-chapter MP3 folder, or two editions wording titles
+/// differently. Only engages when the two mark lists are the same length.
+fn positional_fallback(
+    text: &[TextMark],
+    audio: &[AudioMark],
+    passes: impl Fn(&[Anchor]) -> bool,
+) -> Option<Vec<Anchor>> {
+    if text.len() != audio.len() {
+        return None;
     }
-    // Count alignment last: one-to-one lists pair positionally (the
-    // per-chapter MP3 folder, or two editions wording titles differently).
-    let anchors = match chosen {
-        Some(a) => a,
-        None if text.len() == audio.len() => {
-            let m = monotonic(
-                text.iter()
-                    .zip(audio.iter())
-                    .map(|(t, a)| Anchor {
-                        text_frac: t.frac,
-                        audio_frac: a.frac,
-                    })
-                    .collect(),
-            );
-            if !passes(&m) {
-                return Ok(None);
-            }
-            m
-        }
-        None => return Ok(None),
-    };
-    Ok(Some(AnchorMap {
-        matched: anchors.len() as i64,
-        anchors,
-        ebook_chapters: text.len() as i64,
-    }))
+    let m = monotonic(
+        text.iter()
+            .zip(audio.iter())
+            .map(|(t, a)| Anchor {
+                text_frac: t.frac,
+                audio_frac: a.frac,
+            })
+            .collect(),
+    );
+    passes(&m).then_some(m)
 }
 
 /// Ordered pairing on parsed chapter numbers — the rung that survives

--- a/db/src/epub_rewrite/mod.rs
+++ b/db/src/epub_rewrite/mod.rs
@@ -349,7 +349,89 @@ pub async fn rewrite_all_epubs_with_progress(
         return Ok(summary);
     }
 
-    let id_map = crate::books::resolve_book_ids_bulk(pool, &uuids).await?;
+    let ctx = load_rewrite_context(pool, &uuids).await?;
+
+    let total = u32::try_from(uuids.len()).unwrap_or(u32::MAX);
+    let mut processed = 0u32;
+    for uuid in uuids {
+        processed = processed.saturating_add(1);
+        on_progress(processed, total, ctx.progress_label(&uuid));
+        ctx.rewrite_one(uuid, &mut summary).await;
+    }
+    Ok(summary)
+}
+
+/// The bulk-loaded lookups a whole-library rewrite pass needs, fetched once
+/// up front (see the doc comment above [`rewrite_all_epubs_with_overrides`])
+/// rather than per book inside the loop.
+struct RewriteContext {
+    id_map: HashMap<String, i64>,
+    source_paths: HashMap<i64, PathBuf>,
+    last_modified_map: HashMap<i64, i64>,
+    books_by_id: HashMap<i64, EbookMetadata>,
+}
+
+impl RewriteContext {
+    /// The progress label for one uuid: its (possibly overridden) title,
+    /// falling back to the filename — an empty title (possible in both the
+    /// DB column and an override) must fall through like a missing one, or
+    /// the UI names the book "".
+    fn progress_label(&self, uuid: &str) -> Option<&str> {
+        self.id_map
+            .get(uuid)
+            .and_then(|book_id| self.books_by_id.get(book_id))
+            .map(|b| {
+                b.title
+                    .as_deref()
+                    .filter(|t| !t.is_empty())
+                    .unwrap_or(&b.filename)
+            })
+    }
+
+    /// Rewrite (or skip) one overridden book, folding the outcome into
+    /// `summary`. Every lookup miss here is a book that legitimately
+    /// vanished between the listing query and this pass (ghosted, reformat,
+    /// or a concurrent delete) — not an error.
+    async fn rewrite_one(&self, uuid: String, summary: &mut BulkRewriteSummary) {
+        // Ghosted: the override row outlived its book (source file removed
+        // by a scan, or the book deleted concurrently between the listing
+        // query above and this pass).
+        let Some(&book_id) = self.id_map.get(&uuid) else {
+            summary.skipped += 1;
+            return;
+        };
+        // No EPUB to bake into — an audiobook-only or comic-only book.
+        let Some(source) = self.source_paths.get(&book_id) else {
+            summary.skipped += 1;
+            return;
+        };
+        // The book itself vanished between resolving its id and this bulk
+        // fetch (a concurrent delete) — no longer this pass's problem.
+        let Some(book) = self.books_by_id.get(&book_id) else {
+            summary.skipped += 1;
+            return;
+        };
+        let last_modified = self.last_modified_map.get(&book_id).copied().unwrap_or(0);
+        match rewrite_or_reuse_cache(book_id, source, book, last_modified).await {
+            Ok(Some(_)) => summary.rewritten += 1,
+            // The override cleared between the listing query above and this
+            // call (a concurrent delete) — no longer this pass's problem.
+            Ok(None) => summary.skipped += 1,
+            Err(e) => summary.errors.push(BulkRewriteError {
+                book_uuid: uuid,
+                message: e.to_string(),
+            }),
+        }
+    }
+}
+
+/// Load the bulk lookups [`RewriteContext`] carries: resolved book ids,
+/// each's EPUB source path, `last_modified`, and merged metadata.
+async fn load_rewrite_context(
+    pool: &SqlitePool,
+    uuids: &[String],
+) -> anyhow::Result<RewriteContext> {
+    let id_map = crate::books::resolve_book_ids_bulk(pool, uuids).await?;
     let mut ids: Vec<i64> = id_map.values().copied().collect();
     ids.sort_unstable();
     ids.dedup();
@@ -364,56 +446,12 @@ pub async fn rewrite_all_epubs_with_progress(
         .map(|b| (b.id, b))
         .collect();
 
-    let total = u32::try_from(uuids.len()).unwrap_or(u32::MAX);
-    let mut processed = 0u32;
-    for uuid in uuids {
-        processed = processed.saturating_add(1);
-        {
-            let current = id_map
-                .get(&uuid)
-                .and_then(|book_id| books_by_id.get(book_id))
-                // An empty title (possible in both the DB column and an
-                // override) must fall through to the filename like a
-                // missing one, or the UI names the book "".
-                .map(|b| {
-                    b.title
-                        .as_deref()
-                        .filter(|t| !t.is_empty())
-                        .unwrap_or(&b.filename)
-                });
-            on_progress(processed, total, current);
-        }
-        // Ghosted: the override row outlived its book (source file removed
-        // by a scan, or the book deleted concurrently between the listing
-        // query above and this pass).
-        let Some(&book_id) = id_map.get(&uuid) else {
-            summary.skipped += 1;
-            continue;
-        };
-        // No EPUB to bake into — an audiobook-only or comic-only book.
-        let Some(source) = source_paths.get(&book_id) else {
-            summary.skipped += 1;
-            continue;
-        };
-        // The book itself vanished between resolving its id and this bulk
-        // fetch (a concurrent delete) — no longer this pass's problem.
-        let Some(book) = books_by_id.get(&book_id) else {
-            summary.skipped += 1;
-            continue;
-        };
-        let last_modified = last_modified_map.get(&book_id).copied().unwrap_or(0);
-        match rewrite_or_reuse_cache(book_id, source, book, last_modified).await {
-            Ok(Some(_)) => summary.rewritten += 1,
-            // The override cleared between the listing query above and this
-            // call (a concurrent delete) — no longer this pass's problem.
-            Ok(None) => summary.skipped += 1,
-            Err(e) => summary.errors.push(BulkRewriteError {
-                book_uuid: uuid,
-                message: e.to_string(),
-            }),
-        }
-    }
-    Ok(summary)
+    Ok(RewriteContext {
+        id_map,
+        source_paths,
+        last_modified_map,
+        books_by_id,
+    })
 }
 
 /// A zip entry name from an in-archive path: `to_string_lossy` with backslashes

--- a/db/src/kobo.rs
+++ b/db/src/kobo.rs
@@ -319,79 +319,99 @@ pub async fn reading_state_for(
         return Ok(out);
     }
     for chunk in uuids.chunks(450) {
-        let placeholders = std::iter::repeat_n("?", chunk.len())
-            .collect::<Vec<_>>()
-            .join(",");
-        // FULL OUTER JOIN isn't available in older SQLite, and a book can have
-        // either row independently, so union the two key sets and left-join
-        // both sides onto it.
-        let sql = format!(
-            "WITH keys(book_uuid) AS (
-                 SELECT book_uuid FROM book_read_status
-                  WHERE user_id = ? AND book_uuid IN ({placeholders})
-                 UNION
-                 SELECT book_uuid FROM reading_progress
-                  WHERE user_id = ? AND format = 'epub' AND book_uuid IN ({placeholders})
-             )
-             SELECT k.book_uuid,
-                    rs.status AS status,
-                    rp.progress_percent AS progress_percent,
-                    rp.kobo_location AS kobo_location,
-                    rp.epub_cfi AS epub_cfi,
-                    rp.kobo_spent_reading_minutes AS kobo_spent_reading_minutes,
-                    rp.kobo_remaining_time_minutes AS kobo_remaining_time_minutes,
-                    rp.kobo_statistics_updated_at AS kobo_statistics_updated_at,
-                    COALESCE(rp.client_updated_at, rp.updated_at, 0)
-                        AS progress_updated_at,
-                    COALESCE(rs.updated_at, 0) AS status_updated_at,
-                    MAX(
-                        COALESCE(rs.updated_at, 0),
-                        COALESCE(rp.client_updated_at, rp.updated_at, 0)
-                    ) AS state_updated_at
-               FROM keys k
-               LEFT JOIN book_read_status rs
-                      ON rs.book_uuid = k.book_uuid AND rs.user_id = ?
-               LEFT JOIN reading_progress rp
-                      ON rp.book_uuid = k.book_uuid AND rp.user_id = ? AND rp.format = 'epub'"
-        );
-        let mut q = sqlx::query(&sql).bind(user_id);
-        for uuid in chunk {
-            q = q.bind(uuid);
-        }
-        q = q.bind(user_id);
-        for uuid in chunk {
-            q = q.bind(uuid);
-        }
-        q = q.bind(user_id).bind(user_id);
-        for row in q.fetch_all(pool).await? {
-            let uuid: String = row.try_get("book_uuid")?;
-            let status = row
-                .try_get::<Option<String>, _>("status")?
-                .map(|s| ReadStatus::from_db(&s))
-                .unwrap_or_default();
-            let statistics = crate::progress::KoboStatistics {
-                spent_reading_minutes: row.try_get("kobo_spent_reading_minutes")?,
-                remaining_time_minutes: row.try_get("kobo_remaining_time_minutes")?,
-                updated_at: row.try_get("kobo_statistics_updated_at")?,
-            };
-            out.insert(
-                uuid,
-                KoboBookState {
-                    status,
-                    // A row of NULLs is "no device ever reported": collapse it
-                    // so sync-out omits the block rather than emitting empties.
-                    statistics: (!statistics.is_empty()).then_some(statistics),
-                    percent: row.try_get::<Option<i64>, _>("progress_percent")?,
-                    kobo_location: row.try_get::<Option<String>, _>("kobo_location")?,
-                    epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
-                    state_updated_at: row.try_get::<i64, _>("state_updated_at")?,
-                    progress_updated_at: row.try_get::<i64, _>("progress_updated_at")?,
-                    status_updated_at: row.try_get::<i64, _>("status_updated_at")?,
-                },
-            );
+        for row in fetch_reading_state_chunk(pool, user_id, chunk).await? {
+            let (uuid, state) = row_to_kobo_state(&row)?;
+            out.insert(uuid, state);
         }
     }
     Ok(out)
+}
+
+/// The per-chunk union-and-join query text: `book_read_status` and
+/// `reading_progress` can each have a row independently, so the two key
+/// sets are unioned and both sides are left-joined onto it (SQLite has no
+/// `FULL OUTER JOIN`). `placeholders` is shared by the two `IN (...)`
+/// clauses that scope the union to this chunk's uuids.
+fn reading_state_sql(placeholders: &str) -> String {
+    format!(
+        "WITH keys(book_uuid) AS (
+             SELECT book_uuid FROM book_read_status
+              WHERE user_id = ? AND book_uuid IN ({placeholders})
+             UNION
+             SELECT book_uuid FROM reading_progress
+              WHERE user_id = ? AND format = 'epub' AND book_uuid IN ({placeholders})
+         )
+         SELECT k.book_uuid,
+                rs.status AS status,
+                rp.progress_percent AS progress_percent,
+                rp.kobo_location AS kobo_location,
+                rp.epub_cfi AS epub_cfi,
+                rp.kobo_spent_reading_minutes AS kobo_spent_reading_minutes,
+                rp.kobo_remaining_time_minutes AS kobo_remaining_time_minutes,
+                rp.kobo_statistics_updated_at AS kobo_statistics_updated_at,
+                COALESCE(rp.client_updated_at, rp.updated_at, 0)
+                    AS progress_updated_at,
+                COALESCE(rs.updated_at, 0) AS status_updated_at,
+                MAX(
+                    COALESCE(rs.updated_at, 0),
+                    COALESCE(rp.client_updated_at, rp.updated_at, 0)
+                ) AS state_updated_at
+           FROM keys k
+           LEFT JOIN book_read_status rs
+                  ON rs.book_uuid = k.book_uuid AND rs.user_id = ?
+           LEFT JOIN reading_progress rp
+                  ON rp.book_uuid = k.book_uuid AND rp.user_id = ? AND rp.format = 'epub'"
+    )
+}
+
+/// Run [`reading_state_sql`] for one chunk of uuids, binding `user_id` and
+/// the chunk into each of the query's four parameter slots.
+async fn fetch_reading_state_chunk(
+    pool: &SqlitePool,
+    user_id: i64,
+    chunk: &[String],
+) -> Result<Vec<sqlx::sqlite::SqliteRow>, KoboError> {
+    let placeholders = std::iter::repeat_n("?", chunk.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = reading_state_sql(&placeholders);
+    let mut q = sqlx::query(&sql).bind(user_id);
+    for uuid in chunk {
+        q = q.bind(uuid);
+    }
+    q = q.bind(user_id);
+    for uuid in chunk {
+        q = q.bind(uuid);
+    }
+    q = q.bind(user_id).bind(user_id);
+    Ok(q.fetch_all(pool).await?)
+}
+
+/// Parse one joined row into its `(uuid, state)` pair.
+fn row_to_kobo_state(row: &sqlx::sqlite::SqliteRow) -> Result<(String, KoboBookState), KoboError> {
+    let uuid: String = row.try_get("book_uuid")?;
+    let status = row
+        .try_get::<Option<String>, _>("status")?
+        .map(|s| ReadStatus::from_db(&s))
+        .unwrap_or_default();
+    let statistics = crate::progress::KoboStatistics {
+        spent_reading_minutes: row.try_get("kobo_spent_reading_minutes")?,
+        remaining_time_minutes: row.try_get("kobo_remaining_time_minutes")?,
+        updated_at: row.try_get("kobo_statistics_updated_at")?,
+    };
+    let state = KoboBookState {
+        status,
+        // A row of NULLs is "no device ever reported": collapse it so
+        // sync-out omits the block rather than emitting empties.
+        statistics: (!statistics.is_empty()).then_some(statistics),
+        percent: row.try_get::<Option<i64>, _>("progress_percent")?,
+        kobo_location: row.try_get::<Option<String>, _>("kobo_location")?,
+        epub_cfi: row.try_get::<Option<String>, _>("epub_cfi")?,
+        state_updated_at: row.try_get::<i64, _>("state_updated_at")?,
+        progress_updated_at: row.try_get::<i64, _>("progress_updated_at")?,
+        status_updated_at: row.try_get::<i64, _>("status_updated_at")?,
+    };
+    Ok((uuid, state))
 }
 
 #[cfg(test)]

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -33,80 +33,103 @@ pub(super) async fn sync_removed(
     // library_id + 1 bind per uuid; chunk at 500 to stay under SQLite's
     // 999-param cap when a whole library (or any large diff) is removed.
     for chunk in removed_uuids.chunks(500) {
-        let placeholders = std::iter::repeat_n("?", chunk.len())
-            .collect::<Vec<_>>()
-            .join(", ");
-
         // Resolve the affected ids, then batch-drop their file rows and flag
         // the rows missing — keeping each `books` row (and its links/FTS) as a
         // fileless book. Two chunked statements replace the old per-book
         // `mark_book_files_missing` fan-out (which fired 2 DML per removed
         // book).
-        let id_sql =
-            format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
-        let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
-        for uuid in chunk {
-            q = q.bind(uuid);
-        }
-        let ids = q.fetch_all(&mut **tx).await?;
+        let ids = resolve_removed_book_ids(tx, library_id, chunk).await?;
         missing += ids.len();
         if ids.is_empty() {
             continue;
         }
-
-        let id_placeholders = std::iter::repeat_n("?", ids.len())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        // One DELETE per chunk: `book_file_parts` + `file_chapters` cascade
-        // off the `book_files` row. Scoped to rows with **no** matching
-        // `merged_uuids` entry — a row that IS recorded there is a
-        // cross-format attachment (a different format's file, still present)
-        // and must survive this book's own file going missing; the
-        // old blanket `book_id IN (...)` delete dropped it too, only for it
-        // to re-attach (and re-mint a `book_files` row) on the next scan.
-        let delete_sql = format!(
-            "DELETE FROM book_files
-              WHERE book_id IN ({id_placeholders})
-                AND NOT EXISTS (
-                  SELECT 1 FROM merged_uuids mu
-                   WHERE mu.book_id = book_files.book_id
-                     AND mu.format = book_files.format
-                     AND mu.scan_key = book_files.scan_key
-                )"
-        );
-        let mut delete_q = sqlx::query(&delete_sql);
-        for id in &ids {
-            delete_q = delete_q.bind(id);
-        }
-        delete_q.execute(&mut **tx).await?;
-
-        // One UPDATE per chunk: set the F10 missing flag + start the retention
-        // clock. The `is_missing_files = 0` guard preserves the original
-        // `missing_files_since` on a re-run; the `is_missing_files_override = 0`
-        // guard leaves intentionally-fileless rows (wishlist) unflagged so
-        // reads keep showing them. The `NOT EXISTS book_files` guard excludes a
-        // book whose cross-format attachment (a different format's file, still
-        // present) survived the delete above — it isn't actually fileless, so
-        // it must not be flagged missing.
-        let update_sql = format!(
-            "UPDATE books
-                SET is_missing_files = 1, missing_files_since = unixepoch()
-              WHERE id IN ({id_placeholders})
-                AND is_missing_files = 0
-                AND is_missing_files_override = 0
-                AND NOT EXISTS (SELECT 1 FROM book_files WHERE book_files.book_id = books.id)"
-        );
-        let mut update_q = sqlx::query(&update_sql);
-        for id in &ids {
-            update_q = update_q.bind(id);
-        }
-        update_q.execute(&mut **tx).await?;
+        delete_removed_book_files(tx, &ids).await?;
+        flag_books_missing(tx, &ids).await?;
     }
     if missing > 0 {
         // These rows are flagged missing (F10); `missing_files::gc_books_missing_files`
         // purges the long-missing, user-data-free ones on a later reindex.
         tracing::info!(missing, "sync: retained removed books as fileless books");
     }
+    Ok(())
+}
+
+/// Resolve one chunk's removed uuids to their `books.id`s within the library.
+async fn resolve_removed_book_ids(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    library_id: i64,
+    chunk: &[String],
+) -> Result<Vec<i64>, sqlx::Error> {
+    let placeholders = std::iter::repeat_n("?", chunk.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let id_sql = format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
+    let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
+    for uuid in chunk {
+        q = q.bind(uuid);
+    }
+    q.fetch_all(&mut **tx).await
+}
+
+/// One DELETE per chunk: `book_file_parts` + `file_chapters` cascade off the
+/// `book_files` row. Scoped to rows with **no** matching `merged_uuids`
+/// entry — a row that IS recorded there is a cross-format attachment (a
+/// different format's file, still present) and must survive this book's own
+/// file going missing; the old blanket `book_id IN (...)` delete dropped it
+/// too, only for it to re-attach (and re-mint a `book_files` row) on the
+/// next scan.
+async fn delete_removed_book_files(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    let id_placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let delete_sql = format!(
+        "DELETE FROM book_files
+          WHERE book_id IN ({id_placeholders})
+            AND NOT EXISTS (
+              SELECT 1 FROM merged_uuids mu
+               WHERE mu.book_id = book_files.book_id
+                 AND mu.format = book_files.format
+                 AND mu.scan_key = book_files.scan_key
+            )"
+    );
+    let mut delete_q = sqlx::query(&delete_sql);
+    for id in ids {
+        delete_q = delete_q.bind(id);
+    }
+    delete_q.execute(&mut **tx).await?;
+    Ok(())
+}
+
+/// One UPDATE per chunk: set the F10 missing flag + start the retention
+/// clock. The `is_missing_files = 0` guard preserves the original
+/// `missing_files_since` on a re-run; the `is_missing_files_override = 0`
+/// guard leaves intentionally-fileless rows (wishlist) unflagged so reads
+/// keep showing them. The `NOT EXISTS book_files` guard excludes a book
+/// whose cross-format attachment (a different format's file, still present)
+/// survived the delete above — it isn't actually fileless, so it must not
+/// be flagged missing.
+async fn flag_books_missing(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    let id_placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let update_sql = format!(
+        "UPDATE books
+            SET is_missing_files = 1, missing_files_since = unixepoch()
+          WHERE id IN ({id_placeholders})
+            AND is_missing_files = 0
+            AND is_missing_files_override = 0
+            AND NOT EXISTS (SELECT 1 FROM book_files WHERE book_files.book_id = books.id)"
+    );
+    let mut update_q = sqlx::query(&update_sql);
+    for id in ids {
+        update_q = update_q.bind(id);
+    }
+    update_q.execute(&mut **tx).await?;
     Ok(())
 }

--- a/frontend/src/components/alignment_modal/lanes.rs
+++ b/frontend/src/components/alignment_modal/lanes.rs
@@ -172,12 +172,7 @@ fn lane_geometry<'v>(
 
 /// Both lanes plus the connector field between them: chapter ticks, fills,
 /// labelled position chips, the anchored mapped preview, and the delta
-/// sentence beneath. No hooks anywhere in this tree — it's a plain
-/// data-in/markup-out function, not a `#[component]` — so splitting the rsx
-/// across named helpers below carries none of the hook-order risk rule 07
-/// warns about; each helper is just a sub-tree builder called inline via
-/// `{helper(...)}`, same pattern as `pages/series_index.rs`'s
-/// `render_series_body`.
+/// sentence beneath.
 pub(super) fn render_lanes(
     view: &AlignmentView,
     order: &[i64],

--- a/frontend/src/components/alignment_modal/lanes.rs
+++ b/frontend/src/components/alignment_modal/lanes.rs
@@ -172,7 +172,12 @@ fn lane_geometry<'v>(
 
 /// Both lanes plus the connector field between them: chapter ticks, fills,
 /// labelled position chips, the anchored mapped preview, and the delta
-/// sentence beneath.
+/// sentence beneath. No hooks anywhere in this tree — it's a plain
+/// data-in/markup-out function, not a `#[component]` — so splitting the rsx
+/// across named helpers below carries none of the hook-order risk rule 07
+/// warns about; each helper is just a sub-tree builder called inline via
+/// `{helper(...)}`, same pattern as `pages/series_index.rs`'s
+/// `render_series_body`.
 pub(super) fn render_lanes(
     view: &AlignmentView,
     order: &[i64],
@@ -209,110 +214,13 @@ pub(super) fn render_lanes(
                     }
                 }
             }
-            div { class: "al-lane al-lane-text",
-                if let Some(f) = reading_frac {
-                    div { class: "al-fill", style: "width: {f * 100.0}%" }
-                }
-                for (i, ch) in ebook_chapters.iter().enumerate() {
-                    if i % text_step == 0 {
-                        div {
-                            key: "{ch.title}-{ch.percent}",
-                            class: "al-tick",
-                            title: "{ch.title}",
-                            style: "left: {ch.percent}%",
-                        }
-                    }
-                }
-                if let Some(f) = reading_frac {
-                    div {
-                        class: "al-marker",
-                        "data-testid": "alignment-reading-marker",
-                        style: "left: {f * 100.0}%",
-                    }
-                }
-            }
+            {render_text_lane(reading_frac, &ebook_chapters, text_step)}
             // The connector field: faint threads join matched anchors; the
             // accent dashed thread is the reading position landing in the
             // audio — the thing the user judges before confirming.
-            div { class: "al-connector", "aria-hidden": "true",
-                svg {
-                    view_box: "0 0 1000 44",
-                    preserve_aspect_ratio: "none",
-                    for (t, a) in view.anchor_pairs.iter() {
-                        line {
-                            key: "{t}-{a}",
-                            x1: "{t * 1000.0}",
-                            y1: "0",
-                            x2: "{a * 1000.0}",
-                            y2: "44",
-                            class: "al-thread",
-                        }
-                    }
-                    if let (Some(f), Some(m)) = (reading_frac, mapped_frac) {
-                        line {
-                            x1: "{f * 1000.0}",
-                            y1: "0",
-                            x2: "{m * 1000.0}",
-                            y2: "44",
-                            class: "al-thread-mapped",
-                        }
-                    }
-                }
-            }
-            div { class: "al-lane al-lane-audio",
-                for f in files.iter() {
-                    div {
-                        key: "{f.book_file_id}",
-                        class: "al-seg",
-                        style: format!(
-                            "flex-grow: {}",
-                            if total > 0.0 { f.duration_seconds.max(1.0) } else { 1.0 },
-                        ),
-                        span { class: "al-seg-label", title: "{f.label}", "{basename(&f.label)}" }
-                        span { class: "al-seg-dur", "{fmt_hm(f.duration_seconds)}" }
-                    }
-                }
-                div { class: "al-lane-overlay",
-                    if let Some(f) = listen_frac {
-                        div { class: "al-fill", style: "width: {f * 100.0}%" }
-                    }
-                    for (i, t) in audio_ticks.iter().enumerate() {
-                        if i % audio_step == 0 {
-                            div { key: "{i}", class: "al-tick", style: "left: {t * 100.0}%" }
-                        }
-                    }
-                    if let Some(f) = listen_frac {
-                        div {
-                            class: "al-marker",
-                            "data-testid": "alignment-listening-marker",
-                            style: "left: {f * 100.0}%",
-                        }
-                    }
-                    if let Some(m) = mapped_frac {
-                        div {
-                            class: "al-marker al-marker-mapped",
-                            "data-testid": "alignment-mapped-marker",
-                            style: "left: {m * 100.0}%",
-                        }
-                    }
-                }
-            }
-            div { class: if stagger { "al-chip-row al-chip-row-tall" } else { "al-chip-row" },
-                if let Some(f) = listen_frac {
-                    span {
-                        class: "al-chip",
-                        style: "left: {f * 100.0}%; transform: translateX({chip_translate(f)});",
-                        "Listening · {fmt_hm(f * total)}"
-                    }
-                }
-                if let Some(m) = mapped_frac {
-                    span {
-                        class: if stagger { "al-chip al-chip-accent al-chip-dashed al-chip-staggered" } else { "al-chip al-chip-accent al-chip-dashed" },
-                        style: "left: {m * 100.0}%; transform: translateX({chip_translate(m)});",
-                        "≈ your reading maps here · {fmt_hm(m * total)}"
-                    }
-                }
-            }
+            {render_connector(&view.anchor_pairs, reading_frac, mapped_frac)}
+            {render_audio_lane(files, total, listen_frac, mapped_frac, audio_ticks, audio_step)}
+            {render_position_chip_row(listen_frac, mapped_frac, total, stagger)}
             p { class: "al-lane-label",
                 "Audiobook · "
                 if files.len() == 1 {
@@ -321,23 +229,187 @@ pub(super) fn render_lanes(
                     "{files.len()} files, played end to end · {fmt_hm(total)}"
                 }
             }
-            if g.no_positions {
-                p { class: "al-mapped-note", "data-testid": "alignment-empty-note",
-                    "Nothing to compare yet — read or listen a little first, and the "
-                    "positions will land on these lanes."
-                }
-            } else if let Some(d) = g.delta {
-                p { class: "al-mapped-note",
-                    if d >= 0.0 {
-                        "Your reading spot sits ≈ {fmt_hm(d.abs())} past the listening position."
-                    } else {
-                        "The listening position is ≈ {fmt_hm(d.abs())} past your reading spot."
+            {render_delta_note(g.no_positions, g.delta, mapped_frac, total)}
+        }
+    }
+}
+
+/// The ebook lane: fill up to the reading position, thinned chapter ticks,
+/// and the reading marker.
+fn render_text_lane(
+    reading_frac: Option<f64>,
+    ebook_chapters: &[omnibus_shared::AlignmentEbookChapter],
+    text_step: usize,
+) -> Element {
+    rsx! {
+        div { class: "al-lane al-lane-text",
+            if let Some(f) = reading_frac {
+                div { class: "al-fill", style: "width: {f * 100.0}%" }
+            }
+            for (i, ch) in ebook_chapters.iter().enumerate() {
+                if i % text_step == 0 {
+                    div {
+                        key: "{ch.title}-{ch.percent}",
+                        class: "al-tick",
+                        title: "{ch.title}",
+                        style: "left: {ch.percent}%",
                     }
                 }
-            } else if let (Some(m), true) = (mapped_frac, total > 0.0) {
-                p { class: "al-mapped-note",
-                    "≈ your reading maps to {fmt_hm(m * total)}"
+            }
+            if let Some(f) = reading_frac {
+                div {
+                    class: "al-marker",
+                    "data-testid": "alignment-reading-marker",
+                    style: "left: {f * 100.0}%",
                 }
+            }
+        }
+    }
+}
+
+/// The connector field between the two lanes: one thread per matched anchor
+/// pair, plus the dashed accent thread for the reading position's mapped
+/// landing spot.
+fn render_connector(
+    anchor_pairs: &[(f64, f64)],
+    reading_frac: Option<f64>,
+    mapped_frac: Option<f64>,
+) -> Element {
+    rsx! {
+        div { class: "al-connector", "aria-hidden": "true",
+            svg {
+                view_box: "0 0 1000 44",
+                preserve_aspect_ratio: "none",
+                for (t, a) in anchor_pairs.iter() {
+                    line {
+                        key: "{t}-{a}",
+                        x1: "{t * 1000.0}",
+                        y1: "0",
+                        x2: "{a * 1000.0}",
+                        y2: "44",
+                        class: "al-thread",
+                    }
+                }
+                if let (Some(f), Some(m)) = (reading_frac, mapped_frac) {
+                    line {
+                        x1: "{f * 1000.0}",
+                        y1: "0",
+                        x2: "{m * 1000.0}",
+                        y2: "44",
+                        class: "al-thread-mapped",
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The audiobook lane: file segments sized by duration, plus an overlay of
+/// the fill, thinned chapter ticks, and the listening / mapped markers.
+fn render_audio_lane(
+    files: &[&AlignmentAudioFile],
+    total: f64,
+    listen_frac: Option<f64>,
+    mapped_frac: Option<f64>,
+    audio_ticks: &[f64],
+    audio_step: usize,
+) -> Element {
+    rsx! {
+        div { class: "al-lane al-lane-audio",
+            for f in files.iter() {
+                div {
+                    key: "{f.book_file_id}",
+                    class: "al-seg",
+                    style: format!(
+                        "flex-grow: {}",
+                        if total > 0.0 { f.duration_seconds.max(1.0) } else { 1.0 },
+                    ),
+                    span { class: "al-seg-label", title: "{f.label}", "{basename(&f.label)}" }
+                    span { class: "al-seg-dur", "{fmt_hm(f.duration_seconds)}" }
+                }
+            }
+            div { class: "al-lane-overlay",
+                if let Some(f) = listen_frac {
+                    div { class: "al-fill", style: "width: {f * 100.0}%" }
+                }
+                for (i, t) in audio_ticks.iter().enumerate() {
+                    if i % audio_step == 0 {
+                        div { key: "{i}", class: "al-tick", style: "left: {t * 100.0}%" }
+                    }
+                }
+                if let Some(f) = listen_frac {
+                    div {
+                        class: "al-marker",
+                        "data-testid": "alignment-listening-marker",
+                        style: "left: {f * 100.0}%",
+                    }
+                }
+                if let Some(m) = mapped_frac {
+                    div {
+                        class: "al-marker al-marker-mapped",
+                        "data-testid": "alignment-mapped-marker",
+                        style: "left: {m * 100.0}%",
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The listening / mapped position chip row beneath the audio lane,
+/// staggered onto two rows when the two chips would otherwise collide.
+fn render_position_chip_row(
+    listen_frac: Option<f64>,
+    mapped_frac: Option<f64>,
+    total: f64,
+    stagger: bool,
+) -> Element {
+    rsx! {
+        div { class: if stagger { "al-chip-row al-chip-row-tall" } else { "al-chip-row" },
+            if let Some(f) = listen_frac {
+                span {
+                    class: "al-chip",
+                    style: "left: {f * 100.0}%; transform: translateX({chip_translate(f)});",
+                    "Listening · {fmt_hm(f * total)}"
+                }
+            }
+            if let Some(m) = mapped_frac {
+                span {
+                    class: if stagger { "al-chip al-chip-accent al-chip-dashed al-chip-staggered" } else { "al-chip al-chip-accent al-chip-dashed" },
+                    style: "left: {m * 100.0}%; transform: translateX({chip_translate(m)});",
+                    "≈ your reading maps here · {fmt_hm(m * total)}"
+                }
+            }
+        }
+    }
+}
+
+/// The judgement sentence beneath both lanes: no positions yet, the
+/// measured delta between listening and mapped-reading, or (no listening
+/// position at all) the bare mapped landing spot.
+fn render_delta_note(
+    no_positions: bool,
+    delta: Option<f64>,
+    mapped_frac: Option<f64>,
+    total: f64,
+) -> Element {
+    rsx! {
+        if no_positions {
+            p { class: "al-mapped-note", "data-testid": "alignment-empty-note",
+                "Nothing to compare yet — read or listen a little first, and the "
+                "positions will land on these lanes."
+            }
+        } else if let Some(d) = delta {
+            p { class: "al-mapped-note",
+                if d >= 0.0 {
+                    "Your reading spot sits ≈ {fmt_hm(d.abs())} past the listening position."
+                } else {
+                    "The listening position is ≈ {fmt_hm(d.abs())} past your reading spot."
+                }
+            }
+        } else if let (Some(m), true) = (mapped_frac, total > 0.0) {
+            p { class: "al-mapped-note",
+                "≈ your reading maps to {fmt_hm(m * total)}"
             }
         }
     }

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -259,9 +259,7 @@ async fn load_manifest(
 }
 
 /// Reset every signal a fresh load owns back to its pre-playback default,
-/// before the metadata/manifest fetch below repopulates them. Split out of
-/// [`load_and_drain`] as its own step since it's pure state reset with no
-/// control flow of its own.
+/// before the metadata/manifest fetch repopulates them.
 fn reset_playback_state_for_load(ctx: MobilePlayback) {
     let MobilePlayback {
         mut view,

--- a/frontend/src/pages/listen/mobile/host.rs
+++ b/frontend/src/pages/listen/mobile/host.rs
@@ -258,15 +258,11 @@ async fn load_manifest(
     }
 }
 
-/// Fetch metadata + manifest for `uuid`, seed the context, install the audio
-/// control surface for direct-play books (or flag HLS as unsupported), then
-/// drain its events until superseded.
-async fn load_and_drain(
-    ctx: MobilePlayback,
-    uuid: String,
-    selected_file_id: Option<i64>,
-    server_url: String,
-) {
+/// Reset every signal a fresh load owns back to its pre-playback default,
+/// before the metadata/manifest fetch below repopulates them. Split out of
+/// [`load_and_drain`] as its own step since it's pure state reset with no
+/// control flow of its own.
+fn reset_playback_state_for_load(ctx: MobilePlayback) {
     let MobilePlayback {
         mut view,
         mut loading,
@@ -286,6 +282,25 @@ async fn load_and_drain(
     rate_error.set(None);
     sleep.set(SleepState::Off);
     rate.set(1.0);
+}
+
+/// Fetch metadata + manifest for `uuid`, seed the context, install the audio
+/// control surface for direct-play books (or flag HLS as unsupported), then
+/// drain its events until superseded.
+async fn load_and_drain(
+    ctx: MobilePlayback,
+    uuid: String,
+    selected_file_id: Option<i64>,
+    server_url: String,
+) {
+    reset_playback_state_for_load(ctx);
+    let MobilePlayback {
+        mut loading,
+        mut error,
+        mut unsupported,
+        mut view,
+        ..
+    } = ctx;
 
     let Some(book) = load_book_metadata(&server_url, &uuid, error, loading).await else {
         return;

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -228,62 +228,17 @@ async fn drain_reader_events(
     } = sigs;
     let mut last_cfi: Option<String> = None;
     crate::js_interop::drain_events(eval, move |event: ReaderEvent| match event {
-        ReaderEvent::Relocate { json } => {
-            if let Ok(mut data) = serde_json::from_str::<RelocateData>(&json) {
-                // Re-derive chapter/total from the TOC's own order rather
-                // than trusting the glue's numbers verbatim — see
-                // `signals::resolve_chapter_position` (issue #1909, AC1).
-                let toc_snapshot = toc.peek().clone();
-                let previous_chapter = loc.peek().chapter;
-                let (chapter, total_chapters) =
-                    resolve_chapter_position(&toc_snapshot, &data, previous_chapter);
-                data.chapter = chapter;
-                data.total_chapters = total_chapters;
-
-                // Echo emissions (restore settle, locations re-emit) re-state
-                // a position the server already holds — persisting one stamps
-                // a fresh clock on an unmoved position and shadows a newer
-                // audiobook spot at the cross-format clock gate. Same rule as
-                // the web interop; render, don't write. `last_cfi` tracks the
-                // last SEEN position (echoes included), so a later non-echo
-                // re-emit of the same CFI (a re-render) stays deduped rather
-                // than re-posting the unmoved position.
-                if let Some(cfi) = data.cfi.clone() {
-                    let moved = last_cfi.as_deref() != Some(cfi.as_str());
-                    last_cfi = Some(cfi.clone());
-                    if !data.echo && moved {
-                        crate::reader_progress::save(&uuid, &cfi);
-                        persist_progress(&uuid, &server_url, cfi, data.pct);
-                    }
-                }
-                // A relocate names the (corrected) current position, so it
-                // also signals that an in-flight chapter jump has finished
-                // rendering — flip a TOC-jump-triggered `Loading` back to
-                // `Ready` (issue #1909, AC3). Guarded so a stray relocate
-                // after a load `Failed` can't resurrect the overlay.
-                if *status.peek() == ReaderStatus::Loading {
-                    status.set(ReaderStatus::Ready);
-                }
-                loc.set(data);
-            }
-        }
+        ReaderEvent::Relocate { json } => handle_relocate(
+            &json,
+            &uuid,
+            &server_url,
+            &mut status,
+            &mut loc,
+            toc,
+            &mut last_cfi,
+        ),
         ReaderEvent::Status { state } => {
-            let st = match state.as_str() {
-                "ready" => ReaderStatus::Ready,
-                "error" => ReaderStatus::Failed,
-                _ => ReaderStatus::Loading,
-            };
-            status.set(st);
-            // Replay saved highlights into the freshly-mounted rendition.
-            if matches!(st, ReaderStatus::Ready) && highlights.peek().is_empty() {
-                for h in &saved_highlights {
-                    // Kobo-origin highlights carry no CFI — nothing to paint.
-                    if let Some(cfi) = &h.epub_cfi_range {
-                        reader_call_json2("addAnnotation", cfi, h.color.as_str());
-                    }
-                }
-                highlights.set(saved_highlights.clone());
-            }
+            handle_status(&state, &mut status, &mut highlights, &saved_highlights)
         }
         ReaderEvent::Selection { json } => {
             if let Ok(data) = serde_json::from_str::<SelectionData>(&json) {
@@ -319,6 +274,84 @@ async fn drain_reader_events(
         ReaderEvent::ToggleChrome => chrome_hidden.toggle(),
     })
     .await;
+}
+
+/// Handle a [`ReaderEvent::Relocate`]: re-derive chapter/total from the TOC,
+/// persist a genuinely-moved non-echo position, and clear a TOC-jump
+/// `Loading` overlay. Split out of [`drain_reader_events`] as its own stage
+/// since it carries the bulk of that loop's logic.
+fn handle_relocate(
+    json: &str,
+    uuid: &str,
+    server_url: &str,
+    status: &mut Signal<ReaderStatus>,
+    loc: &mut Signal<RelocateData>,
+    toc: Signal<Vec<TocEntry>>,
+    last_cfi: &mut Option<String>,
+) {
+    let Ok(mut data) = serde_json::from_str::<RelocateData>(json) else {
+        return;
+    };
+    // Re-derive chapter/total from the TOC's own order rather than trusting
+    // the glue's numbers verbatim — see `signals::resolve_chapter_position`
+    // (issue #1909, AC1).
+    let toc_snapshot = toc.peek().clone();
+    let previous_chapter = loc.peek().chapter;
+    let (chapter, total_chapters) =
+        resolve_chapter_position(&toc_snapshot, &data, previous_chapter);
+    data.chapter = chapter;
+    data.total_chapters = total_chapters;
+
+    // Echo emissions (restore settle, locations re-emit) re-state a position
+    // the server already holds — persisting one stamps a fresh clock on an
+    // unmoved position and shadows a newer audiobook spot at the
+    // cross-format clock gate. Same rule as the web interop; render, don't
+    // write. `last_cfi` tracks the last SEEN position (echoes included), so
+    // a later non-echo re-emit of the same CFI (a re-render) stays deduped
+    // rather than re-posting the unmoved position.
+    if let Some(cfi) = data.cfi.clone() {
+        let moved = last_cfi.as_deref() != Some(cfi.as_str());
+        *last_cfi = Some(cfi.clone());
+        if !data.echo && moved {
+            crate::reader_progress::save(uuid, &cfi);
+            persist_progress(uuid, server_url, cfi, data.pct);
+        }
+    }
+    // A relocate names the (corrected) current position, so it also signals
+    // that an in-flight chapter jump has finished rendering — flip a
+    // TOC-jump-triggered `Loading` back to `Ready` (issue #1909, AC3).
+    // Guarded so a stray relocate after a load `Failed` can't resurrect the
+    // overlay.
+    if *status.peek() == ReaderStatus::Loading {
+        status.set(ReaderStatus::Ready);
+    }
+    loc.set(data);
+}
+
+/// Handle a [`ReaderEvent::Status`]: update the reader status and, on the
+/// first `ready`, replay the saved highlights into the freshly-mounted
+/// rendition.
+fn handle_status(
+    state: &str,
+    status: &mut Signal<ReaderStatus>,
+    highlights: &mut Signal<Vec<Highlight>>,
+    saved_highlights: &[Highlight],
+) {
+    let st = match state {
+        "ready" => ReaderStatus::Ready,
+        "error" => ReaderStatus::Failed,
+        _ => ReaderStatus::Loading,
+    };
+    status.set(st);
+    if matches!(st, ReaderStatus::Ready) && highlights.peek().is_empty() {
+        for h in saved_highlights {
+            // Kobo-origin highlights carry no CFI — nothing to paint.
+            if let Some(cfi) = &h.epub_cfi_range {
+                reader_call_json2("addAnnotation", cfi, h.color.as_str());
+            }
+        }
+        highlights.set(saved_highlights.to_vec());
+    }
 }
 
 /// Persist the latest CFI to the server (fire-and-forget); the local in-memory

--- a/frontend/src/pages/reader/mobile.rs
+++ b/frontend/src/pages/reader/mobile.rs
@@ -278,8 +278,7 @@ async fn drain_reader_events(
 
 /// Handle a [`ReaderEvent::Relocate`]: re-derive chapter/total from the TOC,
 /// persist a genuinely-moved non-echo position, and clear a TOC-jump
-/// `Loading` overlay. Split out of [`drain_reader_events`] as its own stage
-/// since it carries the bulk of that loop's logic.
+/// `Loading` overlay.
 fn handle_relocate(
     json: &str,
     uuid: &str,


### PR DESCRIPTION
## Summary
- Closes #2042
- Pure internal refactor, no behavior change: extracts named helper functions (`db/src/worker/`-style small `impl`/free functions) from the 6 functions the tech-debt audit flagged as exceeding the ~80-line soft cap in `.claude/rules/05-rust-style.md`.
- All 6 primary candidates were touched:
  1. `frontend/src/pages/reader/mobile.rs` — `drain_reader_events` (110 → 65 lines): split the `Relocate` and `Status` event-match arms into `handle_relocate` / `handle_status`.
  2. `db/src/cross_format/anchors.rs` — `anchor_map_from_marks` (85 → 40 lines): split into the 5 staged helpers suggested by the issue (`compute_spine_char_totals`, `build_text_marks`, `try_match_rungs`, `positional_fallback`), reusing the existing `usable_audio_mark_count` helper for stage 3 instead of duplicating it.
  3. `frontend/src/components/alignment_modal/lanes.rs` — `render_lanes` (169 → 55 lines): the function has no hooks at all (plain `fn -> Element`, not a `#[component]`), so splitting the rsx tree into named sub-tree builders (`render_text_lane`, `render_connector`, `render_audio_lane`, `render_position_chip_row`, `render_delta_note`) called inline via `{helper(...)}` carries none of the hydration/hook-order risk rule 07 warns about — this mirrors the existing `render_series_body` pattern in `pages/series_index.rs`.
  4. `db/src/sync/books/removed.rs` — `sync_removed` (89 → 32 lines): split the per-chunk body into `resolve_removed_book_ids`, `delete_removed_book_files`, `flag_books_missing`.
  5. `db/src/epub_rewrite/mod.rs` — `rewrite_all_epubs_with_progress` (83 → 28 lines): introduced a `RewriteContext` struct (bulk-loaded id/source-path/last-modified/metadata maps) with `progress_label`/`rewrite_one` methods, plus a `load_rewrite_context` constructor.
  6. `db/src/kobo.rs` — `reading_state_for` (84 → 17 lines): split into `reading_state_sql` (query text), `fetch_reading_state_chunk` (bind + execute), `row_to_kobo_state` (row → `(uuid, state)` parsing).
- Also addressed the lower-confidence secondary candidate: `frontend/src/pages/listen/mobile/host.rs` — `load_and_drain` (83 → 72 lines). A clean split existed after all: the ~8-line signal-reset block at the top has no control flow of its own, so it was pulled into `reset_playback_state_for_load`, bringing the function under the cap without fragmenting the metadata/manifest-load/dispatch logic the audit called "mostly delegation already".
- No public signatures changed; every extracted helper is a private/`pub(super)` function near the code it supports, per the `db/src/worker/` precedent cited in the issue.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — 0 warnings
- [x] `cargo clippy -p omnibus-frontend --all-targets --features server -- -D warnings` — 0 warnings
- [x] `cargo test -p omnibus-db` — 2291 passed, 1 failed; the 1 failure (`audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`) is a pre-existing environmental gap unrelated to this change — it panics because the `test_data/audiobooks/public_domain/` fixture set (a GitHub release asset normally fetched by `just fixtures`) isn't present in this sandbox, which has no `just`/`nix`. None of the 6 refactored functions live in or near `db/src/audiobook/cover.rs`.
- [x] `cargo test -p omnibus-frontend --features server` — 869 passed, 0 failed

## Notes
- All 6 line-cited functions from the issue were still over the cap at the time of this change (no drift); each was verified by re-reading the file before editing.
- Every extracted function is unit-covered transitively through the existing `tests.rs` suites for these modules (`db/src/cross_format/tests.rs`, `db/src/sync/books/tests.rs`, `db/src/epub_rewrite/tests.rs`, `db/src/kobo/tests.rs`), since the public entry points and their behavior are unchanged — no new test cases were added, per the task's "pure refactor" framing and rule 03's guidance to test transitively where a wrapper composes existing calls without new branching.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Ft42YbbrQg87eZpbW1brc)_