### PR TITLE
[OMNI-2124] Rate-adjust the web/Android players' elapsed and total labels

### DIFF
--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -300,13 +300,15 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
             div { class: "{scrub_class}",
                 {segment_bar(&chapters, eff_current, effective, duration)}
 
-                // Visible playhead + drag-time bubble.
+                // Visible playhead + drag-time bubble. The bubble previews
+                // the same rate-adjusted elapsed the row's left label shows,
+                // so the two can't disagree mid-drag.
                 div { class: "lp-chapter-thumb", style: "left: {thumb:.3}%;" }
                 if is_scrubbing {
                     div {
                         class: "lp-chapter-bubble",
                         style: "left: {thumb:.3}%;",
-                        "{format_hms(effective)}"
+                        "{format_hms(helpers::remaining_at_rate(effective, rate))}"
                     }
                 }
 
@@ -325,14 +327,18 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
                 }
             }
 
+            // All three readouts share one rate-adjusted wall-clock basis
+            // (elapsed + remaining = total at the current speed) — a 1x
+            // elapsed or total beside a rate-adjusted remaining disagrees
+            // with its own row off 1x (#2108, matching the iOS player).
+            // Scaled after the scrub preview so a drag previews the
+            // rate-adjusted times too (matches the mobile player).
             div { class: "lp-scrub-times",
-                span { "{format_hms(effective)}" }
+                span { "{format_hms(helpers::remaining_at_rate(effective, rate))}" }
                 span { class: "lp-scrub-remaining",
-                    // Scaled after the scrub preview so a drag previews the
-                    // rate-adjusted time left too (matches the mobile player).
                     "\u{00b7} {format_hms(helpers::remaining_at_rate(eff_remaining, rate))} remaining"
                 }
-                span { "{format_hms(duration)}" }
+                span { "{format_hms(helpers::remaining_at_rate(duration, rate))}" }
             }
             if buffering {
                 div {

--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -122,8 +122,8 @@ pub(super) struct ChapterMapProps {
     pub duration: f64,
     /// Seconds remaining in the whole book.
     pub remaining: f64,
-    /// Current playback rate — the remaining readout divides by it so "time
-    /// left" is wall-clock listening time, not book time.
+    /// Current playback rate — every time readout (elapsed, remaining, total)
+    /// divides by it so the row is wall-clock listening time, not book time.
     pub rate: f64,
     /// Index of the currently-playing chapter.
     pub current_chapter_index: usize,
@@ -349,5 +349,66 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
                 }
             }
         }
+    }
+}
+
+// SSR render-smoke coverage of the time row's one-basis contract — separate
+// module because it needs the `server` feature (`dioxus::ssr`). The drag
+// bubble can't be exercised here (it renders only mid-scrub, behind a
+// signal), but it shares the elapsed label's exact expression.
+#[cfg(all(test, feature = "server"))]
+mod render_tests {
+    use super::*;
+    use crate::test_support::render;
+
+    #[component]
+    fn MapHarness(rate: f64) -> Element {
+        // Two 30-minute chapters, 20 book-minutes in: at 2x the row must
+        // read 10:00 elapsed / 20:00 remaining / 30:00 total.
+        rsx! {
+            ChapterMap {
+                chapters: vec![
+                    ChapterInfo {
+                        ordinal: 1,
+                        title: "One".into(),
+                        start_seconds: 0.0,
+                        duration_seconds: 1800.0,
+                    },
+                    ChapterInfo {
+                        ordinal: 2,
+                        title: "Two".into(),
+                        start_seconds: 1800.0,
+                        duration_seconds: 1800.0,
+                    },
+                ],
+                elapsed: 1200.0,
+                duration: 3600.0,
+                remaining: 2400.0,
+                rate,
+                current_chapter_index: 0,
+                on_seek: EventHandler::new(|_| {}),
+                buffering: false,
+            }
+        }
+    }
+
+    #[test]
+    fn chapter_map_renders_every_time_label_on_the_rate_adjusted_basis() {
+        let html = render(rsx! { MapHarness { rate: 2.0 } });
+        assert!(html.contains("10:00"), "{html}");
+        assert!(html.contains("20:00 remaining"), "{html}");
+        assert!(html.contains("30:00"), "{html}");
+        // The seek range stays in 1x book-time — it's a coordinate, not a
+        // readout.
+        assert!(html.contains("value=\"1200\""), "{html}");
+        assert!(html.contains("max=\"3600\""), "{html}");
+    }
+
+    #[test]
+    fn chapter_map_renders_unchanged_labels_at_1x() {
+        let html = render(rsx! { MapHarness { rate: 1.0 } });
+        assert!(html.contains("20:00"), "{html}");
+        assert!(html.contains("40:00 remaining"), "{html}");
+        assert!(html.contains("1:00:00"), "{html}");
     }
 }

