### PR TITLE
fix: find merged audiobooks in the chapter backfill

### DIFF
--- a/db/src/audiobook/chapters/tests.rs
+++ b/db/src/audiobook/chapters/tests.rs
@@ -3,54 +3,17 @@
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::test_support::build_m4b_with_chapters;
+
 use super::*;
 
-/// Build a minimal MP4 file with a Nero `chpl` atom containing the given
-/// chapter entries. Returns the path to a temp file.
+/// Write a Nero-`chpl` M4B fixture to a temp file. The bytes come from
+/// `test_support::build_m4b_with_chapters`; this only lands them on disk,
+/// since `extract_chapters` takes a path.
 fn make_chpl_fixture(chapters: &[(u64, &str)]) -> (tempfile::NamedTempFile, PathBuf) {
-    let mut chpl_body = Vec::new();
-    // version=0, flags=0x000000
-    chpl_body.extend_from_slice(&[0u8; 4]);
-    // chapter count (u32 BE for version 0)
-    chpl_body.extend_from_slice(&(chapters.len() as u32).to_be_bytes());
-    for (start_100ns, title) in chapters {
-        chpl_body.extend_from_slice(&start_100ns.to_be_bytes());
-        let title_bytes = title.as_bytes();
-        chpl_body.push(title_bytes.len() as u8);
-        chpl_body.extend_from_slice(title_bytes);
-    }
-
-    let chpl_size = (8 + chpl_body.len()) as u32;
-    let mut chpl_box = Vec::new();
-    chpl_box.extend_from_slice(&chpl_size.to_be_bytes());
-    chpl_box.extend_from_slice(b"chpl");
-    chpl_box.extend_from_slice(&chpl_body);
-
-    let udta_size = (8 + chpl_box.len()) as u32;
-    let mut udta_box = Vec::new();
-    udta_box.extend_from_slice(&udta_size.to_be_bytes());
-    udta_box.extend_from_slice(b"udta");
-    udta_box.extend_from_slice(&chpl_box);
-
-    let moov_size = (8 + udta_box.len()) as u32;
-    let mut moov_box = Vec::new();
-    moov_box.extend_from_slice(&moov_size.to_be_bytes());
-    moov_box.extend_from_slice(b"moov");
-    moov_box.extend_from_slice(&udta_box);
-
-    // Prepend a minimal ftyp box so the file looks like a real MP4
-    let mut ftyp = Vec::new();
-    let ftyp_size: u32 = 16; // 8 header + 4 brand + 4 minor
-    ftyp.extend_from_slice(&ftyp_size.to_be_bytes());
-    ftyp.extend_from_slice(b"ftyp");
-    ftyp.extend_from_slice(b"M4B ");
-    ftyp.extend_from_slice(&0u32.to_be_bytes());
-
     let mut file = tempfile::NamedTempFile::new().unwrap();
-    file.write_all(&ftyp).unwrap();
-    file.write_all(&moov_box).unwrap();
+    file.write_all(&build_m4b_with_chapters(chapters)).unwrap();
     file.flush().unwrap();
-
     let path = file.path().to_path_buf();
     (file, path)
 }

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -63,20 +63,26 @@ async fn batch_update_books_column(
     Ok(())
 }
 
