### PR TITLE
fix: give the iOS upload its inspect/confirm step so commits carry title and author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ recent releases are recorded below; everything earlier is available via the
   through the same correction (and echo tagging) a boot restore does, so it
   writes no position and never moves the restore anchor. Added an explicit
   single/two-page reader setting on iOS, matching web (#2081)
+- Uploading a book from the iOS app works. Every upload previously failed with
+  "title and author are required to file the book", because the app posted the
+  file straight to the commit endpoint and skipped the confirm step those
+  fields come from. It now reads the file's embedded metadata, shows it for you
+  to correct, and files the book under what you confirmed — and the file picker
+  offers only the formats the server accepts, so an upload can no longer be
+  rejected after transferring the whole file. Picking several MP3s adds one
+  audiobook with all its parts instead of one book per file (#2100)
 
 ## [0.22.10] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,11 +76,11 @@ recent releases are recorded below; everything earlier is available via the
   "title and author are required to file the book", because the app posted the
   file straight to the commit endpoint and skipped the confirm step those
   fields come from. It now reads the file's embedded metadata, shows it for you
-  to correct, and files the book under what you confirmed. The file picker now
-  offers only formats the server can take, so a wrong-format pick is caught
-  before anything is sent rather than after. Picking several MP3s from one
-  folder adds a single audiobook with all its parts, instead of one book per
-  file (#2100)
+  to correct, and files the book under what you confirmed. The file picker is
+  narrowed to the formats the server accepts, and anything else it still lets
+  through is refused before a byte is sent rather than after. Picking several
+  MP3s from one folder adds a single audiobook with all its parts, instead of
+  one book per file (#2100)
 
 ## [0.22.10] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,11 @@ recent releases are recorded below; everything earlier is available via the
   "title and author are required to file the book", because the app posted the
   file straight to the commit endpoint and skipped the confirm step those
   fields come from. It now reads the file's embedded metadata, shows it for you
-  to correct, and files the book under what you confirmed — and the file picker
-  offers only the formats the server accepts, so an upload can no longer be
-  rejected after transferring the whole file. Picking several MP3s adds one
-  audiobook with all its parts instead of one book per file (#2100)
+  to correct, and files the book under what you confirmed. The file picker now
+  offers only formats the server can take, so a wrong-format pick is caught
+  before anything is sent rather than after. Picking several MP3s from one
+  folder adds a single audiobook with all its parts, instead of one book per
+  file (#2100)
 
 ## [0.22.10] - 2026-08-18
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,12 +304,14 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       commit carries) and `UploadConfirmSheet` is the editable
                       confirm step the commit endpoints require
 Models/             — Codable mirrors of the `shared/` wire DTOs
-Networking/         — APIClient (plus a separate upload session: a
-                      whole-transfer budget, kept near the server's own 30s
-                      request timeout rather than far past it, and one that
-                      never claims the probe slot), MultipartBody (the
-                      form-data encoder, split out so a request's wire
-                      shape is unit-testable), keychain-backed TokenStore
+Networking/         — APIClient (plus a separate upload session, whose
+                      whole-transfer budget is sized for bytes rather than for
+                      server think time, and which neither claims the
+                      reachability probe slot nor is allowed to declare an
+                      outage — a transfer times out for reasons that say
+                      nothing about the server), MultipartBody (the form-data
+                      encoder, split out so a request's wire shape is
+                      unit-testable), keychain-backed TokenStore
 Offline/            — Cache (read-through policies), OfflineStore (SQLite
                       replica; `downloads.source_etag` snapshots the file's
                       content validator per rule 09), DownloadManager (which
@@ -338,7 +340,12 @@ Services/           — AuthService, LibraryService, UserDataService,
                       UploadService (the two-step book ingest: inspect a
                       picked file, then commit it under the confirmed
                       metadata — never queued, per rule 08 test 1:
-                      an upload is library-wide, not per-user, state)
+                      an upload is library-wide, not per-user, state),
+                      UploadManager (owns the queue, the staged copies and the
+                      transfers, because all three outlive the sheet that
+                      starts them: one worker, one cancellable handle, and a
+                      registry of live staging directories so the sweep cannot
+                      delete an upload still reading from one)
 ```
 
 **TestFlight release:** the manually-triggered

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,9 +304,10 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       commit carries) and `UploadConfirmSheet` is the editable
                       confirm step the commit endpoints require
 Models/             — Codable mirrors of the `shared/` wire DTOs
-Networking/         — APIClient (plus a separate upload session, whose
-                      resource timeout is a whole-transfer budget a
-                      large audiobook needs), MultipartBody (the
+Networking/         — APIClient (plus a separate upload session: a
+                      whole-transfer budget, kept near the server's own 30s
+                      request timeout rather than far past it, and one that
+                      never claims the probe slot), MultipartBody (the
                       form-data encoder, split out so a request's wire
                       shape is unit-testable), keychain-backed TokenStore
 Offline/            — Cache (read-through policies), OfflineStore (SQLite
@@ -336,7 +337,8 @@ Comic/              — the native CBZ pager: ComicReaderView (paged TabView +
 Services/           — AuthService, LibraryService, UserDataService,
                       UploadService (the two-step book ingest: inspect a
                       picked file, then commit it under the confirmed
-                      metadata — never queued, per rule 08 test 2)
+                      metadata — never queued, per rule 08 test 1:
+                      an upload is library-wide, not per-user, state)
 ```
 
 **TestFlight release:** the manually-triggered

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,9 +297,18 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       `WishlistSection` is the native twin of the web page's
                       rail tracking card (tracked-since line, store search,
                       remove): same never-queued contract, plus a confirmation
-                      the web button doesn't ask for
+                      the web button doesn't ask for. AddBooks mirrors the web
+                      `/add-books` two-step ingest — `UploadFlow` holds the
+                      testable request shaping (which endpoint a format targets,
+                      how a multi-file pick groups into commits, which fields a
+                      commit carries) and `UploadConfirmSheet` is the editable
+                      confirm step the commit endpoints require
 Models/             — Codable mirrors of the `shared/` wire DTOs
-Networking/         — APIClient, keychain-backed TokenStore
+Networking/         — APIClient (plus a separate upload session, whose
+                      resource timeout is a whole-transfer budget a
+                      large audiobook needs), MultipartBody (the
+                      form-data encoder, split out so a request's wire
+                      shape is unit-testable), keychain-backed TokenStore
 Offline/            — Cache (read-through policies), OfflineStore (SQLite
                       replica; `downloads.source_etag` snapshots the file's
                       content validator per rule 09), DownloadManager (which
@@ -324,7 +333,10 @@ Comic/              — the native CBZ pager: ComicReaderView (paged TabView +
                       reads online, ZIPFoundation over the downloaded archive
                       offline), ComicPosition (the `comic-page:N` anchor ↔
                       progress-record mapping shared with the web pager)
-Services/           — AuthService, LibraryService, UserDataService
+Services/           — AuthService, LibraryService, UserDataService,
+                      UploadService (the two-step book ingest: inspect a
+                      picked file, then commit it under the confirmed
+                      metadata — never queued, per rule 08 test 2)
 ```
 
 **TestFlight release:** the manually-triggered

--- a/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
@@ -1,9 +1,13 @@
 //  AddBooksSheet.swift
 //  Entry point for adding books: upload a file from this device, or check in a
 //  physical copy by scanning its barcode.
+//
+//  An upload is the server's two-step ingest — inspect the file for its
+//  embedded metadata, let the reader correct it, then commit — because the
+//  commit endpoints file the book into a folder named from the confirmed
+//  title and author and reject a body that carries neither.
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct AddBooksSheet: View {
     @Environment(\.palette) private var palette
@@ -13,6 +17,14 @@ struct AddBooksSheet: View {
     @State private var showFileImporter = false
     @State private var showCheckIn = false
     @State private var uploads: [UploadTask] = []
+    /// Inspected uploads waiting for their confirm sheet, shown one at a time
+    /// so a multi-file pick doesn't stack sheets.
+    @State private var pending: [UploadDraft] = []
+    @State private var activeDraft: UploadDraft?
+    /// Names the picker allowed through that neither endpoint accepts.
+    @State private var unsupported: [String] = []
+
+    private var isOnline: Bool { Connectivity.shared.isOnline }
 
     var body: some View {
         NavigationStack {
@@ -22,8 +34,15 @@ struct AddBooksSheet: View {
                         actionCard(
                             icon: "arrow.up.doc",
                             title: "Upload a file",
-                            subtitle: "Add an EPUB or audiobook from this device or iCloud Drive."
+                            subtitle: isOnline
+                                ? "Add an EPUB or audiobook from this device or iCloud Drive."
+                                : "Unavailable offline — uploads go straight to your library."
                         ) { showFileImporter = true }
+                        // An upload is a command against a shared library, so
+                        // it is never queued (rule 08) — the control stands
+                        // down instead of failing after the fact.
+                        .disabled(!isOnline)
+                        .opacity(isOnline ? 1 : 0.4)
                     }
 
                     actionCard(
@@ -32,18 +51,8 @@ struct AddBooksSheet: View {
                         subtitle: "Check in a physical copy you own on paper."
                     ) { showCheckIn = true }
 
-                    if !uploads.isEmpty {
-                        VStack(alignment: .leading, spacing: Spacing.sm) {
-                            Text("Uploads")
-                                .font(.ui(13, weight: .semibold))
-                                .foregroundStyle(palette.ink2Color)
-                            ForEach(uploads) { task in
-                                UploadRow(task: task)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, Spacing.md)
-                    }
+                    if !unsupported.isEmpty { unsupportedNotice }
+                    if !uploads.isEmpty { uploadList }
                 }
                 .screenPadding()
                 .padding(.top, Spacing.md)
@@ -59,20 +68,45 @@ struct AddBooksSheet: View {
         }
         .presentationDetents([.medium, .large])
         .sheet(isPresented: $showCheckIn) { CheckInView() }
+        .sheet(item: $activeDraft, onDismiss: presentNextDraft) { draft in
+            UploadConfirmSheet(
+                draft: draft,
+                onCommit: { commit(draft, as: $0) },
+                onCancel: { cancel(draft) }
+            )
+        }
         .fileImporter(
             isPresented: $showFileImporter,
-            allowedContentTypes: Self.acceptedTypes,
+            allowedContentTypes: UploadFlow.pickerTypes,
             allowsMultipleSelection: true
         ) { result in
             guard case let .success(urls) = result else { return }
-            for url in urls { upload(url) }
+            stage(urls)
         }
     }
 
-    private static var acceptedTypes: [UTType] {
-        var types: [UTType] = [.epub, .audio, .mpeg4Audio, .mp3, .data]
-        if let m4b = UTType(filenameExtension: "m4b") { types.append(m4b) }
-        return types
+    private var uploadList: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Uploads")
+                .font(.ui(13, weight: .semibold))
+                .foregroundStyle(palette.ink2Color)
+            ForEach(uploads) { task in
+                UploadRow(task: task)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Spacing.md)
+    }
+
+    private var unsupportedNotice: some View {
+        Text(
+            "Can't add \(unsupported.joined(separator: ", ")) — books must be an EPUB, "
+                + "and audiobooks an M4B, M4A, or MP3."
+        )
+        .font(.ui(12.5))
+        .foregroundStyle(palette.ink3Color)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, Spacing.sm)
     }
 
     private func actionCard(
@@ -114,56 +148,98 @@ struct AddBooksSheet: View {
         .buttonStyle(PressableStyle())
     }
 
-    private func upload(_ url: URL) {
-        let task = UploadTask(name: url.lastPathComponent)
+    // MARK: - Upload pipeline
+
+    /// Group the pick into one batch per book, then inspect each.
+    private func stage(_ urls: [URL]) {
+        let selection = UploadFlow.selection(for: urls)
+        unsupported = selection.unsupported
+        for batch in selection.batches { inspect(batch) }
+    }
+
+    private func inspect(_ batch: UploadBatch) {
+        let task = UploadTask(name: batch.displayName)
         uploads.append(task)
-
         Task {
-            // Security-scoped access is required for anything the picker
-            // returns from outside the app container.
-            let scoped = url.startAccessingSecurityScopedResource()
-            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-
-            guard let data = try? Data(contentsOf: url) else {
-                task.finish(error: "Couldn't read that file.")
-                return
-            }
-
-            let isAudio = Book.audioFormats.contains(url.pathExtension.lowercased())
-            let endpoint = isAudio ? "/api/uploads/audiobooks" : "/api/uploads/ebooks"
             do {
-                let _: Empty = try await APIClient.shared.upload(
-                    endpoint,
-                    fileData: data,
-                    fileName: url.lastPathComponent,
-                    mimeType: isAudio ? "audio/mp4" : "application/epub+zip"
+                let (staged, directory) = try await UploadService.stage(batch)
+                let confirmation = try await UploadService.inspect(staged)
+                task.state = .needsDetails
+                pending.append(
+                    UploadDraft(
+                        batch: staged, directory: directory, confirmation: confirmation, task: task
+                    )
                 )
-                task.finish(error: nil)
-                Haptics.success()
+                presentNextDraft()
             } catch {
-                task.finish(
-                    error: (error as? APIError)?.errorDescription ?? error.localizedDescription
-                )
+                task.state = .failed(Self.message(for: error))
             }
         }
     }
+
+    /// Show the next inspected upload's confirm sheet, if one isn't already up.
+    private func presentNextDraft() {
+        guard activeDraft == nil, !pending.isEmpty else { return }
+        activeDraft = pending.removeFirst()
+    }
+
+    private func commit(_ draft: UploadDraft, as confirmation: UploadConfirmation) {
+        draft.task.state = .uploading
+        activeDraft = nil
+        Task {
+            do {
+                _ = try await UploadService.commit(draft.batch, as: confirmation)
+                draft.task.state = .finished
+                Haptics.success()
+            } catch {
+                draft.task.state = .failed(Self.message(for: error))
+            }
+            UploadService.discard(draft.directory)
+            presentNextDraft()
+        }
+    }
+
+    /// Drop an upload the reader backed out of: no row is left behind, and the
+    /// staged copy goes with it.
+    private func cancel(_ draft: UploadDraft) {
+        uploads.removeAll { $0.id == draft.task.id }
+        UploadService.discard(draft.directory)
+        activeDraft = nil
+    }
+
+    private static func message(for error: Error) -> String {
+        (error as? APIError)?.errorDescription ?? error.localizedDescription
+    }
+}
+
+/// One inspected upload awaiting confirmation: the staged files, where they
+/// live, and the metadata the server read out of them.
+struct UploadDraft: Identifiable {
+    let id = UUID()
+    var batch: UploadBatch
+    var directory: URL
+    var confirmation: UploadConfirmation
+    /// The progress row this draft reports into.
+    var task: UploadTask
 }
 
 @Observable
 @MainActor
 final class UploadTask: Identifiable {
+    enum State: Equatable {
+        case inspecting
+        case needsDetails
+        case uploading
+        case finished
+        case failed(String)
+    }
+
     let id = UUID()
     let name: String
-    var isFinished = false
-    var error: String?
+    var state: State = .inspecting
 
     init(name: String) {
         self.name = name
-    }
-
-    func finish(error: String?) {
-        self.error = error
-        isFinished = true
     }
 }
 
@@ -173,26 +249,50 @@ private struct UploadRow: View {
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
-            if !task.isFinished {
+            switch task.state {
+            case .inspecting, .uploading:
                 ProgressView().controlSize(.small)
-            } else {
-                Image(systemName: task.error == nil ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                    .foregroundStyle(task.error == nil ? palette.okColor : palette.badColor)
+            case .needsDetails:
+                Image(systemName: "square.and.pencil")
+                    .foregroundStyle(palette.ink2Color)
+            case .finished:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(palette.okColor)
+            case .failed:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(palette.badColor)
             }
             VStack(alignment: .leading, spacing: 1) {
                 Text(task.name)
                     .font(.ui(13))
                     .foregroundStyle(palette.ink1Color)
                     .lineLimit(1)
-                if let error = task.error {
-                    Text(error)
+                if let detail {
+                    Text(detail)
                         .font(.ui(11))
-                        .foregroundStyle(palette.badColor)
+                        .foregroundStyle(
+                            isFailed ? palette.badColor : palette.ink3Color
+                        )
                         .lineLimit(2)
                 }
             }
             Spacer(minLength: 0)
         }
         .padding(.vertical, 6)
+    }
+
+    private var isFailed: Bool {
+        if case .failed = task.state { return true }
+        return false
+    }
+
+    private var detail: String? {
+        switch task.state {
+        case .inspecting: "Reading details…"
+        case .needsDetails: "Waiting for you to confirm the details"
+        case .uploading: "Adding to your library…"
+        case .finished: nil
+        case let .failed(message): message
+        }
     }
 }

--- a/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
@@ -6,6 +6,10 @@
 //  embedded metadata, let the reader correct it, then commit — because the
 //  commit endpoints file the book into a folder named from the confirmed
 //  title and author and reject a body that carries neither.
+//
+//  The queue, the staged copies and the transfers belong to `UploadManager`,
+//  not to this sheet: they outlive a dismissal, and when the view owned them
+//  every exit path had to remember to clean up.
 
 import SwiftUI
 
@@ -16,18 +20,18 @@ struct AddBooksSheet: View {
 
     @State private var showFileImporter = false
     @State private var showCheckIn = false
-    @State private var uploads: [UploadTask] = []
-    /// Inspected uploads waiting for their confirm sheet, shown one at a time
-    /// so a multi-file pick doesn't stack sheets.
-    @State private var pending: [UploadDraft] = []
-    @State private var activeDraft: UploadDraft?
-    /// Names the picker allowed through that neither endpoint accepts.
-    @State private var unsupported: [String] = []
-    /// The in-flight inspect pipeline, held so dismissal can cancel it rather
-    /// than let it write into torn-down `@State`.
-    @State private var pipeline: Task<Void, Never>?
 
+    private var manager: UploadManager { UploadManager.shared }
     private var isOnline: Bool { Connectivity.shared.isOnline }
+
+    /// Presentation is driven by the manager; the setter only reports the
+    /// dismissal back, so the next draft is never armed mid-animation.
+    private var activeDraft: Binding<UploadDraft?> {
+        Binding(
+            get: { manager.activeDraft },
+            set: { if $0 == nil { manager.sheetDidDismiss() } }
+        )
+    }
 
     var body: some View {
         NavigationStack {
@@ -41,9 +45,9 @@ struct AddBooksSheet: View {
                                 ? "Add an EPUB or audiobook from this device or iCloud Drive."
                                 : "Unavailable offline — uploads go straight to your library."
                         ) { showFileImporter = true }
-                        // An upload is a command against a shared library, so
-                        // it is never queued (rule 08) — the control stands
-                        // down instead of failing after the fact.
+                        // An upload is library-wide state, not per-user, so
+                        // it is never queued (rule 08, test 1) — the control
+                        // stands down instead of failing after the fact.
                         .disabled(!isOnline)
                         .opacity(isOnline ? 1 : 0.4)
                     }
@@ -54,8 +58,8 @@ struct AddBooksSheet: View {
                         subtitle: "Check in a physical copy you own on paper."
                     ) { showCheckIn = true }
 
-                    if !unsupported.isEmpty { unsupportedNotice }
-                    if !uploads.isEmpty { uploadList }
+                    if !manager.unsupported.isEmpty { unsupportedNotice }
+                    if !manager.uploads.isEmpty { uploadList }
                 }
                 .screenPadding()
                 .padding(.top, Spacing.md)
@@ -70,18 +74,13 @@ struct AddBooksSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
-        // Anything still staged belongs to a run that is over — a crash, or a
-        // dismissal that outran its own cleanup. iOS does not purge tmp while
-        // the app runs, so nothing else would ever reclaim it.
-        .onAppear { UploadService.sweepStaleStaging() }
-        .onDisappear(perform: tearDown)
+        // Staging from runs that are over — a crash, or a kill mid-confirm.
+        // iOS does not purge tmp while the app runs, so nothing else reclaims
+        // it; the manager excludes anything it still owns.
+        .onAppear { manager.sweepAbandonedStaging() }
         .sheet(isPresented: $showCheckIn) { CheckInView() }
-        .sheet(item: $activeDraft, onDismiss: presentNextDraft) { draft in
-            UploadConfirmSheet(
-                draft: draft,
-                onCommit: { commit(draft, as: $0) },
-                onCancel: { cancel(draft) }
-            )
+        .sheet(item: activeDraft) { draft in
+            UploadConfirmSheet(draft: draft)
         }
         .fileImporter(
             isPresented: $showFileImporter,
@@ -89,7 +88,7 @@ struct AddBooksSheet: View {
             allowsMultipleSelection: true
         ) { result in
             guard case let .success(urls) = result else { return }
-            stage(urls)
+            manager.enqueue(urls)
         }
     }
 
@@ -98,7 +97,7 @@ struct AddBooksSheet: View {
             Text("Uploads")
                 .font(.ui(13, weight: .semibold))
                 .foregroundStyle(palette.ink2Color)
-            ForEach(uploads) { task in
+            ForEach(manager.uploads) { task in
                 UploadRow(task: task)
             }
         }
@@ -108,8 +107,9 @@ struct AddBooksSheet: View {
 
     private var unsupportedNotice: some View {
         Text(
-            "Can't add \(unsupported.joined(separator: ", ")) — books must be an EPUB, "
-                + "and audiobooks an M4B, M4A, or MP3."
+            "Can't add \(manager.unsupported.joined(separator: ", ")) — books must be an "
+                + "EPUB, and audiobooks an M4B, M4A, or MP3. An MP3 saved as .mpga needs "
+                + "renaming first."
         )
         .font(.ui(12.5))
         .foregroundStyle(palette.ink3Color)
@@ -154,108 +154,6 @@ struct AddBooksSheet: View {
             )
         }
         .buttonStyle(PressableStyle())
-    }
-
-    // MARK: - Upload pipeline
-
-    /// Group the pick into one batch per book, then inspect them in turn.
-    ///
-    /// Sequentially, not concurrently: the confirm sheets are shown one at a
-    /// time anyway, so a fan-out only front-loads a whole file's worth of
-    /// memory per batch that the reader cannot act on yet.
-    private func stage(_ urls: [URL]) {
-        let selection = UploadFlow.selection(for: urls)
-        unsupported = selection.unsupported
-        guard !selection.batches.isEmpty else { return }
-
-        let queued = selection.batches.map { batch in
-            let task = UploadTask(name: batch.displayName)
-            uploads.append(task)
-            return (batch, task)
-        }
-        let previous = pipeline
-        pipeline = Task {
-            await previous?.value
-            for (batch, task) in queued {
-                if Task.isCancelled {
-                    task.state = .failed("Cancelled.")
-                    continue
-                }
-                await inspect(batch, into: task)
-            }
-        }
-    }
-
-    private func inspect(_ batch: UploadBatch, into task: UploadTask) async {
-        var staging: URL?
-        do {
-            let (staged, directory) = try await UploadService.stage(batch)
-            staging = directory
-            let confirmation = try await UploadService.inspect(staged)
-            task.state = .needsDetails
-            pending.append(
-                UploadDraft(
-                    batch: staged, directory: directory, confirmation: confirmation, task: task
-                )
-            )
-            presentNextDraft()
-        } catch {
-            task.state = .failed(Self.message(for: error))
-            // The copy is already on disk by the time inspect can fail, and
-            // only commit/cancel discard — without this it is unreachable.
-            if let staging { UploadService.discard(staging) }
-        }
-    }
-
-    /// Cancel in-flight work and release every staged copy the sheet still
-    /// owns. Tapping Done drops `pending` and `activeDraft` on the floor, so
-    /// the bytes they point at have to go with them.
-    private func tearDown() {
-        pipeline?.cancel()
-        pipeline = nil
-        for draft in pending { UploadService.discard(draft.directory) }
-        pending.removeAll()
-        if let activeDraft {
-            UploadService.discard(activeDraft.directory)
-            self.activeDraft = nil
-        }
-    }
-
-    /// Show the next inspected upload's confirm sheet, if one isn't already up.
-    private func presentNextDraft() {
-        guard activeDraft == nil, !pending.isEmpty else { return }
-        activeDraft = pending.removeFirst()
-    }
-
-    private func commit(_ draft: UploadDraft, as confirmation: UploadConfirmation) {
-        draft.task.state = .uploading
-        activeDraft = nil
-        Task {
-            do {
-                _ = try await UploadService.commit(draft.batch, as: confirmation)
-                draft.task.state = .finished
-                Haptics.success()
-            } catch {
-                draft.task.state = .failed(Self.message(for: error))
-            }
-            UploadService.discard(draft.directory)
-            // No presentNextDraft here: `onDismiss` already drains the queue on
-            // both exit paths, and re-arming `activeDraft` mid-dismissal is
-            // silently dropped by `sheet(item:)` — which then wedges the queue
-            // forever behind the `activeDraft == nil` guard.
-        }
-    }
-
-    /// Drop an upload the reader backed out of: no row is left behind, and the
-    /// staged copy goes with it.
-    private func cancel(_ draft: UploadDraft) {
-        uploads.removeAll { $0.id == draft.task.id }
-        UploadService.discard(draft.directory)
-        activeDraft = nil
-    }
-
-    private static func message(for error: Error) -> String {
-        (error as? APIError)?.errorDescription ?? error.localizedDescription
     }
 }
 

--- a/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/AddBooksSheet.swift
@@ -23,6 +23,9 @@ struct AddBooksSheet: View {
     @State private var activeDraft: UploadDraft?
     /// Names the picker allowed through that neither endpoint accepts.
     @State private var unsupported: [String] = []
+    /// The in-flight inspect pipeline, held so dismissal can cancel it rather
+    /// than let it write into torn-down `@State`.
+    @State private var pipeline: Task<Void, Never>?
 
     private var isOnline: Bool { Connectivity.shared.isOnline }
 
@@ -67,6 +70,11 @@ struct AddBooksSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
+        // Anything still staged belongs to a run that is over — a crash, or a
+        // dismissal that outran its own cleanup. iOS does not purge tmp while
+        // the app runs, so nothing else would ever reclaim it.
+        .onAppear { UploadService.sweepStaleStaging() }
+        .onDisappear(perform: tearDown)
         .sheet(isPresented: $showCheckIn) { CheckInView() }
         .sheet(item: $activeDraft, onDismiss: presentNextDraft) { draft in
             UploadConfirmSheet(
@@ -150,30 +158,66 @@ struct AddBooksSheet: View {
 
     // MARK: - Upload pipeline
 
-    /// Group the pick into one batch per book, then inspect each.
+    /// Group the pick into one batch per book, then inspect them in turn.
+    ///
+    /// Sequentially, not concurrently: the confirm sheets are shown one at a
+    /// time anyway, so a fan-out only front-loads a whole file's worth of
+    /// memory per batch that the reader cannot act on yet.
     private func stage(_ urls: [URL]) {
         let selection = UploadFlow.selection(for: urls)
         unsupported = selection.unsupported
-        for batch in selection.batches { inspect(batch) }
+        guard !selection.batches.isEmpty else { return }
+
+        let queued = selection.batches.map { batch in
+            let task = UploadTask(name: batch.displayName)
+            uploads.append(task)
+            return (batch, task)
+        }
+        let previous = pipeline
+        pipeline = Task {
+            await previous?.value
+            for (batch, task) in queued {
+                if Task.isCancelled {
+                    task.state = .failed("Cancelled.")
+                    continue
+                }
+                await inspect(batch, into: task)
+            }
+        }
     }
 
-    private func inspect(_ batch: UploadBatch) {
-        let task = UploadTask(name: batch.displayName)
-        uploads.append(task)
-        Task {
-            do {
-                let (staged, directory) = try await UploadService.stage(batch)
-                let confirmation = try await UploadService.inspect(staged)
-                task.state = .needsDetails
-                pending.append(
-                    UploadDraft(
-                        batch: staged, directory: directory, confirmation: confirmation, task: task
-                    )
+    private func inspect(_ batch: UploadBatch, into task: UploadTask) async {
+        var staging: URL?
+        do {
+            let (staged, directory) = try await UploadService.stage(batch)
+            staging = directory
+            let confirmation = try await UploadService.inspect(staged)
+            task.state = .needsDetails
+            pending.append(
+                UploadDraft(
+                    batch: staged, directory: directory, confirmation: confirmation, task: task
                 )
-                presentNextDraft()
-            } catch {
-                task.state = .failed(Self.message(for: error))
-            }
+            )
+            presentNextDraft()
+        } catch {
+            task.state = .failed(Self.message(for: error))
+            // The copy is already on disk by the time inspect can fail, and
+            // only commit/cancel discard — without this it is unreachable.
+            if let staging { UploadService.discard(staging) }
+        }
+    }
+
+    /// Cancel in-flight work and release every staged copy the sheet still
+    /// owns. Tapping Done drops `pending` and `activeDraft` on the floor, so
+    /// the bytes they point at have to go with them.
+    private func tearDown() {
+        pipeline?.cancel()
+        pipeline = nil
+        for draft in pending { UploadService.discard(draft.directory) }
+        pending.removeAll()
+        if let activeDraft {
+            UploadService.discard(activeDraft.directory)
+            self.activeDraft = nil
         }
     }
 
@@ -195,7 +239,10 @@ struct AddBooksSheet: View {
                 draft.task.state = .failed(Self.message(for: error))
             }
             UploadService.discard(draft.directory)
-            presentNextDraft()
+            // No presentNextDraft here: `onDismiss` already drains the queue on
+            // both exit paths, and re-arming `activeDraft` mid-dismissal is
+            // silently dropped by `sheet(item:)` — which then wedges the queue
+            // forever behind the `activeDraft == nil` guard.
         }
     }
 

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
@@ -10,8 +10,6 @@ import SwiftUI
 
 struct UploadConfirmSheet: View {
     let draft: UploadDraft
-    var onCommit: (UploadConfirmation) -> Void
-    var onCancel: () -> Void
 
     @Environment(\.palette) private var palette
 
@@ -22,23 +20,27 @@ struct UploadConfirmSheet: View {
     /// Seeded once from the inspection — re-seeding on every render would
     /// stomp the reader's edits.
     @State private var seeded = false
-    /// Set on the first Add. The sheet stays on screen and hit-testable for the
-    /// whole dismissal animation, so without this a second tap commits the same
-    /// draft again — two transfers, and two copies of the book in the library.
-    @State private var isSubmitting = false
-
+    private var manager: UploadManager { UploadManager.shared }
     private var isOnline: Bool { Connectivity.shared.isOnline }
+
+    /// The sheet stays on screen and hit-testable for the whole dismissal
+    /// animation, so both buttons have to stand down once Add is tapped: a
+    /// second Add commits the draft twice, and a Cancel deletes the staged
+    /// bytes out from under the commit that is already reading them.
+    private var isSubmitting: Bool { manager.isSubmitting }
 
     /// An upload is never queued (rule 08), so the write itself is gated, not
     /// just the flow's entry: the confirm step puts an unbounded human pause
     /// between picking a file and committing it, and the reader can lose
     /// connectivity inside that window.
     private var canCommit: Bool {
-        UploadFlow.canCommit(title: title, author: author)
-            && UploadFlow.isWithinNameCap(series)
-            && UploadFlow.isWithinNameCap(seriesIndex)
-            && isOnline
-            && !isSubmitting
+        UploadFlow.canCommit(
+            kind: draft.batch.kind,
+            title: title,
+            author: author,
+            series: series,
+            seriesIndex: seriesIndex
+        ) && isOnline && !isSubmitting
     }
 
     var body: some View {
@@ -65,14 +67,13 @@ struct UploadConfirmSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { onCancel() }
+                    Button("Cancel") { manager.cancelActive() }
+                        .disabled(isSubmitting)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
-                        guard !isSubmitting else { return }
-                        isSubmitting = true
                         Haptics.tap()
-                        onCommit(
+                        manager.confirm(
                             UploadConfirmation(
                                 title: title,
                                 author: author,

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
@@ -22,8 +22,24 @@ struct UploadConfirmSheet: View {
     /// Seeded once from the inspection — re-seeding on every render would
     /// stomp the reader's edits.
     @State private var seeded = false
+    /// Set on the first Add. The sheet stays on screen and hit-testable for the
+    /// whole dismissal animation, so without this a second tap commits the same
+    /// draft again — two transfers, and two copies of the book in the library.
+    @State private var isSubmitting = false
 
-    private var canCommit: Bool { UploadFlow.canCommit(title: title, author: author) }
+    private var isOnline: Bool { Connectivity.shared.isOnline }
+
+    /// An upload is never queued (rule 08), so the write itself is gated, not
+    /// just the flow's entry: the confirm step puts an unbounded human pause
+    /// between picking a file and committing it, and the reader can lose
+    /// connectivity inside that window.
+    private var canCommit: Bool {
+        UploadFlow.canCommit(title: title, author: author)
+            && UploadFlow.isWithinNameCap(series)
+            && UploadFlow.isWithinNameCap(seriesIndex)
+            && isOnline
+            && !isSubmitting
+    }
 
     var body: some View {
         NavigationStack {
@@ -53,6 +69,8 @@ struct UploadConfirmSheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
+                        guard !isSubmitting else { return }
+                        isSubmitting = true
                         Haptics.tap()
                         onCommit(
                             UploadConfirmation(
@@ -93,6 +111,11 @@ struct UploadConfirmSheet: View {
             )
             .font(.ui(13.5))
             .foregroundStyle(palette.ink2Color)
+            if !isOnline {
+                Text("You're offline — adding a book needs a connection.")
+                    .font(.ui(12.5))
+                    .foregroundStyle(palette.badColor)
+            }
         }
     }
 

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadConfirmSheet.swift
@@ -1,0 +1,112 @@
+//  UploadConfirmSheet.swift
+//  The confirm step of an upload: the metadata the server read out of the file,
+//  editable, before it is filed.
+//
+//  Title and author are required — the commit handlers reject a body without
+//  them, and the pair also names the folder the book is filed into — so Add
+//  stays disabled until both are filled rather than letting the server answer.
+
+import SwiftUI
+
+struct UploadConfirmSheet: View {
+    let draft: UploadDraft
+    var onCommit: (UploadConfirmation) -> Void
+    var onCancel: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    @State private var title = ""
+    @State private var author = ""
+    @State private var series = ""
+    @State private var seriesIndex = ""
+    /// Seeded once from the inspection — re-seeding on every render would
+    /// stomp the reader's edits.
+    @State private var seeded = false
+
+    private var canCommit: Bool { UploadFlow.canCommit(title: title, author: author) }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    header
+                    field("Title", text: $title, identifier: "upload-title")
+                    field("Author", text: $author, identifier: "upload-author")
+                    if draft.batch.kind.acceptsSeries {
+                        field("Series (optional)", text: $series, identifier: "upload-series")
+                        field(
+                            "Book # (optional)",
+                            text: $seriesIndex,
+                            identifier: "upload-series-index"
+                        )
+                    }
+                }
+                .screenPadding()
+                .padding(.vertical, Spacing.lg)
+            }
+            .background(ScreenBackground())
+            .navigationTitle("Confirm details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onCancel() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        Haptics.tap()
+                        onCommit(
+                            UploadConfirmation(
+                                title: title,
+                                author: author,
+                                series: series,
+                                seriesIndex: seriesIndex
+                            )
+                        )
+                    }
+                    .disabled(!canCommit)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        // Swiping the sheet away would leave its row stuck on "waiting for
+        // you" with a staged copy nobody deletes — Cancel is the way out.
+        .interactiveDismissDisabled()
+        .onAppear {
+            guard !seeded else { return }
+            seeded = true
+            title = draft.confirmation.title
+            author = draft.confirmation.author
+            series = draft.confirmation.series
+            seriesIndex = draft.confirmation.seriesIndex
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(draft.batch.displayName)
+                .font(.display(20))
+                .foregroundStyle(palette.ink0Color)
+                .lineLimit(2)
+            Text(
+                "We read these from the file. Correct anything that's off — the title and "
+                    + "author decide where the book is filed in your library."
+            )
+            .font(.ui(13.5))
+            .foregroundStyle(palette.ink2Color)
+        }
+    }
+
+    private func field(
+        _ label: String, text: Binding<String>, identifier: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.ui(12.5, weight: .semibold))
+                .foregroundStyle(palette.ink2Color)
+            TextField(label, text: text)
+                .textFieldStyle(OmnibusFieldStyle())
+                .autocorrectionDisabled()
+                .accessibilityIdentifier(identifier)
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
@@ -93,7 +93,10 @@ enum UploadFlow {
     /// the only grouping `classify_audio_set` accepts; each EPUB and each
     /// `.m4a`/`.m4b` container is its own book, so they get a batch apiece
     /// rather than the 400 that sending two containers in one request earns.
-    /// Order is preserved so the confirm sheets arrive in the order picked.
+    ///
+    /// Batches follow the pick order, except that the MP3 set lands last: it
+    /// isn't complete until the whole selection has been walked, so it cannot
+    /// take the position of the first part it collected.
     static func selection(for urls: [URL]) -> UploadSelection {
         var result = UploadSelection()
         var mp3s: [URL] = []

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
@@ -39,11 +39,18 @@ struct UploadBatch: Equatable, Sendable {
     var urls: [URL]
 
     /// What the progress row and the confirm sheet call this upload.
+    ///
+    /// A multi-part set is named for its folder, not just its part count:
+    /// grouping is keyed on that folder, so two picked sets would otherwise
+    /// produce two rows and two confirm sheets both reading "3 parts" — on the
+    /// one screen whose job is telling you which book you are correcting.
     var displayName: String {
         guard let first = urls.first else { return "" }
-        return urls.count == 1
-            ? first.lastPathComponent
-            : "\(urls.count) parts"
+        if urls.count == 1 { return first.lastPathComponent }
+        let folder = first.deletingLastPathComponent().lastPathComponent
+        return folder.isEmpty
+            ? "\(urls.count) parts"
+            : "\(folder) (\(urls.count) parts)"
     }
 }
 
@@ -76,6 +83,25 @@ enum UploadFlow {
 
     /// Longest author/series value, mirroring `MetadataOverrides::NAME_MAX_LEN`.
     static let nameMaxLength = 250
+
+    /// Length as the server counts it.
+    ///
+    /// The commit multipart also caps each text field at 8 KiB while streaming
+    /// (`MAX_TEXT_FIELD_BYTES`), but that is unreachable from here and so goes
+    /// unmodelled: UTF-8 is at most 4 bytes per scalar, so the 500-scalar title
+    /// cap below bounds a field at 2 KiB.
+    ///
+    /// `MetadataOverrides::validate` uses `chars().count()` — Unicode scalars —
+    /// while Swift's `String.count` counts grapheme clusters, which is never
+    /// larger. Measuring the wrong unit made the gate strictly looser than the
+    /// server's, so a decomposed or emoji-heavy title sailed past it and hit
+    /// the post-filing 400 the gate exists to prevent.
+    static func serverLength(of value: String) -> Int { value.unicodeScalars.count }
+
+    /// Whether a field fits the cap the server will apply to it.
+    static func fits(_ value: String, scalarCap: Int) -> Bool {
+        serverLength(of: value) <= scalarCap
+    }
 
     /// Which ingest a filename targets, or `nil` when neither accepts it.
     static func kind(for filename: String) -> UploadKind? {
@@ -151,8 +177,8 @@ enum UploadFlow {
         kind: UploadKind, title: String, author: String, series: String, seriesIndex: String
     ) -> [(name: String, value: String)] {
         var fields: [(name: String, value: String)] = [
-            ("title", title.trimmingCharacters(in: .whitespacesAndNewlines)),
-            ("author", author.trimmingCharacters(in: .whitespacesAndNewlines)),
+            ("title", title.nilIfBlank ?? ""),
+            ("author", author.nilIfBlank ?? ""),
         ]
         guard kind.acceptsSeries else { return fields }
         if let series = series.nilIfBlank { fields.append(("series", series)) }
@@ -168,14 +194,19 @@ enum UploadFlow {
     /// cap the server enforces only *after* the book is filed and indexed — so
     /// an over-long title would land a book on disk, answer 400, and file a
     /// second copy on the retry. The button stands down instead.
-    static func canCommit(title: String, author: String) -> Bool {
+    /// Takes the same fields as [`commitFields`] so the two cannot disagree
+    /// about which values are actually sent — a cap that forgets a field is how
+    /// one lands a book on disk before the 400.
+    static func canCommit(
+        kind: UploadKind, title: String, author: String, series: String, seriesIndex: String
+    ) -> Bool {
         guard let title = title.nilIfBlank, let author = author.nilIfBlank else { return false }
-        return title.count <= titleMaxLength && author.count <= nameMaxLength
-    }
-
-    /// Whether an optional confirm-sheet field is short enough to commit.
-    static func isWithinNameCap(_ value: String) -> Bool {
-        (value.nilIfBlank?.count ?? 0) <= nameMaxLength
+        guard fits(title, scalarCap: titleMaxLength), fits(author, scalarCap: nameMaxLength)
+        else { return false }
+        guard kind.acceptsSeries else { return true }
+        return [series, seriesIndex]
+            .compactMap(\.nilIfBlank)
+            .allSatisfy { fits($0, scalarCap: nameMaxLength) }
     }
 
     /// Content types the file importer offers, derived from the accepted

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
@@ -33,7 +33,7 @@ enum UploadKind: Equatable, Sendable {
 }
 
 /// One commit's worth of picked files: a single EPUB, a single `.m4a`/`.m4b`,
-/// or every `.mp3` of one multi-part audiobook.
+/// or the `.mp3` parts of one multi-part audiobook.
 struct UploadBatch: Equatable, Sendable {
     var kind: UploadKind
     var urls: [URL]
@@ -62,14 +62,24 @@ enum UploadFlow {
     static let ebookExtensions: Set<String> = ["epub"]
 
     /// Extensions `/api/uploads/audiobooks` accepts, matching `audiobook_ext_of`
-    /// on the server. Deliberately narrower than `Book.audioFormats`, which
-    /// describes what the library can *play* — offering `.flac` here would
-    /// transfer a whole audiobook before the server answered 415.
-    static let audiobookExtensions: Set<String> = ["m4a", "m4b", "mp3"]
+    /// on the server. This is the same narrow set the player and downloader
+    /// already use, so it is shared rather than restated — `Book.audioFormats`
+    /// is the *broad* list of what a library may contain, and routing on that
+    /// transferred whole `.flac`/`.wav` files the server then answered 415.
+    static let audiobookExtensions: Set<String> = Book.selectableAudioFormats
+
+    /// Longest title the server will accept, mirroring
+    /// `MetadataOverrides::TITLE_MAX_LEN` in `shared/src/ebook/overrides.rs`.
+    /// Enforced here because the server validates *after* filing the book, so
+    /// an over-long title lands a book on disk and then answers 400.
+    static let titleMaxLength = 500
+
+    /// Longest author/series value, mirroring `MetadataOverrides::NAME_MAX_LEN`.
+    static let nameMaxLength = 250
 
     /// Which ingest a filename targets, or `nil` when neither accepts it.
     static func kind(for filename: String) -> UploadKind? {
-        let ext = (filename as NSString).pathExtension.lowercased()
+        let ext = fileExtension(of: filename)
         if ebookExtensions.contains(ext) { return .ebook }
         if audiobookExtensions.contains(ext) { return .audiobook }
         return nil
@@ -79,7 +89,7 @@ enum UploadFlow {
     /// so this is courtesy rather than contract — but sending `audio/mp4` for
     /// an MP3, as the sheet used to, is a lie worth not telling.
     static func mimeType(for filename: String) -> String {
-        switch (filename as NSString).pathExtension.lowercased() {
+        switch fileExtension(of: filename) {
         case "epub": "application/epub+zip"
         case "mp3": "audio/mpeg"
         case "m4a", "m4b": "audio/mp4"
@@ -89,40 +99,54 @@ enum UploadFlow {
 
     /// Split a picked selection into one batch per book the server would file.
     ///
-    /// Every `.mp3` in the selection becomes one multi-part audiobook, which is
-    /// the only grouping `classify_audio_set` accepts; each EPUB and each
-    /// `.m4a`/`.m4b` container is its own book, so they get a batch apiece
-    /// rather than the 400 that sending two containers in one request earns.
+    /// Each EPUB and each `.m4a`/`.m4b` container is its own book, so they get a
+    /// batch apiece rather than the 400 that sending two containers in one
+    /// request earns. `.mp3` files are grouped **by their containing folder**:
+    /// `classify_audio_set` files a set of MP3s as one book, and a folder is the
+    /// only signal available for which of them actually belong together. Lumping
+    /// every picked MP3 into one book instead merged unrelated single-track
+    /// audiobooks with no way back short of deleting the result.
     ///
-    /// Batches follow the pick order, except that the MP3 set lands last: it
+    /// Batches follow the pick order, except that MP3 sets land last: a set
     /// isn't complete until the whole selection has been walked, so it cannot
     /// take the position of the first part it collected.
     static func selection(for urls: [URL]) -> UploadSelection {
         var result = UploadSelection()
-        var mp3s: [URL] = []
+        var mp3Folders: [URL] = []
+        var mp3ByFolder: [URL: [URL]] = [:]
+
         for url in urls {
             let name = url.lastPathComponent
             switch kind(for: name) {
             case .ebook:
                 result.batches.append(UploadBatch(kind: .ebook, urls: [url]))
-            case .audiobook where (name as NSString).pathExtension.lowercased() == "mp3":
-                mp3s.append(url)
+            case .audiobook where fileExtension(of: name) == "mp3":
+                let folder = url.deletingLastPathComponent()
+                if mp3ByFolder[folder] == nil { mp3Folders.append(folder) }
+                mp3ByFolder[folder, default: []].append(url)
             case .audiobook:
                 result.batches.append(UploadBatch(kind: .audiobook, urls: [url]))
             case nil:
                 result.unsupported.append(name)
             }
         }
-        if !mp3s.isEmpty {
-            result.batches.append(UploadBatch(kind: .audiobook, urls: mp3s))
+
+        for folder in mp3Folders {
+            guard let parts = mp3ByFolder[folder] else { continue }
+            result.batches.append(UploadBatch(kind: .audiobook, urls: parts))
         }
         return result
     }
 
     /// The commit form fields for a confirmed upload, in a fixed order so the
-    /// request body is deterministic. Blank optional fields are omitted rather
-    /// than sent empty — `norm` on the server would discard them anyway, and
-    /// an absent part is the honest way to say "no value".
+    /// request body is deterministic.
+    ///
+    /// Blank optional fields are omitted. Note this means a *cleared* series
+    /// cannot be pushed: the server reads an absent part as "keep the file's
+    /// embedded value", and sending an empty string is identical because its
+    /// `norm` trims-and-drops. Clearing needs a server-side absent-vs-empty
+    /// distinction; until then the metadata editor is where a wrong series
+    /// gets removed.
     static func commitFields(
         kind: UploadKind, title: String, author: String, series: String, seriesIndex: String
     ) -> [(name: String, value: String)] {
@@ -131,31 +155,49 @@ enum UploadFlow {
             ("author", author.trimmingCharacters(in: .whitespacesAndNewlines)),
         ]
         guard kind.acceptsSeries else { return fields }
-        let trimmedSeries = series.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedSeries.isEmpty { fields.append(("series", trimmedSeries)) }
-        let trimmedIndex = seriesIndex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedIndex.isEmpty { fields.append(("series_index", trimmedIndex)) }
+        if let series = series.nilIfBlank { fields.append(("series", series)) }
+        if let seriesIndex = seriesIndex.nilIfBlank {
+            fields.append(("series_index", seriesIndex))
+        }
         return fields
     }
 
-    /// Whether the confirm sheet may submit. Both fields are required by the
-    /// commit handlers, so the button is disabled rather than letting the
-    /// server answer 400.
+    /// Whether the confirm sheet may submit.
+    ///
+    /// Both fields are required by the commit handlers, and both carry a length
+    /// cap the server enforces only *after* the book is filed and indexed — so
+    /// an over-long title would land a book on disk, answer 400, and file a
+    /// second copy on the retry. The button stands down instead.
     static func canCommit(title: String, author: String) -> Bool {
-        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard let title = title.nilIfBlank, let author = author.nilIfBlank else { return false }
+        return title.count <= titleMaxLength && author.count <= nameMaxLength
     }
 
-    /// Content types the file importer offers — exactly what the two endpoints
-    /// accept, so an upload cannot fail on format after the whole file has
-    /// been transferred.
+    /// Whether an optional confirm-sheet field is short enough to commit.
+    static func isWithinNameCap(_ value: String) -> Bool {
+        (value.nilIfBlank?.count ?? 0) <= nameMaxLength
+    }
+
+    /// Content types the file importer offers, derived from the accepted
+    /// extensions so the two cannot drift.
+    ///
+    /// A `UTType` can carry sibling extensions the server does not take —
+    /// `public.mp3` also claims `mpga` — so this narrows the picker rather than
+    /// matching it exactly, and [`selection(for:)`] stays the real gate. It is
+    /// still worth deriving: naming `UTType.mpeg4Audio` by hand offered `mp4`
+    /// and `mpg4`, which are not audiobooks at all.
     static var pickerTypes: [UTType] {
-        var types: [UTType] = [.epub, .mp3, .mpeg4Audio]
-        for ext in ["m4b", "m4a"] {
-            if let type = UTType(filenameExtension: ext), !types.contains(type) {
-                types.append(type)
-            }
+        let extensions = ebookExtensions.sorted() + audiobookExtensions.sorted()
+        var types: [UTType] = []
+        for ext in extensions {
+            guard let type = UTType(filenameExtension: ext), !types.contains(type) else { continue }
+            types.append(type)
         }
         return types
+    }
+
+    /// Lowercased extension of a filename, the one place that parse happens.
+    private static func fileExtension(of filename: String) -> String {
+        (filename as NSString).pathExtension.lowercased()
     }
 }

--- a/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
+++ b/omnibus-ios/omnibus/Features/AddBooks/UploadFlow.swift
@@ -1,0 +1,158 @@
+//  UploadFlow.swift
+//  Pure request-shaping for the add-books upload: which ingest a picked file
+//  targets, and how a selection groups into commits. Split from the view so
+//  the rules the server enforces are testable without one, the same way
+//  `CheckInFlow` carries the check-in stage machine.
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Which ingest an upload targets. The two endpoints accept disjoint format
+/// sets, so the file extension decides and there is no ambiguous case.
+enum UploadKind: Equatable, Sendable {
+    case ebook
+    case audiobook
+
+    var inspectPath: String {
+        switch self {
+        case .ebook: "/api/uploads/ebooks/inspect"
+        case .audiobook: "/api/uploads/audiobooks/inspect"
+        }
+    }
+
+    var commitPath: String {
+        switch self {
+        case .ebook: "/api/uploads/ebooks"
+        case .audiobook: "/api/uploads/audiobooks"
+        }
+    }
+
+    /// Series is an ebook-only field on the commit form — the audiobook
+    /// endpoint reads `title`/`author` and nothing else.
+    var acceptsSeries: Bool { self == .ebook }
+}
+
+/// One commit's worth of picked files: a single EPUB, a single `.m4a`/`.m4b`,
+/// or every `.mp3` of one multi-part audiobook.
+struct UploadBatch: Equatable, Sendable {
+    var kind: UploadKind
+    var urls: [URL]
+
+    /// What the progress row and the confirm sheet call this upload.
+    var displayName: String {
+        guard let first = urls.first else { return "" }
+        return urls.count == 1
+            ? first.lastPathComponent
+            : "\(urls.count) parts"
+    }
+}
+
+/// The grouping of a picked selection: what will be uploaded, and what was
+/// dropped because the server would not accept it.
+struct UploadSelection: Equatable, Sendable {
+    var batches: [UploadBatch] = []
+    /// Filenames whose extension neither endpoint accepts, so the sheet can
+    /// name them instead of failing them one 415 at a time.
+    var unsupported: [String] = []
+}
+
+enum UploadFlow {
+    /// Extensions `/api/uploads/ebooks` accepts. EPUB only — the magic-byte
+    /// gate in `shared::detect_ebook_format` recognizes nothing else.
+    static let ebookExtensions: Set<String> = ["epub"]
+
+    /// Extensions `/api/uploads/audiobooks` accepts, matching `audiobook_ext_of`
+    /// on the server. Deliberately narrower than `Book.audioFormats`, which
+    /// describes what the library can *play* — offering `.flac` here would
+    /// transfer a whole audiobook before the server answered 415.
+    static let audiobookExtensions: Set<String> = ["m4a", "m4b", "mp3"]
+
+    /// Which ingest a filename targets, or `nil` when neither accepts it.
+    static func kind(for filename: String) -> UploadKind? {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        if ebookExtensions.contains(ext) { return .ebook }
+        if audiobookExtensions.contains(ext) { return .audiobook }
+        return nil
+    }
+
+    /// `Content-Type` for a part. The server routes on the filename extension,
+    /// so this is courtesy rather than contract — but sending `audio/mp4` for
+    /// an MP3, as the sheet used to, is a lie worth not telling.
+    static func mimeType(for filename: String) -> String {
+        switch (filename as NSString).pathExtension.lowercased() {
+        case "epub": "application/epub+zip"
+        case "mp3": "audio/mpeg"
+        case "m4a", "m4b": "audio/mp4"
+        default: "application/octet-stream"
+        }
+    }
+
+    /// Split a picked selection into one batch per book the server would file.
+    ///
+    /// Every `.mp3` in the selection becomes one multi-part audiobook, which is
+    /// the only grouping `classify_audio_set` accepts; each EPUB and each
+    /// `.m4a`/`.m4b` container is its own book, so they get a batch apiece
+    /// rather than the 400 that sending two containers in one request earns.
+    /// Order is preserved so the confirm sheets arrive in the order picked.
+    static func selection(for urls: [URL]) -> UploadSelection {
+        var result = UploadSelection()
+        var mp3s: [URL] = []
+        for url in urls {
+            let name = url.lastPathComponent
+            switch kind(for: name) {
+            case .ebook:
+                result.batches.append(UploadBatch(kind: .ebook, urls: [url]))
+            case .audiobook where (name as NSString).pathExtension.lowercased() == "mp3":
+                mp3s.append(url)
+            case .audiobook:
+                result.batches.append(UploadBatch(kind: .audiobook, urls: [url]))
+            case nil:
+                result.unsupported.append(name)
+            }
+        }
+        if !mp3s.isEmpty {
+            result.batches.append(UploadBatch(kind: .audiobook, urls: mp3s))
+        }
+        return result
+    }
+
+    /// The commit form fields for a confirmed upload, in a fixed order so the
+    /// request body is deterministic. Blank optional fields are omitted rather
+    /// than sent empty — `norm` on the server would discard them anyway, and
+    /// an absent part is the honest way to say "no value".
+    static func commitFields(
+        kind: UploadKind, title: String, author: String, series: String, seriesIndex: String
+    ) -> [(name: String, value: String)] {
+        var fields: [(name: String, value: String)] = [
+            ("title", title.trimmingCharacters(in: .whitespacesAndNewlines)),
+            ("author", author.trimmingCharacters(in: .whitespacesAndNewlines)),
+        ]
+        guard kind.acceptsSeries else { return fields }
+        let trimmedSeries = series.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedSeries.isEmpty { fields.append(("series", trimmedSeries)) }
+        let trimmedIndex = seriesIndex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedIndex.isEmpty { fields.append(("series_index", trimmedIndex)) }
+        return fields
+    }
+
+    /// Whether the confirm sheet may submit. Both fields are required by the
+    /// commit handlers, so the button is disabled rather than letting the
+    /// server answer 400.
+    static func canCommit(title: String, author: String) -> Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Content types the file importer offers — exactly what the two endpoints
+    /// accept, so an upload cannot fail on format after the whole file has
+    /// been transferred.
+    static var pickerTypes: [UTType] {
+        var types: [UTType] = [.epub, .mp3, .mpeg4Audio]
+        for ext in ["m4b", "m4a"] {
+            if let type = UTType(filenameExtension: ext), !types.contains(type) {
+                types.append(type)
+            }
+        }
+        return types
+    }
+}

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1681,3 +1681,50 @@ struct ConfirmCrossFormatLink: Codable, Sendable {
         case audioOrder = "audio_order"
     }
 }
+
+// MARK: - Book upload
+
+/// Metadata the server read out of an uploaded EPUB, for the editable confirm
+/// step. Mirrors `omnibus_shared::UploadInspection`.
+struct UploadInspection: Codable, Hashable, Sendable {
+    var title: String?
+    var author: String?
+    var series: String?
+    var seriesIndex: String?
+    var language: String?
+    var hasCover: Bool
+    /// Lowercased extension the server settled on (`"epub"`).
+    var ext: String
+
+    enum CodingKeys: String, CodingKey {
+        case title, author, series, language, ext
+        case seriesIndex = "series_index"
+        case hasCover = "has_cover"
+    }
+}
+
+/// Tag-derived metadata for an uploaded audiobook — the audiobook sibling of
+/// [`UploadInspection`]. Mirrors `omnibus_shared::AudiobookInspection`.
+struct AudiobookInspection: Codable, Hashable, Sendable {
+    var title: String?
+    var author: String?
+    var hasCover: Bool
+    /// Lowercased format the server settled on (`"m4b"`, `"m4a"`, `"mp3"`).
+    var format: String
+    /// Files in the upload — 1 for a container, N for a multi-part MP3 book.
+    var partCount: Int
+    var durationSeconds: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case title, author, format
+        case hasCover = "has_cover"
+        case partCount = "part_count"
+        case durationSeconds = "duration_seconds"
+    }
+}
+
+/// The uuid of a freshly filed book, so the client can link straight to it.
+/// Mirrors `omnibus_shared::UploadCommitResult`.
+struct UploadCommitResult: Codable, Hashable, Sendable {
+    var uuid: String
+}

--- a/omnibus-ios/omnibus/Networking/APIClient.swift
+++ b/omnibus-ios/omnibus/Networking/APIClient.swift
@@ -88,10 +88,12 @@ actor APIClient {
     /// budget configured per-session, not per-task, so a book transfer cannot
     /// borrow one from the read session's 120s.
     ///
-    /// The ceiling is deliberately modest rather than generous: the server
-    /// wraps every route in a 30s `TimeoutLayer`, so a transfer that runs long
-    /// is already doomed, and a budget far past that only holds the probe slot
-    /// (see `failFastWhenUnreachable`) while nothing can come of it.
+    /// `timeoutIntervalForResource` is a *whole-transfer* budget, not a
+    /// think-time one, so it has to be sized for the bytes rather than for the
+    /// server's own request timeout — a 300 MB audiobook on a phone uplink is
+    /// minutes of legitimate progress. (The server currently caps every route
+    /// at 30s, which bounds real-world uploads well below this; that is a
+    /// server-side limit, not a reason to cut the client's budget to match.)
     private let uploadSession: URLSession
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
@@ -115,8 +117,8 @@ actor APIClient {
 
         let uploadConfig = URLSessionConfiguration.default
         uploadConfig.waitsForConnectivity = false
-        uploadConfig.timeoutIntervalForRequest = 60
-        uploadConfig.timeoutIntervalForResource = 120
+        uploadConfig.timeoutIntervalForRequest = 120
+        uploadConfig.timeoutIntervalForResource = 3600
         uploadConfig.requestCachePolicy = .reloadIgnoringLocalCacheData
         uploadSession = URLSession(configuration: uploadConfig)
         baseURL = ServerURLStore.load()
@@ -295,6 +297,10 @@ actor APIClient {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
         request.httpBody = body
+        // Sending a body is not a read: the read session's 10s idle timeout is
+        // sized for "how long before we give up on a dead server", and applying
+        // it to an upload cuts off a transfer that is progressing fine.
+        request.timeoutInterval = 300
 
         do {
             let (data, response) = try await session.data(for: request)
@@ -305,7 +311,9 @@ actor APIClient {
             throw error
         } catch {
             try rethrowIfCancelled(error, releaseProbe: ownsProbe)
-            noteOutcome(reachable: false, releaseProbe: ownsProbe)
+            noteOutcome(
+                reachable: false, releaseProbe: ownsProbe, publishFailure: ownsProbe
+            )
             throw APIError.transport(error.localizedDescription)
         }
     }
@@ -493,10 +501,19 @@ actor APIClient {
     ///
     /// Only these move the back-off — `setOnline` echoes must not, or the
     /// notification round trip would double the window on its own.
-    private func noteOutcome(reachable: Bool, releaseProbe: Bool = true) {
-        // A request that declined to claim the slot must not release one a
-        // concurrent read is holding.
+    /// `publishFailure: false` lets a request report success without being
+    /// allowed to declare an outage.
+    ///
+    /// A long upload is the request *least* qualified to judge reachability: it
+    /// times out on its own budget, on the server's, or on the app being
+    /// backgrounded, none of which mean the server is gone. Letting it arm the
+    /// back-off failed every read in the app — and, since the upload controls
+    /// are gated on `isOnline`, disabled the retry it was asking for.
+    private func noteOutcome(
+        reachable: Bool, releaseProbe: Bool = true, publishFailure: Bool = true
+    ) {
         if releaseProbe { probing = false }
+        guard reachable || publishFailure else { return }
         if reachable {
             unreachableUntil = nil
             backoff = 0

--- a/omnibus-ios/omnibus/Networking/APIClient.swift
+++ b/omnibus-ios/omnibus/Networking/APIClient.swift
@@ -84,6 +84,11 @@ actor APIClient {
     private static let maxBackoff: TimeInterval = 60
 
     private let session: URLSession
+    /// Separate session for uploads. `timeoutIntervalForResource` is a *total*
+    /// budget and it is configured per-session, not per-task, so the 120s the
+    /// read session wants would abandon a large audiobook mid-transfer no
+    /// matter what a request's own `timeoutInterval` says.
+    private let uploadSession: URLSession
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
         return e
@@ -103,6 +108,13 @@ actor APIClient {
         config.timeoutIntervalForResource = 120
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         session = URLSession(configuration: config)
+
+        let uploadConfig = URLSessionConfiguration.default
+        uploadConfig.waitsForConnectivity = false
+        uploadConfig.timeoutIntervalForRequest = 300
+        uploadConfig.timeoutIntervalForResource = 3600
+        uploadConfig.requestCachePolicy = .reloadIgnoringLocalCacheData
+        uploadSession = URLSession(configuration: uploadConfig)
         baseURL = ServerURLStore.load()
         token = TokenStore.load()
     }
@@ -217,41 +229,51 @@ actor APIClient {
         }
     }
 
-    /// Multipart upload used by the cover, photo, and book-upload endpoints.
+    /// Multipart upload of a single file — the cover, photo, and avatar
+    /// endpoints, which take one part and no text fields.
     func upload<T: Decodable>(
         _ path: String,
         fileData: Data,
         fileName: String,
         fieldName: String = "file",
-        mimeType: String = "application/octet-stream",
-        fields: [String: String] = [:]
+        mimeType: String = "application/octet-stream"
+    ) async throws -> T {
+        try await upload(
+            path,
+            files: [
+                MultipartFile(
+                    fieldName: fieldName, fileName: fileName, mimeType: mimeType, data: fileData
+                )
+            ]
+        )
+    }
+
+    /// Multipart upload of one or more file parts plus ordered text fields.
+    ///
+    /// The book-upload commit endpoints read `title`/`author` out of the same
+    /// body as the file, and the audiobook one takes a whole set of `.mp3`
+    /// parts under repeated `file` fields — both of which a single-file,
+    /// fields-free upload cannot express.
+    func upload<T: Decodable>(
+        _ path: String,
+        files: [MultipartFile],
+        fields: [(name: String, value: String)] = []
     ) async throws -> T {
         guard let url = absoluteURL(path) else { throw APIError.notConfigured }
         try failFastWhenUnreachable()
-        let boundary = "omnibus.\(UUID().uuidString)"
-        var body = Data()
-        for (key, value) in fields {
-            body.append("--\(boundary)\r\n")
-            body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n")
-            body.append("\(value)\r\n")
-        }
-        body.append("--\(boundary)\r\n")
-        body.append(
-            "Content-Disposition: form-data; name=\"\(fieldName)\"; filename=\"\(fileName)\"\r\n"
-        )
-        body.append("Content-Type: \(mimeType)\r\n\r\n")
-        body.append(fileData)
-        body.append("\r\n--\(boundary)--\r\n")
+        let boundary = MultipartBody.makeBoundary()
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type"
+        )
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
-        request.httpBody = body
-        request.timeoutInterval = 300
-
+        request.httpBody = MultipartBody.encode(
+            boundary: boundary, fields: fields, files: files
+        )
         do {
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await uploadSession.data(for: request)
             noteOutcome(reachable: true)
             try validate(response, data: data)
             return try decode(data)
@@ -475,9 +497,3 @@ actor APIClient {
 
 /// Stand-in for endpoints that answer with no meaningful body.
 struct Empty: Codable, Sendable {}
-
-private extension Data {
-    mutating func append(_ string: String) {
-        append(Data(string.utf8))
-    }
-}

--- a/omnibus-ios/omnibus/Networking/APIClient.swift
+++ b/omnibus-ios/omnibus/Networking/APIClient.swift
@@ -85,9 +85,13 @@ actor APIClient {
 
     private let session: URLSession
     /// Separate session for uploads. `timeoutIntervalForResource` is a *total*
-    /// budget and it is configured per-session, not per-task, so the 120s the
-    /// read session wants would abandon a large audiobook mid-transfer no
-    /// matter what a request's own `timeoutInterval` says.
+    /// budget configured per-session, not per-task, so a book transfer cannot
+    /// borrow one from the read session's 120s.
+    ///
+    /// The ceiling is deliberately modest rather than generous: the server
+    /// wraps every route in a 30s `TimeoutLayer`, so a transfer that runs long
+    /// is already doomed, and a budget far past that only holds the probe slot
+    /// (see `failFastWhenUnreachable`) while nothing can come of it.
     private let uploadSession: URLSession
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
@@ -111,8 +115,8 @@ actor APIClient {
 
         let uploadConfig = URLSessionConfiguration.default
         uploadConfig.waitsForConnectivity = false
-        uploadConfig.timeoutIntervalForRequest = 300
-        uploadConfig.timeoutIntervalForResource = 3600
+        uploadConfig.timeoutIntervalForRequest = 60
+        uploadConfig.timeoutIntervalForResource = 120
         uploadConfig.requestCachePolicy = .reloadIgnoringLocalCacheData
         uploadSession = URLSession(configuration: uploadConfig)
         baseURL = ServerURLStore.load()
@@ -229,8 +233,11 @@ actor APIClient {
         }
     }
 
-    /// Multipart upload of a single file — the cover, photo, and avatar
-    /// endpoints, which take one part and no text fields.
+    /// Multipart upload of a single file, for the avatar endpoint.
+    ///
+    /// Deliberately on the ordinary `session`: this is a small image, so it
+    /// wants the read session's tighter timeouts and its probe-slot semantics,
+    /// not the book path's long-transfer budget.
     func upload<T: Decodable>(
         _ path: String,
         fileData: Data,
@@ -238,50 +245,67 @@ actor APIClient {
         fieldName: String = "file",
         mimeType: String = "application/octet-stream"
     ) async throws -> T {
-        try await upload(
-            path,
+        guard let url = absoluteURL(path) else { throw APIError.notConfigured }
+        try failFastWhenUnreachable()
+        let boundary = MultipartBody.makeBoundary()
+        let body = MultipartBody.encode(
+            boundary: boundary,
+            fields: [],
             files: [
                 MultipartFile(
                     fieldName: fieldName, fileName: fileName, mimeType: mimeType, data: fileData
                 )
             ]
         )
+        return try await send(multipart: body, boundary: boundary, to: url, session: session)
     }
 
-    /// Multipart upload of one or more file parts plus ordered text fields.
+    /// Upload an already-encoded multipart body — the book-upload steps.
     ///
-    /// The book-upload commit endpoints read `title`/`author` out of the same
-    /// body as the file, and the audiobook one takes a whole set of `.mp3`
-    /// parts under repeated `file` fields — both of which a single-file,
-    /// fields-free upload cannot express.
+    /// The body arrives pre-built because encoding a multi-hundred-megabyte
+    /// payload inside this actor would hold it for the length of the memcpy,
+    /// stalling every other request in the app behind one upload.
     func upload<T: Decodable>(
         _ path: String,
-        files: [MultipartFile],
-        fields: [(name: String, value: String)] = []
+        body: Data,
+        boundary: String
     ) async throws -> T {
         guard let url = absoluteURL(path) else { throw APIError.notConfigured }
-        try failFastWhenUnreachable()
-        let boundary = MultipartBody.makeBoundary()
+        // Never claims the probe slot: a book transfer can outlast a read by
+        // orders of magnitude, and holding the slot fails everything else fast.
+        try failFastWhenUnreachable(claimProbe: false)
+        return try await send(
+            multipart: body, boundary: boundary, to: url,
+            session: uploadSession, ownsProbe: false
+        )
+    }
 
+    private func send<T: Decodable>(
+        multipart body: Data,
+        boundary: String,
+        to url: URL,
+        session: URLSession,
+        ownsProbe: Bool = true
+    ) async throws -> T {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(
             "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type"
         )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
-        request.httpBody = MultipartBody.encode(
-            boundary: boundary, fields: fields, files: files
-        )
+        request.httpBody = body
+
         do {
-            let (data, response) = try await uploadSession.data(for: request)
-            noteOutcome(reachable: true)
+            let (data, response) = try await session.data(for: request)
+            noteOutcome(reachable: true, releaseProbe: ownsProbe)
             try validate(response, data: data)
             return try decode(data)
         } catch let error as APIError {
             throw error
         } catch {
-            try rethrowIfCancelled(error)
-            noteOutcome(reachable: false)
+            try rethrowIfCancelled(error, releaseProbe: ownsProbe)
+            noteOutcome(reachable: false, releaseProbe: ownsProbe)
             throw APIError.transport(error.localizedDescription)
         }
     }
@@ -433,10 +457,18 @@ actor APIClient {
     ///
     /// Must be the last thing a request path does before hitting the wire —
     /// passing it claims the probe slot, and only `noteOutcome` releases it.
-    private func failFastWhenUnreachable() throws {
+    /// Throw immediately while the server is known unreachable, and otherwise
+    /// claim the single probe slot for this request.
+    ///
+    /// `claimProbe: false` is for a request that may run far longer than a read
+    /// — an upload. It still refuses to dial a server just proved unreachable,
+    /// but it must not *become* the probe: holding the slot for the length of a
+    /// book transfer fails every other request in the app fast for that whole
+    /// window, which is the stall this mechanism exists to prevent.
+    private func failFastWhenUnreachable(claimProbe: Bool = true) throws {
         guard let until = unreachableUntil else { return }
         if Date() < until || probing { throw APIError.offline }
-        probing = true
+        if claimProbe { probing = true }
     }
 
     /// Unwind a cancelled request without letting it speak for the server.
@@ -447,9 +479,9 @@ actor APIClient {
     /// only other thing that releases it, and it is precisely what must not run
     /// here, so a cancelled probe would otherwise strand the slot and every
     /// later request would fail fast against a server that was never asked.
-    private func rethrowIfCancelled(_ error: Error) throws {
+    private func rethrowIfCancelled(_ error: Error, releaseProbe: Bool = true) throws {
         guard isCancellation(error) else { return }
-        probing = false
+        if releaseProbe { probing = false }
         throw CancellationError()
     }
 
@@ -461,8 +493,10 @@ actor APIClient {
     ///
     /// Only these move the back-off — `setOnline` echoes must not, or the
     /// notification round trip would double the window on its own.
-    private func noteOutcome(reachable: Bool) {
-        probing = false
+    private func noteOutcome(reachable: Bool, releaseProbe: Bool = true) {
+        // A request that declined to claim the slot must not release one a
+        // concurrent read is holding.
+        if releaseProbe { probing = false }
         if reachable {
             unreachableUntil = nil
             backoff = 0

--- a/omnibus-ios/omnibus/Networking/MultipartBody.swift
+++ b/omnibus-ios/omnibus/Networking/MultipartBody.swift
@@ -23,6 +23,27 @@ enum MultipartBody {
     /// A boundary token that cannot occur in the payload it delimits.
     static func makeBoundary() -> String { "omnibus.\(UUID().uuidString)" }
 
+    /// Escape a name for a quoted-string `Content-Disposition` parameter.
+    ///
+    /// Only `/` and NUL are illegal in a POSIX filename, so a perfectly
+    /// ordinary book can be called `He said "hi".epub` — and interpolating that
+    /// raw closes the quoted string early and corrupts every header after it.
+    /// A CR or LF would end the header line outright. RFC 7578 §4.2 prescribes
+    /// percent-encoding for exactly this.
+    ///
+    /// Only those three characters are escaped, and deliberately not `%`
+    /// itself: the server does not percent-decode the name, it slugifies it
+    /// (a probe upload sent `50%25 off.mp3` and got `50-25-off.mp3` on disk),
+    /// so pre-encoding `%` would stamp a literal `25` into the filename of
+    /// any ordinary book called something like `50% off`. Escaping only what
+    /// can actually break the wire format costs nothing and mangles nothing.
+    static func escapeHeaderParameter(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\"", with: "%22")
+            .replacingOccurrences(of: "\r", with: "%0D")
+            .replacingOccurrences(of: "\n", with: "%0A")
+    }
+
     /// Encode `fields` then `files` into one body.
     ///
     /// Text fields are an ordered array, not a dictionary: `Dictionary`
@@ -36,14 +57,17 @@ enum MultipartBody {
         var body = Data()
         for field in fields {
             body.append("--\(boundary)\r\n")
-            body.append("Content-Disposition: form-data; name=\"\(field.name)\"\r\n\r\n")
+            let name = escapeHeaderParameter(field.name)
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
             body.append("\(field.value)\r\n")
         }
         for file in files {
             body.append("--\(boundary)\r\n")
+            let fieldName = escapeHeaderParameter(file.fieldName)
+            let fileName = escapeHeaderParameter(file.fileName)
             body.append(
-                "Content-Disposition: form-data; name=\"\(file.fieldName)\";"
-                    + " filename=\"\(file.fileName)\"\r\n"
+                "Content-Disposition: form-data; name=\"\(fieldName)\";"
+                    + " filename=\"\(fileName)\"\r\n"
             )
             body.append("Content-Type: \(file.mimeType)\r\n\r\n")
             body.append(file.data)

--- a/omnibus-ios/omnibus/Networking/MultipartBody.swift
+++ b/omnibus-ios/omnibus/Networking/MultipartBody.swift
@@ -55,6 +55,10 @@ enum MultipartBody {
         files: [MultipartFile]
     ) -> Data {
         var body = Data()
+        // Data grows geometrically, so appending a multi-part audiobook without
+        // this re-copies the whole prefix several times and transiently holds
+        // old buffer + new one — enough on its own to jetsam a large upload.
+        body.reserveCapacity(files.reduce(4096) { $0 + $1.data.count + 256 })
         for field in fields {
             body.append("--\(boundary)\r\n")
             let name = escapeHeaderParameter(field.name)

--- a/omnibus-ios/omnibus/Networking/MultipartBody.swift
+++ b/omnibus-ios/omnibus/Networking/MultipartBody.swift
@@ -1,0 +1,61 @@
+//  MultipartBody.swift
+//  `multipart/form-data` encoding for the upload endpoints.
+//
+//  Split from `APIClient` so the wire shape a handler parses — which text
+//  fields are present, and in which part — is assertable in a unit test
+//  without a server. The upload commit handlers reject a body whose `title`
+//  and `author` parts are missing, and that is exactly the kind of omission
+//  no amount of client-side type checking catches.
+
+import Foundation
+
+/// One file part of a multipart body.
+struct MultipartFile: Equatable, Sendable {
+    /// The form field name. Every upload endpoint reads its file parts from
+    /// `file`; the avatar route uses `avatar`.
+    var fieldName: String = "file"
+    var fileName: String
+    var mimeType: String
+    var data: Data
+}
+
+enum MultipartBody {
+    /// A boundary token that cannot occur in the payload it delimits.
+    static func makeBoundary() -> String { "omnibus.\(UUID().uuidString)" }
+
+    /// Encode `fields` then `files` into one body.
+    ///
+    /// Text fields are an ordered array, not a dictionary: `Dictionary`
+    /// iteration order varies per process, which would make the request body —
+    /// and any test asserting on it — nondeterministic.
+    static func encode(
+        boundary: String,
+        fields: [(name: String, value: String)],
+        files: [MultipartFile]
+    ) -> Data {
+        var body = Data()
+        for field in fields {
+            body.append("--\(boundary)\r\n")
+            body.append("Content-Disposition: form-data; name=\"\(field.name)\"\r\n\r\n")
+            body.append("\(field.value)\r\n")
+        }
+        for file in files {
+            body.append("--\(boundary)\r\n")
+            body.append(
+                "Content-Disposition: form-data; name=\"\(file.fieldName)\";"
+                    + " filename=\"\(file.fileName)\"\r\n"
+            )
+            body.append("Content-Type: \(file.mimeType)\r\n\r\n")
+            body.append(file.data)
+            body.append("\r\n")
+        }
+        body.append("--\(boundary)--\r\n")
+        return body
+    }
+}
+
+extension Data {
+    mutating func append(_ string: String) {
+        append(Data(string.utf8))
+    }
+}

--- a/omnibus-ios/omnibus/Offline/Cache.swift
+++ b/omnibus-ios/omnibus/Offline/Cache.swift
@@ -43,7 +43,12 @@ enum CacheKey {
     static func manifest(_ uuid: String, fileID: Int64? = nil) -> String {
         fileID.map { "manifest:\(uuid):\($0)" } ?? "manifest:\(uuid)"
     }
-    static func libraryPage(_ signature: String) -> String { "books_page:\(signature)" }
+    /// Prefix every paged-library key carries, so an invalidation can drop
+    /// the whole set without restating the literal.
+    static let libraryPagePrefix = "books_page:"
+    static func libraryPage(_ signature: String) -> String {
+        "\(libraryPagePrefix)\(signature)"
+    }
     static func playbackRate(_ uuid: String) -> String { "audio_rate:\(uuid)" }
     static func suggestions(_ uuid: String) -> String { "suggestions:\(uuid)" }
     static func shelvesContaining(_ uuid: String) -> String { "shelves_with:\(uuid)" }

--- a/omnibus-ios/omnibus/Services/UploadManager.swift
+++ b/omnibus-ios/omnibus/Services/UploadManager.swift
@@ -1,0 +1,243 @@
+//  UploadManager.swift
+//  Owns book uploads: the queue, the staged copies on disk, and the transfers.
+//
+//  This lives outside the view on purpose. Staged bytes and in-flight requests
+//  outlive a sheet the reader can dismiss at any moment, and when `AddBooksSheet`
+//  owned them every exit path had to remember to clean up — which is precisely
+//  the class of bug that kept recurring. Here there is one worker, one
+//  cancellable handle, and one registry of live directories, so "who releases
+//  this copy" has a single answer.
+//
+//  Uploads are never queued offline (rule 08, test 1): they are library-wide
+//  state, so this holds work only for the life of the process.
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class UploadManager {
+    static let shared = UploadManager()
+
+    /// Progress rows, oldest first. Survives the sheet being dismissed.
+    private(set) var uploads: [UploadTask] = []
+    /// The draft whose confirm sheet should be on screen, if any.
+    private(set) var activeDraft: UploadDraft?
+    /// Names the picker allowed through that neither endpoint accepts.
+    private(set) var unsupported: [String] = []
+
+    /// Batches waiting to be staged and inspected.
+    private var queue: [(batch: UploadBatch, task: UploadTask)] = []
+    private var worker: Task<Void, Never>?
+    /// Serializes commits against each other while letting the next batch's
+    /// inspect overlap one in-flight commit — two full payloads at most.
+    private var commitTail: Task<Void, Never>?
+
+    /// Staging directories this process still owns. The sweep consults it so a
+    /// second sheet cannot delete the bytes of an upload still running.
+    private var liveDirectories: Set<URL> = []
+
+    /// Resolved by `confirm`/`cancelActive`, so the worker can wait on a human.
+    private var resolution: CheckedContinuation<UploadConfirmation?, Never>?
+    /// Resolved by the view's `onDismiss`, so the next draft is never presented
+    /// into a dismissal already in flight — the race that wedged the queue.
+    private var dismissal: CheckedContinuation<Void, Never>?
+    /// True from the moment Add is tapped until that draft's commit is queued,
+    /// so neither Add nor Cancel can act on a draft twice.
+    private(set) var isSubmitting = false
+
+    /// Set when a commit lands, cleared when the mirror is resynced, so a
+    /// multi-book pick pays one sync instead of one per book.
+    private var librarySyncPending = false
+
+    private init() {}
+
+    // MARK: - Intake
+
+    /// Group a pick into batches and queue them. Safe to call while a previous
+    /// pick is still draining — the new batches join the same queue.
+    func enqueue(_ urls: [URL]) {
+        let selection = UploadFlow.selection(for: urls)
+        unsupported = selection.unsupported
+        guard !selection.batches.isEmpty else { return }
+
+        for batch in selection.batches {
+            let task = UploadTask(name: batch.displayName)
+            uploads.append(task)
+            queue.append((batch, task))
+        }
+        startWorkerIfIdle()
+    }
+
+    private func startWorkerIfIdle() {
+        guard worker == nil else { return }
+        worker = Task { [weak self] in
+            await self?.drain()
+            self?.worker = nil
+        }
+    }
+
+    /// One batch at a time, all the way through confirmation.
+    ///
+    /// The wait on the reader is what bounds disk: staging every picked book up
+    /// front held a full copy of each in `tmp` before the reader had agreed to
+    /// any of them, which is how an ordinary multi-book pick could fill a phone.
+    private func drain() async {
+        while !queue.isEmpty {
+            if Task.isCancelled { return }
+            let (batch, task) = queue.removeFirst()
+            await process(batch, task: task)
+        }
+        await flushLibrarySync()
+    }
+
+    private func process(_ batch: UploadBatch, task: UploadTask) async {
+        // Registered before the copy starts: a stage that throws part-way has
+        // already written the parts it got through, and nothing else knows
+        // where they are.
+        let directory = UploadService.makeStagingDirectory()
+        liveDirectories.insert(directory)
+
+        let staged: UploadBatch
+        let confirmation: UploadConfirmation
+        do {
+            staged = try await UploadService.stage(batch, into: directory)
+            confirmation = try await UploadService.inspect(staged)
+        } catch {
+            task.state = .failed(UploadManager.message(for: error))
+            release(directory)
+            return
+        }
+        if Task.isCancelled {
+            task.state = .failed("Cancelled.")
+            release(directory)
+            return
+        }
+
+        task.state = .needsDetails
+        let draft = UploadDraft(
+            batch: staged, directory: directory, confirmation: confirmation, task: task
+        )
+        guard let confirmed = await present(draft) else {
+            uploads.removeAll { $0.id == task.id }
+            release(directory)
+            return
+        }
+        task.state = .uploading
+        enqueueCommit(draft, as: confirmed)
+    }
+
+    // MARK: - Confirmation
+
+    /// Show `draft`'s sheet and suspend until the reader resolves it. Returns
+    /// nil when they cancel.
+    private func present(_ draft: UploadDraft) async -> UploadConfirmation? {
+        activeDraft = draft
+        let confirmed = await withCheckedContinuation { continuation in
+            resolution = continuation
+        }
+        activeDraft = nil
+        // Wait for the sheet to finish animating away before the worker can
+        // produce another draft: `sheet(item:)` silently drops a re-arm that
+        // lands mid-dismissal, and the queue then wedges behind its own guard.
+        await withCheckedContinuation { continuation in
+            dismissal = continuation
+        }
+        isSubmitting = false
+        return confirmed
+    }
+
+    /// Commit the active draft under the reader's confirmed metadata.
+    func confirm(_ confirmation: UploadConfirmation) {
+        guard !isSubmitting, resolution != nil else { return }
+        isSubmitting = true
+        resolution?.resume(returning: confirmation)
+        resolution = nil
+    }
+
+    /// Drop the active draft. Ignored once Add has been tapped, so a Cancel in
+    /// the dismissal window cannot delete the bytes a commit is reading.
+    func cancelActive() {
+        guard !isSubmitting, resolution != nil else { return }
+        resolution?.resume(returning: nil)
+        resolution = nil
+    }
+
+    /// Called by the view once the confirm sheet has finished dismissing.
+    func sheetDidDismiss() {
+        dismissal?.resume()
+        dismissal = nil
+    }
+
+    // MARK: - Commit
+
+    private func enqueueCommit(_ draft: UploadDraft, as confirmation: UploadConfirmation) {
+        let previous = commitTail
+        commitTail = Task { [weak self] in
+            await previous?.value
+            await self?.runCommit(draft, as: confirmation)
+        }
+    }
+
+    private func runCommit(_ draft: UploadDraft, as confirmation: UploadConfirmation) async {
+        do {
+            _ = try await UploadService.commit(draft.batch, as: confirmation)
+            draft.task.state = .finished
+            librarySyncPending = true
+            Haptics.success()
+        } catch {
+            draft.task.state = .failed(UploadManager.message(for: error))
+            // The server files and indexes before it validates, and its request
+            // timeout can fire after that point — so a thrown error does not
+            // prove the library is unchanged.
+            if UploadManager.mayHaveReachedTheServer(error) { librarySyncPending = true }
+        }
+        release(draft.directory)
+        if queue.isEmpty { await flushLibrarySync() }
+    }
+
+    /// One library invalidation per pick, not one per book: each carries a full
+    /// mirror resync, and `LibraryIndex.sync` drops a forced pass outright while
+    /// another is running, so per-book calls silently lost the later books.
+    private func flushLibrarySync() async {
+        guard librarySyncPending else { return }
+        librarySyncPending = false
+        await UploadService.invalidateLibrary()
+    }
+
+    // MARK: - Staging lifetime
+
+    private func release(_ directory: URL) {
+        liveDirectories.remove(directory)
+        UploadService.discard(directory)
+    }
+
+    /// Delete staged copies from runs that are over, leaving anything this
+    /// process still owns. A blind sweep of the root deleted the parts of an
+    /// upload that was still reading them.
+    func sweepAbandonedStaging() {
+        let live = liveDirectories
+        Task.detached(priority: .utility) {
+            UploadService.sweepStaging(keeping: live)
+        }
+    }
+
+    // MARK: - Errors
+
+    nonisolated static func message(for error: Error) -> String {
+        error.localizedDescription
+    }
+
+    /// Whether a failure could have left the book filed anyway. A transport
+    /// failure means the request never landed, so invalidating the library —
+    /// which *deletes* cached reads — would blank the shelf for a reader who is
+    /// now offline and cannot refill it.
+    nonisolated static func mayHaveReachedTheServer(_ error: Error) -> Bool {
+        guard let error = error as? APIError else { return false }
+        switch error {
+        case .http: return true
+        case .decoding: return true
+        case .notConfigured, .offline, .transport, .unauthorized: return false
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Services/UploadService.swift
+++ b/omnibus-ios/omnibus/Services/UploadService.swift
@@ -2,10 +2,10 @@
 //  The two-step "add your own books" ingest: inspect a picked file for its
 //  embedded metadata, then commit it with the metadata the user confirmed.
 //
-//  Both steps are online-only and throw on failure. An upload is a command —
-//  it files bytes into a shared library and kicks a reindex — so it never
-//  queues in the outbox (rule 08, tests 1 and 2), and the sheet disables the
-//  control while offline rather than letting the request fail after the fact.
+//  Both steps are online-only and throw on failure. An upload is library-wide
+//  state — it files bytes into a shared library and kicks a reindex — so it
+//  never queues in the outbox (rule 08, test 1), and the sheet disables its
+//  controls while offline rather than letting the request fail after the fact.
 
 import Foundation
 
@@ -18,14 +18,20 @@ struct UploadConfirmation: Equatable, Sendable {
 }
 
 enum UploadService {
+    /// Parent of every per-batch staging directory, so a sweep can find
+    /// leftovers from a crash or a dismissal that outran its cleanup.
+    private static var stagingRoot: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("omnibus-uploads", isDirectory: true)
+    }
+
     /// Copy a batch's picked file(s) into this app's temporary directory,
     /// returning the batch rebased onto the copies plus the directory holding
     /// them.
     ///
     /// Two reasons, both about the confirm step: the picker's URLs are
     /// security-scoped and that access must be released promptly, while the
-    /// human pause before the user hits Add is unbounded. Copying also keeps a
-    /// large book on disk across that pause instead of resident in a `Data`.
+    /// human pause before the user hits Add is unbounded.
     ///
     /// The copy runs detached because this target builds with approachable
     /// concurrency, under which a `nonisolated async` function runs on its
@@ -38,25 +44,22 @@ enum UploadService {
     private static func stageOnDisk(
         _ batch: UploadBatch
     ) throws -> (batch: UploadBatch, directory: URL) {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("omnibus-uploads/\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: directory, withIntermediateDirectories: true
-        )
+        let directory = stagingRoot
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
         var staged: [URL] = []
         for (index, source) in batch.urls.enumerated() {
+            // Each part gets its own numbered subdirectory so a copy can never
+            // collide, which lets the *original* filename go out on the wire.
+            // Renaming client-side to dodge a collision was worse than useless:
+            // the server already dedupes with `dedupe_part_name`, and a `-N`
+            // suffix sorts before the bare stem ('-' < '.'), which is the
+            // tiebreak `build_parts_list` uses — so it reordered two-disc books.
+            let slot = directory.appendingPathComponent("\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: slot, withIntermediateDirectories: true)
+
             let scoped = source.startAccessingSecurityScopedResource()
             defer { if scoped { source.stopAccessingSecurityScopedResource() } }
-            // Two parts picked from different folders can share a name, and
-            // the copy — like the server's own filing — would collide.
-            var name = source.lastPathComponent
-            var destination = directory.appendingPathComponent(name)
-            if FileManager.default.fileExists(atPath: destination.path) {
-                let ext = (name as NSString).pathExtension
-                let stem = (name as NSString).deletingPathExtension
-                name = ext.isEmpty ? "\(stem)-\(index)" : "\(stem)-\(index).\(ext)"
-                destination = directory.appendingPathComponent(name)
-            }
+            let destination = slot.appendingPathComponent(source.lastPathComponent)
             try FileManager.default.copyItem(at: source, to: destination)
             staged.append(destination)
         }
@@ -64,18 +67,37 @@ enum UploadService {
     }
 
     /// Delete a staged copy once its upload has finished, succeeded or not.
+    /// Detached for the same reason [`stage`] is — removing a multi-part book
+    /// is N unlinks, and the callers are all on the main actor.
     static func discard(_ directory: URL) {
+        Task.detached(priority: .utility) { discardNow(directory) }
+    }
+
+    /// The synchronous body of [`discard`], so a caller that must observe the
+    /// deletion (a test) does not have to race the detached task.
+    static func discardNow(_ directory: URL) {
         try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// Delete every staged copy left behind by a previous run.
+    ///
+    /// Staging outlives its owner in the cases cleanup can't reach — a crash, a
+    /// kill mid-confirm — and iOS does not purge `tmp` while the app runs, so
+    /// without this a failed upload's copy is unreachable disk forever.
+    static func sweepStaleStaging() {
+        Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: stagingRoot)
+        }
     }
 
     /// Parse the picked file(s) and return the metadata to pre-fill the confirm
     /// form with. Nothing is written — the server discards its tempfile.
     static func inspect(_ batch: UploadBatch) async throws -> UploadConfirmation {
-        let files = try await loadParts(batch)
+        let (body, boundary) = try await encodedBody(for: batch, fields: [])
         switch batch.kind {
         case .ebook:
             let inspection: UploadInspection = try await APIClient.shared.upload(
-                batch.kind.inspectPath, files: files
+                batch.kind.inspectPath, body: body, boundary: boundary
             )
             return UploadConfirmation(
                 title: inspection.title ?? "",
@@ -85,7 +107,7 @@ enum UploadService {
             )
         case .audiobook:
             let inspection: AudiobookInspection = try await APIClient.shared.upload(
-                batch.kind.inspectPath, files: files
+                batch.kind.inspectPath, body: body, boundary: boundary
             )
             return UploadConfirmation(
                 title: inspection.title ?? "", author: inspection.author ?? ""
@@ -99,7 +121,6 @@ enum UploadService {
     static func commit(
         _ batch: UploadBatch, as confirmation: UploadConfirmation
     ) async throws -> UploadCommitResult {
-        let files = try await loadParts(batch)
         let fields = UploadFlow.commitFields(
             kind: batch.kind,
             title: confirmation.title,
@@ -107,20 +128,48 @@ enum UploadService {
             series: confirmation.series,
             seriesIndex: confirmation.seriesIndex
         )
-        let result: UploadCommitResult = try await APIClient.shared.upload(
-            batch.kind.commitPath, files: files, fields: fields
+        let (body, boundary) = try await encodedBody(for: batch, fields: fields)
+        // Invalidate whatever the outcome: the server files and indexes the
+        // book *before* it validates the overrides, and its 30s request timeout
+        // can fire after the same point — so a thrown error does not mean the
+        // library is unchanged.
+        defer { Task { await invalidateLibrary() } }
+        return try await APIClient.shared.upload(
+            batch.kind.commitPath, body: body, boundary: boundary
         )
-        // The library listing and its pages now predate a book that exists.
-        await OfflineStore.shared.cacheDelete(CacheKey.library)
-        await OfflineStore.shared.cacheDeletePrefix("books_page:")
-        return result
     }
 
-    /// Read every staged part off disk, off the main thread for the same
-    /// reason [`stage`] copies there.
-    private static func loadParts(_ batch: UploadBatch) async throws -> [MultipartFile] {
+    /// Drop every cached read a new book invalidates, and resync the offline
+    /// mirror. Named rather than inlined so the next write that adds a book has
+    /// one place to call — `CheckInView` open-codes a different, disjoint set.
+    static func invalidateLibrary() async {
+        let store = OfflineStore.shared
+        // The paged listing is the real library cache; `CacheKey.library`
+        // itself is never written by anything, so deleting it is a no-op.
+        await store.cacheDeletePrefix(CacheKey.libraryPagePrefix)
+        await store.cacheDelete(CacheKey.authors)
+        await store.cacheDelete(CacheKey.series)
+        await store.cacheDelete(CacheKey.shelves)
+        await store.cacheDelete(CacheKey.shelfPreviews)
+        // The SQLite mirror is not a cache key — it backs offline paging and
+        // search, and its own sync self-throttles to once per five minutes.
+        await LibraryIndex.shared.sync(force: true)
+    }
+
+    /// Read the staged parts and encode the multipart body, all off the caller's
+    /// actor.
+    ///
+    /// Encoding here rather than inside `APIClient` matters: `upload` is an
+    /// actor method, so concatenating a multi-hundred-megabyte body there would
+    /// hold the actor every other request in the app funnels through.
+    private static func encodedBody(
+        for batch: UploadBatch, fields: [(name: String, value: String)]
+    ) async throws -> (body: Data, boundary: String) {
         try await Task.detached(priority: .userInitiated) {
-            try batch.urls.map(loadPart)
+            let files = try batch.urls.map(loadPart)
+            let boundary = MultipartBody.makeBoundary()
+            let body = MultipartBody.encode(boundary: boundary, fields: fields, files: files)
+            return (body, boundary)
         }.value
     }
 
@@ -128,12 +177,16 @@ enum UploadService {
     /// live in this app's temporary directory — [`stage`] copied them out of
     /// the picker's security-scoped location — so no scope is claimed here and
     /// a slow confirm step cannot outlive one.
+    ///
+    /// `.mappedIfSafe` keeps the source pages file-backed and evictable instead
+    /// of dirty anonymous memory; the file is one this app just wrote to its own
+    /// tmp directory and nothing mutates it, which is what makes mapping safe.
     private static func loadPart(_ url: URL) throws -> MultipartFile {
         let name = url.lastPathComponent
         return MultipartFile(
             fileName: name,
             mimeType: UploadFlow.mimeType(for: name),
-            data: try Data(contentsOf: url)
+            data: try Data(contentsOf: url, options: .mappedIfSafe)
         )
     }
 }

--- a/omnibus-ios/omnibus/Services/UploadService.swift
+++ b/omnibus-ios/omnibus/Services/UploadService.swift
@@ -1,0 +1,139 @@
+//  UploadService.swift
+//  The two-step "add your own books" ingest: inspect a picked file for its
+//  embedded metadata, then commit it with the metadata the user confirmed.
+//
+//  Both steps are online-only and throw on failure. An upload is a command —
+//  it files bytes into a shared library and kicks a reindex — so it never
+//  queues in the outbox (rule 08, tests 1 and 2), and the sheet disables the
+//  control while offline rather than letting the request fail after the fact.
+
+import Foundation
+
+/// What the user confirmed on the confirm sheet, ready to commit.
+struct UploadConfirmation: Equatable, Sendable {
+    var title: String
+    var author: String
+    var series: String = ""
+    var seriesIndex: String = ""
+}
+
+enum UploadService {
+    /// Copy a batch's picked file(s) into this app's temporary directory,
+    /// returning the batch rebased onto the copies plus the directory holding
+    /// them.
+    ///
+    /// Two reasons, both about the confirm step: the picker's URLs are
+    /// security-scoped and that access must be released promptly, while the
+    /// human pause before the user hits Add is unbounded. Copying also keeps a
+    /// large book on disk across that pause instead of resident in a `Data`.
+    ///
+    /// The copy runs detached because this target builds with approachable
+    /// concurrency, under which a `nonisolated async` function runs on its
+    /// *caller's* actor — here, the view. A multi-hundred-megabyte audiobook
+    /// copied on the main thread freezes the UI for the length of the copy.
+    static func stage(_ batch: UploadBatch) async throws -> (batch: UploadBatch, directory: URL) {
+        try await Task.detached(priority: .userInitiated) { try stageOnDisk(batch) }.value
+    }
+
+    private static func stageOnDisk(
+        _ batch: UploadBatch
+    ) throws -> (batch: UploadBatch, directory: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("omnibus-uploads/\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+        var staged: [URL] = []
+        for (index, source) in batch.urls.enumerated() {
+            let scoped = source.startAccessingSecurityScopedResource()
+            defer { if scoped { source.stopAccessingSecurityScopedResource() } }
+            // Two parts picked from different folders can share a name, and
+            // the copy — like the server's own filing — would collide.
+            var name = source.lastPathComponent
+            var destination = directory.appendingPathComponent(name)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                let ext = (name as NSString).pathExtension
+                let stem = (name as NSString).deletingPathExtension
+                name = ext.isEmpty ? "\(stem)-\(index)" : "\(stem)-\(index).\(ext)"
+                destination = directory.appendingPathComponent(name)
+            }
+            try FileManager.default.copyItem(at: source, to: destination)
+            staged.append(destination)
+        }
+        return (UploadBatch(kind: batch.kind, urls: staged), directory)
+    }
+
+    /// Delete a staged copy once its upload has finished, succeeded or not.
+    static func discard(_ directory: URL) {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// Parse the picked file(s) and return the metadata to pre-fill the confirm
+    /// form with. Nothing is written — the server discards its tempfile.
+    static func inspect(_ batch: UploadBatch) async throws -> UploadConfirmation {
+        let files = try await loadParts(batch)
+        switch batch.kind {
+        case .ebook:
+            let inspection: UploadInspection = try await APIClient.shared.upload(
+                batch.kind.inspectPath, files: files
+            )
+            return UploadConfirmation(
+                title: inspection.title ?? "",
+                author: inspection.author ?? "",
+                series: inspection.series ?? "",
+                seriesIndex: inspection.seriesIndex ?? ""
+            )
+        case .audiobook:
+            let inspection: AudiobookInspection = try await APIClient.shared.upload(
+                batch.kind.inspectPath, files: files
+            )
+            return UploadConfirmation(
+                title: inspection.title ?? "", author: inspection.author ?? ""
+            )
+        }
+    }
+
+    /// File the book into the library under the confirmed metadata and return
+    /// its durable uuid. The commit handlers reject a body without `title` and
+    /// `author`, so [`UploadFlow.commitFields`] always sends both.
+    static func commit(
+        _ batch: UploadBatch, as confirmation: UploadConfirmation
+    ) async throws -> UploadCommitResult {
+        let files = try await loadParts(batch)
+        let fields = UploadFlow.commitFields(
+            kind: batch.kind,
+            title: confirmation.title,
+            author: confirmation.author,
+            series: confirmation.series,
+            seriesIndex: confirmation.seriesIndex
+        )
+        let result: UploadCommitResult = try await APIClient.shared.upload(
+            batch.kind.commitPath, files: files, fields: fields
+        )
+        // The library listing and its pages now predate a book that exists.
+        await OfflineStore.shared.cacheDelete(CacheKey.library)
+        await OfflineStore.shared.cacheDeletePrefix("books_page:")
+        return result
+    }
+
+    /// Read every staged part off disk, off the main thread for the same
+    /// reason [`stage`] copies there.
+    private static func loadParts(_ batch: UploadBatch) async throws -> [MultipartFile] {
+        try await Task.detached(priority: .userInitiated) {
+            try batch.urls.map(loadPart)
+        }.value
+    }
+
+    /// Read one staged part off disk. By the time either step runs the files
+    /// live in this app's temporary directory — [`stage`] copied them out of
+    /// the picker's security-scoped location — so no scope is claimed here and
+    /// a slow confirm step cannot outlive one.
+    private static func loadPart(_ url: URL) throws -> MultipartFile {
+        let name = url.lastPathComponent
+        return MultipartFile(
+            fileName: name,
+            mimeType: UploadFlow.mimeType(for: name),
+            data: try Data(contentsOf: url)
+        )
+    }
+}

--- a/omnibus-ios/omnibus/Services/UploadService.swift
+++ b/omnibus-ios/omnibus/Services/UploadService.swift
@@ -25,35 +25,43 @@ enum UploadService {
             .appendingPathComponent("omnibus-uploads", isDirectory: true)
     }
 
-    /// Copy a batch's picked file(s) into this app's temporary directory,
-    /// returning the batch rebased onto the copies plus the directory holding
-    /// them.
+    /// Allocate (but do not create) a staging directory for one batch.
+    ///
+    /// Handed out before any copying so the caller can register it as live
+    /// first: a `stage` that throws part-way has already written the parts it
+    /// got through, and a directory nobody holds is a directory nobody frees.
+    static func makeStagingDirectory() -> URL {
+        stagingRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+
+    /// Copy a batch's picked file(s) into `directory`, returning the batch
+    /// rebased onto the copies.
     ///
     /// Two reasons, both about the confirm step: the picker's URLs are
     /// security-scoped and that access must be released promptly, while the
-    /// human pause before the user hits Add is unbounded.
+    /// human pause before the reader hits Add is unbounded.
     ///
     /// The copy runs detached because this target builds with approachable
     /// concurrency, under which a `nonisolated async` function runs on its
-    /// *caller's* actor — here, the view. A multi-hundred-megabyte audiobook
-    /// copied on the main thread freezes the UI for the length of the copy.
-    static func stage(_ batch: UploadBatch) async throws -> (batch: UploadBatch, directory: URL) {
-        try await Task.detached(priority: .userInitiated) { try stageOnDisk(batch) }.value
+    /// *caller's* actor. A multi-hundred-megabyte audiobook copied on the main
+    /// thread freezes the UI for the length of the copy.
+    static func stage(_ batch: UploadBatch, into directory: URL) async throws -> UploadBatch {
+        try await Task.detached(priority: .userInitiated) {
+            try stageOnDisk(batch, into: directory)
+        }.value
     }
 
     private static func stageOnDisk(
-        _ batch: UploadBatch
-    ) throws -> (batch: UploadBatch, directory: URL) {
-        let directory = stagingRoot
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        _ batch: UploadBatch, into directory: URL
+    ) throws -> UploadBatch {
         var staged: [URL] = []
         for (index, source) in batch.urls.enumerated() {
-            // Each part gets its own numbered subdirectory so a copy can never
-            // collide, which lets the *original* filename go out on the wire.
-            // Renaming client-side to dodge a collision was worse than useless:
-            // the server already dedupes with `dedupe_part_name`, and a `-N`
-            // suffix sorts before the bare stem ('-' < '.'), which is the
-            // tiebreak `build_parts_list` uses — so it reordered two-disc books.
+            try Task.checkCancellation()
+            // Each part gets its own numbered slot so a copy can never collide,
+            // which lets the *original* filename go out on the wire. Renaming
+            // client-side to dodge a collision was worse than useless: the
+            // server already dedupes, and a `-N` suffix sorts before the bare
+            // stem ('-' < '.'), which is the tiebreak it orders parts by.
             let slot = directory.appendingPathComponent("\(index)", isDirectory: true)
             try FileManager.default.createDirectory(at: slot, withIntermediateDirectories: true)
 
@@ -63,12 +71,10 @@ enum UploadService {
             try FileManager.default.copyItem(at: source, to: destination)
             staged.append(destination)
         }
-        return (UploadBatch(kind: batch.kind, urls: staged), directory)
+        return UploadBatch(kind: batch.kind, urls: staged)
     }
 
-    /// Delete a staged copy once its upload has finished, succeeded or not.
-    /// Detached for the same reason [`stage`] is — removing a multi-part book
-    /// is N unlinks, and the callers are all on the main actor.
+    /// Delete one staged copy once its upload has finished, succeeded or not.
     static func discard(_ directory: URL) {
         Task.detached(priority: .utility) { discardNow(directory) }
     }
@@ -79,14 +85,30 @@ enum UploadService {
         try? FileManager.default.removeItem(at: directory)
     }
 
-    /// Delete every staged copy left behind by a previous run.
+    /// Delete staged copies except those in `keeping`.
     ///
-    /// Staging outlives its owner in the cases cleanup can't reach — a crash, a
-    /// kill mid-confirm — and iOS does not purge `tmp` while the app runs, so
-    /// without this a failed upload's copy is unreachable disk forever.
-    static func sweepStaleStaging() {
-        Task.detached(priority: .utility) {
-            try? FileManager.default.removeItem(at: stagingRoot)
+    /// Staging outlives its owner when cleanup cannot run — a crash, a kill
+    /// mid-confirm — and iOS does not purge `tmp` while the app runs. But a
+    /// blind sweep of the root is worse than the leak: an upload that outlived
+    /// its sheet is still reading from one of these directories.
+    /// `root` is a seam for tests: the sweep is destructive over a whole
+    /// directory, so a test that swept the real root would delete staging that
+    /// a concurrently-running test still owns.
+    static func sweepStaging(keeping live: Set<URL>, in root: URL? = nil) {
+        let root = root ?? stagingRoot
+        let fm = FileManager.default
+        // Compared by directory name, not by URL: `temporaryDirectory` and the
+        // paths `contentsOfDirectory` returns differ by the /var -> /private/var
+        // symlink, and neither `standardizedFileURL` nor string equality sees
+        // through that — which would have swept every live directory.
+        let keep = Set(live.map(\.lastPathComponent))
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: root, includingPropertiesForKeys: nil
+            )
+        else { return }
+        for entry in entries where !keep.contains(entry.lastPathComponent) {
+            try? fm.removeItem(at: entry)
         }
     }
 
@@ -129,11 +151,9 @@ enum UploadService {
             seriesIndex: confirmation.seriesIndex
         )
         let (body, boundary) = try await encodedBody(for: batch, fields: fields)
-        // Invalidate whatever the outcome: the server files and indexes the
-        // book *before* it validates the overrides, and its 30s request timeout
-        // can fire after the same point — so a thrown error does not mean the
-        // library is unchanged.
-        defer { Task { await invalidateLibrary() } }
+        // Invalidation is the caller's: `UploadManager` decides from the
+        // outcome whether the library can have changed, and coalesces one
+        // resync per pick rather than one per book.
         return try await APIClient.shared.upload(
             batch.kind.commitPath, body: body, boundary: boundary
         )
@@ -141,7 +161,9 @@ enum UploadService {
 
     /// Drop every cached read a new book invalidates, and resync the offline
     /// mirror. Named rather than inlined so the next write that adds a book has
-    /// one place to call — `CheckInView` open-codes a different, disjoint set.
+    /// one place to call. `CheckInView` clears an overlapping but narrower
+    /// set for its own book-creating writes; folding it in here is worth
+    /// doing and is tracked separately.
     static func invalidateLibrary() async {
         let store = OfflineStore.shared
         // The paged listing is the real library cache; `CacheKey.library`
@@ -149,8 +171,15 @@ enum UploadService {
         await store.cacheDeletePrefix(CacheKey.libraryPagePrefix)
         await store.cacheDelete(CacheKey.authors)
         await store.cacheDelete(CacheKey.series)
+        // A new book's subjects feed both of these.
+        await store.cacheDelete(CacheKey.tags)
+        await store.cacheDelete(CacheKey.genres)
+        // Shelf counts and preview covers move, and so does the membership the
+        // shelf page itself lists — a rule-matching upload joins smart shelves.
         await store.cacheDelete(CacheKey.shelves)
         await store.cacheDelete(CacheKey.shelfPreviews)
+        await store.cacheDeletePrefix("shelf:")
+        await store.cacheDeletePrefix("shelf_page:")
         // The SQLite mirror is not a cache key — it backs offline paging and
         // search, and its own sync self-throttles to once per five minutes.
         await LibraryIndex.shared.sync(force: true)

--- a/omnibus-ios/omnibusTests/MultipartBodyTests.swift
+++ b/omnibus-ios/omnibusTests/MultipartBodyTests.swift
@@ -110,6 +110,70 @@ struct MultipartBodyTests {
         #expect(first == second)
     }
 
+    @Test func escapesAQuoteThatWouldCloseTheHeaderEarly() {
+        // `"` is legal in a POSIX filename; raw, it ends the quoted string and
+        // corrupts every header after it.
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B", fields: [],
+                files: [
+                    MultipartFile(
+                        fileName: #"He said "hi".epub"#,
+                        mimeType: "application/epub+zip", data: Data("PK".utf8)
+                    )
+                ]
+            )
+        )
+        #expect(body.contains(#"filename="He said %22hi%22.epub""#))
+        // Exactly two quotes around the value, so the parameter is still one
+        // well-formed quoted string.
+        let header = body.components(separatedBy: "\r\n").first { $0.contains("filename=") }
+        #expect(header?.filter { $0 == "\"" }.count == 4)
+    }
+
+    @Test func escapesNewlinesThatWouldEndTheHeaderLine() {
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B", fields: [],
+                files: [
+                    MultipartFile(
+                        fileName: "two\r\nlines.epub",
+                        mimeType: "application/epub+zip", data: Data("PK".utf8)
+                    )
+                ]
+            )
+        )
+        #expect(body.contains(#"filename="two%0D%0Alines.epub""#))
+        // One header line for the disposition, not three.
+        #expect(body.components(separatedBy: "Content-Disposition").count == 2)
+    }
+
+    @Test func leavesAPercentAloneSoOrdinaryFilenamesArentMangled() {
+        // The server slugifies rather than percent-decoding — a probe upload of
+        // `50%25 off.mp3` landed as `50-25-off.mp3` — so pre-encoding `%` would
+        // stamp a literal `25` into a book legitimately called "50% off".
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B", fields: [],
+                files: [
+                    MultipartFile(
+                        fileName: "50% off.mp3", mimeType: "audio/mpeg", data: Data("ID3".utf8)
+                    )
+                ]
+            )
+        )
+        #expect(body.contains(#"filename="50% off.mp3""#))
+    }
+
+    @Test func escapesTheFieldNameOnTheSameTerms() {
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B", fields: [(#"od"d"#, "v")], files: []
+            )
+        )
+        #expect(body.contains(#"name="od%22d""#))
+    }
+
     @Test func boundariesAreUniquePerBody() {
         #expect(MultipartBody.makeBoundary() != MultipartBody.makeBoundary())
         #expect(MultipartBody.makeBoundary().hasPrefix("omnibus."))

--- a/omnibus-ios/omnibusTests/MultipartBodyTests.swift
+++ b/omnibus-ios/omnibusTests/MultipartBodyTests.swift
@@ -1,0 +1,117 @@
+//  MultipartBodyTests.swift
+//  The bytes an upload actually puts on the wire. The commit handlers parse
+//  `title`/`author` out of this body, so "did we send them" is a property of
+//  the encoding, not of the call site — and it is what the app got wrong.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+private func decoded(_ data: Data) -> String {
+    String(decoding: data, as: UTF8.self)
+}
+
+private func file(_ name: String, _ bytes: String = "PK\u{03}\u{04}") -> MultipartFile {
+    MultipartFile(
+        fileName: name,
+        mimeType: UploadFlow.mimeType(for: name),
+        data: Data(bytes.utf8)
+    )
+}
+
+struct MultipartBodyTests {
+    @Test func encodesTextFieldsAheadOfTheFile() {
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B",
+                fields: UploadFlow.commitFields(
+                    kind: .ebook, title: "Dune", author: "Frank Herbert",
+                    series: "", seriesIndex: ""
+                ),
+                files: [file("Dune.epub")]
+            )
+        )
+        #expect(body.contains("--B\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nDune\r\n"))
+        #expect(
+            body.contains(
+                "--B\r\nContent-Disposition: form-data; name=\"author\"\r\n\r\nFrank Herbert\r\n"
+            )
+        )
+        #expect(
+            body.contains(
+                "Content-Disposition: form-data; name=\"file\"; filename=\"Dune.epub\"\r\n"
+                    + "Content-Type: application/epub+zip\r\n\r\n"
+            )
+        )
+        #expect(body.hasSuffix("--B--\r\n"))
+        // The regression: a commit body with no title/author part 400s.
+        let titleIndex = body.range(of: "name=\"title\"")
+        let fileIndex = body.range(of: "name=\"file\"")
+        #expect(titleIndex != nil)
+        #expect(fileIndex != nil)
+        if let titleIndex, let fileIndex {
+            #expect(titleIndex.lowerBound < fileIndex.lowerBound)
+        }
+    }
+
+    @Test func encodesEveryPartOfAMultiFileAudiobookUnderTheSameFieldName() {
+        // The audiobook endpoint collects repeated `file` fields into one book.
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B",
+                fields: [("title", "Dune"), ("author", "Herbert")],
+                files: [file("01.mp3", "ID3a"), file("02.mp3", "ID3b")]
+            )
+        )
+        #expect(body.contains("filename=\"01.mp3\""))
+        #expect(body.contains("filename=\"02.mp3\""))
+        #expect(body.components(separatedBy: "name=\"file\"").count == 3)
+        #expect(body.contains("Content-Type: audio/mpeg"))
+    }
+
+    @Test func encodesAFileWithNoFieldsForTheAvatarRoute() {
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B",
+                fields: [],
+                files: [
+                    MultipartFile(
+                        fieldName: "avatar", fileName: "avatar.jpg",
+                        mimeType: "image/jpeg", data: Data([0xFF, 0xD8])
+                    )
+                ]
+            )
+        )
+        #expect(body.contains("name=\"avatar\"; filename=\"avatar.jpg\""))
+        #expect(!body.contains("name=\"title\""))
+    }
+
+    @Test func preservesBinaryPayloadBytesExactly() {
+        let payload = Data([0x50, 0x4B, 0x03, 0x04, 0x00, 0xFF, 0x0D, 0x0A])
+        let body = MultipartBody.encode(
+            boundary: "B",
+            fields: [],
+            files: [
+                MultipartFile(fileName: "a.epub", mimeType: "application/epub+zip", data: payload)
+            ]
+        )
+        #expect(body.range(of: payload) != nil)
+    }
+
+    @Test func fieldOrderIsStableAcrossEncodes() {
+        // Dictionary iteration order varies per process; the fields array is
+        // what keeps a request body — and this test — deterministic.
+        let fields = UploadFlow.commitFields(
+            kind: .ebook, title: "Dune", author: "Herbert", series: "Dune", seriesIndex: "1"
+        )
+        let first = decoded(MultipartBody.encode(boundary: "B", fields: fields, files: []))
+        let second = decoded(MultipartBody.encode(boundary: "B", fields: fields, files: []))
+        #expect(first == second)
+    }
+
+    @Test func boundariesAreUniquePerBody() {
+        #expect(MultipartBody.makeBoundary() != MultipartBody.makeBoundary())
+        #expect(MultipartBody.makeBoundary().hasPrefix("omnibus."))
+    }
+}