--- a/frontend/src/pages/listen/helpers.rs
+++ b/frontend/src/pages/listen/helpers.rs
@@ -328,15 +328,20 @@ pub(super) fn format_hms(seconds: f64) -> String {
     }
 }
 
-/// Rate-adjusted "time left" for a real (1x) `remaining` duration; falls back
-/// to `remaining` unscaled when `rate` is non-finite or non-positive. Shared
-/// by the web and mobile players and the landing resume hero so every
-/// remaining-time readout scales the same way.
-pub(crate) fn remaining_at_rate(remaining: f64, rate: f64) -> f64 {
+/// Wall-clock seconds a listener at `rate` experiences for a real (1x)
+/// book-time span — remaining, elapsed, or a whole duration; falls back to
+/// `seconds` unscaled when `rate` is non-finite or non-positive. Shared by
+/// the web and mobile players and the landing resume hero so every readout
+/// on a row shares one basis: a 1x elapsed or total label beside a
+/// rate-adjusted remaining label disagrees with its own row the moment the
+/// speed leaves 1x (#2108). Positions that *name a place* in the book —
+/// bookmark timestamps, chapter start times, chapter-list lengths — stay 1x
+/// book-time; only elapsed/remaining/total rows scale.
+pub(crate) fn remaining_at_rate(seconds: f64, rate: f64) -> f64 {
     if !rate.is_finite() || rate <= 0.0 {
-        return remaining;
+        return seconds;
     }
-    remaining / rate
+    seconds / rate
 }
 
 /// Fire-and-forget POST `/api/rpc/progress` with the audio update.

--- a/frontend/src/pages/listen/helpers/tests.rs
+++ b/frontend/src/pages/listen/helpers/tests.rs
@@ -112,3 +112,26 @@ fn remaining_at_rate_falls_back_unscaled_for_invalid_rates() {
     assert!((remaining_at_rate(600.0, f64::NAN) - 600.0).abs() < f64::EPSILON);
     assert!((remaining_at_rate(600.0, f64::INFINITY) - 600.0).abs() < f64::EPSILON);
 }
+
+#[test]
+fn remaining_at_rate_keeps_elapsed_and_remaining_labels_on_one_basis() {
+    // The scrubber-row contract (mirrors the iOS `scrubberRowLabelsAgree`
+    // test for #2108): a 60-minute span at 2x, 20 book-minutes in, reads
+    // 10:00 elapsed and 20:00 remaining, summing to the 30-minute
+    // rate-adjusted total. An elapsed label left in 1x book-time would show
+    // 20:00 beside 20:00 remaining at the one-third mark.
+    let duration = 3600.0;
+    let elapsed = 1200.0;
+    let rate = 2.0;
+    assert_eq!(format_hms(remaining_at_rate(elapsed, rate)), "10:00");
+    assert_eq!(
+        format_hms(remaining_at_rate(duration - elapsed, rate)),
+        "20:00"
+    );
+    assert!(
+        (remaining_at_rate(elapsed, rate) + remaining_at_rate(duration - elapsed, rate)
+            - remaining_at_rate(duration, rate))
+        .abs()
+            < f64::EPSILON
+    );
+}

--- a/frontend/src/pages/listen/mini_dock/meta.rs
+++ b/frontend/src/pages/listen/mini_dock/meta.rs
@@ -2,7 +2,7 @@
 //! gate shared with the `/read` route, and the subtitle line (chapter ·
 //! clock · time-left).
 
-use super::super::helpers::format_hms;
+use super::super::helpers::{format_hms, remaining_at_rate};
 
 /// Progress fill percent (0–100) for the dock's mini progress bar. Returns 0
 /// when the duration is unknown or `elapsed` is non-finite so the bar never
@@ -74,14 +74,21 @@ pub(super) fn time_left_text(elapsed: f64, duration: f64, rate: f64) -> Option<S
 
 /// Build the dock subtitle: the chapter label (when present), the inline
 /// `elapsed / total` clock, and the speed-adjusted time left. The single-row
-/// bar has no separate time track, so the clock lives here.
+/// bar has no separate time track, so the clock lives here. The clock shares
+/// the time-left's rate-adjusted wall-clock basis — a 1x clock beside a
+/// rate-adjusted "left" disagrees with itself off 1x (#2108, matching the
+/// player surfaces).
 pub(super) fn dock_sub_text(
     chapter_sub: Option<String>,
     elapsed: f64,
     duration: f64,
     rate: f64,
 ) -> String {
-    let time = format!("{} / {}", format_hms(elapsed), format_hms(duration));
+    let time = format!(
+        "{} / {}",
+        format_hms(remaining_at_rate(elapsed, rate)),
+        format_hms(remaining_at_rate(duration, rate))
+    );
     let mut sub = match chapter_sub {
         Some(chapter) => format!("{chapter} \u{00b7} {time}"),
         None => time,

--- a/frontend/src/pages/listen/mini_dock/tests.rs
+++ b/frontend/src/pages/listen/mini_dock/tests.rs
@@ -100,6 +100,17 @@ fn dock_sub_text_is_clock_and_time_left_without_chapters() {
     );
 }
 
+#[test]
+fn dock_sub_text_scales_the_clock_to_the_playback_rate() {
+    // 10 book-minutes into an hour at 2x: the clock and the time-left share
+    // one wall-clock basis (5:00 elapsed + 25m left = the 30:00 total),
+    // rather than a 1x clock beside a rate-adjusted "left" (#2108).
+    assert_eq!(
+        dock_sub_text(None, 600.0, 3600.0, 2.0),
+        "5:00 / 30:00 \u{00b7} about 25m left"
+    );
+}
+
 // Mirrors MiniDock's "renders empty host vs. active bar" branch without needing a full component render.
 #[test]
 fn dock_active_state_is_none_when_nothing_is_playing() {

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -253,6 +253,7 @@ fn render_unsupported(
 /// body.
 struct PlayerDerived {
     effective: f64,
+    elapsed_book: f64,
     chapter_no: usize,
     chapter_count: usize,
     chapter_title: String,
@@ -294,8 +295,13 @@ fn derive_player_state(
     );
     let current = view.chapters.get(disp_index);
     let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
-    let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
-    let within = (effective - chapter_start).max(0.0);
+    // Every displayed time shares one rate-adjusted wall-clock basis — a 1x
+    // elapsed or chapter-total label beside a rate-adjusted "left" disagrees
+    // with its own row off 1x (#2108, matching the iOS player). `effective`
+    // and `scrub_max` stay 1x book-time: they're the range input's seek
+    // coordinate, not a readout.
+    let chapter_dur = remaining_at_rate(current.map(|c| c.duration_seconds).unwrap_or(0.0), rate);
+    let within = remaining_at_rate((effective - chapter_start).max(0.0), rate);
     let chapter_left = remaining_at_rate(
         view::remaining_in_chapter(&view.chapters, disp_index, effective),
         rate,
@@ -303,6 +309,7 @@ fn derive_player_state(
 
     PlayerDerived {
         effective,
+        elapsed_book: remaining_at_rate(effective, rate),
         chapter_no: disp_index + 1,
         chapter_count: view.chapters.len(),
         chapter_title: current.map(|c| c.title.clone()).unwrap_or_default(),
@@ -505,7 +512,7 @@ fn render_player_scrubber(
                 onchange: on_seek_commit,
             }
             div { class: "m-player-times mono",
-                span { "{format_hms(derived.effective)}" }
+                span { "{format_hms(derived.elapsed_book)}" }
                 if derived.has_chapters {
                     span { class: "m-player-chtime",
                         "{format_ms(derived.within)} / {format_ms(derived.chapter_dur)} \u{00b7} {format_ms(derived.chapter_left)} left"

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -24,6 +24,8 @@ mod interop;
 mod mini;
 mod sheets;
 mod state;
+#[cfg(test)]
+mod tests;
 mod view;
 
 use bookmarks_sheet::{use_mobile_bookmarks, BookmarksSheet, MobileBookmarks};

--- a/frontend/src/pages/listen/mobile/tests.rs
+++ b/frontend/src/pages/listen/mobile/tests.rs
@@ -1,0 +1,72 @@
+//! Tests for the mobile player's per-render display derivation — pins the
+//! scrubber row's one-basis contract at the `derive_player_state` boundary.
+
+use omnibus_shared::{ChapterInfo, EbookMetadata};
+
+use super::derive_player_state;
+use super::state::SleepState;
+use super::view::PlayerView;
+
+/// Two 30-minute chapters; the values every test below derives from.
+fn two_chapter_view() -> PlayerView {
+    let chapters = vec![
+        ChapterInfo {
+            ordinal: 1,
+            title: "One".into(),
+            start_seconds: 0.0,
+            duration_seconds: 1800.0,
+        },
+        ChapterInfo {
+            ordinal: 2,
+            title: "Two".into(),
+            start_seconds: 1800.0,
+            duration_seconds: 1800.0,
+        },
+    ];
+    PlayerView::from_direct(&EbookMetadata::default(), chapters, 3600.0, vec![])
+}
+
+#[test]
+fn derive_player_state_scales_every_readout_to_the_playback_rate() {
+    // 20 book-minutes into the first chapter at 2x: elapsed 10:00, chapter
+    // 10:00-in / 15:00-total / 5:00-left, book 10:00-left — the row sums on
+    // one wall-clock basis (#2108).
+    let d = derive_player_state(
+        &two_chapter_view(),
+        1200.0,
+        3600.0,
+        0,
+        2.0,
+        SleepState::Off,
+        None,
+    );
+    assert!((d.elapsed_book - 600.0).abs() < f64::EPSILON);
+    assert!((d.within - 600.0).abs() < f64::EPSILON);
+    assert!((d.chapter_dur - 900.0).abs() < f64::EPSILON);
+    assert!((d.chapter_left - 300.0).abs() < f64::EPSILON);
+    assert!((d.remaining_book - 1200.0).abs() < f64::EPSILON);
+    assert!((d.within + d.chapter_left - d.chapter_dur).abs() < f64::EPSILON);
+    assert!((d.elapsed_book + d.remaining_book - 1800.0).abs() < f64::EPSILON);
+    // The seek coordinates stay 1x book-time — the range input's value/max,
+    // not readouts.
+    assert!((d.effective - 1200.0).abs() < f64::EPSILON);
+    assert!((d.scrub_max - 3600.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn derive_player_state_keeps_book_time_labels_at_1x() {
+    let d = derive_player_state(
+        &two_chapter_view(),
+        1200.0,
+        3600.0,
+        0,
+        1.0,
+        SleepState::Off,
+        None,
+    );
+    assert!((d.elapsed_book - 1200.0).abs() < f64::EPSILON);
+    assert!((d.within - 1200.0).abs() < f64::EPSILON);
+    assert!((d.chapter_dur - 1800.0).abs() < f64::EPSILON);
+    assert!((d.chapter_left - 600.0).abs() < f64::EPSILON);
+    assert!((d.remaining_book - 2400.0).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- Ports the iOS #2108 fix (PR #2123) to the shared web/Android players: elapsed and total time labels rendered in 1x book-time beside rate-adjusted remaining labels, so every mixed row disagreed with itself off 1x.
- Scales the mobile player row, the full player's `lp-scrub-times` row + drag bubble, and the mini-dock clock through the existing `remaining_at_rate` helper; range inputs keep 1x book-time as their seek coordinate.
- Position labels that name a place in the book (bookmarks, chapter starts, chapter-list lengths) deliberately stay 1x book-time — only elapsed/remaining/total rows scale.

Closes #2124

## Test plan
- [x] New `remaining_at_rate_keeps_elapsed_and_remaining_labels_on_one_basis` (mirrors iOS `scrubberRowLabelsAgree`) and `dock_sub_text_scales_the_clock_to_the_playback_rate`; existing 1x tests pin that nothing changes at normal speed.
- [x] `cargo test -p omnibus-frontend --features server` (920) and `cargo nextest run -p omnibus-frontend --features mobile` (778) green.
- [x] `cargo fmt --check` + clippy `-D warnings` on server, mobile, and wasm32 web feature surfaces.
- [x] No Playwright spec asserts these label texts (checked `listen.spec.ts` / `mini-dock.spec.ts`).

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.