### PR TITLE
[OMNI-2133] Expose Longest Sit, Daily Activity, and Shelf Membership

### DIFF
--- a/db/src/stats/book.rs
+++ b/db/src/stats/book.rs
@@ -1,9 +1,10 @@
-//! Per-book insights aggregation for the book-detail page's Insights card —
-//! Started / Time read / Sessions, scoped to one `(user, book_uuid)` rather
-//! than [`super::user_stats`]'s user-wide window. Same `reading_sessions` /
+//! Per-book insights aggregation for the book-detail page's stats stop —
+//! Started / Time read / Pickups / Longest sit plus the per-day activity
+//! spark, scoped to one `(user, book_uuid)` rather than
+//! [`super::user_stats`]'s user-wide window. Same `reading_sessions` /
 //! `listening_sessions` tables, no new query-time schema.
 
-use omnibus_shared::BookInsights;
+use omnibus_shared::{BookInsights, DayActivity};
 use sqlx::{Row, SqlitePool};
 
 use super::StatsError;
@@ -18,13 +19,14 @@ const BOOK_SESSIONS: &str = "\
         WHERE user_id = ? AND book_uuid = ?";
 
 /// Aggregate one user's reading/listening insights for a single book:
-/// earliest session start, total seconds across both formats, and session
-/// count. `uuid` is resolved to the canonical `books.uuid` first (mirroring
-/// `db::progress`'s write path), so a link into a book that was later merged
-/// away still finds the sessions recorded under the surviving book. Returns
-/// `None` when the uuid doesn't resolve to a live book, or the book resolves
-/// but has no sessions yet — both drive the Insights card's em-dash empty
-/// state.
+/// earliest session start, total seconds and session count across both
+/// formats, the single longest session (length + when it started), and
+/// per-day activity for the spark. `uuid` is resolved to the canonical
+/// `books.uuid` first (mirroring `db::progress`'s write path), so a link into
+/// a book that was later merged away still finds the sessions recorded under
+/// the surviving book. Returns `None` when the uuid doesn't resolve to a live
+/// book, or the book resolves but has no sessions yet — both drive the stats
+/// stop's empty state.
 pub async fn book_insights(
     pool: &SqlitePool,
     user_id: i64,
@@ -51,10 +53,53 @@ pub async fn book_insights(
     if sessions == 0 {
         return Ok(None);
     }
+    let started_at: i64 = row.get("started_at");
+    let seconds_total: i64 = row.get("seconds_total");
+
+    // Longest single sit. Ties break to the earliest occurrence so the
+    // answer is stable across runs.
+    let sql = format!(
+        "SELECT started_at, secs FROM ({BOOK_SESSIONS}) \
+         ORDER BY secs DESC, started_at ASC LIMIT 1"
+    );
+    let row = sqlx::query(&sql)
+        .bind(user_id)
+        .bind(&book_uuid)
+        .bind(user_id)
+        .bind(&book_uuid)
+        .fetch_one(pool)
+        .await?;
+    let longest_seconds: i64 = row.get("secs");
+    let longest_started_at: i64 = row.get("started_at");
+
+    // Per-day totals, same UTC bucketing as the user-wide heatmap. Active
+    // days only — the client fills calendar gaps against `as_of_day`.
+    let sql = format!(
+        "SELECT date(started_at, 'unixepoch') AS day, SUM(secs) AS seconds \
+         FROM ({BOOK_SESSIONS}) GROUP BY day ORDER BY day"
+    );
+    let daily = sqlx::query(&sql)
+        .bind(user_id)
+        .bind(&book_uuid)
+        .bind(user_id)
+        .bind(&book_uuid)
+        .fetch_all(pool)
+        .await?
+        .into_iter()
+        .map(|r| DayActivity {
+            day: r.get("day"),
+            seconds: r.get("seconds"),
+        })
+        .collect();
+
     Ok(Some(BookInsights {
-        started_at: row.get("started_at"),
-        seconds_total: row.get("seconds_total"),
+        started_at,
+        seconds_total,
         sessions,
+        longest_seconds,
+        longest_started_at,
+        daily,
+        as_of_day: super::compute::as_of_day(pool).await?,
     }))
 }
 

--- a/db/src/stats/book/tests.rs
+++ b/db/src/stats/book/tests.rs
@@ -153,3 +153,49 @@ async fn book_insights_propagates_sqlx_error_when_sessions_table_is_missing() {
     let err = book_insights(&pool, user, "uuid-1").await.unwrap_err();
     assert!(matches!(err, StatsError::Sqlx(_)), "got: {err:?}");
 }
+
+#[tokio::test]
+async fn book_insights_reports_longest_sit_breaking_ties_to_the_earliest() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let user = seed_user(&pool, "alice").await;
+    reading_session(&pool, user, "uuid-1", T0, 600).await;
+    listening_session(&pool, user, "uuid-1", T0 + 7_200, 1_800).await;
+    // Same length as the winner, but later — the earlier one must win.
+    reading_session(&pool, user, "uuid-1", T0 + 86_400, 1_800).await;
+
+    let insights = book_insights(&pool, user, "uuid-1").await.unwrap().unwrap();
+
+    assert_eq!(insights.longest_seconds, 1_800);
+    assert_eq!(insights.longest_started_at, T0 + 7_200);
+}
+
+#[tokio::test]
+async fn book_insights_buckets_daily_activity_by_utc_day_ascending() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 1).await;
+    let user = seed_user(&pool, "alice").await;
+    // T0 = 2023-11-14 22:13:20 UTC. Two sessions the same UTC day (reading +
+    // listening merge into one bucket), one two days later.
+    reading_session(&pool, user, "uuid-1", T0, 600).await;
+    listening_session(&pool, user, "uuid-1", T0 + 60, 300).await;
+    reading_session(&pool, user, "uuid-1", T0 + 2 * 86_400, 240).await;
+
+    let insights = book_insights(&pool, user, "uuid-1").await.unwrap().unwrap();
+
+    assert_eq!(
+        insights.daily,
+        vec![
+            DayActivity {
+                day: "2023-11-14".into(),
+                seconds: 900
+            },
+            DayActivity {
+                day: "2023-11-16".into(),
+                seconds: 240
+            },
+        ]
+    );
+    // Stamped from the server clock — only its shape is stable in a test.
+    assert_eq!(insights.as_of_day.len(), 10);
+}