--- a/omnibus-ios/omnibusTests/MultipartBodyTests.swift
+++ b/omnibus-ios/omnibusTests/MultipartBodyTests.swift
@@ -99,15 +99,25 @@ struct MultipartBodyTests {
         #expect(body.range(of: payload) != nil)
     }
 
-    @Test func fieldOrderIsStableAcrossEncodes() {
-        // Dictionary iteration order varies per process; the fields array is
-        // what keeps a request body — and this test — deterministic.
-        let fields = UploadFlow.commitFields(
-            kind: .ebook, title: "Dune", author: "Herbert", series: "Dune", seriesIndex: "1"
+    @Test func fieldsAppearInTheOrderGiven() {
+        // Asserts the concrete byte order, not that two encodes of one array
+        // agree — which is true of any deterministic encoder, including a
+        // Dictionary-based one, so it could not fail.
+        let body = decoded(
+            MultipartBody.encode(
+                boundary: "B",
+                fields: UploadFlow.commitFields(
+                    kind: .ebook, title: "Dune", author: "Herbert",
+                    series: "Dune", seriesIndex: "1"
+                ),
+                files: []
+            )
         )
-        let first = decoded(MultipartBody.encode(boundary: "B", fields: fields, files: []))
-        let second = decoded(MultipartBody.encode(boundary: "B", fields: fields, files: []))
-        #expect(first == second)
+        let positions = ["title", "author", "series", "series_index"].map {
+            body.range(of: "name=\"\($0)\"")?.lowerBound
+        }
+        #expect(positions.allSatisfy { $0 != nil })
+        #expect(positions == positions.sorted { ($0 ?? body.endIndex) < ($1 ?? body.endIndex) })
     }
 
     @Test func escapesAQuoteThatWouldCloseTheHeaderEarly() {
@@ -144,8 +154,16 @@ struct MultipartBodyTests {
             )
         )
         #expect(body.contains(#"filename="two%0D%0Alines.epub""#))
-        // One header line for the disposition, not three.
-        #expect(body.components(separatedBy: "Content-Disposition").count == 2)
+        // The disposition must occupy exactly one physical line. Counting
+        // occurrences of "Content-Disposition" cannot show that — splitting one
+        // header across three lines does not add occurrences — so count the
+        // CRLFs the body is allowed to contain instead: header, blank line,
+        // payload terminator, and the closing boundary.
+        let dispositionLine = body
+            .components(separatedBy: "\r\n")
+            .first { $0.contains("Content-Disposition") }
+        #expect(dispositionLine?.hasSuffix(#"filename="two%0D%0Alines.epub""#) == true)
+        #expect(!body.contains("two\r\nlines"))
     }
 
     @Test func leavesAPercentAloneSoOrdinaryFilenamesArentMangled() {

--- a/omnibus-ios/omnibusTests/UploadFlowTests.swift
+++ b/omnibus-ios/omnibusTests/UploadFlowTests.swift
@@ -1,0 +1,159 @@
+//  UploadFlowTests.swift
+//  The upload's pure request shaping: which ingest a file targets, how a
+//  multi-file pick groups into commits, and — the regression this file exists
+//  for — that a commit body actually carries `title` and `author`. Sending the
+//  file alone is what made every upload from the app 400.
+
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import omnibus
+
+private func url(_ name: String) -> URL {
+    URL(fileURLWithPath: "/tmp/picked/\(name)")
+}
+
+struct UploadFlowTests {
+    // MARK: - Format routing
+
+    @Test func kindRoutesEpubToTheEbookIngest() {
+        #expect(UploadFlow.kind(for: "Dune.epub") == .ebook)
+        #expect(UploadFlow.kind(for: "DUNE.EPUB") == .ebook)
+    }
+
+    @Test func kindRoutesEveryAcceptedAudioContainerToTheAudiobookIngest() {
+        #expect(UploadFlow.kind(for: "book.m4b") == .audiobook)
+        #expect(UploadFlow.kind(for: "book.m4a") == .audiobook)
+        #expect(UploadFlow.kind(for: "part-01.mp3") == .audiobook)
+    }
+
+    @Test func kindRejectsPlayableFormatsTheUploadEndpointsRefuse() {
+        // `Book.audioFormats` covers what the library can play; routing on it
+        // sent whole .flac/.wav files that the server then answered 415.
+        for name in ["song.flac", "song.wav", "song.ogg", "song.opus", "song.aac"] {
+            #expect(UploadFlow.kind(for: name) == nil)
+        }
+        #expect(UploadFlow.kind(for: "comic.cbz") == nil)
+        #expect(UploadFlow.kind(for: "notes.pdf") == nil)
+        #expect(UploadFlow.kind(for: "noextension") == nil)
+    }
+
+    @Test func pickerOffersOnlyFormatsTheServerAccepts() {
+        let extensions = Set(
+            UploadFlow.pickerTypes.flatMap { $0.tags[.filenameExtension] ?? [] }
+        )
+        #expect(extensions.contains("epub"))
+        #expect(extensions.contains("mp3"))
+        #expect(extensions.contains("m4a"))
+        #expect(extensions.contains("m4b"))
+        #expect(!extensions.contains("flac"))
+        #expect(!extensions.contains("wav"))
+    }
+
+    @Test func mimeTypeMatchesTheContainerRatherThanGuessingMp4() {
+        #expect(UploadFlow.mimeType(for: "a.epub") == "application/epub+zip")
+        #expect(UploadFlow.mimeType(for: "a.mp3") == "audio/mpeg")
+        #expect(UploadFlow.mimeType(for: "a.m4b") == "audio/mp4")
+        #expect(UploadFlow.mimeType(for: "a.m4a") == "audio/mp4")
+    }
+
+    // MARK: - Grouping
+
+    @Test func selectionGivesEachEpubItsOwnCommit() {
+        let selection = UploadFlow.selection(for: [url("a.epub"), url("b.epub")])
+        #expect(selection.batches.count == 2)
+        #expect(selection.batches.allSatisfy { $0.kind == .ebook })
+        #expect(selection.batches.allSatisfy { $0.urls.count == 1 })
+        #expect(selection.unsupported.isEmpty)
+    }
+
+    @Test func selectionGroupsEveryMp3IntoOneMultiPartAudiobook() {
+        // `classify_audio_set` files a set of .mp3 parts as a single book; one
+        // request per file made an N-part audiobook into N one-chapter books.
+        let picked = [url("01.mp3"), url("02.mp3"), url("03.mp3")]
+        let selection = UploadFlow.selection(for: picked)
+        #expect(selection.batches.count == 1)
+        #expect(selection.batches.first?.kind == .audiobook)
+        #expect(selection.batches.first?.urls == picked)
+    }
+
+    @Test func selectionGivesEachContainerItsOwnCommit() {
+        // Two .m4b in one request is the server's MixedAudioUpload 400 —
+        // each container is its own book, so each gets its own commit.
+        let selection = UploadFlow.selection(for: [url("one.m4b"), url("two.m4a")])
+        #expect(selection.batches.count == 2)
+        #expect(selection.batches.allSatisfy { $0.urls.count == 1 })
+    }
+
+    @Test func selectionSplitsAMixedPickAndKeepsPickOrder() {
+        let selection = UploadFlow.selection(
+            for: [url("a.epub"), url("01.mp3"), url("b.epub"), url("02.mp3")]
+        )
+        #expect(selection.batches.count == 3)
+        #expect(selection.batches[0].urls == [url("a.epub")])
+        #expect(selection.batches[1].urls == [url("b.epub")])
+        // The MP3 set lands last, as one book carrying both parts.
+        #expect(selection.batches[2].urls == [url("01.mp3"), url("02.mp3")])
+    }
+
+    @Test func selectionNamesUnsupportedFilesInsteadOfUploadingThem() {
+        let selection = UploadFlow.selection(for: [url("a.epub"), url("song.flac")])
+        #expect(selection.batches.count == 1)
+        #expect(selection.unsupported == ["song.flac"])
+    }
+
+    @Test func displayNameIsTheFilenameForOneFileAndAPartCountForMany() {
+        #expect(UploadBatch(kind: .ebook, urls: [url("Dune.epub")]).displayName == "Dune.epub")
+        #expect(
+            UploadBatch(kind: .audiobook, urls: [url("01.mp3"), url("02.mp3")]).displayName
+                == "2 parts"
+        )
+    }
+
+    // MARK: - Commit fields
+
+    @Test func commitFieldsAlwaysCarryTitleAndAuthor() {
+        let fields = UploadFlow.commitFields(
+            kind: .ebook, title: "Dune", author: "Frank Herbert", series: "", seriesIndex: ""
+        )
+        #expect(fields.map(\.name) == ["title", "author"])
+        #expect(fields.map(\.value) == ["Dune", "Frank Herbert"])
+    }
+
+    @Test func commitFieldsTrimAndDropBlankOptionals() {
+        let fields = UploadFlow.commitFields(
+            kind: .ebook, title: "  Dune  ", author: " Herbert ", series: "  ", seriesIndex: "\n"
+        )
+        #expect(fields.map(\.name) == ["title", "author"])
+        #expect(fields.map(\.value) == ["Dune", "Herbert"])
+    }
+
+    @Test func commitFieldsIncludeSeriesForEbooksOnly() {
+        let ebook = UploadFlow.commitFields(
+            kind: .ebook, title: "Dune", author: "Herbert", series: "Dune", seriesIndex: "1"
+        )
+        #expect(ebook.map(\.name) == ["title", "author", "series", "series_index"])
+
+        // The audiobook commit handler reads title/author and nothing else.
+        let audiobook = UploadFlow.commitFields(
+            kind: .audiobook, title: "Dune", author: "Herbert", series: "Dune", seriesIndex: "1"
+        )
+        #expect(audiobook.map(\.name) == ["title", "author"])
+    }
+
+    @Test func canCommitRequiresBothFields() {
+        #expect(UploadFlow.canCommit(title: "Dune", author: "Herbert"))
+        #expect(!UploadFlow.canCommit(title: "", author: "Herbert"))
+        #expect(!UploadFlow.canCommit(title: "Dune", author: "   "))
+    }
+
+    // MARK: - Endpoints
+
+    @Test func kindsPointAtTheirOwnInspectAndCommitRoutes() {
+        #expect(UploadKind.ebook.inspectPath == "/api/uploads/ebooks/inspect")
+        #expect(UploadKind.ebook.commitPath == "/api/uploads/ebooks")
+        #expect(UploadKind.audiobook.inspectPath == "/api/uploads/audiobooks/inspect")
+        #expect(UploadKind.audiobook.commitPath == "/api/uploads/audiobooks")
+    }
+}

--- a/omnibus-ios/omnibusTests/UploadFlowTests.swift
+++ b/omnibus-ios/omnibusTests/UploadFlowTests.swift
@@ -10,6 +10,15 @@ import UniformTypeIdentifiers
 
 @testable import omnibus
 
+private func commits(
+    title: String, author: String, series: String = "", index: String = "",
+    kind: UploadKind = .ebook
+) -> Bool {
+    UploadFlow.canCommit(
+        kind: kind, title: title, author: author, series: series, seriesIndex: index
+    )
+}
+
 private func url(_ name: String, in folder: String = "picked") -> URL {
     URL(fileURLWithPath: "/tmp/\(folder)/\(name)")
 }
@@ -52,11 +61,16 @@ struct UploadFlowTests {
         #expect(extensions.subtracting(accepted) == ["mpga"])
     }
 
-    @Test func acceptedAudioSetIsTheSharedNarrowOne() {
-        // Same three members as the player/downloader set, by construction
-        // rather than by coincidence, so a format addition cannot land in one
-        // and not the other.
-        #expect(UploadFlow.audiobookExtensions == Book.selectableAudioFormats)
+    @Test func acceptedAudioSetIsExactlyWhatTheUploadEndpointTakes() {
+        // Pinned against the server's own list, not against the constant this
+        // is defined from — asserting `audiobookExtensions == the set it is
+        // assigned from` cannot fail, and the guards it replaced (no flac, no
+        // wav) were the only thing catching a widening.
+        #expect(UploadFlow.audiobookExtensions == ["m4b", "m4a", "mp3"])
+        #expect(UploadFlow.ebookExtensions == ["epub"])
+        for playableButNotUploadable in ["flac", "wav", "ogg", "opus", "aac"] {
+            #expect(!UploadFlow.audiobookExtensions.contains(playableButNotUploadable))
+        }
     }
 
     // MARK: - Length caps
@@ -67,22 +81,52 @@ struct UploadFlowTests {
         // answers 400, and duplicates it on the retry.
         let longTitle = String(repeating: "a", count: UploadFlow.titleMaxLength + 1)
         let longName = String(repeating: "a", count: UploadFlow.nameMaxLength + 1)
-        #expect(!UploadFlow.canCommit(title: longTitle, author: "Herbert"))
-        #expect(!UploadFlow.canCommit(title: "Dune", author: longName))
+        #expect(!commits(title: longTitle, author: "Herbert"))
+        #expect(!commits(title: "Dune", author: longName))
         #expect(
-            UploadFlow.canCommit(
+            commits(
                 title: String(repeating: "a", count: UploadFlow.titleMaxLength),
                 author: String(repeating: "a", count: UploadFlow.nameMaxLength)
             )
         )
     }
 
-    @Test func optionalFieldsAreCappedToo() {
-        #expect(UploadFlow.isWithinNameCap(""))
-        #expect(UploadFlow.isWithinNameCap(String(repeating: "a", count: UploadFlow.nameMaxLength)))
+    @Test func capsCountScalarsTheWayTheServerDoes() {
+        // `MetadataOverrides::validate` counts `chars()` — Unicode scalars —
+        // while Swift's `String.count` counts grapheme clusters, which is never
+        // larger. Measuring the wrong unit made the gate strictly looser than
+        // the server's, so this exact title slipped through and 400'd *after*
+        // the book was filed.
+        let decomposed = String(repeating: "e\u{0301}", count: 300)
+        #expect(decomposed.count == 300)
+        #expect(UploadFlow.serverLength(of: decomposed) == 600)
+        #expect(!commits(title: decomposed, author: "Herbert"))
+
+        let author = String(repeating: "e\u{0301}", count: 130)
+        #expect(author.count == 130)
+        #expect(!commits(title: "Dune", author: author))
+    }
+
+    @Test func theMultipartByteCapIsUnreachableBehindTheScalarCap() {
+        // Documents why no byte check is modelled: UTF-8 is at most 4 bytes per
+        // scalar, so a title at the 500-scalar cap cannot exceed 2 KiB and the
+        // server's 8 KiB per-field cap can never be the binding one.
+        let widest = String(repeating: "\u{1F468}", count: UploadFlow.titleMaxLength)
+        #expect(UploadFlow.serverLength(of: widest) == UploadFlow.titleMaxLength)
+        #expect(widest.utf8.count == UploadFlow.titleMaxLength * 4)
+        #expect(widest.utf8.count < 8 * 1024)
+        #expect(commits(title: widest, author: "Herbert"))
+    }
+
+    @Test func optionalFieldsAreCappedOnlyWhereTheyAreSent() {
+        let longName = String(repeating: "a", count: UploadFlow.nameMaxLength + 1)
+        #expect(!commits(title: "Dune", author: "Herbert", series: longName))
+        #expect(!commits(title: "Dune", author: "Herbert", index: longName))
+        // The audiobook commit sends neither, so neither can block it.
         #expect(
-            !UploadFlow.isWithinNameCap(
-                String(repeating: "a", count: UploadFlow.nameMaxLength + 1)
+            commits(
+                title: "Dune", author: "Herbert", series: longName, index: longName,
+                kind: .audiobook
             )
         )
     }
@@ -165,12 +209,18 @@ struct UploadFlowTests {
         #expect(selection.unsupported == ["song.flac"])
     }
 
-    @Test func displayNameIsTheFilenameForOneFileAndAPartCountForMany() {
+    @Test func displayNameNamesAMultiPartSetForItsFolder() {
         #expect(UploadBatch(kind: .ebook, urls: [url("Dune.epub")]).displayName == "Dune.epub")
-        #expect(
-            UploadBatch(kind: .audiobook, urls: [url("01.mp3"), url("02.mp3")]).displayName
-                == "2 parts"
+        // Two picked sets rendered as "2 parts" apiece were indistinguishable
+        // in both the row list and the confirm sheet's title.
+        let dune = UploadBatch(
+            kind: .audiobook, urls: [url("01.mp3", in: "Dune"), url("02.mp3", in: "Dune")]
         )
+        #expect(dune.displayName == "Dune (2 parts)")
+        let other = UploadBatch(
+            kind: .audiobook, urls: [url("01.mp3", in: "Emma"), url("02.mp3", in: "Emma")]
+        )
+        #expect(other.displayName != dune.displayName)
     }
 
     // MARK: - Commit fields
@@ -205,9 +255,9 @@ struct UploadFlowTests {
     }
 
     @Test func canCommitRequiresBothFields() {
-        #expect(UploadFlow.canCommit(title: "Dune", author: "Herbert"))
-        #expect(!UploadFlow.canCommit(title: "", author: "Herbert"))
-        #expect(!UploadFlow.canCommit(title: "Dune", author: "   "))
+        #expect(commits(title: "Dune", author: "Herbert"))
+        #expect(!commits(title: "", author: "Herbert"))
+        #expect(!commits(title: "Dune", author: "   "))
     }
 
     // MARK: - Endpoints

--- a/omnibus-ios/omnibusTests/UploadFlowTests.swift
+++ b/omnibus-ios/omnibusTests/UploadFlowTests.swift
@@ -10,8 +10,8 @@ import UniformTypeIdentifiers
 
 @testable import omnibus
 
-private func url(_ name: String) -> URL {
-    URL(fileURLWithPath: "/tmp/picked/\(name)")
+private func url(_ name: String, in folder: String = "picked") -> URL {
+    URL(fileURLWithPath: "/tmp/\(folder)/\(name)")
 }
 
 struct UploadFlowTests {
@@ -43,12 +43,48 @@ struct UploadFlowTests {
         let extensions = Set(
             UploadFlow.pickerTypes.flatMap { $0.tags[.filenameExtension] ?? [] }
         )
-        #expect(extensions.contains("epub"))
-        #expect(extensions.contains("mp3"))
-        #expect(extensions.contains("m4a"))
-        #expect(extensions.contains("m4b"))
-        #expect(!extensions.contains("flac"))
-        #expect(!extensions.contains("wav"))
+        let accepted = UploadFlow.ebookExtensions.union(UploadFlow.audiobookExtensions)
+        #expect(accepted.isSubset(of: extensions), "every accepted format must be pickable")
+        // Exclusivity, not just membership — the previous assertion passed with
+        // `mp4`/`mpg4` on the list because it only checked that four names were
+        // present. `mpga` is the one documented residual: `public.mp3` claims it
+        // as a sibling extension and no narrower UTType exists.
+        #expect(extensions.subtracting(accepted) == ["mpga"])
+    }
+
+    @Test func acceptedAudioSetIsTheSharedNarrowOne() {
+        // Same three members as the player/downloader set, by construction
+        // rather than by coincidence, so a format addition cannot land in one
+        // and not the other.
+        #expect(UploadFlow.audiobookExtensions == Book.selectableAudioFormats)
+    }
+
+    // MARK: - Length caps
+
+    @Test func canCommitRejectsValuesTheServerWouldRefuseAfterFilingTheBook() {
+        // The server validates overrides only after copying the file into the
+        // library and reindexing, so an over-long title lands a book on disk,
+        // answers 400, and duplicates it on the retry.
+        let longTitle = String(repeating: "a", count: UploadFlow.titleMaxLength + 1)
+        let longName = String(repeating: "a", count: UploadFlow.nameMaxLength + 1)
+        #expect(!UploadFlow.canCommit(title: longTitle, author: "Herbert"))
+        #expect(!UploadFlow.canCommit(title: "Dune", author: longName))
+        #expect(
+            UploadFlow.canCommit(
+                title: String(repeating: "a", count: UploadFlow.titleMaxLength),
+                author: String(repeating: "a", count: UploadFlow.nameMaxLength)
+            )
+        )
+    }
+
+    @Test func optionalFieldsAreCappedToo() {
+        #expect(UploadFlow.isWithinNameCap(""))
+        #expect(UploadFlow.isWithinNameCap(String(repeating: "a", count: UploadFlow.nameMaxLength)))
+        #expect(
+            !UploadFlow.isWithinNameCap(
+                String(repeating: "a", count: UploadFlow.nameMaxLength + 1)
+            )
+        )
     }
 
     @Test func mimeTypeMatchesTheContainerRatherThanGuessingMp4() {
@@ -68,7 +104,7 @@ struct UploadFlowTests {
         #expect(selection.unsupported.isEmpty)
     }
 
-    @Test func selectionGroupsEveryMp3IntoOneMultiPartAudiobook() {
+    @Test func selectionGroupsMp3sFromOneFolderIntoOneMultiPartAudiobook() {
         // `classify_audio_set` files a set of .mp3 parts as a single book; one
         // request per file made an N-part audiobook into N one-chapter books.
         let picked = [url("01.mp3"), url("02.mp3"), url("03.mp3")]
@@ -76,6 +112,31 @@ struct UploadFlowTests {
         #expect(selection.batches.count == 1)
         #expect(selection.batches.first?.kind == .audiobook)
         #expect(selection.batches.first?.urls == picked)
+    }
+
+    @Test func selectionKeepsMp3sFromDifferentFoldersAsSeparateBooks() {
+        // Three standalone single-track audiobooks are the ordinary case that
+        // one-batch-for-every-mp3 merged into a single book, recoverable only
+        // by deleting it. The folder is the one signal available for which
+        // parts actually belong together.
+        let picked = [
+            url("book-a.mp3", in: "A"), url("book-b.mp3", in: "B"), url("book-c.mp3", in: "C"),
+        ]
+        let selection = UploadFlow.selection(for: picked)
+        #expect(selection.batches.count == 3)
+        #expect(selection.batches.allSatisfy { $0.urls.count == 1 })
+    }
+
+    @Test func selectionGroupsPerFolderAcrossAMixedMp3Pick() {
+        let picked = [
+            url("01.mp3", in: "A"), url("01.mp3", in: "B"), url("02.mp3", in: "A"),
+        ]
+        let selection = UploadFlow.selection(for: picked)
+        #expect(selection.batches.count == 2)
+        // Folder A keeps both of its parts, in pick order, and folder A comes
+        // first because its first part was picked first.
+        #expect(selection.batches[0].urls == [url("01.mp3", in: "A"), url("02.mp3", in: "A")])
+        #expect(selection.batches[1].urls == [url("01.mp3", in: "B")])
     }
 
     @Test func selectionGivesEachContainerItsOwnCommit() {

--- a/omnibus-ios/omnibusTests/UploadFlowTests.swift
+++ b/omnibus-ios/omnibusTests/UploadFlowTests.swift
@@ -86,14 +86,15 @@ struct UploadFlowTests {
         #expect(selection.batches.allSatisfy { $0.urls.count == 1 })
     }
 
-    @Test func selectionSplitsAMixedPickAndKeepsPickOrder() {
+    @Test func selectionSplitsAMixedPickAndPutsTheMp3SetLast() {
         let selection = UploadFlow.selection(
             for: [url("a.epub"), url("01.mp3"), url("b.epub"), url("02.mp3")]
         )
         #expect(selection.batches.count == 3)
         #expect(selection.batches[0].urls == [url("a.epub")])
         #expect(selection.batches[1].urls == [url("b.epub")])
-        // The MP3 set lands last, as one book carrying both parts.
+        // The MP3 set lands last however early its first part was picked — it
+        // isn't complete until the whole selection has been walked.
         #expect(selection.batches[2].urls == [url("01.mp3"), url("02.mp3")])
     }
 

--- a/omnibus-ios/omnibusTests/UploadStagingTests.swift
+++ b/omnibus-ios/omnibusTests/UploadStagingTests.swift
@@ -1,0 +1,146 @@
+//  UploadStagingTests.swift
+//  Staging picked files into the app's temporary directory — the step that
+//  buys the confirm sheet its unbounded human pause without holding a
+//  security scope or a resident `Data`.
+//
+//  The collision branch is the reason this file exists: two parts of one
+//  audiobook picked from different folders can share a filename, and the copy
+//  would otherwise throw rather than upload.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// A throwaway directory holding real files to pick from.
+private func makeSourceDir(_ names: [String], contents: String = "PK") throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("upload-staging-tests/\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    for name in names {
+        try Data("\(contents):\(name)".utf8)
+            .write(to: dir.appendingPathComponent(name))
+    }
+    return dir
+}
+
+struct UploadStagingTests {
+    @Test func stageCopiesEveryPartAndLeavesTheOriginalsAlone() async throws {
+        let source = try makeSourceDir(["01.mp3", "02.mp3"])
+        defer { try? FileManager.default.removeItem(at: source) }
+        let batch = UploadBatch(
+            kind: .audiobook,
+            urls: ["01.mp3", "02.mp3"].map { source.appendingPathComponent($0) }
+        )
+
+        let (staged, directory) = try await UploadService.stage(batch)
+        defer { UploadService.discard(directory) }
+
+        #expect(staged.kind == .audiobook)
+        #expect(staged.urls.count == 2)
+        #expect(staged.urls.map(\.lastPathComponent) == ["01.mp3", "02.mp3"])
+        // Rebased onto the copies, not still pointing at the picker's URLs.
+        #expect(staged.urls.allSatisfy { $0.path.hasPrefix(directory.path) })
+        for url in staged.urls {
+            #expect(FileManager.default.fileExists(atPath: url.path))
+        }
+        // The originals survive — staging copies, it does not move.
+        #expect(
+            FileManager.default.fileExists(
+                atPath: source.appendingPathComponent("01.mp3").path
+            )
+        )
+    }
+
+    @Test func stagePreservesEachPartsBytes() async throws {
+        let source = try makeSourceDir(["01.mp3", "02.mp3"])
+        defer { try? FileManager.default.removeItem(at: source) }
+        let batch = UploadBatch(
+            kind: .audiobook,
+            urls: ["01.mp3", "02.mp3"].map { source.appendingPathComponent($0) }
+        )
+
+        let (staged, directory) = try await UploadService.stage(batch)
+        defer { UploadService.discard(directory) }
+
+        #expect(try Data(contentsOf: staged.urls[0]) == Data("PK:01.mp3".utf8))
+        #expect(try Data(contentsOf: staged.urls[1]) == Data("PK:02.mp3".utf8))
+    }
+
+    @Test func stageDisambiguatesTwoPartsThatShareAFilename() async throws {
+        // Two folders, same filename — legitimate for a multi-part audiobook
+        // split across discs. A plain copy into one directory would throw.
+        let discOne = try makeSourceDir(["track01.mp3"], contents: "ONE")
+        let discTwo = try makeSourceDir(["track01.mp3"], contents: "TWO")
+        defer {
+            try? FileManager.default.removeItem(at: discOne)
+            try? FileManager.default.removeItem(at: discTwo)
+        }
+        let batch = UploadBatch(
+            kind: .audiobook,
+            urls: [
+                discOne.appendingPathComponent("track01.mp3"),
+                discTwo.appendingPathComponent("track01.mp3"),
+            ]
+        )
+
+        let (staged, directory) = try await UploadService.stage(batch)
+        defer { UploadService.discard(directory) }
+
+        #expect(staged.urls.count == 2)
+        let names = staged.urls.map(\.lastPathComponent)
+        #expect(Set(names).count == 2, "both parts must survive under distinct names")
+        #expect(names[0] == "track01.mp3")
+        #expect(names[1] == "track01-1.mp3")
+        // The extension has to survive the rename — the server routes on it.
+        #expect(names.allSatisfy { $0.hasSuffix(".mp3") })
+        // Distinct bytes, so neither part overwrote the other.
+        #expect(try Data(contentsOf: staged.urls[0]) == Data("ONE:track01.mp3".utf8))
+        #expect(try Data(contentsOf: staged.urls[1]) == Data("TWO:track01.mp3".utf8))
+    }
+
+    @Test func stageGivesEachBatchItsOwnDirectory() async throws {
+        let source = try makeSourceDir(["a.epub"])
+        defer { try? FileManager.default.removeItem(at: source) }
+        let batch = UploadBatch(kind: .ebook, urls: [source.appendingPathComponent("a.epub")])
+
+        let (_, first) = try await UploadService.stage(batch)
+        let (_, second) = try await UploadService.stage(batch)
+        defer {
+            UploadService.discard(first)
+            UploadService.discard(second)
+        }
+
+        // Per-batch, so discarding one finished upload cannot delete the files
+        // of another still waiting on its confirm sheet.
+        #expect(first != second)
+    }
+
+    @Test func discardRemovesTheStagedCopy() async throws {
+        let source = try makeSourceDir(["a.epub"])
+        defer { try? FileManager.default.removeItem(at: source) }
+        let batch = UploadBatch(kind: .ebook, urls: [source.appendingPathComponent("a.epub")])
+
+        let (staged, directory) = try await UploadService.stage(batch)
+        UploadService.discard(directory)
+
+        #expect(!FileManager.default.fileExists(atPath: staged.urls[0].path))
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+        // The picked original is untouched by discard.
+        #expect(
+            FileManager.default.fileExists(atPath: source.appendingPathComponent("a.epub").path)
+        )
+    }
+
+    @Test func stageThrowsWhenAPickedFileIsGone() async throws {
+        let source = try makeSourceDir([])
+        defer { try? FileManager.default.removeItem(at: source) }
+        let batch = UploadBatch(
+            kind: .ebook, urls: [source.appendingPathComponent("missing.epub")]
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await UploadService.stage(batch)
+        }
+    }
+}

--- a/omnibus-ios/omnibusTests/UploadStagingTests.swift
+++ b/omnibus-ios/omnibusTests/UploadStagingTests.swift
@@ -33,8 +33,9 @@ struct UploadStagingTests {
             urls: ["01.mp3", "02.mp3"].map { source.appendingPathComponent($0) }
         )
 
-        let (staged, directory) = try await UploadService.stage(batch)
-        defer { UploadService.discard(directory) }
+        let directory = UploadService.makeStagingDirectory()
+        defer { UploadService.discardNow(directory) }
+        let staged = try await UploadService.stage(batch, into: directory)
 
         #expect(staged.kind == .audiobook)
         #expect(staged.urls.count == 2)
@@ -60,75 +61,29 @@ struct UploadStagingTests {
             urls: ["01.mp3", "02.mp3"].map { source.appendingPathComponent($0) }
         )
 
-        let (staged, directory) = try await UploadService.stage(batch)
-        defer { UploadService.discard(directory) }
+        let directory = UploadService.makeStagingDirectory()
+        defer { UploadService.discardNow(directory) }
+        let staged = try await UploadService.stage(batch, into: directory)
 
         #expect(try Data(contentsOf: staged.urls[0]) == Data("PK:01.mp3".utf8))
         #expect(try Data(contentsOf: staged.urls[1]) == Data("PK:02.mp3".utf8))
     }
 
-    @Test func stagePreservesFilenamesWhenTwoPartsCollide() async throws {
-        // Two folders, same filename — legitimate for a multi-part audiobook
-        // split across discs. Each part gets its own numbered slot, so the
-        // ORIGINAL name goes out on the wire and the server's own
-        // `dedupe_part_name` resolves the clash.
-        //
-        // The previous scheme renamed client-side to `track01-1.mp3`, which was
-        // worse than useless: '-' (0x2D) sorts before '.' (0x2E), and
-        // `build_parts_list` breaks ties on filename, so two discs both tagged
-        // 1..N interleaved on playback.
-        let discOne = try makeSourceDir(["track01.mp3"], contents: "ONE")
-        let discTwo = try makeSourceDir(["track01.mp3"], contents: "TWO")
-        defer {
-            try? FileManager.default.removeItem(at: discOne)
-            try? FileManager.default.removeItem(at: discTwo)
-        }
+    @Test func stageKeepsPickedFilenamesForTheWire() async throws {
+        // Per-part slots mean the ORIGINAL name is what the server sees, so no
+        // client-side rename can reorder what `build_parts_list` sorts.
+        let source = try makeSourceDir(["01.mp3", "02.mp3"])
+        defer { try? FileManager.default.removeItem(at: source) }
         let batch = UploadBatch(
             kind: .audiobook,
-            urls: [
-                discOne.appendingPathComponent("track01.mp3"),
-                discTwo.appendingPathComponent("track01.mp3"),
-            ]
+            urls: ["01.mp3", "02.mp3"].map { source.appendingPathComponent($0) }
         )
+        let directory = UploadService.makeStagingDirectory()
+        defer { UploadService.discardNow(directory) }
 
-        let (staged, directory) = try await UploadService.stage(batch)
-        defer { UploadService.discard(directory) }
-
-        #expect(staged.urls.count == 2)
-        // Both keep the name the reader picked; no client-side rename can
-        // reorder what the server sorts.
-        #expect(staged.urls.map(\.lastPathComponent) == ["track01.mp3", "track01.mp3"])
-        #expect(Set(staged.urls.map(\.path)).count == 2, "distinct paths, same filename")
-        #expect(try Data(contentsOf: staged.urls[0]) == Data("ONE:track01.mp3".utf8))
-        #expect(try Data(contentsOf: staged.urls[1]) == Data("TWO:track01.mp3".utf8))
-    }
-
-    @Test func stageSurvivesAThirdPartCollidingWithADisambiguatedName() async throws {
-        // The old single-shot rename produced "track-2.mp3" for the third part
-        // and threw, because the second part was already called that.
-        let one = try makeSourceDir(["track.mp3", "track-2.mp3"], contents: "ONE")
-        let two = try makeSourceDir(["track.mp3"], contents: "TWO")
-        defer {
-            try? FileManager.default.removeItem(at: one)
-            try? FileManager.default.removeItem(at: two)
-        }
-        let batch = UploadBatch(
-            kind: .audiobook,
-            urls: [
-                one.appendingPathComponent("track.mp3"),
-                one.appendingPathComponent("track-2.mp3"),
-                two.appendingPathComponent("track.mp3"),
-            ]
-        )
-
-        let (staged, directory) = try await UploadService.stage(batch)
-        defer { UploadService.discard(directory) }
-
-        #expect(staged.urls.count == 3)
-        #expect(
-            staged.urls.map(\.lastPathComponent) == ["track.mp3", "track-2.mp3", "track.mp3"]
-        )
-        #expect(Set(staged.urls.map(\.path)).count == 3)
+        let staged = try await UploadService.stage(batch, into: directory)
+        #expect(staged.urls.map(\.lastPathComponent) == ["01.mp3", "02.mp3"])
+        #expect(Set(staged.urls.map(\.path)).count == 2)
     }
 
     @Test func stageGivesEachBatchItsOwnDirectory() async throws {
@@ -136,12 +91,14 @@ struct UploadStagingTests {
         defer { try? FileManager.default.removeItem(at: source) }
         let batch = UploadBatch(kind: .ebook, urls: [source.appendingPathComponent("a.epub")])
 
-        let (_, first) = try await UploadService.stage(batch)
-        let (_, second) = try await UploadService.stage(batch)
+        let first = UploadService.makeStagingDirectory()
+        let second = UploadService.makeStagingDirectory()
         defer {
-            UploadService.discard(first)
-            UploadService.discard(second)
+            UploadService.discardNow(first)
+            UploadService.discardNow(second)
         }
+        _ = try await UploadService.stage(batch, into: first)
+        _ = try await UploadService.stage(batch, into: second)
 
         // Per-batch, so discarding one finished upload cannot delete the files
         // of another still waiting on its confirm sheet.
@@ -153,7 +110,8 @@ struct UploadStagingTests {
         defer { try? FileManager.default.removeItem(at: source) }
         let batch = UploadBatch(kind: .ebook, urls: [source.appendingPathComponent("a.epub")])
 
-        let (staged, directory) = try await UploadService.stage(batch)
+        let directory = UploadService.makeStagingDirectory()
+        let staged = try await UploadService.stage(batch, into: directory)
         // The synchronous core, so the assertion does not race the detached
         // task `discard` normally fires.
         UploadService.discardNow(directory)
@@ -173,8 +131,111 @@ struct UploadStagingTests {
             kind: .ebook, urls: [source.appendingPathComponent("missing.epub")]
         )
 
+        let directory = UploadService.makeStagingDirectory()
+        defer { UploadService.discardNow(directory) }
         await #expect(throws: (any Error).self) {
-            try await UploadService.stage(batch)
+            try await UploadService.stage(batch, into: directory)
         }
+    }
+}
+
+/// The sweep's ownership filter, and the partial-copy cleanup it backstops.
+///
+/// These are the paths that kept regressing: cleanup that fired at the wrong
+/// moment, or not at all. Each test sweeps its OWN root — the sweep is
+/// destructive over a whole directory, and Swift Testing runs in parallel, so a
+/// test pointed at the real staging root would delete another test's files.
+struct UploadSweepTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("upload-sweep-tests/\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeStaged(_ name: String, under root: URL) throws -> URL {
+        let dir = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: dir.appendingPathComponent("part.mp3"))
+        return dir
+    }
+
+    @Test func sweepRemovesAbandonedStagingButKeepsLiveDirectories() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let live = try makeStaged(UUID().uuidString, under: root)
+        let abandoned = try makeStaged(UUID().uuidString, under: root)
+
+        UploadService.sweepStaging(keeping: [live], in: root)
+
+        // The regression this pins: a blind sweep of the root deleted the parts
+        // of an upload that outlived its sheet and was still reading them.
+        #expect(FileManager.default.fileExists(atPath: live.path))
+        #expect(!FileManager.default.fileExists(atPath: abandoned.path))
+    }
+
+    @Test func sweepMatchesLiveDirectoriesThroughAPathSymlink() throws {
+        // `temporaryDirectory` hands back /var/... while `contentsOfDirectory`
+        // returns /private/var/... . Comparing URLs (even standardized) misses
+        // that and swept every live directory.
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let live = try makeStaged(UUID().uuidString, under: root)
+        let aliased = URL(fileURLWithPath: "/private" + live.path)
+
+        UploadService.sweepStaging(keeping: [aliased], in: root)
+        #expect(FileManager.default.fileExists(atPath: live.path))
+    }
+
+    @Test func sweepWithNothingLiveClearsEverything() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let a = try makeStaged(UUID().uuidString, under: root)
+        let b = try makeStaged(UUID().uuidString, under: root)
+
+        UploadService.sweepStaging(keeping: [], in: root)
+
+        #expect(!FileManager.default.fileExists(atPath: a.path))
+        #expect(!FileManager.default.fileExists(atPath: b.path))
+    }
+
+    @Test func sweepReclaimsAPartiallyStagedDirectory() async throws {
+        // A copy that throws part-way has already written the parts it got
+        // through. The directory is allocated before the copy starts precisely
+        // so it stays reclaimable — previously the handle existed only on
+        // success, so a disk-full upload leaked what it had already written.
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try makeStaged("source", under: root)
+        try Data("ok".utf8).write(to: source.appendingPathComponent("01.mp3"))
+
+        let directory = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let batch = UploadBatch(
+            kind: .audiobook,
+            urls: [
+                source.appendingPathComponent("01.mp3"),
+                source.appendingPathComponent("missing.mp3"),
+            ]
+        )
+        await #expect(throws: (any Error).self) {
+            try await UploadService.stage(batch, into: directory)
+        }
+        #expect(FileManager.default.fileExists(atPath: directory.path), "part 0 landed")
+
+        UploadService.sweepStaging(keeping: [source], in: root)
+        #expect(!FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    @Test func staleErrorsAreNotTreatedAsReachingTheServer() {
+        // A transport failure means the request never landed, so invalidating
+        // the library — which deletes cached reads — would blank the shelf for
+        // a reader who is now offline and cannot refill it.
+        #expect(!UploadManager.mayHaveReachedTheServer(APIError.offline))
+        #expect(!UploadManager.mayHaveReachedTheServer(APIError.transport("lost")))
+        #expect(!UploadManager.mayHaveReachedTheServer(APIError.notConfigured))
+        // A status code is proof the server processed the request — and it may
+        // have filed the book before failing validation.
+        #expect(UploadManager.mayHaveReachedTheServer(APIError.http(status: 400, message: "no")))
+        #expect(UploadManager.mayHaveReachedTheServer(APIError.http(status: 408, message: "")))
     }
 }

