### PR TITLE
refactor: give non-DB failures dedicated error variants instead of synthetic sqlx::Error (#2052)

### DIFF
--- a/db/src/annotations/mod.rs
+++ b/db/src/annotations/mod.rs
@@ -41,6 +41,7 @@ impl From<crate::books::BooksError> for HighlightError {
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/bookmarks/mod.rs
+++ b/db/src/bookmarks/mod.rs
@@ -30,6 +30,7 @@ impl From<crate::books::BooksError> for BookmarkError {
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/books.rs
+++ b/db/src/books.rs
@@ -44,6 +44,12 @@ pub enum BooksError {
     /// Corrupt JSON in the `metadata_overrides` blob.
     #[error("overrides deserialization failed: {0}")]
     OverridesJson(serde_json::Error),
+    /// A non-database failure surfaced from a dependency of these reads.
+    /// Coarse and message-carrying: no caller branches on the source, and
+    /// folding it into `Db` would make that variant mean "a database error
+    /// occurred" only most of the time.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<crate::metadata_overrides::MetadataOverridesError> for BooksError {
@@ -65,7 +71,7 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for BooksError {
             other @ (crate::metadata_overrides::MetadataOverridesError::BookNotFound(_)
             | crate::metadata_overrides::MetadataOverridesError::TooManyValues {
                 ..
-            }) => BooksError::Db(sqlx::Error::Protocol(other.to_string())),
+            }) => BooksError::Other(other.to_string()),
         }
     }
 }

--- a/db/src/books/tests/overrides.rs
+++ b/db/src/books/tests/overrides.rs
@@ -499,3 +499,26 @@ fn books_error_maps_overrides_serialization_to_overrides_json_variant() {
         "got {err}"
     );
 }
+
+#[test]
+fn books_error_from_metadata_overrides_error_returns_other_for_bulk_write_variants() {
+    let not_found = BooksError::from(
+        crate::metadata_overrides::MetadataOverridesError::BookNotFound("abc".into()),
+    );
+    assert!(
+        matches!(&not_found, BooksError::Other(msg) if msg.contains("abc")),
+        "expected Other carrying the source message, got {not_found:?}"
+    );
+
+    let too_many = BooksError::from(
+        crate::metadata_overrides::MetadataOverridesError::TooManyValues {
+            uuid: "abc".into(),
+            field: "tag",
+            max: 3,
+        },
+    );
+    assert!(
+        matches!(&too_many, BooksError::Other(msg) if msg.contains("tag")),
+        "expected Other carrying the source message, got {too_many:?}"
+    );
+}

--- a/db/src/cross_format.rs
+++ b/db/src/cross_format.rs
@@ -47,10 +47,14 @@ impl From<crate::books::BooksError> for CrossFormatError {
     fn from(e: crate::books::BooksError) -> Self {
         match e {
             crate::books::BooksError::Db(inner) => CrossFormatError::Sqlx(inner),
-            // This module never decodes overrides JSON; fold the variant
-            // rather than panic so a future caller can't slip through.
+            // This module never reads overrides, so neither the decode nor
+            // the fold-through variant is reachable here; fold them rather
+            // than panic so a future caller can't slip through.
             crate::books::BooksError::OverridesJson(inner) => {
                 CrossFormatError::Sqlx(sqlx::Error::Decode(Box::new(inner)))
+            }
+            crate::books::BooksError::Other(msg) => {
+                CrossFormatError::Sqlx(sqlx::Error::Decode(msg.into()))
             }
         }
     }

--- a/db/src/discovery/mod.rs
+++ b/db/src/discovery/mod.rs
@@ -27,6 +27,12 @@ pub use tags::get_tag_cloud;
 pub enum DiscoveryError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    /// A non-database failure surfaced from a dependency of these reads.
+    /// Coarse and message-carrying: no caller branches on the source, and
+    /// folding it into `Db` would make that variant mean "a database error
+    /// occurred" only most of the time.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<crate::metadata_overrides::MetadataOverridesError> for DiscoveryError {
@@ -47,7 +53,7 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for DiscoveryError 
             other @ (crate::metadata_overrides::MetadataOverridesError::BookNotFound(_)
             | crate::metadata_overrides::MetadataOverridesError::TooManyValues {
                 ..
-            }) => DiscoveryError::Db(sqlx::Error::Protocol(other.to_string())),
+            }) => DiscoveryError::Other(other.to_string()),
         }
     }
 }

