### PR TITLE
feat: enlarge the home cover wall to ten covers per row

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -11059,7 +11059,10 @@ html {
 .lmq .lib-sort-select, .lmq .lib-sort-dir { border-radius: 999px; }
 
 /* ── The cover wall ──────────────────────────────────────────────── */
-.lmq .lib-grid { grid-template-columns: repeat(auto-fill, minmax(126px, 1fr)); gap: 26px 22px; }
+/* 170px is chosen, not inherited: with the 22px column gap it is the widest
+   minimum that still fits ten covers across a laptop-width window, and the
+   narrowest that cannot fit eleven. Moving either number moves the count. */
+.lmq .lib-grid { grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 30px 22px; }
 .lmq .lib-tile .cover-wrap { filter: drop-shadow(0 14px 18px oklch(0 0 0 / .45)); }
 .lmq .lib-tile-art {
   display: block;


### PR DESCRIPTION
## Summary
- The revamped cover wall's `minmax(126px, 1fr)` fitted thirteen covers across a laptop-width window — smaller than the eleven the pre-revamp grid showed. Raises the minimum tile to `170px` for ten across, and opens the row gap `26px` → `30px` so the taller tiles don't crowd vertically.
- The column gap stays at `22px` deliberately: it is part of the count arithmetic, so moving it moves the column count. The rule carries a comment saying so.
- Scoped to `.lmq .lib-grid` (the home wall). The base `.lib-grid` that governs shelf detail is untouched.

## Test plan
- [x] `just lint-css` passes (structural stylelint over `frontend/assets/**.css`).
- [x] Verified on the running dev server with the 37 committed fixtures indexed: 10 columns, covers 172×258, grid width 1944px.
- [x] Swept the served (minified) stylesheet across content widths 1850–2110px in-browser: 10 columns holds from 1910px to 2070px, and degrades to 8 at a 1728px window and 7 at 1512px.
- [x] No spec changes needed — no Playwright spec asserts grid sizing, and the markup contract is unchanged.

## Version
- [ ] **Minor**
- [x] **Patch** — default.
- [ ] **No release**

## Notes
- The hover caption typography (13px title / 9.5px author) was tuned for 126px tiles and now reads proportionally smaller on the larger covers. Left as-is — worth a follow-up look at full size.