### PR TITLE
[OMNI-2108] Rate-adjust the iOS player's elapsed readout

### DIFF
--- a/omnibus-ios/omnibus/Features/Player/PlayerView.swift
+++ b/omnibus-ios/omnibus/Features/Player/PlayerView.swift
@@ -294,9 +294,12 @@ struct PlayerView: View {
 
             // Chapter elapsed, book remaining, chapter remaining — all three at
             // once. The middle one is the whole-book context that a
-            // chapter-scoped bar would otherwise cost you.
+            // chapter-scoped bar would otherwise cost you. All three are
+            // rate-adjusted wall-clock: an elapsed readout left at 1x book-time
+            // disagrees with its own row's remaining labels the moment the
+            // speed leaves 1x.
             HStack(spacing: Spacing.sm) {
-                Text(Format.duration(displayedOffset))
+                Text(Format.duration(Format.atRate(displayedOffset, rate: player.rate)))
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if player.hasChapters {

--- a/omnibus-ios/omnibusTests/RateAdjustedTimeTests.swift
+++ b/omnibus-ios/omnibusTests/RateAdjustedTimeTests.swift
@@ -3,10 +3,10 @@
 //
 //  `Format.atRate` converts book-time seconds into the wall-clock time a
 //  listener at a given playback rate actually experiences. Two consumers
-//  depend on it staying exact: the player's remaining-time readouts, and the
-//  session tracker's per-tick accrual (the periodic observer fires in media
-//  time, so each 0.5s tick is divided by the rate before it counts toward
-//  listening stats).
+//  depend on it staying exact: the player's scrubber-row readouts (elapsed
+//  and both remaining labels), and the session tracker's per-tick accrual
+//  (the periodic observer fires in media time, so each 0.5s tick is divided
+//  by the rate before it counts toward listening stats).
 
 import Testing
 
@@ -27,6 +27,24 @@ struct RateAdjustedTimeTests {
         #expect(Format.atRate(600, rate: -1) == 600)
         #expect(Format.atRate(600, rate: .nan) == 600)
         #expect(Format.atRate(600, rate: .infinity) == 600)
+    }
+
+    @Test("elapsed and remaining labels share one wall-clock basis")
+    func scrubberRowLabelsAgree() {
+        // A 60-minute chapter at 2x, 20 book-minutes in: the row reads 10:00
+        // elapsed and 20:00 left, summing to the 30-minute rate-adjusted
+        // span. An elapsed label left in 1x book-time would show 20:00
+        // elapsed beside 20:00 left at the chapter's one-third mark.
+        let chapterDuration = 3600.0
+        let offset = 1200.0
+        let rate = 2.0
+        #expect(Format.duration(Format.atRate(offset, rate: rate)) == "10:00")
+        #expect(
+            Format.duration(Format.atRate(chapterDuration - offset, rate: rate)) == "20:00")
+        #expect(
+            Format.atRate(offset, rate: rate)
+                + Format.atRate(chapterDuration - offset, rate: rate)
+                == Format.atRate(chapterDuration, rate: rate))
     }
 
     @Test("a media-time observer tick accrues wall-clock stats time")


### PR DESCRIPTION
## Summary
- The iOS player's scrubber row rendered chapter elapsed (left label) in 1x book-time while the book-remaining (center) and chapter-remaining (right) labels were already rate-adjusted, so at any speed other than 1x the row disagreed with itself.
- Apply `Format.atRate` to the elapsed readout too, so all three labels share the same wall-clock basis and elapsed + remaining sum to the chapter's rate-adjusted span.

Closes #2108

## Test plan
- [x] New `scrubberRowLabelsAgree` test in `RateAdjustedTimeTests` pins the contract (60-min chapter at 2x, 20 book-minutes in → 10:00 elapsed / 20:00 left).
- [x] `scripts/ios-test.sh unit` (the `just ios-test` / CI invocation) — full `omnibusTests` suite green.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.