### PR TITLE
fix: render journal lists, quotes, headings, and paragraph breaks as authored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ recent releases are recorded below; everything earlier is available via the
 
 ### Fixed
 
+- Journal entries now publish the way they read in the editor. Numbered and
+  nested lists render with their numbers, bullets, and indentation instead of
+  collapsing flush against the card; quotes get their accent bar and keep each
+  quoted line on its own row; every heading depth uses the journal's own
+  typeface rather than falling back to the site's display serif; a blank line
+  between paragraphs shows as a visible gap in both the preview tab and the
+  published entry; and the editor no longer displays a phantom extra blank
+  line for every empty line typed
 - Checking a book in with "I own it" — or adding one to the wishlist — now
   keeps the cover the check-in card showed. The server fetched it under terms
   that refused redirects, so every cover from Open Library's CDN (which

--- a/db/src/journals/markdown.rs
+++ b/db/src/journals/markdown.rs
@@ -4,7 +4,7 @@
 //! regions in a native `<button class="spoiler">` so keyboard and screen-reader
 //! users get the same reveal affordance as mouse users.
 
-use pulldown_cmark::{html, Options, Parser};
+use pulldown_cmark::{html, Event, Options, Parser};
 
 /// Path prefix every embedded journal image must be served from. The
 /// sanitizer drops any `<img>` whose `src` points elsewhere, so entries can't
@@ -21,7 +21,14 @@ pub fn render(md: &str) -> String {
     // render as a disabled `<input type="checkbox">` which the sanitizer keeps
     // in a tightly constrained form (see `sanitize`).
     opts.insert(Options::ENABLE_TASKLISTS);
-    let parser = Parser::new_ext(&with_spoilers, opts);
+    // The live editor shows one visual line per source line, so a single
+    // newline the author can see must survive publishing. CommonMark's soft
+    // break would collapse it to a space — promote it to a hard `<br>` so a
+    // multi-line quote (or paragraph) keeps its line structure.
+    let parser = Parser::new_ext(&with_spoilers, opts).map(|ev| match ev {
+        Event::SoftBreak => Event::HardBreak,
+        ev => ev,
+    });
     let mut raw_html = String::new();
     html::push_html(&mut raw_html, parser);
     wrap_figures(&sanitize(&raw_html))

--- a/db/src/journals/markdown/tests.rs
+++ b/db/src/journals/markdown/tests.rs
@@ -61,6 +61,36 @@ fn render_leaves_unterminated_spoiler_marker_literal() {
 }
 
 #[test]
+fn render_emits_ordered_lists_and_keeps_nested_lists_nested() {
+    let html = render("1. first\n2. second\n\n- parent\n  - child");
+    assert!(html.contains("<ol>"), "ordered list survives: {html}");
+    assert!(html.contains("<li>first</li>"), "got: {html}");
+    assert!(
+        html.contains("<li>parent\n<ul>\n<li>child</li>"),
+        "nested list stays inside its parent item: {html}"
+    );
+}
+
+#[test]
+fn render_promotes_single_newlines_to_hard_breaks() {
+    // The live editor shows one visual line per source line; a CommonMark
+    // soft break would collapse that newline to a space on publish.
+    let html = render("line one\nline two");
+    assert!(html.contains("<br"), "single newline becomes <br>: {html}");
+}
+
+#[test]
+fn render_keeps_lazy_blockquote_continuation_lines_on_their_own_rows() {
+    let html = render("> quoted one\nquoted two\nquoted three");
+    assert!(html.contains("<blockquote>"), "got: {html}");
+    let quote_has_breaks = html
+        .split("<blockquote>")
+        .nth(1)
+        .is_some_and(|q| q.matches("<br").count() >= 2);
+    assert!(quote_has_breaks, "each quoted line keeps its row: {html}");
+}
+
+#[test]
 fn render_emits_task_list_checkboxes() {
     let html = render("- [x] done\n- [ ] todo");
     // A checked + an unchecked disabled checkbox survive sanitization.

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1427,10 +1427,10 @@ html, body { overscroll-behavior: none; }
   line-height: 1.7;
   color: var(--ink-1);
 }
-.bd-journal-preview :first-child,
-.bd-journal-entry-body :first-child { margin-top: 0; }
-.bd-journal-preview :last-child,
-.bd-journal-entry-body :last-child { margin-bottom: 0; }
+.bd-journal-preview > :first-child,
+.bd-journal-entry-body > :first-child { margin-top: 0; }
+.bd-journal-preview > :last-child,
+.bd-journal-entry-body > :last-child { margin-bottom: 0; }
 .bd-journal-preview h1,
 .bd-journal-entry-body h1,
 .bd-journal-preview h2,

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1427,7 +1427,9 @@ html, body { overscroll-behavior: none; }
   line-height: 1.7;
   color: var(--ink-1);
 }
