### PR TITLE
feat: give the iOS metadata editor ISBN-10 and print page count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ recent releases are recorded below; everything earlier is available via the
   genres it already had, so the phone and the web no longer disagree about
   which fields a book has. A save still sends only what you changed, so editing
   from a phone that predates a field cannot wipe a value set on the web (#1664)
+- The iOS editor now **says why a save was refused** instead of failing
+  quietly: a page count that isn't a whole number or sits outside 1–20,000, a
+  malformed ISBN-10, or a page count you cleared — which the field has no way
+  to express — are all caught before the request, with the message scrolled
+  into view rather than left below the fold. A rejected save no longer eats a
+  half-typed author, and a book you opened but didn't really change is no
+  longer marked "Edited" for good (#1664)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ recent releases are recorded below; everything earlier is available via the
 - **Book #** is now one of the fields the compare view can copy. Hardcover is
   the only source that publishes a book's position in its series, so a book
   numbered there can be numbered here in one click (#1665)
+- The **iOS metadata editor** now carries ISBN-10 and Print Pages alongside the
+  genres it already had, so the phone and the web no longer disagree about
+  which fields a book has. A save still sends only what you changed, so editing
+  from a phone that predates a field cannot wipe a value set on the web (#1664)
 
 ### Changed
 

--- a/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
@@ -56,6 +56,24 @@ struct MetadataDraft: Equatable {
         description = book.description ?? ""
     }
 
+    /// Field checks that don't need the server, run by `save` *before* it
+    /// touches any state — the web editor rejects the same entries in
+    /// `build_on_save`'s first statement, ahead of its own `spawn`, for the
+    /// reason this ordering matters: a rejected save must leave the form
+    /// exactly as the user left it.
+    ///
+    /// The checks mirror `MetadataOverrides::validate` rather than
+    /// duplicating the whole of it. What's here is what the server would
+    /// reject for these two fields, caught before a round trip that would
+    /// take every *other* edit in the same body down with it.
+    func validate(since loaded: MetadataDraft) throws {
+        if printPages.nilIfBlank == nil, loaded.printPagesValue != nil {
+            throw MetadataDraftError.printPagesNotClearable
+        }
+        _ = try MetadataDraft.parsePrintPages(printPages)
+        try MetadataDraft.validateIsbn10(isbn10)
+    }
+
     /// The changed-fields-only body for `POST /api/ebooks/{uuid}/overrides`.
     ///
     /// Sending every field on every save wrote overrides for fields nobody
@@ -63,10 +81,12 @@ struct MetadataDraft: Equatable {
     /// update them. The endpoint merges, so omitting a field leaves it as it
     /// was, and an empty string clears an existing override.
     ///
-    /// Throws `MetadataDraftError` when the print-pages field holds something
-    /// that isn't a whole number — rejected here so the editor can say so
-    /// instead of posting a body the server would 400.
-    func payload(since loaded: MetadataDraft) throws -> MetadataOverridesPayload {
+    /// Total, deliberately: this is a diff between two snapshots, and
+    /// rejecting user input is `validate(since:)`'s job. An entry this can't
+    /// use is simply not sent — which is safe only because `save` validates
+    /// first, and is why `MetadataOverridesPayload.isEmpty` exists to catch a
+    /// body with nothing in it.
+    func payload(since loaded: MetadataDraft) -> MetadataOverridesPayload {
         func changed(_ key: KeyPath<MetadataDraft, String>) -> String? {
             self[keyPath: key] == loaded[keyPath: key] ? nil : self[keyPath: key]
         }
@@ -82,10 +102,21 @@ struct MetadataDraft: Equatable {
             published: changed(\.published),
             language: changed(\.language),
             isbn13: changed(\.isbn13),
-            isbn10: changed(\.isbn10),
-            print_pages: try changedPrintPages(since: loaded),
+            isbn10: changedIsbn10(since: loaded),
+            print_pages: changedPrintPages(since: loaded),
             description: changed(\.description)
         )
+    }
+
+    /// ISBN-10 diffed on its *trimmed* form. The field is `.asciiCapable`
+    /// (an ISBN-10's check digit can be `X`), so unlike the `.numberPad`
+    /// ISBN-13 beside it a pasted value can carry surrounding whitespace —
+    /// which the server rejects rather than strips.
+    private func changedIsbn10(since loaded: MetadataDraft) -> String? {
+        // `?? ""` keeps the empty-string-clears sentinel: a blanked field
+        // still has to reach the server as `""` to clear the override.
+        let value = isbn10.nilIfBlank ?? ""
+        return value == (loaded.isbn10.nilIfBlank ?? "") ? nil : value
     }
 
     /// The print-pages value a save sends, or `nil` to omit the field.
@@ -95,41 +126,87 @@ struct MetadataDraft: Equatable {
     /// the empty-string-clears convention. So a blanked field means *leave the
     /// override alone*, not *clear it* — matching the web editor
     /// (`build_overrides` in `frontend/src/pages/metadata_edit.rs`), which the
-    /// two editors have to agree on.
-    private func changedPrintPages(since loaded: MetadataDraft) throws -> Int64? {
-        guard let parsed = try MetadataDraft.parsePrintPages(printPages) else { return nil }
+    /// two editors have to agree on. `validate(since:)` refuses that blank up
+    /// front so the gap surfaces as a message rather than a silent no-op.
+    private func changedPrintPages(since loaded: MetadataDraft) -> Int64? {
+        guard let parsed = printPagesValue else { return nil }
         return parsed == loaded.printPagesValue ? nil : parsed
     }
 
-    /// This draft's print-pages field as an integer, ignoring a blank or
-    /// unparseable entry. Only meaningful on a `loaded` snapshot, whose value
-    /// came from the server and so always parses.
+    /// This draft's print-pages field as an integer, or `nil` when blank or
+    /// unusable. `validate(since:)` is what turns "unusable" into a message.
     private var printPagesValue: Int64? {
         try? MetadataDraft.parsePrintPages(printPages)
     }
 
-    /// Parses the print-pages field: blank is `nil` (nothing to send), and a
-    /// non-numeric entry is rejected with a specific message rather than
-    /// silently dropped, which would look like a save that worked.
+    /// Parses the print-pages field: blank is `nil` (nothing to send), and
+    /// anything the server would refuse is rejected here instead, so the
+    /// reader gets the message without spending a round trip that would also
+    /// discard every other edit in the same body.
     static func parsePrintPages(_ input: String) throws -> Int64? {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
+        guard let trimmed = input.nilIfBlank else { return nil }
         guard let value = Int64(trimmed) else {
             throw MetadataDraftError.invalidPrintPages
         }
+        // Mirrors `MetadataOverrides::validate_print_pages`, whose bound is
+        // `1..=PRINT_PAGES_MAX`. Checked here so "0" — one tap away on a
+        // number pad — reads as the range error it is rather than as the
+        // "not a number" one it isn't.
+        guard (1...printPagesMax).contains(value) else {
+            throw MetadataDraftError.printPagesOutOfRange
+        }
         return value
+    }
+
+    /// `MetadataOverrides::PRINT_PAGES_MAX`. Duplicated rather than fetched:
+    /// it is a compile-time constant on a type this app never sees, and the
+    /// server still enforces it if the two ever drift.
+    static let printPagesMax: Int64 = 20_000
+
+    /// ISBN-10 shape, mirroring `MetadataOverrides::validate_isbn10`: blank
+    /// (which clears), or 10 characters — 9 digits plus a check digit that
+    /// may be `X`. Format only, no mod-11 check, matching the server's
+    /// reasoning that this is typed metadata rather than a scanned barcode.
+    static func validateIsbn10(_ input: String) throws {
+        guard let trimmed = input.nilIfBlank else { return }
+        let shapeOK = trimmed.count == 10
+            && trimmed.prefix(9).allSatisfy(\.isASCIIDigit)
+            && trimmed.last.map { $0.isASCIIDigit || $0 == "X" || $0 == "x" } == true
+        guard shapeOK else { throw MetadataDraftError.invalidIsbn10 }
     }
 }
 
-/// Client-side rejections raised before a save leaves the device.
+/// Client-side rejections raised before a save leaves the device. Each one
+/// is a check the server also makes — caught here so the reader reads it
+/// immediately, and so a bad entry in one field doesn't take the rest of
+/// the form's edits down with it in a rejected body.
 enum MetadataDraftError: LocalizedError, Equatable {
     case invalidPrintPages
+    case printPagesOutOfRange
+    case printPagesNotClearable
+    case invalidIsbn10
 
     var errorDescription: String? {
         switch self {
-        case .invalidPrintPages: "Print page count must be a whole number."
+        case .invalidPrintPages:
+            "Print page count must be a whole number."
+        case .printPagesOutOfRange:
+            "Print page count must be between 1 and \(MetadataDraft.printPagesMax)."
+        case .printPagesNotClearable:
+            """
+            Print page count can't be cleared once set. Enter a number, or use \
+            Revert to scanned metadata to remove every override on this book.
+            """
+        case .invalidIsbn10:
+            "ISBN-10 must be 10 characters: 9 digits plus a digit or X check digit."
         }
     }
+}
+
+private extension Character {
+    /// `Character.isNumber` is true for "٣" and "Ⅶ"; the server's check is
+    /// `is_ascii_digit`, and an ISBN that passes here must pass there.
+    var isASCIIDigit: Bool { isASCII && isNumber }
 }
 
 /// Body for `POST /api/ebooks/{uuid}/overrides`. Field names match the wire.
@@ -161,6 +238,24 @@ struct MetadataOverridesPayload: Encodable, Equatable {
     /// field actually changed — it has no empty-string-clears form.
     var print_pages: Int64?
     var description: String?
+
+    /// Whether this body would say nothing at all.
+    ///
+    /// Worth a guard because `{}` is not a no-op server-side: with no prior
+    /// row, `merge_one_in_tx` takes its `None` branch and *inserts* an empty
+    /// override, which makes `apply_overrides` report `has_override = true`
+    /// forever — the book reads "Edited" with nothing to revert, and it
+    /// leaves the byte-faithful passthrough branch for EPUB downloads. The
+    /// same write also bumps `books.last_modified`, the invalidation clock
+    /// for the thumbnail, KEPUB, and export-EPUB caches. `clear_cover_override`
+    /// already reaps such rows for exactly this reason ("an empty-but-present
+    /// row would leave the 'Override active' indicator stuck on"); the merge
+    /// path has no equivalent, so the client must not create one.
+    ///
+    /// Reachable whenever a field is edited to a value that normalizes back
+    /// to what was loaded — retyping `180` as `0180`, or adding a stray
+    /// space — since the editor's dirty check compares raw text.
+    var isEmpty: Bool { self == MetadataOverridesPayload() }
 }
 
 /// Chip-entry commit semantics shared by the authors and tags fields — and by

--- a/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataDraft.swift
@@ -30,6 +30,10 @@ struct MetadataDraft: Equatable {
     var published = ""
     var language = ""
     var isbn13 = ""
+    var isbn10 = ""
+    /// Held as text, not `Int64?`, because that is what a text field edits —
+    /// the parse to the wire's integer happens once, in `payload(since:)`.
+    var printPages = ""
     var description = ""
 
     init() {}
@@ -47,6 +51,8 @@ struct MetadataDraft: Equatable {
         published = book.published ?? ""
         language = book.language ?? ""
         isbn13 = book.isbn13 ?? ""
+        isbn10 = book.isbn10 ?? ""
+        printPages = book.printPages.map(String.init) ?? ""
         description = book.description ?? ""
     }
 
@@ -56,7 +62,11 @@ struct MetadataDraft: Equatable {
     /// touched, pinning scanned values so a later rescan could no longer
     /// update them. The endpoint merges, so omitting a field leaves it as it
     /// was, and an empty string clears an existing override.
-    func payload(since loaded: MetadataDraft) -> MetadataOverridesPayload {
+    ///
+    /// Throws `MetadataDraftError` when the print-pages field holds something
+    /// that isn't a whole number — rejected here so the editor can say so
+    /// instead of posting a body the server would 400.
+    func payload(since loaded: MetadataDraft) throws -> MetadataOverridesPayload {
         func changed(_ key: KeyPath<MetadataDraft, String>) -> String? {
             self[keyPath: key] == loaded[keyPath: key] ? nil : self[keyPath: key]
         }
@@ -72,8 +82,53 @@ struct MetadataDraft: Equatable {
             published: changed(\.published),
             language: changed(\.language),
             isbn13: changed(\.isbn13),
+            isbn10: changed(\.isbn10),
+            print_pages: try changedPrintPages(since: loaded),
             description: changed(\.description)
         )
+    }
+
+    /// The print-pages value a save sends, or `nil` to omit the field.
+    ///
+    /// Unlike every scalar above, this one can't be diffed as a raw string:
+    /// the wire field is an integer, and there is no "empty" integer to carry
+    /// the empty-string-clears convention. So a blanked field means *leave the
+    /// override alone*, not *clear it* — matching the web editor
+    /// (`build_overrides` in `frontend/src/pages/metadata_edit.rs`), which the
+    /// two editors have to agree on.
+    private func changedPrintPages(since loaded: MetadataDraft) throws -> Int64? {
+        guard let parsed = try MetadataDraft.parsePrintPages(printPages) else { return nil }
+        return parsed == loaded.printPagesValue ? nil : parsed
+    }
+
+    /// This draft's print-pages field as an integer, ignoring a blank or
+    /// unparseable entry. Only meaningful on a `loaded` snapshot, whose value
+    /// came from the server and so always parses.
+    private var printPagesValue: Int64? {
+        try? MetadataDraft.parsePrintPages(printPages)
+    }
+
+    /// Parses the print-pages field: blank is `nil` (nothing to send), and a
+    /// non-numeric entry is rejected with a specific message rather than
+    /// silently dropped, which would look like a save that worked.
+    static func parsePrintPages(_ input: String) throws -> Int64? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let value = Int64(trimmed) else {
+            throw MetadataDraftError.invalidPrintPages
+        }
+        return value
+    }
+}
+
+/// Client-side rejections raised before a save leaves the device.
+enum MetadataDraftError: LocalizedError, Equatable {
+    case invalidPrintPages
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPrintPages: "Print page count must be a whole number."
+        }
     }
 }
 
@@ -101,6 +156,10 @@ struct MetadataOverridesPayload: Encodable, Equatable {
     var published: String?
     var language: String?
     var isbn13: String?
+    var isbn10: String?
+    /// Snake-cased to match the wire, like `series_index`. Absent unless the
+    /// field actually changed — it has no empty-string-clears form.
+    var print_pages: Int64?
     var description: String?
 }
 

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -37,6 +37,12 @@ struct MetadataEditView: View {
     /// Same, for the genres field.
     @State private var pendingGenre = ""
 
+    /// Set to `errorAnchor` to scroll the error banner into view, then
+    /// cleared by `ScrollViewReader`'s `onChange`. A plain `Bool` wouldn't
+    /// re-fire for a second failed save.
+    @State private var scrollTarget: String?
+    private static let errorAnchor = "metadata-edit-error"
+
     /// Autocomplete pools for the chip and series fields, filled best-effort
     /// while the editor is up — an empty pool just means no dropdown.
     @State private var authorPool: [SuggestionItem] = []
@@ -78,6 +84,20 @@ struct MetadataEditView: View {
     }
 
     private var content: some View {
+        ScrollViewReader { proxy in
+            formScroll
+                .onChange(of: scrollTarget) { _, target in
+                    guard let target else { return }
+                    // `.center`, not `.bottom`: the bottom of the scroll view
+                    // is where the tab bar and a still-retracting keyboard
+                    // are, and a message parked under either is no message.
+                    proxy.scrollTo(target, anchor: .center)
+                    scrollTarget = nil
+                }
+        }
+    }
+
+    private var formScroll: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Spacing.xl) {
                 if let book { header(book) }
@@ -156,6 +176,8 @@ struct MetadataEditView: View {
                         .font(.ui(13))
                         .foregroundStyle(palette.badColor)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .id(Self.errorAnchor)
+                        .accessibilityIdentifier("metadata-edit-error")
                 }
 
                 if book?.hasOverride == true {
@@ -319,13 +341,70 @@ struct MetadataEditView: View {
     }
 
     private func save() async {
-        isSaving = true
         error = nil
+
+        // Before the chip flush below, which mutates `draft`: a rejected save
+        // has to leave the form exactly as the reader left it, or a bad page
+        // count silently consumes the author they were half-way through
+        // typing. The web editor orders it the same way, rejecting in
+        // `build_on_save`'s first statement.
+        do {
+            try draft.validate(since: loaded)
+        } catch {
+            reportSaveFailure(error)
+            return
+        }
+
+        isSaving = true
         defer { isSaving = false }
 
-        // A value typed into an add field but never committed to a chip is
-        // still what the user meant to save; dropping it silently is worse
-        // than accepting it.
+        flushPendingChips()
+
+        let body = draft.payload(since: loaded)
+        // Nothing to send. Not merely wasteful: an empty body makes the
+        // server insert an override row that latches this book to "Edited"
+        // permanently — see `MetadataOverridesPayload.isEmpty`.
+        guard !body.isEmpty else {
+            dismiss()
+            return
+        }
+
+        do {
+            let _: Empty = try await APIClient.shared.post(
+                "/api/ebooks/\(uuid)/overrides", body: body
+            )
+            await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
+            Haptics.success()
+            onSaved?()
+            dismiss()
+        } catch {
+            reportSaveFailure(error)
+        }
+    }
+
+    /// Surface a failed save. The message alone isn't enough: it renders at
+    /// the bottom of a scrolling form, well below the fields that cause it,
+    /// so without the haptic and the scroll a rejected Save looks to the
+    /// reader like a Save that did nothing at all. The keyboard has to go
+    /// too — the field being rejected is usually the one still focused, and
+    /// its keypad covers exactly the part of the form the message lands in.
+    private func reportSaveFailure(_ error: Error) {
+        self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
+        Haptics.warning()
+        dismissKeyboard()
+        withAnimation(Motion.snap) { scrollTarget = Self.errorAnchor }
+    }
+
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+        )
+    }
+
+    /// A value typed into an add field but never committed to a chip is still
+    /// what the user meant to save; dropping it silently is worse than
+    /// accepting it.
+    private func flushPendingChips() {
         if let chip = ChipEntry.committed(
             from: pendingAuthor, existing: draft.authors, deduplicating: false
         ) {
@@ -344,21 +423,6 @@ struct MetadataEditView: View {
             draft.genres.append(chip)
         }
         pendingGenre = ""
-
-        do {
-            // Built before the request so a bad print-page entry is rejected
-            // here rather than by the server's 400.
-            let body = try draft.payload(since: loaded)
-            let _: Empty = try await APIClient.shared.post(
-                "/api/ebooks/\(uuid)/overrides", body: body
-            )
-            await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
-            Haptics.success()
-            onSaved?()
-            dismiss()
-        } catch {
-            self.error = (error as? APIError)?.errorDescription ?? error.localizedDescription
-        }
     }
 
     private func revert() async {

--- a/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
+++ b/omnibus-ios/omnibus/Features/Settings/MetadataEditView.swift
@@ -109,6 +109,9 @@ struct MetadataEditView: View {
                         field("Published", \.published, hint: "YYYY-MM-DD")
                         field("Language", \.language, hint: "e.g. en")
                         field("ISBN-13", \.isbn13, keyboard: .numberPad)
+                        // Not `.numberPad`: an ISBN-10's check digit can be X.
+                        field("ISBN-10", \.isbn10, hint: "10 characters", keyboard: .asciiCapable)
+                        field("Print Pages", \.printPages, hint: "whole number", keyboard: .numberPad)
                     }
                 }
 
@@ -343,8 +346,11 @@ struct MetadataEditView: View {
         pendingGenre = ""
 
         do {
+            // Built before the request so a bad print-page entry is rejected
+            // here rather than by the server's 400.
+            let body = try draft.payload(since: loaded)
             let _: Empty = try await APIClient.shared.post(
-                "/api/ebooks/\(uuid)/overrides", body: draft.payload(since: loaded)
+                "/api/ebooks/\(uuid)/overrides", body: body
             )
             await OfflineStore.shared.cacheDelete(CacheKey.book(uuid))
             Haptics.success()

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -84,6 +84,10 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     var genres: [String] = []
     var identifiers: [Identifier] = []
     var isbn13: String?
+    /// Secondary ISBN-10. Unlike `isbn13` — which the server derives from the
+    /// scanned `identifiers` when no override exists — no format Omnibus reads
+    /// carries a distinct ISBN-10, so this is only ever an explicit edit.
+    var isbn10: String?
     var series: String?
     var seriesIndex: String?
     var seriesId: Int64?
@@ -102,10 +106,14 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     /// comic books only — the pager's slider range and progress mapping.
     /// `nil` on every other payload (list projections, non-comics).
     var pageCount: Int64?
+    /// Print edition page count. Deliberately *not* `pageCount`, which is the
+    /// CBZ archive's image count and drives the comic pager's slider — the two
+    /// mean different things on a book that has both.
+    var printPages: Int64?
 
     enum CodingKeys: String, CodingKey {
         case id, filename, title, description, publisher, published, modified
-        case language, creators, subjects, genres, identifiers, isbn13, series, formats
+        case language, creators, subjects, genres, identifiers, isbn13, isbn10, series, formats
         case accent, error
         case seriesIndex = "series_index"
         case seriesId = "series_id"
@@ -118,6 +126,7 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
         case bookFiles = "book_files"
         case epubSizeBytes = "epub_size_bytes"
         case pageCount = "page_count"
+        case printPages = "print_pages"
     }
 
     /// Stable identity used for every `/books/:uuid` and `/api/covers/:uuid`

--- a/omnibus-ios/omnibusTests/MetadataDraftTests.swift
+++ b/omnibus-ios/omnibusTests/MetadataDraftTests.swift
@@ -16,6 +16,9 @@ private func gatsby() -> Book {
     book.series = "—"
     book.publisher = "Scribner"
     book.language = "en"
+    book.isbn13 = "9780743273565"
+    book.isbn10 = "0743273567"
+    book.printPages = 180
     return book
 }
 
@@ -27,13 +30,13 @@ struct MetadataDraftTests {
         #expect(draft.title == "The Great Gatsby")
     }
 
-    @Test func payloadSendsOnlyTheFieldsThatChanged() {
+    @Test func payloadSendsOnlyTheFieldsThatChanged() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.title = "Trimalchio"
         draft.tags = ["Classics", "Novel", "Jazz Age"]
 
-        let payload = draft.payload(since: loaded)
+        let payload = try draft.payload(since: loaded)
         #expect(payload.title == "Trimalchio")
         #expect(payload.subjects == ["Classics", "Novel", "Jazz Age"])
         // Untouched fields stay absent so the merge endpoint leaves them
@@ -51,65 +54,206 @@ struct MetadataDraftTests {
         #expect(draft.tags == ["Classics", "Novel"])
     }
 
-    @Test func payloadSendsGenresOnlyWhenTheListChanged() {
+    @Test func payloadSendsGenresOnlyWhenTheListChanged() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.genres = ["Literary Fiction", "Tragedy"]
 
-        let payload = draft.payload(since: loaded)
+        let payload = try draft.payload(since: loaded)
         #expect(payload.genres == ["Literary Fiction", "Tragedy"])
         // Editing genres must not drag the tag list along with it — they are
         // two independent wholesale-replace overrides.
         #expect(payload.subjects == nil)
     }
 
-    @Test func payloadOmitsGenresWhenOnlyTagsChanged() {
+    @Test func payloadOmitsGenresWhenOnlyTagsChanged() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.tags = ["Classics"]
 
-        let payload = draft.payload(since: loaded)
+        let payload = try draft.payload(since: loaded)
         #expect(payload.genres == nil)
         #expect(payload.subjects == ["Classics"])
     }
 
-    @Test func payloadOmitsTagsWhenTheListIsUntouched() {
+    @Test func payloadOmitsTagsWhenTheListIsUntouched() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.publisher = "Modern Library"
 
-        let payload = draft.payload(since: loaded)
+        let payload = try draft.payload(since: loaded)
         #expect(payload.subjects == nil)
         #expect(payload.publisher == "Modern Library")
     }
 
-    @Test func payloadSendsTheWholeTagListWhenOneTagIsRemoved() {
+    @Test func payloadSendsTheWholeTagListWhenOneTagIsRemoved() throws {
         // The server's subjects override replaces wholesale, so a removal is
         // expressed as the surviving list — not a delta.
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.tags = ["Classics"]
 
-        #expect(draft.payload(since: loaded).subjects == ["Classics"])
+        #expect(try draft.payload(since: loaded).subjects == ["Classics"])
     }
 
-    @Test func payloadClearsAScalarFieldWithAnEmptyString() {
+    @Test func payloadClearsAScalarFieldWithAnEmptyString() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.publisher = ""
 
-        #expect(draft.payload(since: loaded).publisher == "")
+        #expect(try draft.payload(since: loaded).publisher == "")
     }
 
-    @Test func payloadReplacesTheWholeCreatorListWhenAuthorsChange() {
+    @Test func payloadReplacesTheWholeCreatorListWhenAuthorsChange() throws {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.authors = ["F. Scott Fitzgerald", "Zelda Fitzgerald"]
 
-        #expect(draft.payload(since: loaded).creators == [
+        #expect(try draft.payload(since: loaded).creators == [
             MetadataOverridesPayload.Creator(name: "F. Scott Fitzgerald"),
             MetadataOverridesPayload.Creator(name: "Zelda Fitzgerald"),
         ])
+    }
+
+    // MARK: - ISBN-10 and print pages
+
+    @Test func draftFromBookCarriesIsbn10AndPrintPages() {
+        let draft = MetadataDraft(book: gatsby())
+        #expect(draft.isbn10 == "0743273567")
+        // Held as text, so a book with a value arrives as its digits.
+        #expect(draft.printPages == "180")
+    }
+
+    @Test func draftFromABookWithoutTheNewFieldsLeavesThemBlank() {
+        // A server that predates the fields omits them; both must read as
+        // "nothing set" rather than decoding to a placeholder.
+        var book = gatsby()
+        book.isbn10 = nil
+        book.printPages = nil
+
+        let draft = MetadataDraft(book: book)
+        #expect(draft.isbn10 == "")
+        #expect(draft.printPages == "")
+    }
+
+    @Test func payloadSendsIsbn10WhenChanged() throws {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.isbn10 = "0141182636"
+
+        #expect(try draft.payload(since: loaded).isbn10 == "0141182636")
+    }
+
+    @Test func payloadClearsAPopulatedIsbn10WithAnEmptyString() throws {
+        // Same empty-string-clears convention as ISBN-13 — the one scalar
+        // sentinel the server honours.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.isbn10 = ""
+
+        #expect(try draft.payload(since: loaded).isbn10 == "")
+    }
+
+    @Test func payloadSendsPrintPagesWhenChanged() throws {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "412"
+
+        #expect(try draft.payload(since: loaded).print_pages == 412)
+    }
+
+    @Test func payloadOmitsPrintPagesWhenTheFieldIsBlanked() throws {
+        // There is no "empty" integer on the wire, so a blanked field means
+        // leave the override alone — not clear it. The web editor's
+        // `build_overrides` makes the same choice; the two must agree.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = ""
+
+        #expect(try draft.payload(since: loaded).print_pages == nil)
+    }
+
+    @Test func payloadOmitsPrintPagesWhenRetypedUnchanged() throws {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = " 180 "
+
+        #expect(try draft.payload(since: loaded).print_pages == nil)
+    }
+
+    @Test func payloadRejectsANonNumericPrintPagesEntry() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "about 400"
+
+        #expect(throws: MetadataDraftError.invalidPrintPages) {
+            try draft.payload(since: loaded)
+        }
+    }
+
+    @Test func payloadOmitsTheNewFieldsWhenNothingElseChangedThem() throws {
+        // AC3, and the merge guarantee this ticket exists to protect: an
+        // edit elsewhere must not restate ISBN-10 or the print page count,
+        // because `POST /overrides` merges — a client that restates a stale
+        // value clobbers whatever the other editor set.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.title = "Trimalchio"
+
+        let payload = try draft.payload(since: loaded)
+        #expect(payload.isbn10 == nil)
+        #expect(payload.print_pages == nil)
+        #expect(payload.genres == nil)
+    }
+
+    @Test func encodedPayloadOmitsUntouchedNewFieldsEntirely() throws {
+        // The merge is keyed on the JSON key being *absent*, not null — so
+        // assert the encoded body, which is what the server actually reads.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.title = "Trimalchio"
+
+        let payload = try draft.payload(since: loaded)
+        let data = try JSONEncoder().encode(payload)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["title"] as? String == "Trimalchio")
+        #expect(!json.keys.contains("isbn10"))
+        #expect(!json.keys.contains("print_pages"))
+        #expect(!json.keys.contains("genres"))
+    }
+}
+
+/// The wire half of the same contract: the server's key names, which no
+/// amount of draft-level testing would catch if they were wrong.
+struct BookOverrideFieldDecodeTests {
+    @Test func bookDecodesTheOverrideOnlyFields() throws {
+        let json = """
+            {"id":7,"filename":"gatsby.epub","title":"The Great Gatsby",
+             "genres":["Literary Fiction"],"isbn10":"0743273567",
+             "print_pages":180,"page_count":24}
+            """
+        let book = try JSONDecoder().decode(Book.self, from: Data(json.utf8))
+        #expect(book.isbn10 == "0743273567")
+        #expect(book.printPages == 180)
+        #expect(book.genres == ["Literary Fiction"])
+        // `print_pages` is the print edition's count; `page_count` is the CBZ
+        // archive's image count. Decoding one into the other would put a
+        // comic's image count on the metadata editor.
+        #expect(book.pageCount == 24)
+    }
+
+    @Test func bookDecodesWithoutTheOverrideOnlyFields() throws {
+        // The server omits each of them when unset, and a list projection
+        // omits them always — absence must read as "nothing set".
+        let json = """
+            {"id":7,"filename":"gatsby.epub","title":"The Great Gatsby"}
+            """
+        let book = try JSONDecoder().decode(Book.self, from: Data(json.utf8))
+        #expect(book.isbn10 == nil)
+        #expect(book.printPages == nil)
+        #expect(book.genres.isEmpty)
     }
 }
 

--- a/omnibus-ios/omnibusTests/MetadataDraftTests.swift
+++ b/omnibus-ios/omnibusTests/MetadataDraftTests.swift
@@ -30,13 +30,13 @@ struct MetadataDraftTests {
         #expect(draft.title == "The Great Gatsby")
     }
 
-    @Test func payloadSendsOnlyTheFieldsThatChanged() throws {
+    @Test func payloadSendsOnlyTheFieldsThatChanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.title = "Trimalchio"
         draft.tags = ["Classics", "Novel", "Jazz Age"]
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         #expect(payload.title == "Trimalchio")
         #expect(payload.subjects == ["Classics", "Novel", "Jazz Age"])
         // Untouched fields stay absent so the merge endpoint leaves them
@@ -54,62 +54,62 @@ struct MetadataDraftTests {
         #expect(draft.tags == ["Classics", "Novel"])
     }
 
-    @Test func payloadSendsGenresOnlyWhenTheListChanged() throws {
+    @Test func payloadSendsGenresOnlyWhenTheListChanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.genres = ["Literary Fiction", "Tragedy"]
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         #expect(payload.genres == ["Literary Fiction", "Tragedy"])
         // Editing genres must not drag the tag list along with it — they are
         // two independent wholesale-replace overrides.
         #expect(payload.subjects == nil)
     }
 
-    @Test func payloadOmitsGenresWhenOnlyTagsChanged() throws {
+    @Test func payloadOmitsGenresWhenOnlyTagsChanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.tags = ["Classics"]
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         #expect(payload.genres == nil)
         #expect(payload.subjects == ["Classics"])
     }
 
-    @Test func payloadOmitsTagsWhenTheListIsUntouched() throws {
+    @Test func payloadOmitsTagsWhenTheListIsUntouched() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.publisher = "Modern Library"
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         #expect(payload.subjects == nil)
         #expect(payload.publisher == "Modern Library")
     }
 
-    @Test func payloadSendsTheWholeTagListWhenOneTagIsRemoved() throws {
+    @Test func payloadSendsTheWholeTagListWhenOneTagIsRemoved() {
         // The server's subjects override replaces wholesale, so a removal is
         // expressed as the surviving list — not a delta.
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.tags = ["Classics"]
 
-        #expect(try draft.payload(since: loaded).subjects == ["Classics"])
+        #expect(draft.payload(since: loaded).subjects == ["Classics"])
     }
 
-    @Test func payloadClearsAScalarFieldWithAnEmptyString() throws {
+    @Test func payloadClearsAScalarFieldWithAnEmptyString() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.publisher = ""
 
-        #expect(try draft.payload(since: loaded).publisher == "")
+        #expect(draft.payload(since: loaded).publisher == "")
     }
 
-    @Test func payloadReplacesTheWholeCreatorListWhenAuthorsChange() throws {
+    @Test func payloadReplacesTheWholeCreatorListWhenAuthorsChange() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.authors = ["F. Scott Fitzgerald", "Zelda Fitzgerald"]
 
-        #expect(try draft.payload(since: loaded).creators == [
+        #expect(draft.payload(since: loaded).creators == [
             MetadataOverridesPayload.Creator(name: "F. Scott Fitzgerald"),
             MetadataOverridesPayload.Creator(name: "Zelda Fitzgerald"),
         ])
@@ -136,33 +136,33 @@ struct MetadataDraftTests {
         #expect(draft.printPages == "")
     }
 
-    @Test func payloadSendsIsbn10WhenChanged() throws {
+    @Test func payloadSendsIsbn10WhenChanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.isbn10 = "0141182636"
 
-        #expect(try draft.payload(since: loaded).isbn10 == "0141182636")
+        #expect(draft.payload(since: loaded).isbn10 == "0141182636")
     }
 
-    @Test func payloadClearsAPopulatedIsbn10WithAnEmptyString() throws {
+    @Test func payloadClearsAPopulatedIsbn10WithAnEmptyString() {
         // Same empty-string-clears convention as ISBN-13 — the one scalar
         // sentinel the server honours.
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.isbn10 = ""
 
-        #expect(try draft.payload(since: loaded).isbn10 == "")
+        #expect(draft.payload(since: loaded).isbn10 == "")
     }
 
-    @Test func payloadSendsPrintPagesWhenChanged() throws {
+    @Test func payloadSendsPrintPagesWhenChanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.printPages = "412"
 
-        #expect(try draft.payload(since: loaded).print_pages == 412)
+        #expect(draft.payload(since: loaded).print_pages == 412)
     }
 
-    @Test func payloadOmitsPrintPagesWhenTheFieldIsBlanked() throws {
+    @Test func payloadOmitsPrintPagesWhenTheFieldIsBlanked() {
         // There is no "empty" integer on the wire, so a blanked field means
         // leave the override alone — not clear it. The web editor's
         // `build_overrides` makes the same choice; the two must agree.
@@ -170,28 +170,252 @@ struct MetadataDraftTests {
         var draft = loaded
         draft.printPages = ""
 
-        #expect(try draft.payload(since: loaded).print_pages == nil)
+        #expect(draft.payload(since: loaded).print_pages == nil)
     }
 
-    @Test func payloadOmitsPrintPagesWhenRetypedUnchanged() throws {
+    @Test func payloadOmitsPrintPagesWhenRetypedUnchanged() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.printPages = " 180 "
 
-        #expect(try draft.payload(since: loaded).print_pages == nil)
+        #expect(draft.payload(since: loaded).print_pages == nil)
     }
 
-    @Test func payloadRejectsANonNumericPrintPagesEntry() {
+    // MARK: - The nil baseline, which is what a real library has
+
+    // Both fields are override-only — `books/projection.rs` sets them to
+    // `None` with "No scanned baseline" — so an unedited book has nil for
+    // both and *every first edit* takes this path. `gatsby()` seeds values,
+    // so without these the load-bearing `parsed == loaded.printPagesValue`
+    // comparison against nil is never exercised.
+
+    private static func unedited() -> Book {
+        var book = gatsby()
+        book.isbn10 = nil
+        book.printPages = nil
+        return book
+    }
+
+    @Test func payloadSendsPrintPagesOnABookThatNeverHadOne() {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.printPages = "412"
+
+        #expect(draft.payload(since: loaded).print_pages == 412)
+    }
+
+    @Test func payloadSendsIsbn10OnABookThatNeverHadOne() {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "0141182636"
+
+        #expect(draft.payload(since: loaded).isbn10 == "0141182636")
+    }
+
+    @Test func payloadOmitsBothOnAnUneditedBookWhenNeitherWasTouched() {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.title = "Trimalchio"
+
+        let payload = draft.payload(since: loaded)
+        #expect(payload.print_pages == nil)
+        // Not `""`: the field was blank and stayed blank, so there is no
+        // clear to express and the key must not appear at all.
+        #expect(payload.isbn10 == nil)
+    }
+
+    // MARK: - Whitespace
+
+    @Test func payloadSendsIsbn10Trimmed() {
+        // The field is `.asciiCapable`, so unlike the `.numberPad` ISBN-13
+        // beside it a pasted value can carry whitespace — which the server
+        // rejects rather than strips, taking every other edit in the same
+        // body down with it.
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "  0141182636\n"
+
+        #expect(draft.payload(since: loaded).isbn10 == "0141182636")
+    }
+
+    @Test func payloadOmitsIsbn10WhenOnlyItsWhitespaceChanged() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.isbn10 = " 0743273567 "
+
+        #expect(draft.payload(since: loaded).isbn10 == nil)
+    }
+
+    // MARK: - An empty body is not a no-op server-side
+
+    @Test func payloadIsEmptyWhenAReformattedEntryNormalizesBackToLoaded() {
+        // The editor's dirty check compares raw text, so Save enables here.
+        // If this body were posted, `merge_one_in_tx` would insert an empty
+        // override row and `apply_overrides` would report has_override =
+        // true forever — the book reads "Edited" with nothing to revert.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = " 180 "
+
+        #expect(draft != loaded, "precondition: the editor would enable Save")
+        #expect(draft.payload(since: loaded).isEmpty)
+    }
+
+    @Test func payloadIsEmptyWhenPrintPagesIsRetypedWithALeadingZero() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "0180"
+
+        #expect(draft != loaded)
+        #expect(draft.payload(since: loaded).isEmpty)
+    }
+
+    @Test func payloadIsNotEmptyWhenSomethingActuallyChanged() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.title = "Trimalchio"
+
+        #expect(!draft.payload(since: loaded).isEmpty)
+    }
+
+    // MARK: - validate, which runs before a save touches any state
+
+    @Test func validatePassesForAnOrdinaryEdit() throws {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "412"
+        draft.isbn10 = "0141182636"
+
+        try draft.validate(since: loaded)
+    }
+
+    @Test func validateRejectsANonNumericPrintPagesEntry() {
         let loaded = MetadataDraft(book: gatsby())
         var draft = loaded
         draft.printPages = "about 400"
 
         #expect(throws: MetadataDraftError.invalidPrintPages) {
-            try draft.payload(since: loaded)
+            try draft.validate(since: loaded)
         }
     }
 
-    @Test func payloadOmitsTheNewFieldsWhenNothingElseChangedThem() throws {
+    @Test func validateRejectsAPrintPagesEntryBelowTheServersFloor() {
+        // "0" is one tap away on a number pad, and the server's bound is
+        // `1..=PRINT_PAGES_MAX`. Catching it here makes it read as the range
+        // error it is rather than the "not a number" one it isn't.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "0"
+
+        #expect(throws: MetadataDraftError.printPagesOutOfRange) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateRejectsAPrintPagesEntryAboveTheServersCeiling() {
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = String(MetadataDraft.printPagesMax + 1)
+
+        #expect(throws: MetadataDraftError.printPagesOutOfRange) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateRejectsBlankingAPrintPagesValueThatWasSet() {
+        // The wire field is an integer with no empty-string sentinel, so this
+        // save would drop the edit silently. Refusing it is the difference
+        // between "can't do that" and a Save that lies.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = ""
+
+        #expect(throws: MetadataDraftError.printPagesNotClearable) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateAllowsABlankPrintPagesWhenTheBookNeverHadOne() throws {
+        // Nothing to clear, so nothing to refuse — otherwise every book in an
+        // unedited library would be unsaveable.
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.title = "Trimalchio"
+
+        try draft.validate(since: loaded)
+    }
+
+    @Test func validateRejectsAHyphenatedIsbn10() {
+        // The form printed on most copyright pages. The server strips
+        // nothing, so without this the whole save 400s.
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "0-7432-7356-7"
+
+        #expect(throws: MetadataDraftError.invalidIsbn10) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateRejectsAnIsbn10OfTheWrongLength() {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "9780743273565"
+
+        #expect(throws: MetadataDraftError.invalidIsbn10) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateAcceptsAnIsbn10WithAnXCheckDigit() throws {
+        // Why the field is `.asciiCapable` rather than `.numberPad`.
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "043942089X"
+
+        try draft.validate(since: loaded)
+    }
+
+    @Test func validateRejectsAnXAnywhereButTheCheckDigit() {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "X439420891"
+
+        #expect(throws: MetadataDraftError.invalidIsbn10) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func validateAcceptsAnIsbn10ClearedToBlank() throws {
+        // Empty *is* the clear sentinel for this one, unlike print pages.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.isbn10 = ""
+
+        try draft.validate(since: loaded)
+    }
+
+    @Test func validateAcceptsAnIsbn10WithSurroundingWhitespace() throws {
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = " 0141182636 "
+
+        try draft.validate(since: loaded)
+    }
+
+    @Test func validateRejectsNonASCIIDigitsInAnIsbn10() {
+        // `Character.isNumber` is true for these; the server's check is
+        // `is_ascii_digit`, so anything accepted here must pass there.
+        let loaded = MetadataDraft(book: Self.unedited())
+        var draft = loaded
+        draft.isbn10 = "٠١٤١١٨٢٦٣٦"
+
+        #expect(throws: MetadataDraftError.invalidIsbn10) {
+            try draft.validate(since: loaded)
+        }
+    }
+
+    @Test func payloadOmitsTheNewFieldsWhenNothingElseChangedThem() {
         // AC3, and the merge guarantee this ticket exists to protect: an
         // edit elsewhere must not restate ISBN-10 or the print page count,
         // because `POST /overrides` merges — a client that restates a stale
@@ -200,7 +424,7 @@ struct MetadataDraftTests {
         var draft = loaded
         draft.title = "Trimalchio"
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         #expect(payload.isbn10 == nil)
         #expect(payload.print_pages == nil)
         #expect(payload.genres == nil)
@@ -213,7 +437,7 @@ struct MetadataDraftTests {
         var draft = loaded
         draft.title = "Trimalchio"
 
-        let payload = try draft.payload(since: loaded)
+        let payload = draft.payload(since: loaded)
         let data = try JSONEncoder().encode(payload)
         let json = try #require(
             JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -222,6 +446,31 @@ struct MetadataDraftTests {
         #expect(!json.keys.contains("isbn10"))
         #expect(!json.keys.contains("print_pages"))
         #expect(!json.keys.contains("genres"))
+    }
+
+    @Test func encodedPayloadUsesTheServersKeyNamesForChangedFields() throws {
+        // The positive half, and the one that actually pins the outbound
+        // names. `MetadataOverrides` has no `deny_unknown_fields`, so a
+        // misspelled key deserializes to nothing: the server returns 200 with
+        // the full book and the editor dismisses on success while the value
+        // is silently discarded. Asserting only *absence* would not catch it,
+        // and neither would reading the Swift properties back.
+        let loaded = MetadataDraft(book: gatsby())
+        var draft = loaded
+        draft.printPages = "412"
+        draft.isbn10 = "0141182636"
+        draft.genres = ["Literary Fiction", "Tragedy"]
+
+        let data = try JSONEncoder().encode(draft.payload(since: loaded))
+        let json = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["print_pages"] as? Int == 412)
+        #expect(json["isbn10"] as? String == "0141182636")
+        #expect(json["genres"] as? [String] == ["Literary Fiction", "Tragedy"])
+        // Not camelCase — the sibling `Book` decoder uses `printPages` for
+        // this same wire key, which is exactly the rename that would slip by.
+        #expect(!json.keys.contains("printPages"))
     }
 }
 


### PR DESCRIPTION
## Summary
- The native editor was missing two of the three override fields the web editor gained in #1658, so a book edited on the phone and the same book edited on the web disagreed about what metadata it has. Genres already landed with #1697, so this closes the remaining gap: ISBN-10 and Print Pages.
- `Book` decodes `isbn10` and `print_pages`. `printPages` is deliberately not folded into `pageCount` — that one is the CBZ archive's *image* count and drives the comic pager's slider, so the two mean different things on a book that has both.
- `MetadataDraft` holds both as text, which is what a text field edits, and parses print pages once inside `payload(since:)`. A non-numeric entry (a paste, since the field is a number pad) is rejected client-side with a specific message rather than dropped silently — dropping it would read as a save that worked.
- A blanked print-pages field leaves the override alone rather than clearing it. The wire field is an integer and has no empty-string sentinel to carry the clears convention that ISBN-10 and the other scalars use. This matches `build_overrides` in `frontend/src/pages/metadata_edit.rs`, which the two editors have to agree on — see the note below.
- Three rows on the editor, reusing the same `field()` helper as the four Publication rows above them.
- Scope is the fields only, per the ticket: search, edition picker, and compare view stay web-first.

Closes #1664

## Test plan
- [x] `just ios-test` — 21 tests in the `MetadataDraft` suite pass, including the new coverage.
- [x] AC3, the merge guarantee, tested twice deliberately: once at the payload level (an unrelated edit leaves `isbn10` / `print_pages` / `genres` nil) and once on the **encoded JSON**, since the server's merge is keyed on the key being absent rather than null — a payload-level assertion alone would not catch an encoder that emitted explicit nulls.
- [x] New wire-decode tests pin the snake_case key names (`isbn10`, `print_pages`) and prove absence reads as "nothing set", which is what a list projection and an older server both send.
- [x] `just ios-build` succeeds.
- [x] AC2/AC4's server half is already covered by the Rust suite from #1658 (`upsert_and_get_metadata_overrides_roundtrips_isbn10_and_print_pages`, `merge_metadata_overrides_preserves_isbn10_and_print_pages_when_a_later_edit_omits_them`, `get_book_returns_effective_isbn10_and_print_pages_from_the_override_layer`).
- [ ] **Not verified on a device or simulator.** The rows render through the same helper as the existing Publication fields and the app builds, but I could not drive the editor: reaching it needs a live server, and per [rule 04](.claude/rules/04-playwright.md) the `omnibusUITests` suite is hermetic and offline, so library content is deliberately out of its reach. Worth a manual pass on AC1 (the three rows edit and enable Save) before merge.

## Version
- [x] **Patch** — the default.

## Notes

>[!NOTE]
> **A blanked Print Pages field silently does nothing, on both editors.** Clearing the field enables Save, the save succeeds, and the value stays. That is not new here — the web editor has behaved this way since #1658, because `MetadataOverrides::print_pages` is an `Option<i64>` and the merge treats an absent key as "leave it alone". Giving iOS a clear path would mean a wire sentinel, which is #1658's territory, and doing it on one client only would recreate exactly the disagreement this ticket exists to remove. Flagging it as a shared gap worth its own follow-up rather than fixing it unilaterally here.

>[!NOTE]
> The ticket lists genres as part of the scope; they already shipped in #1697 and needed no change. The existing genre tests are extended alongside the new fields where they share a payload assertion.