--- a/db/src/discovery/tests.rs
+++ b/db/src/discovery/tests.rs
@@ -1243,3 +1243,14 @@ async fn get_genre_cloud_propagates_db_error_when_pool_is_closed() {
     let err = get_genre_cloud(&pool).await.unwrap_err();
     assert!(matches!(err, DiscoveryError::Db(_)));
 }
+
+#[test]
+fn discovery_error_from_metadata_overrides_error_returns_other_for_bulk_write_variants() {
+    let err = DiscoveryError::from(
+        crate::metadata_overrides::MetadataOverridesError::BookNotFound("abc".into()),
+    );
+    assert!(
+        matches!(&err, DiscoveryError::Other(msg) if msg.contains("abc")),
+        "expected Other carrying the source message, got {err:?}"
+    );
+}

--- a/db/src/indexer/mod.rs
+++ b/db/src/indexer/mod.rs
@@ -36,6 +36,12 @@ pub use progress::{ScanUpdate, PHASE_PARSING, PHASE_SYNCING, PHASE_WALKING};
 pub enum IndexerError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    /// A non-database failure surfaced from a dependency of these reads.
+    /// Coarse and message-carrying: no caller branches on which dependency
+    /// it came from, and folding it into `Db` would make that variant mean
+    /// "a database error occurred" only most of the time.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<crate::settings::SettingsError> for IndexerError {
@@ -44,14 +50,13 @@ impl From<crate::settings::SettingsError> for IndexerError {
             crate::settings::SettingsError::Db(inner) => IndexerError::Db(inner),
             // `Validation`/`Json` are only produced by `set_hardcover_api_key`
             // and the F5.1 metadata-precedence writes, which no indexer path
-            // calls — keep the arms exhaustive but do not widen
-            // `IndexerError`'s surface for cases the caller graph can't reach.
-            crate::settings::SettingsError::Validation(msg) => IndexerError::Db(
-                sqlx::Error::Protocol(format!("unexpected settings validation error: {msg}")),
-            ),
-            crate::settings::SettingsError::Json(inner) => IndexerError::Db(sqlx::Error::Protocol(
-                format!("unexpected settings JSON error: {inner}"),
-            )),
+            // calls.
+            crate::settings::SettingsError::Validation(msg) => {
+                IndexerError::Other(format!("unexpected settings validation error: {msg}"))
+            }
+            crate::settings::SettingsError::Json(inner) => {
+                IndexerError::Other(format!("unexpected settings JSON error: {inner}"))
+            }
         }
     }
 }

--- a/db/src/indexer/tests/mod.rs
+++ b/db/src/indexer/tests/mod.rs
@@ -97,3 +97,20 @@ async fn seed_ebook_at(pool: &SqlitePool, library_path: &str, filename: &str, ti
     .await
     .unwrap();
 }
+
+#[test]
+fn indexer_error_from_settings_error_returns_other_for_non_db_variants() {
+    let validation =
+        IndexerError::from(crate::settings::SettingsError::Validation("bad key".into()));
+    assert!(
+        matches!(&validation, IndexerError::Other(msg) if msg.contains("bad key")),
+        "expected Other carrying the validation message, got {validation:?}"
+    );
+
+    let json_err = serde_json::from_str::<i32>("nope").unwrap_err();
+    let json = IndexerError::from(crate::settings::SettingsError::Json(json_err));
+    assert!(
+        matches!(json, IndexerError::Other(_)),
+        "expected Other, got {json:?}"
+    );
+}

