### PR TITLE
[OMNI-2140] Journal Row Actions & Uncapped Passage List

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -1141,8 +1141,6 @@ html, body { overscroll-behavior: none; }
 }
 .bd-hl-meta { font-size: 11px; color: var(--ink-3); }
 .bd-hl-actions { display: flex; gap: 6px; flex-wrap: wrap; }
-/* Matches `.bd-hl-list`'s row gap so the control reads as one more row. */
-.bd-hl-show-more { margin-top: 14px; font-family: var(--sans); font-size: 12px; }
 @media (hover: hover) { .bd-hl-delete:hover { color: var(--bad); } }
 
 /* Quote-card modal — the shared reader editor (rd-quote-*) hosted in the
@@ -10443,12 +10441,8 @@ html {
 .bdw4-stack-avatar-photo, .bdw4-lrow-avatar-photo { width: 100%; height: 100%; object-fit: cover; }
 .bdw4-journal .bd-journal-blurb { display: none; }
 .bdw4-journal .bd-journal-composer, .bdw4 .bd-journal-open { margin-top: 14px; }
-.bdw4-ladderhint {
-  font-size: 10px; color: var(--ink-3); margin: 10px 0 8px; letter-spacing: .06em;
-  text-transform: uppercase;
-}
 .bdw4-ladder {
-  overflow-y: auto; max-height: min(400px, 50vh); padding-right: 10px;
+  overflow-y: auto; max-height: min(400px, 50vh); margin-top: 10px; padding-right: 10px;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--accent) 75%, var(--bg-3)) var(--bg-2);
 }
@@ -10458,29 +10452,36 @@ html {
 }
 .bdw4-ladder::-webkit-scrollbar-track { background: var(--bg-2); border-radius: 99px; }
 .bdw4-lrow {
-  display: flex; gap: 10px; align-items: center; width: 100%;
-  padding: 8px 0; border: 0; border-bottom: 1px solid var(--line-2);
+  display: flex; gap: 14px; align-items: flex-start; width: 100%;
+  padding: 13px 0; border: 0; border-bottom: 1px solid var(--line-2);
   background: transparent; cursor: pointer; font: inherit; color: inherit;
   text-align: left; border-radius: 0;
 }
 .bdw4-lrow:hover { background: color-mix(in oklch, var(--bg-2) 55%, transparent); }
-.bdw4-lrow .nm { font-family: var(--mono); font-size: 10px; color: var(--ink-2); flex: 0 0 60px; letter-spacing: .04em; }
+.bdw4-lrow-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.bdw4-lrow-head { display: flex; align-items: baseline; flex-wrap: wrap; gap: 4px 8px; }
+.bdw4-lrow .nm { font-size: 13px; color: var(--ink-0); flex: 0 0 auto; }
+.bdw4-lrow .bdw4-lrow-you { color: var(--ink-3); }
 .bdw4-lrow .ex {
-  flex: 1; min-width: 0;
-  font-family: var(--serif); font-style: italic; font-size: 15.5px; color: var(--ink-1);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-family: var(--serif); font-style: italic; font-size: 15.5px;
+  color: var(--ink-1); line-height: 1.5;
 }
 .bdw4-lrow:hover .ex { color: var(--ink-0); }
+/* The row itself is the button, so this is a text cue, not a nested control. */
+.bdw4-lrow-read {
+  font-family: var(--mono); font-style: normal; font-size: 10px;
+  letter-spacing: .06em; color: var(--accent); white-space: nowrap;
+}
 .bdw4-lrow .at { font-family: var(--mono); font-size: 10px; color: var(--ink-3); flex: 0 0 auto; }
 .bdw4-lrow-avatar {
-  width: 22px; height: 22px; border-radius: 50%; flex: 0 0 auto;
+  width: 28px; height: 28px; border-radius: 50%; flex: 0 0 auto; margin-top: 1px;
   display: inline-grid; place-items: center; overflow: hidden;
   background: var(--bg-3); color: var(--ink-1);
-  font-family: var(--mono); font-size: 9px; font-weight: 700;
+  font-family: var(--mono); font-size: 10px; font-weight: 700;
 }
 .bdw4-lrow.draft {
   border: 1px dashed color-mix(in oklch, var(--accent) 45%, transparent);
-  border-radius: 8px; padding: 8px 10px; margin: 2px 0;
+  border-radius: 8px; padding: 12px 10px; margin: 2px 0;
 }
 .bdw4-draftchip {
   font-family: var(--mono); font-size: 8.5px; letter-spacing: .12em;

--- a/frontend/src/pages/book_detail/highlights.rs
+++ b/frontend/src/pages/book_detail/highlights.rs
@@ -78,37 +78,25 @@ pub(super) fn BdHighlightsSection(uuid: String, quote_meta: BdQuoteMeta) -> Elem
     }
 }
 