+.bd-journal-preview :first-child,
 .bd-journal-entry-body :first-child { margin-top: 0; }
+.bd-journal-preview :last-child,
 .bd-journal-entry-body :last-child { margin-bottom: 0; }
 .bd-journal-preview h1,
 .bd-journal-entry-body h1,
@@ -1450,10 +1452,55 @@ html, body { overscroll-behavior: none; }
   line-height: 1.35;
   margin: 0 0 10px;
 }
+/* h3–h6 too — the renderer emits every heading depth, and an unstyled one
+   falls through to the `.atrium h3` display-serif rule, which reads as a
+   different typeface entirely inside an entry. */
+.bd-journal-preview h3,
+.bd-journal-entry-body h3,
+.bd-journal-preview h4,
+.bd-journal-entry-body h4,
+.bd-journal-preview h5,
+.bd-journal-entry-body h5,
+.bd-journal-preview h6,
+.bd-journal-entry-body h6 {
+  font-family: var(--sans);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink-0);
+  font-size: 1.1em;
+  line-height: 1.4;
+  margin: 0 0 10px;
+}
+/* Block spacing — shared by the published body and the composer's preview
+   tab so the preview is an honest rehearsal of the published entry. 14px
+   (~1em) so a blank line in the source reads as a visible gap, not a
+   line-wrap. */
+.bd-journal-preview p,
 .bd-journal-entry-body p,
+.bd-journal-preview ul,
 .bd-journal-entry-body ul,
+.bd-journal-preview ol,
 .bd-journal-entry-body ol,