--- a/db/src/journals/mod.rs
+++ b/db/src/journals/mod.rs
@@ -52,12 +52,13 @@ impl From<crate::books::BooksError> for JournalError {
         match e {
             crate::books::BooksError::Db(inner) => Self::Sqlx(inner),
             // `resolve_canonical_book_uuid` is the only `BooksError`-returning
-            // call this module makes and it never decodes JSON, so the
-            // `OverridesJson` variant is unreachable here — fold it into a
-            // decode error rather than panicking (mirrors `ratings`).
+            // call this module makes and it never reads overrides, so neither
+            // remaining variant is reachable here — fold them into a decode
+            // error rather than panicking (mirrors `ratings`).
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/kobo.rs
+++ b/db/src/kobo.rs
@@ -77,6 +77,11 @@ pub enum KoboError {
     /// log instead of being disguised as a protocol error.
     #[error("shelf membership lookup failed: {0}")]
     Shelf(String),
+    /// A non-database failure surfaced from another data-layer module, for
+    /// the same reason [`Self::Shelf`] exists: the real cause survives into
+    /// the log instead of being disguised as a `Sqlx` error.
+    #[error("{0}")]
+    Other(String),
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
 }
@@ -94,12 +99,13 @@ impl From<crate::books::BooksError> for KoboError {
     fn from(e: crate::books::BooksError) -> Self {
         match e {
             crate::books::BooksError::Db(inner) => Self::Sqlx(inner),
-            // `resolve_canonical_book_uuid` never decodes overrides JSON, so
-            // this arm is unreachable in practice; fold it into a decode error
-            // rather than panicking, mirroring `ratings`/`read_status`.
+            // `resolve_canonical_book_uuid` never reads overrides, so these
+            // arms are unreachable in practice; fold them rather than
+            // panicking, mirroring `ratings`/`read_status`.
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Other(msg),
         }
     }
 }
@@ -120,7 +126,7 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for KoboError {
             other @ (crate::metadata_overrides::MetadataOverridesError::BookNotFound(_)
             | crate::metadata_overrides::MetadataOverridesError::TooManyValues {
                 ..
-            }) => Self::Sqlx(sqlx::Error::Protocol(other.to_string())),
+            }) => Self::Other(other.to_string()),
         }
     }
 }

--- a/db/src/kobo/tests.rs
+++ b/db/src/kobo/tests.rs
@@ -635,3 +635,14 @@ async fn reading_state_for_returns_empty_for_no_uuids() {
         .unwrap()
         .is_empty());
 }
+
+#[test]
+fn kobo_error_from_metadata_overrides_error_returns_other_for_bulk_write_variants() {
+    let err = KoboError::from(
+        crate::metadata_overrides::MetadataOverridesError::BookNotFound("abc".into()),
+    );
+    assert!(
+        matches!(&err, KoboError::Other(msg) if msg.contains("abc")),
+        "expected Other carrying the source message, got {err:?}"
+    );
+}