-/// Passages listed before the reader expands the section. A heavily
-/// highlighted book runs to hundreds of rows, and this is one section of
-/// several on the page.
-const COLLAPSED_PASSAGES: usize = 5;
-
-/// The passage list, capped at [`COLLAPSED_PASSAGES`] rows until the reader
-/// expands it. Both renders start collapsed so SSR and hydration match
-/// (rule 07).
+/// Every saved passage, in one list. A heavily highlighted book runs to
+/// hundreds of rows, so the W4 stop scrolls the list inside the stage
+/// (`.bdw4 .bd-hl-list`) rather than holding rows back behind a control.
 #[component]
 fn BdHighlightList(
     highlights: Signal<Vec<Highlight>>,
     server_url: String,
     quote_target: Signal<Option<Highlight>>,
 ) -> Element {
-    let mut expanded = use_signal(|| false);
     // Hoisted once for the whole list rather than once per card — a heavily
     // highlighted book runs to hundreds of rows, and each row resolves its
     // own offset from its own `created_at` via `local_date_offset` (see
     // `dates.rs`), so sharing this signal doesn't share a stale offset.
     let dates_ready = use_local_dates_ready();
     let list = highlights();
-    let total = list.len();
-    let visible = if expanded() {
-        total
-    } else {
-        total.min(COLLAPSED_PASSAGES)
-    };
 
     rsx! {
         div { class: "bd-hl-list", "data-testid": "highlights-list",
-            for h in list.iter().take(visible) {
+            for h in list.iter() {
                 BdHighlightCard {
                     key: "{h.id}",
                     highlight: h.clone(),
@@ -117,16 +105,6 @@ fn BdHighlightList(
                     quote_target,
                     dates_ready,
                 }
-            }
-        }
-        if total > visible {
-            button {
-                r#type: "button",
-                class: "btn ghost sm bd-hl-show-more",
-                "data-testid": "highlights-show-more",
-                "aria-expanded": "{expanded()}",
-                onclick: move |_| expanded.set(true),
-                "Show {total - visible} more \u{2193}"
             }
         }
     }

--- a/frontend/src/pages/book_detail/highlights/tests.rs
+++ b/frontend/src/pages/book_detail/highlights/tests.rs
@@ -242,12 +242,6 @@ mod render_tests {
         LongListHost {},
     }
 
-    #[derive(Clone, Debug, PartialEq, Routable)]
-    enum ShortListRoute {
-        #[route("/")]
-        ShortListHost {},
-    }
-
     /// `n` distinct passages, each id'd so the list's `key` stays unique.
     fn seeded_list(n: i64) -> Vec<Highlight> {
         (0..n)
@@ -281,40 +275,13 @@ mod render_tests {
     }
 
     #[test]
-    fn list_renders_only_the_collapsed_count_and_offers_the_rest() {
-        // A heavily highlighted book would otherwise push every other section
-        // off the page; the first COLLAPSED_PASSAGES rows show and the button
-        // names how many are held back.
+    fn list_renders_every_passage_without_a_show_more_control() {
+        // The W4 stop scrolls the list inside the stage, so a long list is
+        // bounded by the surface rather than by a load-more button.
         let html = render_in_vdom(render_long_list);
-        assert_eq!(count_cards(&html), COLLAPSED_PASSAGES);
+        assert_eq!(count_cards(&html), 8);
         assert!(html.contains("passage 0"));
-        assert!(html.contains("passage 4"));
-        assert!(!html.contains("passage 5"));
-        assert!(html.contains("data-testid=\"highlights-show-more\""));
-        assert!(html.contains("Show 3 more"));
-    }
-
-    #[component]
-    fn ShortListHost() -> Element {
-        rsx! {
-            BdHighlightList {
-                highlights: use_signal(|| seeded_list(COLLAPSED_PASSAGES as i64)),
-                server_url: String::new(),
-                quote_target: use_signal(|| None),
-            }
-        }
-    }
-
-    fn render_short_list() -> Element {
-        rsx! {
-            Router::<ShortListRoute> {}
-        }
-    }
-
-    #[test]
-    fn list_omits_the_show_more_button_when_nothing_is_held_back() {
-        let html = render_in_vdom(render_short_list);
-        assert_eq!(count_cards(&html), COLLAPSED_PASSAGES);
+        assert!(html.contains("passage 7"));
         assert!(!html.contains("data-testid=\"highlights-show-more\""));
     }
 

--- a/frontend/src/pages/book_detail/journal.rs
+++ b/frontend/src/pages/book_detail/journal.rs
@@ -18,6 +18,11 @@ use super::BdSectionHead;
 mod composer;
 mod entry_card;
 
+// The ladder row and its excerpt helper are web-stage-only, so the suite is
+// too — the mobile feature build has neither.
+#[cfg(all(test, not(feature = "mobile")))]
+mod tests;
+
 use composer::BdJournalComposer;
 use entry_card::BdJournalEntryCard;
 
@@ -135,8 +140,8 @@ fn journal_kicker(list: &[JournalEntry]) -> String {
 }
 
 /// Stop 05 · Journals for the W4 stage: header (entry/reader counts + the
-/// reader avatar stack), the composer, and the excerpt ladder — one line per
-/// entry, tap to open the full entry card over the stop. Wishlist-only books
+/// reader avatar stack), the composer, and the excerpt ladder — a two-line
+/// row per entry that opens the full card over the stop. Wishlist-only books
 /// render the design's empty state instead.
 #[cfg(not(feature = "mobile"))]
 #[component]
@@ -221,12 +226,9 @@ pub(super) fn W4JournalStop(uuid: String, wish_mode: bool) -> Element {
                     p { class: "mono", "No journal entries yet \u{2014} be the first to write one." }
                 }
             } else {
-                p { class: "mono bdw4-ladderhint", aria_hidden: "true",
-                    "one line each \u{2014} tap to open the full entry"
-                }
                 div { class: "bdw4-ladder", "data-testid": "journal-list",
                     for entry in list.iter() {
-                        {render_ladder_row(entry, open_entry)}
+                        {render_ladder_row(entry, current_user().map(|u| u.id), dates_ready, open_entry)}
                     }
                 }
             }
@@ -259,19 +261,29 @@ pub(super) fn W4JournalStop(uuid: String, wish_mode: bool) -> Element {
     }
 }
 
-/// One excerpt-ladder row: avatar · first name · (draft chip) · first line ·
-/// progress percent.
+/// One excerpt-ladder row, in the design's two-line shape: avatar, then a
+/// header line (author · you · draft chip · date · progress) over the
+/// excerpt, which ends in the `read →` affordance. The whole row is the
+/// button that opens the full entry, so the affordance stays reachable by
+/// keyboard without nesting a second control inside it.
 #[cfg(not(feature = "mobile"))]
-fn render_ladder_row(entry: &JournalEntry, mut open_entry: Signal<Option<i64>>) -> Element {
+fn render_ladder_row(
+    entry: &JournalEntry,
+    current_user_id: Option<i64>,
+    dates_ready: ReadSignal<bool>,
+    mut open_entry: Signal<Option<i64>>,
+) -> Element {
     let id = entry.id;
     let is_draft = entry.status == omnibus_shared::JournalStatus::Draft;
-    let first_name = entry
-        .author_name
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_string();
+    let is_owner = current_user_id == Some(entry.author_id);
+    let author = entry.author_name.clone();
     let excerpt = journal_excerpt(&entry.body_md);
+    let offset = super::dates::local_date_offset(dates_ready(), entry.created_at);
+    let date = super::dates::fmt_long_date(entry.created_at, offset);
+    let meta_line = match entry.progress {
+        Some(p) => format!("{date} \u{b7} at {p}%"),
+        None => date,
+    };
     rsx! {
         button {
             key: "{id}",
@@ -285,13 +297,21 @@ fn render_ladder_row(entry: &JournalEntry, mut open_entry: Signal<Option<i64>>) 
                 has_avatar: entry.author_has_avatar,
                 class: "bdw4-lrow-avatar".to_string(),
             }
-            span { class: "nm", "{first_name}" }
-            if is_draft {
-                span { class: "bdw4-draftchip", "data-testid": "journal-draft-chip-row", "Draft" }
-            }
-            span { class: "ex", "{excerpt}" }
-            if let Some(p) = entry.progress {
-                span { class: "at", "{p}%" }
+            span { class: "bdw4-lrow-body",
+                span { class: "bdw4-lrow-head",
+                    span { class: "nm", "{author}" }
+                    if is_owner {
+                        span { class: "nm bdw4-lrow-you", "\u{b7} you" }
+                    }
+                    if is_draft {
+                        span { class: "bdw4-draftchip", "data-testid": "journal-draft-chip-row", "Draft" }
+                    }
+                    span { class: "at", "{meta_line}" }
+                }
+                span { class: "ex",
+                    "{excerpt} "
+                    span { class: "bdw4-lrow-read", "read \u{2192}" }
+                }
             }
         }
     }
@@ -319,8 +339,13 @@ fn w4_journal_kicker(published: usize, readers: usize, drafts: usize, wish_mode:
     out
 }
 
+/// How much of an entry's first line a ladder row carries — the design's
+/// slice, sized to land on the row's second line rather than a third.
+#[cfg(not(feature = "mobile"))]
+const LADDER_EXCERPT_CHARS: usize = 170;
+
 /// First non-empty line of a markdown body, markup stripped and spoilers
-/// masked, capped for the one-line ladder row.
+/// masked, capped at [`LADDER_EXCERPT_CHARS`] for the ladder row.
 #[cfg(not(feature = "mobile"))]
 fn journal_excerpt(md: &str) -> String {
     let line = md
@@ -343,8 +368,8 @@ fn journal_excerpt(md: &str) -> String {
         .filter(|c| !matches!(c, '*' | '_' | '>' | '#' | '`'))
         .collect();
     let stripped = stripped.trim_start_matches("- ").trim().to_string();
-    let mut out: String = stripped.chars().take(160).collect();
-    if stripped.chars().count() > 160 {
+    let mut out: String = stripped.chars().take(LADDER_EXCERPT_CHARS).collect();
+    if stripped.chars().count() > LADDER_EXCERPT_CHARS {
         out.push('\u{2026}');
     }
     out

--- a/frontend/src/pages/book_detail/journal/tests.rs
+++ b/frontend/src/pages/book_detail/journal/tests.rs
@@ -1,0 +1,114 @@
+//! Tests for the W4 journal stop's excerpt helper and its two-line ladder row.
+
+use super::*;
+
+#[test]
+fn journal_excerpt_takes_the_first_non_empty_line_and_strips_markup() {
+    assert_eq!(
+        journal_excerpt("\n\n## **A held** breath\nsecond line"),
+        "A held breath"
+    );
+}
+
+#[test]
+fn journal_excerpt_masks_spoiler_spans_so_they_never_reach_the_row() {
+    // The row is always visible, so a `||spoiler||` span has to be blocked
+    // out rather than merely un-marked.
+    assert_eq!(
+        journal_excerpt("she ||dies|| in chapter four"),
+        "she \u{2588}\u{2588}\u{2588} in chapter four"
+    );
+}
+
+#[test]
+fn journal_excerpt_truncates_past_the_row_cap() {
+    let long = "x".repeat(LADDER_EXCERPT_CHARS + 40);
+    let out = journal_excerpt(&long);
+    assert_eq!(out.chars().count(), LADDER_EXCERPT_CHARS + 1);
+    assert!(out.ends_with('\u{2026}'));
+}
+
+// SSR render coverage for the ladder row. Needs the `server` feature
+// (`dioxus::ssr`), like the sibling highlights render tests.
+#[cfg(feature = "server")]
+mod render_tests {
+    use super::*;
+    use crate::test_support::render_in_vdom;
+
+    fn seeded_entry() -> JournalEntry {
+        JournalEntry {
+            id: 7,
+            book_uuid: "book-uuid".to_string(),
+            author_id: 3,
+            author_name: "Mira Reyes".to_string(),
+            author_has_avatar: false,
+            body_md: "The footnotes have footnotes.".to_string(),
+            body_html: "<p>The footnotes have footnotes.</p>".to_string(),
+            progress: Some(42),
+            status: omnibus_shared::JournalStatus::Published,
+            client_id: None,
+            created_at: 1_779_019_200,
+            updated_at: 1_779_019_200,
+        }
+    }
+
+    #[component]
+    fn RowHost() -> Element {
+        let dates_ready = super::super::use_local_dates_ready();
+        let open_entry = use_signal(|| None::<i64>);
+        render_ladder_row(&seeded_entry(), Some(3), dates_ready, open_entry)
+    }
+
+    fn render_row() -> Element {
+        rsx! {
+            RowHost {}
+        }
+    }
+
+    #[test]
+    fn ladder_row_carries_the_byline_the_excerpt_and_the_read_affordance() {
+        // Two lines per the design: author (with the owner's "you") plus the
+        // date/progress stamp, then the excerpt ending in `read →`.
+        let html = render_in_vdom(render_row);
+        assert!(
+            html.contains("data-testid=\"journal-ladder-row\""),
+            "{html}"
+        );
+        assert!(html.contains("Mira Reyes"), "{html}");
+        assert!(html.contains("you"), "{html}");
+        assert!(html.contains("May 17, 2026 \u{b7} at 42%"), "{html}");
+        assert!(html.contains("The footnotes have footnotes."), "{html}");
+        assert!(html.contains("read \u{2192}"), "{html}");
+        // The hint the design never asked for stays gone.
+        assert!(!html.contains("tap to open the full entry"), "{html}");
+    }
+
+    #[component]
+    fn DraftRowHost() -> Element {
+        let dates_ready = super::super::use_local_dates_ready();
+        let open_entry = use_signal(|| None::<i64>);
+        let mut entry = seeded_entry();
+        entry.status = omnibus_shared::JournalStatus::Draft;
+        entry.progress = None;
+        render_ladder_row(&entry, None, dates_ready, open_entry)
+    }
+
+    fn render_draft_row() -> Element {
+        rsx! {
+            DraftRowHost {}
+        }
+    }
+
+    #[test]
+    fn ladder_row_marks_a_draft_and_drops_the_progress_stamp_when_absent() {
+        let html = render_in_vdom(render_draft_row);
+        assert!(
+            html.contains("data-testid=\"journal-draft-chip-row\""),
+            "{html}"
+        );
+        assert!(html.contains("May 17, 2026"), "{html}");
+        assert!(!html.contains("at 42%"), "{html}");
+        // Not the current user's entry — no "you" chip.
+        assert!(!html.contains("\u{b7} you"), "{html}");
+    }
+}

--- a/frontend/src/pages/book_detail/sync_link.rs
+++ b/frontend/src/pages/book_detail/sync_link.rs
@@ -80,7 +80,7 @@ fn sync_line(view: &AlignmentView, mut open_modal: Signal<bool>) -> Element {
                         r#type: "button",
                         "data-testid": "sync-link-manage",
                         onclick: move |_| open_modal.set(true),
-                        "manage \u{2192}"
+                        "Manage Ebook & Audiobook Sync"
                     }
                 }
             }

--- a/frontend/src/pages/book_detail/sync_link/tests.rs
+++ b/frontend/src/pages/book_detail/sync_link/tests.rs
@@ -86,6 +86,8 @@ fn sync_line_names_the_saved_audio_position_when_linked() {
     assert!(html.contains("one spot, both formats"), "{html}");
     assert!(html.contains("audio at 30m"), "{html}");
     assert!(html.contains("data-testid=\"sync-link-manage\""), "{html}");
+    // The affordance names what it manages rather than reading "manage →".
+    assert!(html.contains("Manage Ebook &#38; Audiobook Sync"), "{html}");
 }
 
 #[test]

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -975,7 +975,7 @@ test("opens the quote-card editor in a modal and closes it again", async ({
   expect((await request.delete(`/api/highlights/${id}`)).status()).toBe(204);
 });
 
-test("collapses a long passage list behind a show-more control", async ({
+test("lists every saved passage with no show-more control", async ({
   page,
   request,
 }) => {
@@ -989,16 +989,10 @@ test("collapses a long passage list behind a show-more control", async ({
   }
 
   await gotoReady(page, `/books/${uuid}`);
-  const cards = page.getByTestId("highlight-card");
-  await expect(cards).toHaveCount(5);
-
-  const showMore = page.getByTestId("highlights-show-more");
-  await expect(showMore).toHaveText("Show 3 more ↓");
-  await showMore.click();
-
-  // Expanding is one-way: every passage lists and the control goes away.
-  await expect(cards).toHaveCount(8);
-  await expect(showMore).toHaveCount(0);
+  // The stop scrolls the list rather than holding rows back, so all eight
+  // are in the DOM and nothing offers to load more.
+  await expect(page.getByTestId("highlight-card")).toHaveCount(8);
+  await expect(page.getByTestId("highlights-show-more")).toHaveCount(0);
 
   // Clean up shared state so the next run starts from the empty state.
   for (const id of ids) {


### PR DESCRIPTION
## Summary
- Drops the all-caps `ONE LINE EACH — TAP TO OPEN THE FULL ENTRY` hint above the W4 journal ladder — it read as instructional chrome the design never had.
- Re-shapes each ladder row into the design's two-line row (`W4S4J` / `.bdw4-jrow`): author, an owner's "you", and the date · progress stamp over the excerpt, which now ends in a `read →` affordance. The whole row stays one `<button>`, so the affordance is reachable by keyboard without nesting a second control.
- Lists every saved passage instead of holding rows back behind "Show N more" — the W4 highlights stop already scrolls the list inside the stage, so the control was capping a surface that wasn't overflowing.
- Renames the linked sync-line affordance from `manage →` to `Manage Ebook & Audiobook Sync`.

Closes #2140

## Test plan
- [x] `just test` — full matrix green (910 server / 918 frontend-server / 778 frontend-mobile / 363 shared), including a new `journal/tests.rs` covering the excerpt helper and both row states.
- [x] `just lint` — fmt, clippy across the crate/feature matrix incl. wasm32, and stylelint.
- [x] `pnpm exec playwright test tests/flows/journal.spec.ts tests/flows/book_detail.spec.ts` — 40 passed.
- [x] Verified live on the dev server: journal rows render two lines ending in `read →` and still open the entry overlay; eight seeded passages all list with no show-more; a freshly linked ebook+audiobook book shows the new sync label.

## Version
- [ ] **Minor**
- [x] **Patch**
- [ ] **No release**