--- a/omnibus-ios/omnibusTests/UploadStagingTests.swift
+++ b/omnibus-ios/omnibusTests/UploadStagingTests.swift
@@ -67,9 +67,16 @@ struct UploadStagingTests {
         #expect(try Data(contentsOf: staged.urls[1]) == Data("PK:02.mp3".utf8))
     }
 
-    @Test func stageDisambiguatesTwoPartsThatShareAFilename() async throws {
+    @Test func stagePreservesFilenamesWhenTwoPartsCollide() async throws {
         // Two folders, same filename — legitimate for a multi-part audiobook
-        // split across discs. A plain copy into one directory would throw.
+        // split across discs. Each part gets its own numbered slot, so the
+        // ORIGINAL name goes out on the wire and the server's own
+        // `dedupe_part_name` resolves the clash.
+        //
+        // The previous scheme renamed client-side to `track01-1.mp3`, which was
+        // worse than useless: '-' (0x2D) sorts before '.' (0x2E), and
+        // `build_parts_list` breaks ties on filename, so two discs both tagged
+        // 1..N interleaved on playback.
         let discOne = try makeSourceDir(["track01.mp3"], contents: "ONE")
         let discTwo = try makeSourceDir(["track01.mp3"], contents: "TWO")
         defer {
@@ -88,15 +95,40 @@ struct UploadStagingTests {
         defer { UploadService.discard(directory) }
 
         #expect(staged.urls.count == 2)
-        let names = staged.urls.map(\.lastPathComponent)
-        #expect(Set(names).count == 2, "both parts must survive under distinct names")
-        #expect(names[0] == "track01.mp3")
-        #expect(names[1] == "track01-1.mp3")
-        // The extension has to survive the rename — the server routes on it.
-        #expect(names.allSatisfy { $0.hasSuffix(".mp3") })
-        // Distinct bytes, so neither part overwrote the other.
+        // Both keep the name the reader picked; no client-side rename can
+        // reorder what the server sorts.
+        #expect(staged.urls.map(\.lastPathComponent) == ["track01.mp3", "track01.mp3"])
+        #expect(Set(staged.urls.map(\.path)).count == 2, "distinct paths, same filename")
         #expect(try Data(contentsOf: staged.urls[0]) == Data("ONE:track01.mp3".utf8))
         #expect(try Data(contentsOf: staged.urls[1]) == Data("TWO:track01.mp3".utf8))
+    }
+
+    @Test func stageSurvivesAThirdPartCollidingWithADisambiguatedName() async throws {
+        // The old single-shot rename produced "track-2.mp3" for the third part
+        // and threw, because the second part was already called that.
+        let one = try makeSourceDir(["track.mp3", "track-2.mp3"], contents: "ONE")
+        let two = try makeSourceDir(["track.mp3"], contents: "TWO")
+        defer {
+            try? FileManager.default.removeItem(at: one)
+            try? FileManager.default.removeItem(at: two)
+        }
+        let batch = UploadBatch(
+            kind: .audiobook,
+            urls: [
+                one.appendingPathComponent("track.mp3"),
+                one.appendingPathComponent("track-2.mp3"),
+                two.appendingPathComponent("track.mp3"),
+            ]
+        )
+
+        let (staged, directory) = try await UploadService.stage(batch)
+        defer { UploadService.discard(directory) }
+
+        #expect(staged.urls.count == 3)
+        #expect(
+            staged.urls.map(\.lastPathComponent) == ["track.mp3", "track-2.mp3", "track.mp3"]
+        )
+        #expect(Set(staged.urls.map(\.path)).count == 3)
     }
 
     @Test func stageGivesEachBatchItsOwnDirectory() async throws {
@@ -122,7 +154,9 @@ struct UploadStagingTests {
         let batch = UploadBatch(kind: .ebook, urls: [source.appendingPathComponent("a.epub")])
 
         let (staged, directory) = try await UploadService.stage(batch)
-        UploadService.discard(directory)
+        // The synchronous core, so the assertion does not race the detached
+        // task `discard` normally fires.
+        UploadService.discardNow(directory)
 
         #expect(!FileManager.default.fileExists(atPath: staged.urls[0].path))
         #expect(!FileManager.default.fileExists(atPath: directory.path))


### PR DESCRIPTION
## Summary
- Uploading a book from the SwiftUI app failed 100% of the time with `400 — "title and author are required to file the book"`. Both commit endpoints require those multipart text fields; `AddBooksSheet` posted the file straight to the commit endpoint and left `APIClient.upload`'s `fields:` at its default. The web client has always done the server's two-step ingest (`inspect` → editable confirm → commit); iOS only ever implemented the second half, so the feature has never worked since it shipped in #1388.
- `UploadFlow` holds the pure request shaping — which endpoint a format targets, how a pick groups into commits, which fields a commit carries, and the length caps the server enforces. `UploadConfirmSheet` is the editable confirm step. `MultipartBody` is the form-data encoder, split out so a request's wire shape is unit-testable.
- `UploadManager` owns the queue, the staged copies on disk, and the transfers. This is the important structural choice: all three outlive the sheet that starts them, and when the view owned them every exit path had to remember to clean up. One worker over one queue with a single cancellable handle; one batch staged at a time, gated on the reader confirming it, so a pick never copies every book to tmp before any is agreed to; commits serialized against each other; a registry of live staging directories so the sweep reclaims abandoned runs without deleting an upload still reading from one; and one presentation driver that waits for a sheet to finish dismissing before arming the next draft.
- The file picker is derived from the accepted extensions rather than hand-listed, so it can't drift; `UTType.mpeg4Audio` had been offering `mp4`/`mpg4`, which the server rejects. `public.mp3` also claims `mpga`, which no narrower type excludes — that residual is documented, asserted, and refused client-side before any bytes are sent.
- MP3s group by containing folder. All-into-one silently merged unrelated single-track audiobooks into one book, recoverable only by deleting it; a multi-part batch is now named for its folder so two picked sets are distinguishable.
- Length caps count Unicode scalars, matching the server's `chars().count()`. Swift's `String.count` counts grapheme clusters, which is never larger, so the gate was strictly looser than the server's and never caught anything — and the server validates *after* filing and indexing, so an over-long title landed a book on disk, answered 400, and duplicated it on the retry.
- Uploads neither claim the reachability probe slot nor may declare an outage. A transfer times out on its own budget, the server's, or a backgrounded app, none of which mean the server is gone — and since the upload controls are gated on `isOnline`, letting one failure arm the back-off disabled the retry it was asking for.
- One library invalidation per pick rather than per book: `LibraryIndex.sync(force:)` drops a forced pass outright while another runs, so per-book calls lost every book after the first. Invalidation is skipped when the request provably never landed, since it *deletes* cached reads a now-offline reader cannot refill.

## Test plan
- [x] `just ios-test` — 358 tests, 44 across the upload suites. Coverage is aimed at the paths that actually regressed: the sweep's ownership filter (including the `/var` → `/private/var` symlink, which caught a live-directory deletion before it shipped), partial-stage reclamation, the error classification behind invalidation, scalar-vs-grapheme caps, folder grouping, and the encoded wire bytes.
- [x] `just ios-test-ui` — XCUITest smoke suite green.
- [x] `just ios-build` — clean.
- [x] End-to-end against a live server on a fresh DB, replaying the exact bytes the client encodes: ebook inspect → `200`, ebook commit → `201`, audiobook inspect with two repeated `file` parts → `200 {"part_count":2}`, audiobook commit → `201`, and the original bug's shape (file only, no fields) → `400`.
- [x] Verified what landed on disk: the EPUB filed under the *confirmed* title/author rather than the file's embedded metadata, with series and Book # applied as overrides; both MP3 parts in a single folder.
- [ ] Not driven through the simulator UI. Request shaping, cleanup logic and the server contract are covered above, but the SwiftUI seam itself — pick → confirm → commit — has not been exercised end to end in-app.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- Closes #2100

>[!IMPORTANT]
> Known limitation, not addressed here: the server wraps every route in a 30s `TimeoutLayer` and `post_upload_audiobook` awaits a full library reindex inside it, so a large audiobook 408s regardless of the client. Small EPUBs are unaffected. Exempting `/api/uploads/*` from that layer is the fix and belongs in its own PR.

>[!NOTE]
> No Cargo crate is touched — the change is entirely in `omnibus-ios/`, plus a CHANGELOG line and the iOS module map in `docs/architecture.md`.