--- a/db/src/merge/mod.rs
+++ b/db/src/merge/mod.rs
@@ -32,6 +32,11 @@ pub enum MergeError {
     Snapshot(#[from] serde_json::Error),
     #[error(transparent)]
     Physical(#[from] crate::physical::PhysicalError),
+    /// A non-database failure surfaced from a dependency of the merge/undo
+    /// path. Coarse and message-carrying: the UI treats it as an opaque
+    /// internal failure, so no caller branches on the source.
+    #[error("{0}")]
+    Other(String),
 }
 
 /// What [`merge_books`] hands back to the caller: the audit-log id (the

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -990,3 +990,20 @@ async fn merge_books_promotes_a_physical_root_target_that_gains_files() {
         "merge must promote off the pseudo-root"
     );
 }
+
+#[test]
+fn map_settings_error_returns_other_for_non_db_variants() {
+    let validation =
+        super::undo::map_settings_error(crate::settings::SettingsError::Validation("bad".into()));
+    assert!(
+        matches!(&validation, MergeError::Other(msg) if msg.contains("bad")),
+        "expected Other carrying the validation message, got {validation:?}"
+    );
+
+    let json_err = serde_json::from_str::<i32>("nope").unwrap_err();
+    let json = super::undo::map_settings_error(crate::settings::SettingsError::Json(json_err));
+    assert!(
+        matches!(json, MergeError::Other(_)),
+        "expected Other, got {json:?}"
+    );
+}

--- a/db/src/merge/undo.rs
+++ b/db/src/merge/undo.rs
@@ -123,6 +123,22 @@ async fn rebuild_target_fts_best_effort(
     Ok(())
 }
 
+/// Fold a `settings::SettingsError` from [`upsert_library`] into `MergeError`.
+/// `upsert_library` only ever emits `Db`; `Validation`/`Json` exist on
+/// `SettingsError` for `set_hardcover_api_key` / the F5.1 metadata-precedence
+/// JSON column, so they collapse defensively onto `Other`.
+pub(super) fn map_settings_error(e: crate::settings::SettingsError) -> MergeError {
+    match e {
+        crate::settings::SettingsError::Db(inner) => MergeError::Db(inner),
+        crate::settings::SettingsError::Validation(msg) => {
+            MergeError::Other(format!("unexpected settings validation error: {msg}"))
+        }
+        crate::settings::SettingsError::Json(inner) => {
+            MergeError::Other(format!("unexpected settings JSON error: {inner}"))
+        }
+    }
+}
+
 /// Recreate the source `books` row from the snapshot. The original uuid
 /// is free to reuse — the `merged_uuids` guard kept reindexes from
 /// resurrecting it. `scan_key` is restored too so the next reindex matches
@@ -133,19 +149,7 @@ async fn recreate_source_row(
 ) -> Result<i64, MergeError> {
     let library_id = upsert_library(tx, &snap.library_path)
         .await
-        .map_err(|e| match e {
-            crate::settings::SettingsError::Db(inner) => MergeError::Db(inner),
-            // `upsert_library` never returns `Validation`/`Json` — those arms
-            // exist only to keep the match exhaustive after `SettingsError`
-            // grew variants for `set_hardcover_api_key` / the F5.1 metadata
-            // precedence JSON column.
-            crate::settings::SettingsError::Validation(msg) => MergeError::Db(
-                sqlx::Error::Protocol(format!("unexpected settings validation error: {msg}")),
-            ),
-            crate::settings::SettingsError::Json(inner) => MergeError::Db(sqlx::Error::Protocol(
-                format!("unexpected settings JSON error: {inner}"),
-            )),
-        })?;
+        .map_err(map_settings_error)?;
     // `timestamp` is restored from the snapshot, falling back to now when a
     // pre-0038 snapshot's timestamp couldn't be parsed to an epoch
     // (`de_epoch_flexible` -> None) — the `books` column is nullable since the

--- a/db/src/metadata_overrides/upsert/mod.rs
+++ b/db/src/metadata_overrides/upsert/mod.rs
@@ -55,6 +55,11 @@ impl From<crate::books::BooksError> for MetadataOverridesError {
             crate::books::BooksError::OverridesJson(inner) => {
                 MetadataOverridesError::Serialization(inner)
             }
+            // A `BooksError` this module can receive never carries one: the
+            // variant exists for the overrides *read* path's fold-through.
+            crate::books::BooksError::Other(msg) => {
+                MetadataOverridesError::Db(sqlx::Error::Decode(msg.into()))
+            }
         }
     }
 }

--- a/db/src/palette/mod.rs
+++ b/db/src/palette/mod.rs
@@ -41,6 +41,12 @@ use tags::{count_tags, search_tags};
 pub enum PaletteError {
     #[error(transparent)]
     Db(#[from] sqlx::Error),
+    /// A non-database failure surfaced from a dependency of these reads.
+    /// Coarse and message-carrying: no caller branches on the source, and
+    /// folding it into `Db` would make that variant mean "a database error
+    /// occurred" only most of the time.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<crate::metadata_overrides::MetadataOverridesError> for PaletteError {
@@ -59,7 +65,7 @@ impl From<crate::metadata_overrides::MetadataOverridesError> for PaletteError {
             other @ (crate::metadata_overrides::MetadataOverridesError::BookNotFound(_)
             | crate::metadata_overrides::MetadataOverridesError::TooManyValues {
                 ..
-            }) => PaletteError::Db(sqlx::Error::Protocol(other.to_string())),
+            }) => PaletteError::Other(other.to_string()),
         }
     }
 }

--- a/db/src/palette/tests.rs
+++ b/db/src/palette/tests.rs
@@ -1939,3 +1939,14 @@ async fn search_palette_hides_a_wishlist_only_book_in_every_arm() {
     assert!(results.series.is_empty(), "series arm: {results:?}");
     assert!(results.tags.is_empty(), "tags arm: {results:?}");
 }