-/// Query the first-part filename (ordinal=0) and format for every book
-/// under `library_path` that needs chapter backfill (no `file_chapters`
-/// rows yet).
+/// Query the first-part filename (ordinal=0), format, and effective scan
+/// root for every book under `library_path` that needs chapter backfill (no
+/// `file_chapters` rows yet).
+///
+/// Scoped on the file's own root (`COALESCE(bf.library_path, l.path)`, the
+/// shape `book_file_path` resolves with), not the book's: a merged
+/// audiobook's files hang off a target book whose `library_id` is the
+/// *target's* scan root, so scoping on the book's would drop every merged
+/// audiobook from the backfill.
 async fn fetch_backfill_candidates(
     pool: &SqlitePool,
     library_path: &str,
-) -> anyhow::Result<Vec<(i64, String, String)>> {
-    let rows: Vec<(i64, String, String)> = sqlx::query_as(
-        "SELECT bf.id, bfp.filename, bf.format \
+) -> anyhow::Result<Vec<(i64, String, String, String)>> {
+    let rows: Vec<(i64, String, String, String)> = sqlx::query_as(
+        "SELECT bf.id, bfp.filename, bf.format, COALESCE(bf.library_path, l.path) \
          FROM book_files bf \
          JOIN books b ON bf.book_id = b.id \
          JOIN scan_roots l ON b.library_id = l.id \
          JOIN book_file_parts bfp ON bfp.book_file_id = bf.id \
-         WHERE l.path = ? \
+         WHERE COALESCE(bf.library_path, l.path) = ? \
            AND bf.format IN ('M4B', 'M4A', 'MP3') \
            AND bfp.ordinal = 0 \
            AND NOT EXISTS (SELECT 1 FROM file_chapters fc WHERE fc.book_file_id = bf.id) \
@@ -163,17 +169,20 @@ pub(crate) async fn backfill_chapters(
         "backfilling chapters for existing audiobooks"
     );
 
-    let book_file_ids: Vec<i64> = rows.iter().map(|(id, _, _)| *id).collect();
+    let book_file_ids: Vec<i64> = rows.iter().map(|(id, ..)| *id).collect();
     let parts_by_id = bulk_fetch_parts(pool, &book_file_ids).await?;
 
     // Process books in batches of 250 to bound transaction size (mirrors the
     // sync/audiobooks.rs backfill pattern).
     let root_name = super::root_display_name(library_path);
-    let lib_root = PathBuf::from(library_path);
     for (batch_idx, chunk) in rows.chunks(250).enumerate() {
         let mut tx = pool.begin().await?;
-        for (i, (book_file_id, first_part_filename, format)) in chunk.iter().enumerate() {
-            let abs = lib_root.join(first_part_filename);
+        for (i, (book_file_id, first_part_filename, format, file_root)) in chunk.iter().enumerate()
+        {
+            // The row's own root, not the task's: a stat under the wrong
+            // root extracts nothing and writes the synthetic `Part N`
+            // fallback over the book's real chapters.
+            let abs = PathBuf::from(file_root).join(first_part_filename);
             let fmt = format.clone();
             let chapters =
                 tokio::task::spawn_blocking(move || audiobook::extract_chapters(&abs, &fmt))

--- a/db/src/indexer/backfill.rs
+++ b/db/src/indexer/backfill.rs
@@ -63,21 +63,23 @@ async fn batch_update_books_column(
     Ok(())
 }
 
-/// Query the first-part filename (ordinal=0), format, and effective scan
-/// root for every book under `library_path` that needs chapter backfill (no
-/// `file_chapters` rows yet).
+/// Query the first-part filename (ordinal=0) and format for every book
+/// under `library_path` that needs chapter backfill (no `file_chapters`
+/// rows yet).
 ///
 /// Scoped on the file's own root (`COALESCE(bf.library_path, l.path)`, the
 /// shape `book_file_path` resolves with), not the book's: a merged
 /// audiobook's files hang off a target book whose `library_id` is the
 /// *target's* scan root, so scoping on the book's would drop every merged
-/// audiobook from the backfill.
+/// audiobook from the backfill. Because that same expression is what the
+/// filter equates to `library_path`, every row returned lives under
+/// `library_path` — the caller resolves paths against it directly.
 async fn fetch_backfill_candidates(
     pool: &SqlitePool,
     library_path: &str,
-) -> anyhow::Result<Vec<(i64, String, String, String)>> {
-    let rows: Vec<(i64, String, String, String)> = sqlx::query_as(
-        "SELECT bf.id, bfp.filename, bf.format, COALESCE(bf.library_path, l.path) \
+) -> anyhow::Result<Vec<(i64, String, String)>> {
+    let rows: Vec<(i64, String, String)> = sqlx::query_as(
+        "SELECT bf.id, bfp.filename, bf.format \
          FROM book_files bf \
          JOIN books b ON bf.book_id = b.id \
          JOIN scan_roots l ON b.library_id = l.id \
@@ -137,6 +139,10 @@ async fn bulk_fetch_parts(
     Ok(parts_by_id)
 }
 
+/// Books per chapter-backfill batch: one transaction and one set of file
+/// reads each, bounding both transaction size and peak `extracted` memory.
+const CHAPTER_BATCH: usize = 250;
+
 /// Fill `file_chapters` for audiobook `book_files` rows that have none.
 ///
 /// The chapter extraction pipeline was added after the initial audiobook
@@ -150,9 +156,9 @@ async fn bulk_fetch_parts(
 ///
 /// All `book_file_parts` rows for the backfill set are fetched in a single
 /// `WHERE book_file_id IN (…)` bulk query before the loop rather than one
-/// per book, and all chapter inserts are committed in batches of 250 books
-/// to avoid per-book WAL flushes (mirrors the sync/audiobooks.rs backfill
-/// pattern).
+/// per book, and all chapter inserts are committed in [`CHAPTER_BATCH`]-sized
+/// batches to avoid per-book WAL flushes (mirrors the sync/audiobooks.rs
+/// backfill pattern).
 pub(crate) async fn backfill_chapters(
     pool: &SqlitePool,
     library_path: &str,
@@ -169,41 +175,30 @@ pub(crate) async fn backfill_chapters(
         "backfilling chapters for existing audiobooks"
     );
 
-    let book_file_ids: Vec<i64> = rows.iter().map(|(id, ..)| *id).collect();
+    let book_file_ids: Vec<i64> = rows.iter().map(|(id, _, _)| *id).collect();
     let parts_by_id = bulk_fetch_parts(pool, &book_file_ids).await?;
 
-    // Process books in batches of 250 to bound transaction size (mirrors the
-    // sync/audiobooks.rs backfill pattern).
     let root_name = super::root_display_name(library_path);
-    for (batch_idx, chunk) in rows.chunks(250).enumerate() {
-        let mut tx = pool.begin().await?;
-        for (i, (book_file_id, first_part_filename, format, file_root)) in chunk.iter().enumerate()
-        {
-            // The row's own root, not the task's: a stat under the wrong
-            // root extracts nothing and writes the synthetic `Part N`
-            // fallback over the book's real chapters.
-            let abs = PathBuf::from(file_root).join(first_part_filename);
-            let fmt = format.clone();
-            let chapters =
-                tokio::task::spawn_blocking(move || audiobook::extract_chapters(&abs, &fmt))
-                    .await
-                    .unwrap_or_else(|join_err| {
-                        tracing::warn!(
-                            book_file_id,
-                            %join_err,
-                            is_panic = join_err.is_panic(),
-                            "chapter extraction task failed; using synthetic fallback"
-                        );
-                        Vec::new()
-                    });
+    let lib_root = PathBuf::from(library_path);
+    for (batch_idx, chunk) in rows.chunks(CHAPTER_BATCH).enumerate() {
+        // Read every file in the batch *before* opening the transaction. The
+        // first insert takes SQLite's write lock and holds it until commit,
+        // so extracting inside it would stall every other writer for the
+        // length of a whole batch of disk reads — past the 5s `busy_timeout`
+        // in `pool.rs` for large files, which surfaces as SQLITE_BUSY in the
+        // indexer and in readers saving progress.
+        let mut extracted = Vec::with_capacity(chunk.len());
+        for (i, (book_file_id, first_part_filename, format)) in chunk.iter().enumerate() {
+            extracted.push(
+                extract_chapters_off_thread(
+                    *book_file_id,
+                    lib_root.join(first_part_filename),
+                    format.clone(),
+                )
+                .await,
+            );
 
-            let parts = parts_by_id
-                .get(book_file_id)
-                .map(Vec::as_slice)
-                .unwrap_or(&[]);
-            sync::insert_chapters(&mut tx, *book_file_id, &chapters, parts).await?;
-
-            let global_idx = batch_idx * 250 + i;
+            let global_idx = batch_idx * CHAPTER_BATCH + i;
             let progress = u32::try_from(global_idx)
                 .unwrap_or(u32::MAX)
                 .saturating_add(1);
@@ -213,10 +208,40 @@ pub(crate) async fn backfill_chapters(
                 &super::display_item(&root_name, first_part_filename),
             );
         }
+
+        let mut tx = pool.begin().await?;
+        for ((book_file_id, _, _), chapters) in chunk.iter().zip(&extracted) {
+            let parts = parts_by_id
+                .get(book_file_id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            sync::insert_chapters(&mut tx, *book_file_id, chapters, parts).await?;
+        }
         tx.commit().await?;
     }
 
     Ok(())
+}
+
+/// Extract one file's chapters on the blocking pool. A panicked or cancelled
+/// extraction degrades to the synthetic fallback rather than failing the
+/// whole backfill.
+async fn extract_chapters_off_thread(
+    book_file_id: i64,
+    path: PathBuf,
+    format: String,
+) -> Vec<audiobook::RawChapter> {
+    tokio::task::spawn_blocking(move || audiobook::extract_chapters(&path, &format))
+        .await
+        .unwrap_or_else(|join_err| {
+            tracing::warn!(
+                book_file_id,
+                %join_err,
+                is_panic = join_err.is_panic(),
+                "chapter extraction task failed; using synthetic fallback"
+            );
+            Vec::new()
+        })
 }
 
 /// Fill `books.word_count` for EPUB-backed books under `library_path` that

--- a/db/src/indexer/tests/backfill.rs
+++ b/db/src/indexer/tests/backfill.rs
@@ -167,11 +167,11 @@ async fn backfill_chapters_is_idempotent_after_all_books_have_chapters() {
 
 /// A merged audiobook — one whose `book_files` row was re-parented onto a
 /// book under a *different* scan root by `merge_books`, keeping its own
-/// `library_path`. Both halves of the resolution are under test at once: the
-/// candidate query must select the row by the file's root rather than the
-/// book's, and extraction must read the bytes at that same root. Failing the
-/// first yields no chapters at all; failing the second yields the synthetic
-/// `Part N` fallback over the book's real ones.
+/// `library_path`. Scoping the candidate query on the book's root instead of
+/// the file's drops the row, and the assertion sees no chapters at all.
+///
+/// Real titles rather than a row count, because the synthetic fallback would
+/// also write one row here: `Part 1` means the file was found but not parsed.
 #[tokio::test]
 async fn backfill_chapters_extracts_real_chapters_for_an_audiobook_merged_into_another_root() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/indexer/tests/backfill.rs
+++ b/db/src/indexer/tests/backfill.rs
@@ -3,13 +3,20 @@
 //! null/stale rows and idempotent once caught up.
 
 use crate::pool::init_db;
-use crate::test_support::{build_stored_zip, make_test_dir, EnvVarGuard};
+use crate::test_support::{build_m4b_with_chapters, build_stored_zip, make_test_dir, EnvVarGuard};
 
 use super::super::*;
 
+/// Seed one audiobook `book_files` row with a part but no chapters.
+///
+/// `file_root` is the file's own `book_files.library_path`. `None` is the
+/// unmerged shape (the file lives under its book's scan root); `Some(root)`
+/// is what `merge_books` leaves behind — the row re-parented onto a book in
+/// `library_path` while the bytes stay under `root`.
 async fn seed_audiobook_for_backfill(
     pool: &SqlitePool,
     library_path: &str,
+    file_root: Option<&str>,
     uuid: &str,
     first_part_filename: &str,
     format: &str,
@@ -44,12 +51,13 @@ async fn seed_audiobook_for_backfill(
     .unwrap();
 
     let book_file_id: i64 = sqlx::query_scalar(
-        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch) \
-         VALUES (?, ?, ?, 100, 100) RETURNING id",
+        "INSERT INTO book_files (book_id, format, filename, size_bytes, mtime_epoch, library_path) \
+         VALUES (?, ?, ?, 100, 100, ?) RETURNING id",
     )
     .bind(book_id)
     .bind(format)
     .bind(uuid)
+    .bind(file_root)
     .fetch_one(pool)
     .await
     .unwrap();
@@ -73,8 +81,10 @@ async fn backfill_chapters_inserts_synthetic_chapters_for_all_books_in_batch() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib = "/tmp/backfill_test_lib";
 
-    let bfid_a = seed_audiobook_for_backfill(&pool, lib, "book-a", "book-a/part.m4b", "M4B").await;
-    let bfid_b = seed_audiobook_for_backfill(&pool, lib, "book-b", "book-b/part.m4b", "M4B").await;
+    let bfid_a =
+        seed_audiobook_for_backfill(&pool, lib, None, "book-a", "book-a/part.m4b", "M4B").await;
+    let bfid_b =
+        seed_audiobook_for_backfill(&pool, lib, None, "book-b", "book-b/part.m4b", "M4B").await;
 
     let mut progress_calls: Vec<(u32, u32)> = Vec::new();
     let mut items: Vec<String> = Vec::new();
@@ -129,7 +139,8 @@ async fn backfill_chapters_is_idempotent_after_all_books_have_chapters() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     let lib = "/tmp/backfill_idempotent_lib";
 
-    let bfid = seed_audiobook_for_backfill(&pool, lib, "book-c", "book-c/part.m4b", "M4B").await;
+    let bfid =
+        seed_audiobook_for_backfill(&pool, lib, None, "book-c", "book-c/part.m4b", "M4B").await;
 
     sqlx::query(
         "INSERT INTO file_chapters \
@@ -151,6 +162,61 @@ async fn backfill_chapters_is_idempotent_after_all_books_have_chapters() {
     assert_eq!(
         progress_calls, 0,
         "on_progress must not be called when all books already have chapters"
+    );
+}
+
+/// A merged audiobook — one whose `book_files` row was re-parented onto a
+/// book under a *different* scan root by `merge_books`, keeping its own
+/// `library_path`. Both halves of the resolution are under test at once: the
+/// candidate query must select the row by the file's root rather than the
+/// book's, and extraction must read the bytes at that same root. Failing the
+/// first yields no chapters at all; failing the second yields the synthetic
+/// `Part N` fallback over the book's real ones.
+#[tokio::test]
+async fn backfill_chapters_extracts_real_chapters_for_an_audiobook_merged_into_another_root() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let audio_root = make_test_dir("backfill-merged-audio");
+    let ebook_root = make_test_dir("backfill-merged-ebook");
+    let audio_lib = audio_root.to_str().unwrap();
+    let ebook_lib = ebook_root.to_str().unwrap();
+
+    // The real file lands under the AUDIO root; nothing is written under the
+    // ebook root, so a stat there can only come back empty.
+    let part = "merged/part.m4b";
+    let abs = audio_root.join(part);
+    std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+    std::fs::write(
+        &abs,
+        build_m4b_with_chapters(&[(0, "Opening"), (30_000_000, "Descent")]),
+    )
+    .unwrap();
+
+    let book_file_id = seed_audiobook_for_backfill(
+        &pool,
+        ebook_lib,
+        Some(audio_lib),
+        "merged-book",
+        part,
+        "M4B",
+    )
+    .await;
+
+    backfill_chapters(&pool, audio_lib, |_, _, _| {})
+        .await
+        .unwrap();
+
+    let titles: Vec<String> = sqlx::query_scalar(
+        "SELECT title FROM file_chapters WHERE book_file_id = ? ORDER BY ordinal",
+    )
+    .bind(book_file_id)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        titles,
+        vec!["Opening".to_string(), "Descent".to_string()],
+        "a merged audiobook must be selected by the backfill and read at its own library_path"
     );
 }
 

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -230,6 +230,50 @@ pub fn build_test_kepub(spine: &[(&str, &str)]) -> Vec<u8> {
 }
 
 // ---------------------------------------------------------------------------
+// In-memory audiobook fixtures
+// ---------------------------------------------------------------------------
+
+/// Minimal MP4/M4B carrying a Nero `chpl` atom with the given chapters,
+/// as `(start_100ns, title)` pairs. Just `ftyp` + `moov/udta/chpl` — enough
+/// for `audiobook::extract_chapters` to walk, with no media payload.
+pub fn build_m4b_with_chapters(chapters: &[(u64, &str)]) -> Vec<u8> {
+    let mut chpl_body = Vec::new();
+    // version=0, flags=0x000000
+    chpl_body.extend_from_slice(&[0u8; 4]);
+    // chapter count (u32 BE for version 0)
+    chpl_body.extend_from_slice(&(chapters.len() as u32).to_be_bytes());
+    for (start_100ns, title) in chapters {
+        chpl_body.extend_from_slice(&start_100ns.to_be_bytes());
+        let title_bytes = title.as_bytes();
+        chpl_body.push(title_bytes.len() as u8);
+        chpl_body.extend_from_slice(title_bytes);
+    }
+
+    let chpl = wrap_mp4_box(b"chpl", &chpl_body);
+    let udta = wrap_mp4_box(b"udta", &chpl);
+    let moov = wrap_mp4_box(b"moov", &udta);
+
+    // A minimal `ftyp` up front so the file looks like a real MP4.
+    let mut ftyp_body = Vec::new();
+    ftyp_body.extend_from_slice(b"M4B ");
+    ftyp_body.extend_from_slice(&0u32.to_be_bytes());
+
+    let mut out = wrap_mp4_box(b"ftyp", &ftyp_body);
+    out.extend_from_slice(&moov);
+    out
+}
+
+/// Wrap `body` in an MP4 box header: 32-bit big-endian total size, then the
+/// four-byte type.
+fn wrap_mp4_box(box_type: &[u8; 4], body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + body.len());
+    out.extend_from_slice(&((8 + body.len()) as u32).to_be_bytes());
+    out.extend_from_slice(box_type);
+    out.extend_from_slice(body);
+    out
+}
+
+// ---------------------------------------------------------------------------
 // Generic env-var guard
 // ---------------------------------------------------------------------------
 

--- a/db/src/test_support.rs
+++ b/db/src/test_support.rs
@@ -236,16 +236,23 @@ pub fn build_test_kepub(spine: &[(&str, &str)]) -> Vec<u8> {
 /// Minimal MP4/M4B carrying a Nero `chpl` atom with the given chapters,
 /// as `(start_100ns, title)` pairs. Just `ftyp` + `moov/udta/chpl` — enough
 /// for `audiobook::extract_chapters` to walk, with no media payload.
+///
+/// Panics on a title over 255 bytes: `chpl` gives each one a single-byte
+/// length prefix, and silently truncating it would emit a container that
+/// parses into garbage chapters rather than failing the test that built it.
 pub fn build_m4b_with_chapters(chapters: &[(u64, &str)]) -> Vec<u8> {
     let mut chpl_body = Vec::new();
     // version=0, flags=0x000000
     chpl_body.extend_from_slice(&[0u8; 4]);
     // chapter count (u32 BE for version 0)
-    chpl_body.extend_from_slice(&(chapters.len() as u32).to_be_bytes());
+    let count = u32::try_from(chapters.len()).expect("chpl chapter count must fit in u32");
+    chpl_body.extend_from_slice(&count.to_be_bytes());
     for (start_100ns, title) in chapters {
         chpl_body.extend_from_slice(&start_100ns.to_be_bytes());
         let title_bytes = title.as_bytes();
-        chpl_body.push(title_bytes.len() as u8);
+        let title_len =
+            u8::try_from(title_bytes.len()).expect("chpl chapter title must be <= 255 bytes");
+        chpl_body.push(title_len);
         chpl_body.extend_from_slice(title_bytes);
     }
 
@@ -264,10 +271,13 @@ pub fn build_m4b_with_chapters(chapters: &[(u64, &str)]) -> Vec<u8> {
 }
 
 /// Wrap `body` in an MP4 box header: 32-bit big-endian total size, then the
-/// four-byte type.
+/// four-byte type. Panics past 4 GiB rather than wrapping the size field into
+/// a header that claims less than it holds — this builder feeds a parser
+/// hardened against exactly that, so it must not be the one producing it.
 fn wrap_mp4_box(box_type: &[u8; 4], body: &[u8]) -> Vec<u8> {
+    let size = u32::try_from(8 + body.len()).expect("mp4 box must be under 4 GiB");
     let mut out = Vec::with_capacity(8 + body.len());
-    out.extend_from_slice(&((8 + body.len()) as u32).to_be_bytes());
+    out.extend_from_slice(&size.to_be_bytes());
     out.extend_from_slice(box_type);
     out.extend_from_slice(body);
     out


### PR DESCRIPTION
## Summary
- Closes #2167 — the "Extract Audiobook Chapters" action silently skipped any audiobook that had been merged into a book under a different scan root, reporting success having done nothing.
- `db::merge::merge_books` re-parents a source book's `book_files` rows onto the target and stamps the file's origin into `book_files.library_path`, so a merged audiobook's book row points at the *target's* scan root while its bytes stay under the original one. `fetch_backfill_candidates` scoped its work set through `books.library_id -> scan_roots.path`, and `rpc_backfill_chapters` always posts the task with `settings.audiobook_library_path` — so the `WHERE` excluded every merged audiobook.
- Rescoped the candidate query on `COALESCE(bf.library_path, l.path)`, the same effective-root expression `book_file_path` in `db/src/books/get.rs` resolves with and the one the sibling `fetch_epub_structure_candidates` already builds its paths from.
- Moved chapter extraction out of the batch transaction. `pool.begin()` is deferred, so the write lock landed on the first insert and was then held across up to 250 blocking file reads — past the 5s `busy_timeout` in `pool.rs` for large files, which surfaces as SQLITE_BUSY in the indexer and in readers saving progress. Extraction now completes before the transaction opens; the transaction wraps only the inserts, and progress reports from the extraction loop that is actually the slow phase.
- Hoisted the Nero-`chpl` M4B builder out of `db/src/audiobook/chapters/tests.rs` into `test_support` so the new regression test and the existing extraction tests share one fixture instead of two copies of the box-assembly code.

## Test plan
- [x] New `backfill_chapters_extracts_real_chapters_for_an_audiobook_merged_into_another_root` seeds the post-merge shape — a book under one scan root whose `book_files.library_path` points at another, with a real two-chapter M4B on disk under the second — and asserts the real titles come back rather than an empty set. It covers the candidate query; asserting titles rather than a row count distinguishes a parsed file from the synthetic `Part 1` fallback.
- [x] Confirmed the test fails against the unfixed query (`left: []`, the row filtered out entirely) and passes with the fix, so it is a genuine regression guard rather than a passing assertion. Re-confirmed after the follow-up commit restructured the function.
- [x] `just test` — 5,449 tests across all five lanes, 0 failures.
- [x] `just lint` — clean.
- [x] The existing chapter-extraction tests still pass against the hoisted fixture builder, so the refactor is behaviour-preserving.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- A self-review pass after the first commit found 8 issues; 6 are fixed in the follow-up commit and 2 are closed as no-change with measurements. See the [review comment](https://github.com/seamus-sloan/omnibus/pull/2169#issuecomment-5419660302) — notably, the first commit's claim that the test covered both halves of the fix was wrong, and the per-row scan root it justified has been removed.
- No migration and no schema change — `book_files.library_path` (migration `0016`) already carried the fact; this is entirely a read-side fix.
- The backfill's `NOT EXISTS (SELECT 1 FROM file_chapters …)` guard is untouched and still correct. This fixes books with *zero* chapter rows never getting them; it does not re-extract existing ones. A genuine re-extract still only happens when a file's stat pair moves and the scan's Changed bucket routes through `attach_audiobook_file`, which drops the `book_files` row and rewrites its chapters — that path already handled merged books correctly via the `merged_uuids` guard row.

>[!NOTE]
> Three sibling backfills in the same file — `fetch_word_count_candidates`, `fetch_page_count_candidates`, and `fetch_epub_structure_candidates` — still scope on `WHERE l.path = ?` and have the same blind spot, so e.g. an EPUB merged into an audiobook never gets its `books.word_count` filled. Left out of this PR to keep it to the reported bug; worth a follow-up. `fetch_thumb_candidates` keys on `books.has_cover` with no `book_files` join, so it may be correct as-is and deserves a deliberate look rather than a pattern-match.