--- a/frontend/src/data/shelves.rs
+++ b/frontend/src/data/shelves.rs
@@ -316,6 +316,16 @@ pub async fn get_shelf(_server_url: &str, id: i64) -> Result<Shelf, DataError> {
         .map_err(note_server_fn_err)
 }
 
+/// Ids of the visible hand-picked shelves holding this book. Web-only caller
+/// (the book page's shelf stop); mobile's book screen already consumes the
+/// REST twin directly.
+#[cfg(not(feature = "mobile"))]
+pub async fn shelves_containing(_server_url: &str, uuid: &str) -> Result<Vec<i64>, DataError> {
+    crate::rpc::rpc_shelves_containing(uuid.to_string())
+        .await
+        .map_err(note_server_fn_err)
+}
+
 /// Create a shelf.
 #[cfg(not(feature = "mobile"))]
 pub async fn create_shelf(_server_url: &str, req: CreateShelfRequest) -> Result<Shelf, DataError> {

--- a/frontend/src/pages/book_detail/body/tests.rs
+++ b/frontend/src/pages/book_detail/body/tests.rs
@@ -22,6 +22,10 @@ fn bd_insight_values_formats_started_time_read_sessions_and_pace() {
         started_at: 1_700_000_000, // 2023-11-14
         seconds_total: 5400,       // 1h 30m across 3 sessions
         sessions: 3,
+        longest_seconds: 3600,
+        longest_started_at: 1_700_000_000,
+        daily: Vec::new(),
+        as_of_day: "2023-11-14".into(),
     };
     // `dates_ready: false` pins the deterministic UTC day (offset 0), same
     // as SSR and the first client paint.
@@ -41,6 +45,10 @@ fn bd_insight_values_guards_against_a_zero_session_count() {
         started_at: 0,
         seconds_total: 0,
         sessions: 0,
+        longest_seconds: 0,
+        longest_started_at: 0,
+        daily: Vec::new(),
+        as_of_day: String::new(),
     };
     assert_eq!(
         bd_insight_values(Some(insights), false),

--- a/frontend/src/rpc/shelves.rs
+++ b/frontend/src/rpc/shelves.rs
@@ -71,6 +71,19 @@ pub async fn rpc_get_shelf(id: i64) -> Result<Shelf> {
     shelf_for_view(&pool.0, id, &user).await
 }
 
+/// Ids of the caller-visible hand-picked shelves holding this book — the
+/// book page's "on your shelves" row (RPC twin of `GET
+/// /api/shelves/containing/{uuid}`). Smart shelves are excluded: their
+/// membership is rule-derived, not something the row can toggle.
+#[post("/api/rpc/shelves/containing", pool: PoolExt, user: AuthUser)]
+pub async fn rpc_shelves_containing(uuid: String) -> Result<Vec<i64>> {
+    Ok(
+        db::shelves::manual_shelves_containing(&pool.0, user.id, user.is_admin, &uuid)
+            .await
+            .map_err(|e| map_shelf_error("shelves containing", e))?,
+    )
+}
+
 /// Create a shelf owned by the caller.
 #[post("/api/rpc/shelves/create", pool: PoolExt, user: AuthUser)]
 pub async fn rpc_create_shelf(req: CreateShelfRequest) -> Result<Shelf> {

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -83,7 +83,7 @@ pub struct RankedEntity {
 /// a single `(user, book_uuid)` rather than a user-wide window. The RPC wraps
 /// this in `Option` — `None` means the book has no recorded sessions yet,
 /// driving the card's em-dash empty state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BookInsights {
     /// Unix seconds of the earliest recorded session (reading or listening).
     pub started_at: i64,
@@ -91,6 +91,17 @@ pub struct BookInsights {
     pub seconds_total: i64,
     /// Count of reading + listening sessions on this book.
     pub sessions: i64,
+    /// Seconds of the single longest session on this book.
+    pub longest_seconds: i64,
+    /// Unix seconds when that longest session started.
+    pub longest_started_at: i64,
+    /// Per-day activity on this book (active days only, ascending). Days use
+    /// the same UTC `YYYY-MM-DD` bucketing as [`DayActivity`] elsewhere;
+    /// callers fill calendar gaps against [`Self::as_of_day`].
+    pub daily: Vec<DayActivity>,
+    /// The server's current UTC day (`YYYY-MM-DD`) — the right edge of the
+    /// `daily` window, so clients don't have to guess the server's "today".
+    pub as_of_day: String,
 }
 
 /// One genre-donut slice: a tag and how many distinct books carrying it had

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -77,12 +77,13 @@ pub struct RankedEntity {
 }
 
 /// Reading/listening insights for one book, scoped to one user — the
-/// book-detail page's Insights card (Started / Time read / Sessions / Pace).
-/// Produced by `db::stats::book_insights` from the same `reading_sessions` /
+/// book-detail page's Stats stop (Started / Time in book / Pickups + avg sit /
+/// Longest sit, plus the per-day activity spark). Produced by
+/// `db::stats::book_insights` from the same `reading_sessions` /
 /// `listening_sessions` tables [`StatsSummary`] aggregates from, but scoped to
 /// a single `(user, book_uuid)` rather than a user-wide window. The RPC wraps
 /// this in `Option` — `None` means the book has no recorded sessions yet,
-/// driving the card's em-dash empty state.
+/// driving the stop's quiet empty state.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BookInsights {
     /// Unix seconds of the earliest recorded session (reading or listening).


### PR DESCRIPTION
## Summary
- Extends `BookInsights` with the single longest session (length + start), per-day `DayActivity` buckets, and the server's `as_of_day`, and teaches `db::stats::book_insights` to aggregate them from the existing session tables.
- Adds `rpc_shelves_containing` + a web `data::shelves_containing` wrapper — the RPC twin of the existing `GET /api/shelves/containing/{uuid}` REST route — so the web book page can render manual-shelf membership.
- Data groundwork for the W4 book-detail redesign in the stacked follow-up (`-2` branch).

Part of #2133

## Test plan
- [x] `just check` (full lint + test matrix) green; 8 db tests cover the new aggregation (longest-sit tie-break, UTC day bucketing) and existing insights/shelf coverage.

## Version
- [x] **No release** — add the `no release` label to skip cutting a release.