+
+#[test]
+fn palette_error_from_metadata_overrides_error_returns_other_for_bulk_write_variants() {
+    let err = PaletteError::from(
+        crate::metadata_overrides::MetadataOverridesError::BookNotFound("abc".into()),
+    );
+    assert!(
+        matches!(&err, PaletteError::Other(msg) if msg.contains("abc")),
+        "expected Other carrying the source message, got {err:?}"
+    );
+}

--- a/db/src/physical/mod.rs
+++ b/db/src/physical/mod.rs
@@ -54,4 +54,10 @@ pub enum PhysicalError {
     /// A database error not covered by a more specific variant above.
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+    /// A non-database failure surfaced from a dependency of these writes.
+    /// Coarse and message-carrying: callers render it as an opaque internal
+    /// failure, so folding it into `Sqlx` would only make that variant mean
+    /// "a database error occurred" less than always.
+    #[error("{0}")]
+    Other(String),
 }

--- a/db/src/physical/remove.rs
+++ b/db/src/physical/remove.rs
@@ -64,12 +64,12 @@ pub async fn delete_fileless_book(pool: &SqlitePool, book_uuid: &str) -> Result<
 
 /// Fold a `deletion::DeleteError` from the shared purge into `PhysicalError`.
 /// `purge_book` only ever emits `Sqlx` here (the book is already resolved and
