### PR TITLE
fix: keep iOS reader settings across an app update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,13 @@ recent releases are recorded below; everything earlier is available via the
   through the same correction (and echo tagging) a boot restore does, so it
   writes no position and never moves the restore anchor. Added an explicit
   single/two-page reader setting on iOS, matching web (#2081)
+- Updating the iOS app no longer resets the EPUB reader's typography. Theme,
+  font, size, line height, margins, justification, and page layout share one
+  stored blob that was discarded wholesale the moment a new build added a
+  setting to it — which the single/two-page option (#2081) did, sending anyone
+  who had chosen Sepia back to Dark on first launch. Each setting is now read
+  on its own, so an update — or a rollback to an older build — keeps the rest
+  (#2117)
 - Uploading a book from the iOS app works. Every upload previously failed with
   "title and author are required to file the book", because the app posted the
   file straight to the commit endpoint and skipped the confirm step those

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -78,11 +78,15 @@ struct ReaderSettings: Codable, Equatable {
     var justify: Bool = true
     /// epub.js theme token — matches the four `themes.register` names.
     var theme: String = "dark"
-    /// Matches epub.js's own default ("auto") so a reader upgrading from a
-    /// build that never sent `spread` sees no change in behavior.
+    /// Matches epub.js's own default ("auto"), which is what a build predating
+    /// the setting rendered.
     var spread: ReaderSpread = .double
 
     static let storageKey = "omnibus.readerSettings"
+
+    enum CodingKeys: String, CodingKey {
+        case fontSize, fontFamily, lineHeight, margins, justify, theme, spread
+    }
 
     static func load() -> ReaderSettings {
         guard let data = UserDefaults.standard.data(forKey: storageKey),
@@ -94,6 +98,39 @@ struct ReaderSettings: Codable, Equatable {
     func save() {
         guard let data = try? JSONEncoder().encode(self) else { return }
         UserDefaults.standard.set(data, forKey: Self.storageKey)
+    }
+}
+
+/// Decoded field by field, so one unreadable value costs one setting instead of
+/// all of them.
+///
+/// Swift's synthesized decoder ignores property defaults: a key the stored blob
+/// doesn't carry throws `keyNotFound`, and `load()`'s `try?` then hands back a
+/// fresh `ReaderSettings()` — every *other* setting reset with it. Adding
+/// `spread` (#2081) did exactly that to the theme, face, and size of anyone who
+/// had ever changed one. A new field must stay additive, so it goes here too.
+/// Written in an extension to keep the struct's synthesized initializers.
+extension ReaderSettings {
+    init(from decoder: any Decoder) throws {
+        self.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Each `or:` reads what `self.init()` just seeded, so the property
+        // defaults above stay the one place a default is written down.
+        fontSize = container.value(.fontSize, or: fontSize)
+        fontFamily = container.value(.fontFamily, or: fontFamily)
+        lineHeight = container.value(.lineHeight, or: lineHeight)
+        margins = container.value(.margins, or: margins)
+        justify = container.value(.justify, or: justify)
+        theme = container.value(.theme, or: theme)
+        spread = container.value(.spread, or: spread)
+    }
+}
+
+private extension KeyedDecodingContainer where K == ReaderSettings.CodingKeys {
+    /// The stored value, or `fallback` when the key is absent, holds the wrong
+    /// type, or carries a rawValue this build doesn't know (a downgrade).
+    func value<T: Decodable>(_ key: K, or fallback: T) -> T {
+        (try? decode(T.self, forKey: key)) ?? fallback
     }
 }
 

--- a/omnibus-ios/omnibusTests/ReaderSettingsTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderSettingsTests.swift
@@ -1,0 +1,171 @@
+//  ReaderSettingsTests.swift
+//  A stored reader-settings blob survives the struct growing a field.
+//
+//  All seven typography settings share one JSON blob under
+//  `omnibus.readerSettings`, and Swift's synthesized decoder ignores property
+//  defaults — so before #2117 a key the stored payload didn't carry threw
+//  `keyNotFound`, `load()`'s `try?` swallowed it, and the reader came back on
+//  the factory theme, face, and size. Adding `spread` (#2081) shipped exactly
+//  that. These tests pin the upgrade path a new field has to keep working: the
+//  payloads here are deliberately every-field-off-default, so a reset is
+//  unmistakable rather than accidentally matching a default.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// A reader who has changed every setting.
+private let stored = ReaderSettings(
+    fontSize: 24, fontFamily: "sans-serif", lineHeight: 1.9,
+    margins: .wide, justify: false, theme: "sepia", spread: .single
+)
+
+/// `stored` on the wire.
+private func fullPayload() -> [String: Any] {
+    [
+        "fontSize": 24,
+        "fontFamily": "sans-serif",
+        "lineHeight": 1.9,
+        "margins": "wide",
+        "justify": false,
+        "theme": "sepia",
+        "spread": "single",
+    ]
+}
+
+private func decode(_ payload: [String: Any]) throws -> ReaderSettings {
+    try JSONDecoder().decode(ReaderSettings.self, from: JSONSerialization.data(withJSONObject: payload))
+}
+
+/// Runs `body` against an empty `omnibus.readerSettings`, then puts back
+/// whatever the test host held.
+private func withCleanStore(_ body: () throws -> Void) rethrows {
+    let defaults = UserDefaults.standard
+    let held = defaults.data(forKey: ReaderSettings.storageKey)
+    defaults.removeObject(forKey: ReaderSettings.storageKey)
+    defer {
+        if let held {
+            defaults.set(held, forKey: ReaderSettings.storageKey)
+        } else {
+            defaults.removeObject(forKey: ReaderSettings.storageKey)
+        }
+    }
+    try body()
+}
+
+// Serialized: every test in here shares the one `UserDefaults` key.
+@Suite("Reader settings persistence", .serialized)
+struct ReaderSettingsTests {
+    /// The regression itself: the payload shape a build before #2084 wrote.
+    @Test("a payload written before `spread` existed keeps every setting it did carry")
+    func decodesTheShapeWrittenBeforeSpreadExisted() throws {
+        var payload = fullPayload()
+        payload.removeValue(forKey: "spread")
+
+        let decoded = try decode(payload)
+
+        var expected = stored
+        expected.spread = ReaderSettings().spread
+        #expect(decoded == expected)
+        // Spelled out, because this is the one the reader notices.
+        #expect(decoded.theme == "sepia")
+    }
+
+    @Test(
+        "a payload missing one key keeps every other setting",
+        arguments: [
+            "fontSize", "fontFamily", "lineHeight", "margins", "justify", "theme", "spread",
+        ]
+    )
+    func missingOneKeyCostsOnlyThatSetting(dropped: String) throws {
+        var payload = fullPayload()
+        payload.removeValue(forKey: dropped)
+
+        let decoded = try decode(payload)
+
+        let defaults = ReaderSettings()
+        var expected = stored
+        switch dropped {
+        case "fontSize": expected.fontSize = defaults.fontSize
+        case "fontFamily": expected.fontFamily = defaults.fontFamily
+        case "lineHeight": expected.lineHeight = defaults.lineHeight
+        case "margins": expected.margins = defaults.margins
+        case "justify": expected.justify = defaults.justify
+        case "theme": expected.theme = defaults.theme
+        case "spread": expected.spread = defaults.spread
+        default: Issue.record("unhandled key \(dropped)")
+        }
+        #expect(decoded == expected)
+    }
+
+    /// The other direction — a TestFlight rollback reading a newer blob.
+    @Test("a key this build doesn't know is ignored")
+    func unknownKeyIsIgnored() throws {
+        var payload = fullPayload()
+        payload["pageTurnAnimation"] = "slide"
+
+        #expect(try decode(payload) == stored)
+    }
+
+    @Test("a value of the wrong type costs only its own setting")
+    func mistypedValueFallsBackAlone() throws {
+        var payload = fullPayload()
+        payload["fontSize"] = "extra large"
+
+        let decoded = try decode(payload)
+
+        #expect(decoded.fontSize == ReaderSettings().fontSize)
+        #expect(decoded.theme == "sepia")
+        #expect(decoded.margins == .wide)
+    }
+
+    /// Also the rollback case: an enum case a newer build introduced.
+    @Test("an unknown enum case costs only its own setting")
+    func unknownEnumCaseFallsBackAlone() throws {
+        var payload = fullPayload()
+        payload["margins"] = "colossal"
+
+        let decoded = try decode(payload)
+
+        #expect(decoded.margins == ReaderSettings().margins)
+        #expect(decoded.theme == "sepia")
+        #expect(decoded.fontSize == 24)
+    }
+
+    @Test("a saved blob round-trips through UserDefaults")
+    func savedBlobRoundTrips() {
+        withCleanStore {
+            stored.save()
+
+            #expect(ReaderSettings.load() == stored)
+        }
+    }
+
+    /// End-to-end through the real key: what the reader actually experiences on
+    /// first launch after the update.
+    @Test("an upgrade onto a build with a new field loads the reader's own theme")
+    func upgradeLoadsTheStoredTheme() throws {
+        try withCleanStore {
+            var payload = fullPayload()
+            payload.removeValue(forKey: "spread")
+            UserDefaults.standard.set(
+                try JSONSerialization.data(withJSONObject: payload),
+                forKey: ReaderSettings.storageKey
+            )
+
+            let loaded = ReaderSettings.load()
+
+            #expect(loaded.theme == "sepia")
+            #expect(loaded.fontSize == 24)
+            #expect(loaded.spread == .double)
+        }
+    }
+
+    @Test("nothing stored loads the defaults")
+    func emptyStoreLoadsDefaults() {
+        withCleanStore {
+            #expect(ReaderSettings.load() == ReaderSettings())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #2117
- **The bug.** All seven iOS reader typography settings — theme, font family, size, line height, margins, justify, spread — share one JSON blob under `omnibus.readerSettings`, and `ReaderSettings` relied on Swift's synthesized `Codable`. The synthesized decoder ignores property default values, so a key the stored payload doesn't carry throws `keyNotFound`; `load()`'s `try?` swallows that and hands back a fresh `ReaderSettings()`, resetting every *other* setting with it. Adding `spread` in #2084 shipped exactly that: anyone who had picked Sepia came back on Dark the first time they opened a book after updating.
- Verified the premise directly rather than assuming it — decoding `{"theme":"sepia"}` into a two-field struct whose second field has a default throws `DecodingError.keyNotFound: Key 'spread' not found`, and the `try?` fallback yields `theme: "dark"`.
- **The fix.** `ReaderSettings` now has a hand-written `init(from:)` that reads each field with `decodeIfPresent`-style fallback to that field's default, via a small `value(_:or:)` helper on the keyed container. A value that is absent, of the wrong type, or carries an enum rawValue this build doesn't know costs one setting instead of all of them — the last case covering a TestFlight rollback onto an older build.
- The initializer lives in an `extension` so the struct keeps both its synthesized memberwise and no-argument initializers, and each `or:` argument reads the value `self.init()` just seeded, so the property defaults stay the single place a default is written down.
- `CodingKeys` is now spelled out rather than synthesized, so the wire keys survive anyone later hand-writing `encode(to:)`.
- Added `omnibus-ios/omnibusTests/ReaderSettingsTests.swift` — there was no test touching `ReaderSettings` at all. 13 cases: the exact pre-`spread` payload shape, a parametrized sweep dropping each of the seven keys in turn and asserting the other six survive, an unknown key being ignored, a mistyped value and an unknown enum case each falling back alone, a `save()`/`load()` round trip, the end-to-end upgrade through the real `UserDefaults` key, and an empty store loading the defaults. The suite is `.serialized` because those last three share that one key, and each restores whatever the test host held.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `just ios-test` — `** TEST SUCCEEDED **`, all 13 new cases passing, no new compiler warnings from either changed file.
- [x] Confirmed the new tests actually pin the regression: with the synthesized decoder, the pre-`spread` payload throws rather than decoding, so `decodesTheShapeWrittenBeforeSpreadExisted` fails on the old code.
- [ ] No Rust crates touched, so `just lint` / `just test` / Playwright are not implicated.

## Version
- [x] **Patch** — the default; leaving it unlabeled.

## Notes
- An iOS *OS* update was never implicated — `UserDefaults` survives one, along with a reboot and offloading the app. Only an app update onto a build that had grown a field did this, which is why it reads as random.
- The `spread` doc comment asserted the opposite of what happened ("Matches epub.js's own default (`auto`) so a reader upgrading from a build that never sent `spread` sees no change in behavior"). The default was never consulted, because the whole blob failed to decode first — rewritten, with the constraint a new field has to meet now documented on the extension.