-.bd-journal-entry-body blockquote { margin: 0 0 10px; }
+.bd-journal-preview blockquote,
+.bd-journal-entry-body blockquote { margin: 0 0 14px; }
+/* The global `* { padding: 0 }` reset strips the UA's list indent, which
+   pushes `outside` markers into (and past) the card gutter and renders
+   nested lists flush with their parents — restore it here. */
+.bd-journal-preview ul,
+.bd-journal-entry-body ul,
+.bd-journal-preview ol,
+.bd-journal-entry-body ol { padding-left: 1.4em; }
+.bd-journal-preview li > ul,
+.bd-journal-entry-body li > ul,
+.bd-journal-preview li > ol,
+.bd-journal-entry-body li > ol { margin-bottom: 0; }
+.bd-journal-preview blockquote,
+.bd-journal-entry-body blockquote {
+  /* Mirrors the editor's `.cm-quote` treatment. */
+  border-left: 3px solid var(--accent);
+  padding-left: 8px;
+  font-style: italic;
+}
 .bd-journal-entry-body-collapsed {
   max-height: 230px;
   overflow: hidden;

--- a/frontend/src/pages/book_detail/journal_editor.js
+++ b/frontend/src/pages/book_detail/journal_editor.js
@@ -138,15 +138,21 @@ if (!window.OmnibusJournalEditor) {
     // Newlines kept as literal text so textContent === the markdown source.
     // Each line is wrapped in a `.cm-line` span (adds no text) so the
     // active-line pass below can reveal markers per line.
-    const render = (md) =>
-      md
-        .split("\n")
-        // Empty lines get a `<br>` placeholder so they have layout height (a
-        // bare empty inline span collapses to zero and can't be clicked) and a
-        // caret landing spot. It contributes no text, so textContent still
-        // equals the markdown source exactly.
-        .map((line) => `<span class="cm-line">${blockLine(line) || "<br>"}</span>`)
+    const render = (md) => {
+      const lines = md.split("\n");
+      return lines
+        // An empty *final* line gets a `<br>` placeholder so it has layout
+        // height and a caret landing spot (a bare empty inline span collapses
+        // to zero). Interior empty lines must NOT get one: the literal "\n"
+        // join on each side already produces their line box, and a `<br>`
+        // there adds a second break — every blank line displayed double. The
+        // `<br>` contributes no text, so textContent still equals the source.
+        .map((line, i) => {
+          const filler = i === lines.length - 1 ? "<br>" : "";
+          return `<span class="cm-line">${blockLine(line) || filler}</span>`;
+        })
         .join("\n");
+    };
 
     // --- active-line marker reveal (Obsidian-style) ---------------------------
     // Markers are fully faded by CSS except on the `.cm-active` line. The

--- a/ui_tests/playwright/tests/flows/journal.spec.ts
+++ b/ui_tests/playwright/tests/flows/journal.spec.ts
@@ -256,6 +256,50 @@ test("publishes an entry attributed to the current user, edits it, then deletes 
 });
 
 // ---------------------------------------------------------------------------
+// Action — block markdown (lists, quote, paragraphs) publishes structurally
+// ---------------------------------------------------------------------------
+
+test("publishes lists, a quote, and paragraphs as structured markup", async ({
+  page,
+  request,
+}) => {
+  const uuid = await fetchBookUuidByTitle(request, TARGET.title);
+  await gotoReady(page, `/books/${uuid}`);
+
+  const marker = `e2e-blocks-${Date.now()}`;
+  await page.getByTestId("journal-open-composer").click();
+  // Type through the keyboard (not `fill`) so `\n` presses Enter and the
+  // multi-line body goes through the editor's own newline handling — the
+  // path a real author uses.
+  await editor(page).click();
+  await page.keyboard.type(
+    `${marker} intro\n\n1. first\n2. second\n\n- parent\n  - child\n\n> quoted one\nquoted two`,
+  );
+  // The mirror carries the exact markdown: blank lines and the sub-bullet's
+  // leading indent must survive the contenteditable round-trip.
+  await expect(editorMarkdown(page)).toHaveValue(
+    `${marker} intro\n\n1. first\n2. second\n\n- parent\n  - child\n\n> quoted one\nquoted two`,
+  );
+  await expectMutation(
+    page,
+    { method: "POST", url: SAVE_URL, expectedStatus: 200 },
+    async () => page.getByTestId("journal-publish").click(),
+  );
+
+  const card = page.getByTestId("journal-entry").filter({ hasText: marker });
+  await expect(card).toBeVisible();
+  // Numbered list → a real <ol>; the sub-bullet stays nested in its parent.
+  await expect(card.locator("ol > li")).toHaveCount(2);
+  await expect(card.locator("li > ul > li")).toHaveText("child");
+  // The quote keeps its blockquote wrapper, and the lazy continuation line
+  // keeps its own row (soft breaks are promoted to <br> on publish).
+  await expect(card.locator("blockquote")).toContainText("quoted two");
+  await expect(card.locator("blockquote br")).toHaveCount(1);
+
+  await deleteEntry(page, marker);
+});
+
+// ---------------------------------------------------------------------------
 // Action — markdown preview + spoiler reveal
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Journal entries published with block markdown now render as authored: the journal body/preview CSS restores the list indent the global `* { padding: 0 }` reset strips (numbered lists get their numbers back, sub-bullets nest), styles blockquotes with the editor's accent-bar treatment, covers h3–h6 so deep headings stop falling through to the site's display serif, and gives both surfaces a shared 14px block gap so a blank line reads as one.
- The renderer promotes CommonMark soft breaks to hard `<br>`s at publish, so a single newline the author sees in the line-per-line editor survives to the published entry (multi-line quotes keep their rows).
- The live editor no longer displays a phantom extra blank line per empty line: the `<br>` placeholder now goes only on a trailing empty line, since interior ones already get their line box from the literal `\n` joins.

## Test plan
- [x] 3 new unit tests in `db::journals::markdown` (ordered/nested lists, soft-break promotion, multi-line quote rows); full `just test` matrix green
- [x] New Playwright test types the repro through the keyboard, asserts the markdown mirror verbatim, publishes, and asserts `<ol>`, nested `<ul>`, and blockquote `<br>` structure — journal spec 13/13 against a live dev server
- [x] Editor fix measured in-browser: `a\n\nb` occupies 3 line boxes (was 4); trailing blank line keeps its caret landing spot
- [x] `just lint` + `just lint-ts` clean

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.