-/// fileless), so the other variants collapse defensively onto `Sqlx`.
-fn map_delete_error(e: crate::deletion::DeleteError) -> PhysicalError {
+/// fileless), so the remaining variants collapse defensively onto `Other`.
+pub(super) fn map_delete_error(e: crate::deletion::DeleteError) -> PhysicalError {
     match e {
         crate::deletion::DeleteError::Sqlx(inner) => PhysicalError::Sqlx(inner),
         crate::deletion::DeleteError::Physical(inner) => inner,
         crate::deletion::DeleteError::Books(inner) => PhysicalError::Books(inner),
-        other => PhysicalError::Sqlx(sqlx::Error::Protocol(other.to_string())),
+        other => PhysicalError::Other(other.to_string()),
     }
 }

--- a/db/src/physical/tests/remove.rs
+++ b/db/src/physical/tests/remove.rs
@@ -77,3 +77,13 @@ async fn delete_fileless_book_returns_book_not_found_for_unknown_uuid() {
     let err = delete_fileless_book(&pool, "nope").await.unwrap_err();
     assert!(matches!(err, PhysicalError::BookNotFound));
 }
+
+#[test]
+fn map_delete_error_returns_other_for_non_db_variants() {
+    let err =
+        crate::physical::remove::map_delete_error(crate::deletion::DeleteError::FileNotFound(7));
+    assert!(
+        matches!(&err, PhysicalError::Other(msg) if msg.contains('7')),
+        "expected Other carrying the source message, got {err:?}"
+    );
+}

--- a/db/src/progress.rs
+++ b/db/src/progress.rs
@@ -49,12 +49,15 @@ impl From<crate::books::BooksError> for ProgressError {
         match e {
             crate::books::BooksError::Db(inner) => ProgressError::Sqlx(inner),
             // `resolve_book_id_by_uuid` is the only `BooksError`-returning
-            // call this module makes, and it never decodes JSON, so the
-            // `OverridesJson` variant is unreachable here in practice. Fold
-            // it into a generic decode error rather than panicking so a
-            // future caller can't introduce an unhandled path silently.
+            // call this module makes, and it never reads overrides, so neither
+            // remaining variant is reachable here in practice. Fold them into a
+            // generic decode error rather than panicking so a future caller
+            // can't introduce an unhandled path silently.
             crate::books::BooksError::OverridesJson(inner) => {
                 ProgressError::Sqlx(sqlx::Error::Decode(Box::new(inner)))
+            }
+            crate::books::BooksError::Other(msg) => {
+                ProgressError::Sqlx(sqlx::Error::Decode(msg.into()))
             }
         }
     }

--- a/db/src/ratings/mod.rs
+++ b/db/src/ratings/mod.rs
@@ -28,12 +28,13 @@ impl From<crate::books::BooksError> for RatingError {
         match e {
             crate::books::BooksError::Db(inner) => Self::Sqlx(inner),
             // `resolve_canonical_book_uuid` is the only `BooksError`-returning
-            // call this module makes and it never decodes JSON, so the
-            // `OverridesJson` variant is unreachable here. Fold it into a
-            // decode error rather than panicking, mirroring `progress`.
+            // call this module makes and it never reads overrides, so neither
+            // remaining variant is reachable here. Fold them into a decode
+            // error rather than panicking, mirroring `progress`.
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/read_status/mod.rs
+++ b/db/src/read_status/mod.rs
@@ -22,12 +22,13 @@ impl From<crate::books::BooksError> for ReadStatusError {
         match e {
             crate::books::BooksError::Db(inner) => Self::Sqlx(inner),
             // `resolve_canonical_book_uuid` is the only `BooksError`-returning
-            // call this module makes and it never decodes JSON, so the
-            // `OverridesJson` variant is unreachable here. Fold it into a decode
+            // call this module makes and it never reads overrides, so neither
+            // remaining variant is reachable here. Fold them into a decode
             // error rather than panicking, mirroring `ratings`/`progress`.
             crate::books::BooksError::OverridesJson(inner) => {
                 Self::Sqlx(sqlx::Error::Decode(Box::new(inner)))
             }
+            crate::books::BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/shelves.rs
+++ b/db/src/shelves.rs
@@ -49,8 +49,9 @@ impl From<BooksError> for ShelfError {
         match e {
             BooksError::Db(inner) => Self::Sqlx(inner),
             // The only `BooksError`-returning call here is the uuid resolver,
-            // which never decodes overrides JSON — fold defensively.
+            // which never reads overrides — fold defensively.
             BooksError::OverridesJson(inner) => Self::Sqlx(sqlx::Error::Decode(Box::new(inner))),
+            BooksError::Other(msg) => Self::Sqlx(sqlx::Error::Decode(msg.into())),
         }
     }
 }

--- a/db/src/stats/mod.rs
+++ b/db/src/stats/mod.rs
@@ -47,12 +47,15 @@ impl From<crate::books::BooksError> for StatsError {
         match e {
             crate::books::BooksError::Db(inner) => StatsError::Sqlx(inner),
             // `resolve_canonical_book_uuid` (the only `BooksError`-returning
-            // call this module makes) never decodes JSON, so this variant is
-            // unreachable here in practice — folded into a generic decode
+            // call this module makes) never reads overrides, so these variants
+            // are unreachable here in practice — folded into a generic decode
             // error rather than panicking, mirroring `db::progress`'s same
             // mapping.
             crate::books::BooksError::OverridesJson(inner) => {
                 StatsError::Sqlx(sqlx::Error::Decode(Box::new(inner)))
+            }
+            crate::books::BooksError::Other(msg) => {
+                StatsError::Sqlx(sqlx::Error::Decode(msg.into()))
             }
         }
     }

--- a/db/src/sync/books/mod.rs
+++ b/db/src/sync/books/mod.rs
@@ -46,6 +46,11 @@ pub(crate) enum SyncError {
     Db(#[from] sqlx::Error),
     #[error(transparent)]
     Physical(#[from] crate::physical::PhysicalError),
+    /// A non-database failure surfaced from a dependency of the sync
+    /// helpers. Coarse and message-carrying: no caller branches on which
+    /// dependency it came from.
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<crate::settings::SettingsError> for SyncError {
@@ -54,14 +59,13 @@ impl From<crate::settings::SettingsError> for SyncError {
             crate::settings::SettingsError::Db(inner) => SyncError::Db(inner),
             // `Validation`/`Json` are only produced by `set_hardcover_api_key`
             // and the F5.1 metadata-precedence writes, which no sync path
-            // calls — keep the arms exhaustive but do not widen
-            // `SyncError`'s surface for cases the caller graph can't reach.
-            crate::settings::SettingsError::Validation(msg) => SyncError::Db(
-                sqlx::Error::Protocol(format!("unexpected settings validation error: {msg}")),
-            ),
-            crate::settings::SettingsError::Json(inner) => SyncError::Db(sqlx::Error::Protocol(
-                format!("unexpected settings JSON error: {inner}"),
-            )),
+            // calls.
+            crate::settings::SettingsError::Validation(msg) => {
+                SyncError::Other(format!("unexpected settings validation error: {msg}"))
+            }
+            crate::settings::SettingsError::Json(inner) => {
+                SyncError::Other(format!("unexpected settings JSON error: {inner}"))
+            }
         }
     }
 }

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -10,7 +10,7 @@ use sqlx::SqlitePool;
 use super::shared::{insert_book_row, insert_metadata_links};
 use super::{
     collect_entity_alias_maps, sync_books, sync_changed, sync_new, sync_removed,
-    wipe_per_book_link_rows, EntityAliasMaps, SyncPlan,
+    wipe_per_book_link_rows, EntityAliasMaps, SyncError, SyncPlan,
 };
 use crate::cleanup::{apply_merge_authors, apply_merge_series, apply_merge_tags};
 use crate::ebook::IndexedBook;
@@ -2132,5 +2132,21 @@ async fn try_attach_new_ebook_promotes_a_wishlist_target_off_the_physical_root()
             .iter()
             .any(|x| x.unique_identifier.as_deref() == Some(wishlist_uuid.as_str())),
         "the promoted book must surface in the path-scoped listing"
+    );
+}
+
+#[test]
+fn sync_error_from_settings_error_returns_other_for_non_db_variants() {
+    let validation = SyncError::from(crate::settings::SettingsError::Validation("bad key".into()));
+    assert!(
+        matches!(&validation, SyncError::Other(msg) if msg.contains("bad key")),
+        "expected Other carrying the validation message, got {validation:?}"
+    );
+
+    let json_err = serde_json::from_str::<i32>("nope").unwrap_err();
+    let json = SyncError::from(crate::settings::SettingsError::Json(json_err));
+    assert!(
+        matches!(json, SyncError::Other(_)),
+        "expected Other, got {json:?}"
     );
 }


### PR DESCRIPTION
## Summary
- Takes the "add a dedicated variant" branch of #2052's acceptance criteria rather than the "document the idiom" branch: all 8 sites that built a `sqlx::Error::Protocol(string)` purely to fit a non-DB failure into a `Db`/`Sqlx` variant now return a coarse, message-carrying `Other(String)` on their own enum.
- `XError::Db` / `XError::Sqlx` once again strictly means "a database error occurred" on all 8 enums. The real cause survives into the log as itself instead of being disguised as a protocol error.
- Drops the per-site justification comments that only existed to explain the borrowed `Protocol` variant, and keeps the (still true) notes about which arms are unreachable in practice.
- Extracts the inline `map_err` closure in `merge/undo.rs::recreate_source_row` into a named `map_settings_error`, mirroring `physical/remove.rs::map_delete_error`, so both mappings are directly unit-testable.
- Adds one test per converted site (8 total) asserting the mapping yields `Other` and that the source message survives into it.
- No behavioural change: every converted site was already an error path, and the rendered message is the same or better.

Closes #2052

## Test plan
- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p omnibus-db --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus --all-targets -- -D warnings` — PASS
- [x] `cargo clippy -p omnibus-frontend --features server --all-targets -- -D warnings` — PASS
- [x] `cargo test -p omnibus-db` — PASS (2300 passed, 1 pre-existing failure, see Notes)
- [x] `cargo test -p omnibus` — PASS (874 passed, 2 pre-existing failures, see Notes)
- [x] All 8 new tests pass: `cargo test -p omnibus-db --lib returns_other_for` → 8 passed; plus `map_delete_error` and `map_settings_error` by name.

The three clippy runs are the load-bearing check for acceptance criterion 2 ("any caller that pattern-matches on the enum's `Db`/`Sqlx` variant is checked"). A new enum variant makes every exhaustive `match` non-exhaustive, so `-D warnings` across `db`, `server`, and `frontend --features server` mechanically surfaces every caller that matches on these enums. The only ones it found were inside `db` itself (table below) — no `server/` or `frontend/` caller matches on any of the 8 enums, so nothing outside the data layer was relying on the synthetic occurrences.

## Notes

### Per-enum changes

| Enum | New variant | Site(s) replaced | Callers updated, and why |
|---|---|---|---|
| `books::BooksError` | `Other(String)` | `books.rs:68` — `From<MetadataOverridesError>` | 11 `From<BooksError>` impls became non-exhaustive; see below |
| `discovery::DiscoveryError` | `Other(String)` | `discovery/mod.rs:50` | none |
| `indexer::IndexerError` | `Other(String)` | `indexer/mod.rs:50,52` — `From<SettingsError>` | none |
| `kobo::KoboError` | `Other(String)` | `kobo.rs:123` | its own `From<BooksError>` now forwards `BooksError::Other` → `KoboError::Other` (the one place the new variant threads straight through) |
| `merge::MergeError` | `Other(String)` | `merge/undo.rs:143,145` | none; the closure became `map_settings_error` (`pub(super)`) so it can be tested directly |
| `palette::PaletteError` | `Other(String)` | `palette/mod.rs:62` | none |
| `physical::PhysicalError` | `Other(String)` | `physical/remove.rs:73` | none; `map_delete_error` widened to `pub(super)` to match |
| `sync::books::SyncError` | `Other(String)` | `sync/books/mod.rs:60,62` — `From<SettingsError>` | none |

### Scope kept vs. deliberately not taken

**Kept (forced, not optional).** Adding `BooksError::Other` makes 11 exhaustive `From<BooksError> for …` impls fail to compile, so each needed a new arm: `annotations`, `bookmarks`, `cross_format`, `journals`, `kobo`, `metadata_overrides/upsert`, `progress`, `ratings`, `read_status`, `shelves`, `stats`. These are compiler-mandated, not scope creep — without them the branch does not build.

**Not taken (a judgement call worth a look).** In 10 of those 11, the new arm folds `BooksError::Other(msg)` into that enum's existing `Sqlx(sqlx::Error::Decode(msg))`, exactly matching the fold each of those files *already* applies to `BooksError::OverridesJson` — itself a non-DB (serde_json) error. That is technically the same family of smell this issue is about, so it is a conscious boundary rather than an oversight:

- The arms are unreachable in practice (each module's only `BooksError`-returning call is `resolve_canonical_book_uuid` / `resolve_book_id_by_uuid`, neither of which reads overrides), and the existing comments saying so were updated rather than removed.
- Giving those 10 enums their own `Other` would roughly triple the diff and pull in `HighlightError`, `BookmarkError`, `ProgressError`, `RatingError`, `ReadStatusError`, `ShelfError`, `StatsError`, `JournalError`, `CrossFormatError`, and `MetadataOverridesError` — none of which are named in #2052.

> [!NOTE]
> If you'd rather close the whole family in one go, the pre-existing `OverridesJson` → `Sqlx(Decode)` folds in those 10 modules are the natural follow-up ticket, and this PR's per-enum pattern is the template. Happy to extend it here instead if you prefer — say the word.

`kobo` is the exception: it already had a hand-rolled `Shelf(String)` variant for precisely this reason, so giving it `Other` and forwarding into it was clearly the intended shape there.

### Rebase note
The branch was started before ~15 PRs landed on `main`, including #2085/#2086/#2090/#2091, which split `db/src/{books,indexer,physical}/tests.rs` into `tests/` directories and added `Physical(#[from] PhysicalError)` to both `MergeError` and `SyncError`. The merge took `main`'s structure in every case and re-applied this branch's intent on top: the three new tests were ported into `books/tests/overrides.rs`, `indexer/tests/mod.rs`, and `physical/tests/remove.rs` respectively, and both enums carry `main`'s `Physical` variant alongside the new `Other`.

### Pre-existing failures (not caused by this PR, present on `main`)
- `backend::uploads::tests::commit_rejects_read_only_library_with_400`
- `backend::uploads::tests::audiobook_commit_rejects_read_only_library_with_400`
  — the test container runs as uid 0, so a `chmod`-read-only directory is still writable and the expected 400 never happens.
- `audiobook::cover::tests::extract_cover_returns_none_when_valid_audio_has_no_embedded_picture`
  — the public-domain fixtures are a release asset, not in git; `just fixtures` needs Nix, which this environment lacks.

No other test failed in either suite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmMuZvBbXPyLmMpmtLu3u)_