### PR TITLE
docs: add per-surface feature maps for the web and iOS clients

### DIFF
--- a/.claude/rules/98-keep-skills-fresh.md
+++ b/.claude/rules/98-keep-skills-fresh.md
@@ -13,6 +13,29 @@ When touching any of the following areas, re-read the matching skill and update 
 
 If a skill no longer has a corresponding code area (the pattern was removed), delete the skill rather than leaving it outdated.
 
+## The feature maps rot the same way
+
+[docs/feature-map-web.md](../../docs/feature-map-web.md) and
+[docs/feature-map-ios.md](../../docs/feature-map-ios.md) are the first place an
+agent looks to find code, so a wrong path there costs more than a wrong path
+anywhere else — it sends the reader somewhere that doesn't exist and makes the
+whole map untrustworthy. Update the matching map in the **same** change when
+you:
+
+| Change | What to update |
+|---|---|
+| Add a user-visible feature | A new row, in the section it belongs to |
+| Rename or move a module a row cites | That cell |
+| Split a module into a subdirectory | The cell, to the directory rather than the old file |
+| Add or rename a Playwright spec / `omnibusTests` file | The E2E / Tests cell |
+| Add a REST route or server function | The route cell of the feature it serves |
+| Change whether an iOS write queues (rule [08](08-offline-writes.md)) | The Offline cell |
+| Delete a feature | The row, and any "coverage gaps" bullet naming it |
+
+Keep them **paths only**. Rationale belongs in
+[architecture.md](../../docs/architecture.md); a map that grows explanations
+stops being scannable, which is the one thing it is for.
+
 A skill is "stale" if: the file paths it references no longer exist, the function/module names it names have been renamed, or the steps it prescribes would no longer produce a working result, or if the underlying assumptions it relies on have changed.
 
 The same applies to **file:line citations** in the rules, skills, and [docs/style-guide.md](../../docs/style-guide.md): a bare `path/to/file.rs:NN` anchor rots the moment the cited file is edited or split. Prefer function-name anchors (e.g. "`reindex` in `db/src/indexer/ebooks.rs`"); when you touch a file that other docs cite by line, refresh those citations in the same change.

--- a/.claude/rules/99-end-of-session.md
+++ b/.claude/rules/99-end-of-session.md
@@ -4,6 +4,7 @@ Before ending a session where code changed, run this checklist:
 
 1. **Docs sync.** Update the right file for the change:
    - New module or subdirectory → add it to [docs/architecture.md](../../docs/architecture.md) (per-crate module map). If it adds a new top-level crate or top-level concept worth listing in the index, also link it from [CLAUDE.md](../../CLAUDE.md).
+   - New feature, or a feature whose files moved/renamed → the matching [feature map](../../docs/feature-map-web.md) ([iOS](../../docs/feature-map-ios.md)). [98-keep-skills-fresh.md](98-keep-skills-fresh.md) lists what counts.
    - New dependency in `Cargo.toml` → call it out wherever it's relevant (CLAUDE.md if it affects build commands, the matching rule file if it shifts a convention).
    - New environment variable or configuration key → [.claude/rules/01-dev-environment.md](01-dev-environment.md) and [.env.example](../../.env.example).
    - New or changed convention (error handling, test patterns, etc.) → the matching rule file under [.claude/rules/](.) and the [CLAUDE.md](../../CLAUDE.md) rules index if it's a new file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ regardless of which agent or tool you are:
   content validators, keep-skills-fresh, end-of-session).
 - **[.claude/skills/](.claude/skills/)** — task recipes: `add-backend-route`,
   `add-playwright-flow`, `create-github-issue`, `ui-validate`.
+- **[docs/feature-map-web.md](docs/feature-map-web.md)** /
+  **[docs/feature-map-ios.md](docs/feature-map-ios.md)** — start here to locate
+  code: one row per feature, listing the files it spans. They cover features,
+  not every file, so fall through to `architecture.md` and then `grep` when a
+  row comes up short.
 - **[docs/architecture.md](docs/architecture.md)** — the five-crate
   workspace map (per-crate module maps + request-flow diagrams).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,20 @@ Guidance for Claude Code when working in this repo. This file is an index — de
 
 Omnibus is a self-hosted ebook/audiobook library. Foundations and browse/discovery have shipped; reading/listening is in progress — the UI is a real library app (landing grid + table, EPUB reader, audiobook player, command-palette search, auth, author/series/tag discovery).
 
+## Finding code
+
+**Start with the feature maps.** They answer "where does X live" — one row per user-visible feature, listing every file it spans across the stack.
+
+- [docs/feature-map-web.md](docs/feature-map-web.md) — the web app, and the Android WebView shell that renders the same markup: `shared/` → `db/` → `server/` → `frontend/` per feature, plus the Playwright spec that covers it.
+- [docs/feature-map-ios.md](docs/feature-map-ios.md) — the native SwiftUI client: views, service, REST route, offline contract, and test per feature.
+
+**They are a starting point, not a complete index — look elsewhere when they fall short.** A cell names the module that owns a concern, not always the exact file, and only user-visible features get rows. If what you need isn't listed, the row is thinner than you need, or it looks like it has drifted, fall through to:
+
+1. [docs/architecture.md](docs/architecture.md) — the per-crate module map, with the design rationale behind each module.
+2. `grep` / `Glob` over the tree — always authoritative. The maps are hand-maintained and can lag a rename.
+
+Trust the code over either document, and update the map in the same change when you find it stale (rule [98](.claude/rules/98-keep-skills-fresh.md)).
+
 ## Rules
 
 Numbered rules in [.claude/rules/](.claude/rules/), applied in order. Follow them mechanically.
@@ -43,7 +57,7 @@ Five-crate Cargo workspace: `shared/` (serde types), `db/` (data layer + indexer
 
 Alongside it, `omnibus-ios/` is a native SwiftUI client — an Xcode project, not a Cargo crate; `just ios-build` / `ios-test` / `ios-test-ui` / `ios-sim` wrap xcodebuild + simctl for it (no cargo target touches it). It is the iOS surface; `mobile/` is the Android shell (nothing builds the `mobile/` crate for iOS anymore). It speaks the same `/api/*` REST surface.
 
-Full crate descriptions, per-crate module maps, request flow diagrams, and mobile-auth details live in [docs/architecture.md](docs/architecture.md).
+Full crate descriptions, per-crate module maps, request flow diagrams, and mobile-auth details live in [docs/architecture.md](docs/architecture.md) — that file is organized by directory, so it answers "what does this module do". To go the other way, from a feature to the files it spans, use the [feature maps](#finding-code).
 
 ## Version control
 

--- a/docs/feature-map-ios.md
+++ b/docs/feature-map-ios.md
@@ -1,0 +1,143 @@
+# Feature map — iOS
+
+**Start here to find code; this file answers "where does X live", not "why".**
+
+One row per user-visible feature of the native SwiftUI client, giving its views,
+its service, the REST route it calls, how it behaves offline, and its test. For
+*why* a module is shaped the way it is, read
+[architecture.md](architecture.md#omnibus-ios). For the rules a change must obey,
+read [.claude/rules/](../.claude/rules/) — especially
+[08-offline-writes.md](../.claude/rules/08-offline-writes.md), which governs the
+Offline column below.
+
+`omnibus-ios/` is an **Xcode project, not a Cargo crate** — invisible to
+`cargo build` / `just lint` / `just test`. Build and test it with `just ios-build`
+/ `just ios-test` / `just ios-test-ui`. The server side of every route below lives
+in the Rust workspace — see [feature-map-web.md](feature-map-web.md) to find the
+handler.
+
+## Reading a row
+
+Every path is **relative to `omnibus-ios/`** and complete, so it can be opened as
+written: `omnibus/Reader/ReaderView.swift`, `omnibusTests/ReaderEchoTests.swift`.
+A path ending in `/` means the whole directory is that feature.
+
+The **Offline** column is the rule-08 contract, and it is not a description of
+current behaviour — it's a constraint on what you may add:
+
+| Value | Means |
+|---|---|
+| `queued` | Goes through `SyncEngine`'s outbox; applies optimistically, replays on reconnect |
+| `direct` | Calls `APIClient` straight through and **must fail visibly** — never `try?`-swallowed |
+| `cached` | Read served from the local replica first, revalidated in the background |
+| `local` | Never touches the server |
+
+A write that is `direct` is that way because it failed one of rule 08's four
+tests. Do not "improve" it into the outbox without re-running them.
+
+## Shell, connection, account
+
+| Feature | Views | Service / model | Route | Offline | Tests |
+|---|---|---|---|---|---|
+| App shell, tabs, phase routing | `omnibus/App/`, `omnibus/Design/Components/OmnibusTabBar.swift` | — | — | `local` | `omnibusUITests/omnibusUITests.swift` |
+| Server connect | `omnibus/Features/Auth/ServerConnectView.swift` | `omnibus/Services/AuthService.swift` | `/api/_health` | `direct` | — |
+| Login / register | `omnibus/Features/Auth/LoginView.swift` | `omnibus/Services/AuthService.swift`, `omnibus/Networking/TokenStore.swift` | `/api/auth/login`, `/register`, `/logout`, `/me` | `direct` | — |
+| Account screen | `omnibus/Features/Account/AccountView.swift` | `omnibus/Services/AuthService.swift` | `/api/account/kindle-email`, `/api/account/hidden-formats` | `direct` | `omnibusTests/HiddenFormatsTests.swift` |
+| Profile & avatar | `omnibus/Features/Account/ProfileEditSheet.swift` | `omnibus/Services/AuthService.swift` | `/api/account/profile`, `/api/account/avatar` | `direct` | `omnibusTests/ProfileDraftTests.swift`, `omnibusTests/AvatarAttributionTests.swift` |
+| HTTP plumbing | — | `omnibus/Networking/` | all | — | `omnibusTests/MultipartBodyTests.swift` |
+| Wire types | — | `omnibus/Models/Models.swift`, `omnibus/Models/KnownFormats.swift` | all | — | — |
+
+## Library & browse
+
+| Feature | Views | Service / model | Route | Offline | Tests |
+|---|---|---|---|---|---|
+| Library grid & categories | `omnibus/Features/Library/LibraryView.swift`, `omnibus/Features/Library/LibraryCategory.swift`, `omnibus/Features/Library/BookContextMenu.swift` | `omnibus/Services/LibraryService.swift` | `/api/ebooks` | `cached` | `omnibusTests/LibraryPollTests.swift` |
+| Continue-reading rail | `omnibus/Features/Library/ContinueHero.swift` | `omnibus/Services/UserDataService.swift` | `/api/progress/recent` | `cached` | `omnibusTests/ContinueRailTests.swift` |
+| Search | `omnibus/Features/Search/`, `omnibus/Design/Components/SearchField.swift` | `omnibus/Services/LibraryService.swift` | `/api/search`, `/api/search/palette` | `cached` + offline substring | `omnibusTests/SuggestionPoolTests.swift` |
+| Authors / series / tags / genres | `omnibus/Features/Discovery/DiscoveryViews.swift` | `omnibus/Services/LibraryService.swift` | `/api/authors*`, `/api/series*`, `/api/tags`, `/api/genres` | `cached` | — |
+| Shelves | `omnibus/Features/Shelves/` | `omnibus/Services/UserDataService.swift` | `/api/shelves*` | membership `queued`, create `direct` | `omnibusTests/LibraryShelfRailTests.swift` |
+| Book detail | `omnibus/Features/BookDetail/BookDetailView.swift`, `omnibus/Features/BookDetail/BookHero.swift` | `omnibus/Services/LibraryService.swift`, `omnibus/Services/UserDataService.swift` | `/api/ebooks/{uuid}` | `cached` | — |
+| Covers & remote images | `omnibus/Design/Components/BookCover.swift`, `omnibus/Design/Components/RemoteImage.swift` | — | `/api/covers/{uuid}`, `/api/thumbs/{uuid}/{size}` | disk-cached | — |
+
+> `omnibus/Features/BookDetail/BookDetailView.swift` is ~1,000 lines and is the
+> hub for ratings, read status, genres, journals, wishlist, bookmarks, and
+> suggestions. Grep inside it before assuming a book-detail concern has its own
+> file.
+
+## Reading & listening
+
+| Feature | Views | Service / model | Route | Offline | Tests |
+|---|---|---|---|---|---|
+| EPUB reader | `omnibus/Reader/ReaderView.swift`, `omnibus/Reader/ReaderWebView.swift`, `omnibus/Reader/ReaderChrome.swift`, `omnibus/Reader/Web/` | — | `/api/ebooks/{uuid}/file` | download-backed | `omnibusTests/ReaderEchoTests.swift`, `omnibusTests/ReaderRebootTests.swift` |
+| Reader settings & typography | `omnibus/Reader/ReaderSettingsSheet.swift`, `omnibus/Reader/ReaderIndicators.swift` | — | — | `local` | `omnibusTests/ReaderSettingsTests.swift`, `omnibusTests/ReaderIndicatorsTests.swift` |
+| Table of contents | `omnibus/Reader/ReaderContentsSheet.swift` | — | — | `local` | — |
+| Comic (CBZ) reader | `omnibus/Comic/` | — | `/api/ebooks/{uuid}/file` | download-backed | `omnibusTests/ComicArchiveTests.swift`, `omnibusTests/ComicPositionTests.swift` |
+| Audiobook player | `omnibus/Features/Player/AudioPlayer.swift`, `omnibus/Features/Player/PlayerView.swift`, `omnibus/Features/Player/PlayerScrubber.swift`, `omnibus/Features/Player/ChapterTimeline.swift` | `omnibus/Services/LibraryService.swift` | `/api/audiobooks/{uuid}/manifest` | download-backed | `omnibusTests/ChapterTimelineTests.swift`, `omnibusTests/RateAdjustedTimeTests.swift` |
+| Sleep timer & speed | `omnibus/Features/Player/PlayerSheets.swift` | — | — | rate `queued` | `omnibusTests/PlayerSheetsTests.swift` |
+| Car mode | `omnibus/Features/Player/CarModeView.swift` | — | — | `local` | — |
+| Progress sync | — | `omnibus/Offline/PositionSync.swift`, `omnibus/Offline/PositionPushThrottle.swift`, `omnibus/Services/UserDataService.swift` | `/api/progress`, `/api/progress/{uuid}` | `queued` (coalesced) | `omnibusTests/PositionPushThrottleTests.swift` |
+| Highlights & notes | `omnibus/Reader/AnnotationMenu.swift`, `omnibus/Reader/ReaderSelectionLayer.swift` | `omnibus/Services/UserDataService.swift` | `/api/highlights*` | `queued` | `omnibusTests/HighlightsListTests.swift`, `omnibusTests/ReaderSelectionTests.swift` |
+| Quote cards | `omnibus/Reader/QuoteCardView.swift` | — | — | `local` | — |
+| Bookmarks | `omnibus/Reader/ReaderContentsSheet.swift` | `omnibus/Services/UserDataService.swift` | `/api/bookmarks*` | `queued` | — |
+| Read status (auto) | `omnibus/Reader/ReadStatusAuto.swift` | `omnibus/Services/UserDataService.swift` | `/api/read-status*` | `queued` | `omnibusTests/ReadStatusAutoTests.swift` |
+| Cross-format link & resume | `omnibus/Features/BookDetail/AlignmentSheet.swift`, `omnibus/Features/BookDetail/AudioFilePicker.swift` | `omnibus/Services/UserDataService.swift` | `/api/books/{uuid}/cross-format-link`, `/cross-format-resume`, `/alignment`, `/sync-point` | `direct` | `omnibusTests/CrossFormatTests.swift` |
+
+## Personal shelf data
+
+| Feature | Views | Service / model | Route | Offline | Tests |
+|---|---|---|---|---|---|
+| Star ratings | `omnibus/Features/BookDetail/BookDetailView.swift`, `omnibus/Design/Components/Primitives.swift` | `omnibus/Services/UserDataService.swift` | `/api/ratings`, `/api/ratings/others/{uuid}` | `queued` | — |
+| Reading journals | `omnibus/Features/BookDetail/JournalViews.swift` | `omnibus/Services/UserDataService.swift` | `/api/journals*` | `queued` | — |
+| Reading stats | `omnibus/Features/Stats/StatsView.swift` | `omnibus/Services/UserDataService.swift` | `/api/stats` | `cached` | — |
+| Physical check-in | `omnibus/Features/CheckIn/` | `omnibus/Models/MetadataLookup.swift` | `/api/scan/resolve`, `/search`, `/resolve-meta`, `/check-in` | `direct` (fails rule 08 test 3) | `omnibusTests/CheckInFlowTests.swift`, `omnibusTests/ScanCodecTests.swift` |
+| Wishlist | `omnibus/Features/BookDetail/WishlistSection.swift` | `omnibus/Services/UserDataService.swift` | `/api/physical/{uuid}/wishlist` | `direct` | `omnibusTests/WishlistSectionTests.swift` |
+| Store links | `omnibus/Features/BookDetail/StoreLink.swift` | — | — | `local` | `omnibusTests/StoreLinkTests.swift` |
+| Suggestions | `omnibus/Features/BookDetail/BookDetailView.swift` | `omnibus/Services/LibraryService.swift` | `/api/ebooks/{uuid}/suggestions` | `cached` | — |
+
+## Editing & upload
+
+| Feature | Views | Service / model | Route | Offline | Tests |
+|---|---|---|---|---|---|
+| Metadata editing | `omnibus/Features/Settings/MetadataEditView.swift`, `omnibus/Features/Settings/MetadataDraft.swift` | `omnibus/Models/Models.swift` | overrides via `/api/ebooks/{uuid}` | `direct` | `omnibusTests/MetadataDraftTests.swift` |
+| Provider metadata fetch | `omnibus/Features/Settings/MetadataFetchSheet.swift`, `omnibus/Features/Settings/MetadataFetch.swift`, `omnibus/Features/Settings/MetadataFetchCards.swift` | `omnibus/Models/MetadataLookup.swift` | `/api/metadata/providers` | `direct` | `omnibusTests/MetadataFetchTests.swift` |
+| Add books (upload) | `omnibus/Features/AddBooks/` | `omnibus/Services/UploadService.swift`, `omnibus/Services/UploadManager.swift` | `/api/uploads/ebooks` | `direct` | `omnibusTests/UploadFlowTests.swift`, `omnibusTests/UploadStagingTests.swift` |
+| Settings screen | `omnibus/Features/Settings/SettingsView.swift` | `omnibus/Services/AuthService.swift` | `/api/settings` | `direct` | — |
+
+## Offline infrastructure
+
+Rule [08](../.claude/rules/08-offline-writes.md) governs the outbox; rule
+[09](../.claude/rules/09-content-validators.md) governs downloads.
+
+| Concern | Files | Tests |
+|---|---|---|
+| Replica cache + SQLite store | `omnibus/Offline/Cache.swift`, `omnibus/Offline/OfflineStore.swift` | `omnibusTests/OfflineSyncTests.swift` |
+| Mutation outbox (`OpKind`, drain) | `omnibus/Offline/SyncEngine.swift` | `omnibusTests/OfflineSyncTests.swift` |
+| Whole-library local index | `omnibus/Offline/LibraryIndex.swift` | `omnibusTests/LibraryPollTests.swift` |
+| Downloads (resume, staleness, verify) | `omnibus/Offline/DownloadManager.swift` | `omnibusTests/MultipartDownloadTests.swift` |
+| Connectivity signal | `omnibus/Offline/Connectivity.swift` | — |
+| Background refresh & lifecycle | `omnibus/Offline/LifecycleSync.swift`, `omnibus/App/RefreshTask.swift` | `omnibusTests/RefreshTaskTests.swift` |
+| Cross-device sync prompt | `omnibus/Offline/SyncPromptStore.swift`, `omnibus/Design/Components/SyncOfferBanner.swift` | — |
+| Position reconcile | `omnibus/Offline/PositionSync.swift` | `omnibusTests/PositionPushThrottleTests.swift` |
+
+## Design system
+
+| Concern | Files | Tests |
+|---|---|---|
+| Theme tokens, type scale, colour | `omnibus/Design/Theme.swift`, `omnibus/Design/OKLCH.swift`, `omnibus/Design/Appearance.swift` | `omnibusTests/ThemeFontTests.swift`, `omnibusTests/SymbolNameTests.swift` |
+| Motion curves | `omnibus/Design/Motion.swift` | — |
+| Shared components | `omnibus/Design/Components/` | `omnibusTests/ConfettiTests.swift` |
+
+## Coverage gaps worth knowing
+
+- **`omnibusUITests` is one file** — `ConnectSmokeTests`. The shell's chrome has
+  no UI coverage; the keyboard-vs-tab-bar test was deleted as flaky, and rule
+  [04](../.claude/rules/04-playwright.md) explains why a replacement must be a
+  layout test in `omnibusTests`, not a simulator drive.
+- **Never drive the on-screen keyboard through XCUITest** — it blows the
+  framework's internal snapshot budget and no test-side timeout can extend it.
+- **A UI-test failure message lives only inside the `.xcresult`**, not stdout or
+  JUnit. Read it back with `xcrun xcresulttool`; see
+  [01-dev-environment.md](../.claude/rules/01-dev-environment.md).
+- **No iOS surface** for: log viewer, admin health, user management, library
+  cleanup, OPDS, Kobo device management, or send-to-Kindle/Kobo. Those are
+  web-only — see [feature-map-web.md](feature-map-web.md).

--- a/docs/feature-map-web.md
+++ b/docs/feature-map-web.md
@@ -1,0 +1,123 @@
+# Feature map — web
+
+**Start here to find code; this file answers "where does X live", not "why".**
+
+One row per user-visible feature of the web app, giving the files it spans across
+the four Rust crates plus its E2E spec. For *why* a module is shaped the way it
+is, read [architecture.md](architecture.md). For the rules a change must obey,
+read [.claude/rules/](../.claude/rules/).
+
+The Android shell (`mobile/`) renders this same `frontend/` markup in a WebView
+with `features = ["mobile"]`, so its features are the ones below. The native iOS
+client is a separate codebase — see [feature-map-ios.md](feature-map-ios.md).
+
+## Reading a row
+
+Paths are **relative to each column's crate root**, so the `db/` cell
+`annotations/` means `db/src/annotations/`:
+
+| Column | Root | What's in it |
+|---|---|---|
+| `shared/` | `shared/src/` | serde wire types both sides agree on |
+| `db/` | `db/src/` | SQL, queries, the indexing pipeline |
+| `server/` | `server/src/` | REST handlers (mobile) + the route it answers |
+| `frontend/` | `frontend/src/` | UI pages, `data/` transport, `rpc/` server fns |
+| E2E | `ui_tests/playwright/tests/flows/` | the spec that covers it |
+
+A blank cell means that layer genuinely isn't involved. Web-only features skip
+`server/` entirely — they're Dioxus server functions under `frontend/src/rpc/`,
+reachable at `/api/rpc/*`, and mobile never calls them.
+
+**The two transports are not interchangeable.** `frontend/src/data/` is the
+platform-agnostic wrapper every page calls; under `web`/`server` it proxies the
+`rpc/` server function, under `mobile` it hits the `/api/*` route with `reqwest`.
+Adding a read usually means touching both sides of that split — see the
+[add-backend-route](../.claude/skills/add-backend-route/SKILL.md) skill.
+
+## Library & browse
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| Landing (marquee, shelves row, cover wall) | `view_prefs/`, `discovery.rs` | `books/page.rs`, `books/facets.rs` | `backend/ebooks/` · `/api/ebooks`, `/api/library` | `pages/landing/`, `data/books/library.rs`, `rpc/books.rs` | `landing.spec.ts` |
+| Sort / filter / persisted view prefs | `view_prefs/` | `books/page.rs`, `sort_keys.rs` | | `view_prefs.rs`, `pages/landing/sorting/`, `pages/landing/filtering/`, `client_store.rs` | `persistence.spec.ts` |
+| Full-text search + ⌘K palette | `discovery.rs` | `books/search.rs` | `backend/search/` · `/api/search`, `/api/search/palette` | `components/search_palette/`, `pages/search.rs`, `rpc/palette.rs` | `search.spec.ts`, `search-palette.spec.ts` |
+| Authors & series (index + detail) | `discovery.rs` | `browse/`, `discovery/` | `backend/authors/`, `backend/series/` · `/api/authors*`, `/api/series*` | `pages/authors_index/`, `pages/author.rs`, `pages/series_index/`, `pages/series.rs`, `data/authors.rs`, `data/series.rs`, `index_prefs.rs` | `browse_indices.spec.ts`, `discovery.spec.ts` |
+| Tags & genres | `discovery.rs` | `taxonomy.rs` | `backend/tags/`, `backend/genres/` · `/api/tags`, `/api/genres` | `pages/tag_cloud.rs`, `data/tags.rs`, `data/genres.rs`, `components/chip_editor.rs` | `genres.spec.ts` |
+| Shelves (smart / manual / wishlist) | `shelves/` | `shelves/` | `backend/shelves/` · `/api/shelves*` | `pages/shelf_detail/`, `pages/shelves_index.rs`, `pages/landing/shelf_gallery/`, `components/shelves_rail/`, `components/shelf_rule_builder.rs`, `data/shelves.rs`, `rpc/shelves/` | `shelves.spec.ts`, `shelf_gallery.spec.ts` |
+| Book detail page | `ebook/` | `books/get.rs` | `backend/ebooks/` · `/api/ebooks/{uuid}` | `pages/book_detail/` | `book_detail.spec.ts`, `book_detail_chips.spec.ts` |
+| Covers & thumbnails | `image_format.rs` | `covers/`, `thumbs/`, `palette/` | `backend/covers/` · `/api/covers/{uuid}`, `/api/thumbs/{uuid}/{size}` | `components/cover_tile.rs`, `pages/metadata_edit/cover_editor.rs`, `contexts/` | `thumbnails.spec.ts` |
+| Author photos | `discovery.rs` | `author_photos/`, `author_photos_data/` | `backend/author_photos/` | `components/author_photo_edit.rs`, `data/authors.rs` | `author_photo.spec.ts` |
+
+## Editing the library
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| Metadata editing / overrides | `ebook/overrides.rs` | `metadata_overrides/` | `backend/overrides/` | `pages/metadata_edit/`, `rpc/overrides.rs`, `data/books/manage.rs` | `metadata_edit.spec.ts` |
+| Edition picker (provider fan-out) | `metadata_lookup/` | `metadata_lookup/` | `backend/metadata/` · `/api/metadata/providers` | `pages/metadata_edit/metadata_search/`, `data/metadata_search.rs`, `rpc/metadata_search.rs` | `metadata_edit_search.spec.ts` |
+| Bulk + inline edit (table view) | `ebook/overrides.rs` | `metadata_overrides/` | `backend/overrides/` | `pages/landing/bulk_edit/`, `pages/landing/table/` | `landing_bulk_edit.spec.ts`, `landing_inline_edit.spec.ts` |
+| Merge books / attach formats | `merge.rs`, `cross_format/` | `merge/`, `cross_format/` | `backend/cross_format/` | `components/merge_dialog.rs`, `components/format_switcher/`, `pages/book_detail/merge.rs`, `data/cross_format.rs` | `merge.spec.ts`, `cross_format_link.spec.ts` |
+| Delete book / author | `deletion.rs` | `deletion/`, `missing_files/` | `backend/ebooks/`, `backend/authors/` | `components/delete_book_dialog/`, `pages/book_detail/delete.rs` | `book_delete.spec.ts`, `author_delete.spec.ts` |
+| Add your own books (upload) | `upload.rs` | `identity/` | `backend/uploads/` · `/api/uploads/ebooks` | `pages/add_books.rs`, `components/add_books_sheet.rs`, `data/uploads.rs` | `add_books.spec.ts`, `add_books_sheet.spec.ts` |
+| Library cleanup (dedup review) | `cleanup/` | `cleanup/` | *rpc-only* · `/api/rpc/cleanup/*` | `pages/cleanup_review/`, `pages/settings/cleanup.rs`, `data/cleanup.rs`, `rpc/cleanup/` | `cleanup_review.spec.ts` |
+
+## Reading & listening
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| EPUB reader | `ebook/`, `progress/` | `epub_structure/`, `epub_rewrite/` | `backend/ebooks/` · `/api/ebooks/{uuid}/file` | `pages/reader/`, `reader_progress.rs` | `reader.spec.ts` |
+| Comic (CBZ) reader | `ebook/` | `comic/` | `backend/ebooks/` | `pages/comic_reader.rs` | `comic_reader.spec.ts` |
+| Audiobook player + mini dock | `audiobook.rs` | `audiobook/`, `hls/` | `backend/audiobooks/` | `pages/listen/`, `audiobook_progress.rs` | `listen.spec.ts`, `mini-dock.spec.ts` |
+| Progress sync | `progress/` | `progress/` | `backend/progress/` · `/api/progress*` | `data/progress.rs`, `rpc/progress.rs`, `reader_progress.rs` | `persistence.spec.ts` |
+| Immersive read / cross-format follow | `cross_format/` | `cross_format/` | `backend/cross_format/` | `pages/book_detail/immersive.rs`, `pages/book_detail/sync_link/`, `components/alignment_modal/` | `immersive.spec.ts`, `cross_format_prompts.spec.ts` |
+| Highlights & notes | `highlight/` | `annotations/` | `backend/highlights/` · `/api/highlights*` | `pages/reader/highlights_drawer/`, `pages/book_detail/highlights/`, `data/highlights.rs`, `rpc/highlights.rs` | `reader.spec.ts` |
+| Bookmarks | `bookmark/` | `bookmarks/` | `backend/bookmarks/` · `/api/bookmarks*` | `pages/reader/reader_bookmarks.rs`, `pages/listen/bookmarks.rs`, `data/bookmarks.rs` | `reader.spec.ts`, `listen.spec.ts` |
+| Quote cards | `highlight/` | | | `components/quote_card/`, `pages/reader/quote_panel.rs` | `book_detail.spec.ts` |
+| Read status (want / reading / finished) | `read_status/` | `read_status/` | `backend/read_status/` · `/api/read-status*` | `read_status_auto/`, `pages/book_detail/read_status.rs`, `data/read_status.rs` | `book_detail.spec.ts` |
+| Reading sessions | `progress/` | `progress/session.rs` | `backend/progress/` · `/api/progress/sessions` | `session_tracker/` | `stats.spec.ts` |
+| Sleep timer | | | | `pages/listen/sleep.rs`, `platform_sleep.rs` | `listen.spec.ts` |
+| Reader typography & prefs | | | | `pages/reader/prefs/`, `pages/reader/typography.rs`, `pages/reader/aa_panel.rs` | `reader.spec.ts` |
+
+## Personal shelf data
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| Star ratings | `ratings/` | `ratings/` | `backend/ratings/` · `/api/ratings*` | `pages/book_detail/rating.rs`, `data/ratings.rs` | `book_detail.spec.ts` |
+| Reading journals | `journal/` | `journals/` | `backend/journals/` · `/api/journals*` | `pages/book_detail/journal/`, `data/journals.rs` | `journal.spec.ts` |
+| Reading stats & insights | `stats/` | `stats/` | `backend/stats/` · `/api/stats` | `pages/stats/`, `data/stats.rs`, `data/insights.rs` | `stats.spec.ts` |
+| Physical check-in & wishlist | `physical/`, `scan/`, `isbn/` | `physical/`, `scan/` | `backend/physical/`, `backend/scan/` · `/api/physical/*`, `/api/scan/*` | `pages/check_in/`, `pages/book_detail/physical/`, `components/barcode_scanner/`, `data/physical.rs`, `data/scan.rs` | `check_in_*.spec.ts`, `physical_collection.spec.ts` |
+| "Readers also enjoyed" | `suggestion/` | `suggestions/` | `backend/suggestions/` | `pages/book_detail/discovery.rs`, `data/suggestions.rs` | `suggestions.spec.ts` |
+| Fetch summary | `summary.rs` | `book_summary/` | `backend/summary/` · `/api/summary/sources` | `components/fetch_summary.rs`, `data/summary.rs` | `fetch_summary.spec.ts` |
+
+## Getting books off the server
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| Send to Kindle (SMTP) | `settings/` | `kindle/` | `backend/kindle/` · `/api/kindle/*`, `/api/smtp*` | `data/kindle.rs`, `pages/settings/smtp.rs` | `settings.spec.ts` |
+| Send to Kobo (KEPUB) | `kobo.rs` | `kepub/`, `kobo_devices/` | `backend/ebooks/` · `/api/ebooks/{uuid}/kepub` | `pages/account/kobo.rs`, `data/kobo.rs`, `rpc/kobo.rs` | `account.spec.ts` |
+| Kobo sync API (device-facing) | `kobo.rs` | `kobo/`, `kobo_position/` | `backend/kobo/` · `/kobo/{token}/v1/*` | | *none* — [docs/kobo-smoke-test.md](kobo-smoke-test.md) |
+| OPDS catalog | `opds/` | `books/`, `browse/` | `backend/opds/` · `/opds*`, `/opds/v2*` | | *none* |
+| Format conversion (Calibre) | `settings/` | `convert/` | worker task `ConvertFormat` | `pages/settings/ebook_convert/` | `book_detail.spec.ts` |
+| Hidden formats | `auth.rs` | `auth/` | `backend/account/` · `/api/account/hidden-formats` | `pages/account/hidden_formats.rs` | `hidden_formats.spec.ts` |
+| Byte serving & validators | `ebook/validator.rs`, `http_range.rs` | `books/` | `backend/conditional/` | | — rule [09](../.claude/rules/09-content-validators.md) |
+
+## Accounts & administration
+
+| Feature | `shared/` | `db/` | `server/` | `frontend/` | E2E |
+|---|---|---|---|---|---|
+| Login / register / logout | `auth.rs` | `auth/` | `auth/` (not `backend/`) · `/api/auth/*` | `pages/auth/`, `components/auth/`, `data/auth.rs` | `auth.spec.ts` |
+| Users & permissions (admin) | `auth.rs` | `auth/` | `backend/users/` · `/api/users*` | `pages/settings/users/`, `data/users.rs` | `users.spec.ts` |
+| Sessions & devices | `auth.rs` | `auth/` | `backend/admin_sessions/` · `/api/auth/sessions*` | `pages/account/sessions.rs`, `data/sessions.rs`, `data/admin_sessions.rs` | `account.spec.ts` |
+| Profile & avatar | `auth.rs` | `auth/` | `backend/profile/` · `/api/account/profile`, `/api/account/avatar` | `pages/account/profile/`, `components/user_avatar/`, `data/profile.rs` | `account.spec.ts`, `user_menu.spec.ts` |
+| Settings page | `settings/` | `settings/` | `backend/settings/` · `/api/settings` | `pages/settings/`, `data/books/admin.rs` | `settings.spec.ts` |
+| Indexer / scanner / worker | `worker/` | `scanner/`, `indexer/`, `sync/`, `worker/` | `backend/settings/` · `/api/reindex`, `/api/scan-library` | `components/worker_status/`, `pages/settings/background_tasks.rs`, `data/background_tasks.rs` | `worker-status.spec.ts` |
+| Log viewer | `logs/` | `logs/` | *rpc-only* | `pages/logs.rs`, `data/logs.rs`, `rpc/logs.rs` | `logs.spec.ts` |
+| Admin server health | `admin_health.rs` | `admin_health/` | `backend/admin_health/` · `/api/admin/health` | `pages/admin_health/`, `data/admin_health.rs` | `admin_health.spec.ts` |
+| Theme / Atrium design system | | | | `components/atrium.rs`, `frontend/assets/atrium.css` | `theme_toggle.spec.ts` |
+| Rate limiting, CSRF, headers | | | `rate_limit/`, `auth/csrf/`, `security_headers/` | | `auth.spec.ts` |
+
+## Coverage gaps worth knowing
+
+- **OPDS has no E2E spec at all** — `server/src/backend/opds/tests/` is the only coverage.
+- **The Kobo sync API has no automated test** — it's a manual runbook, [docs/kobo-smoke-test.md](kobo-smoke-test.md).
+- **`/shelves` and `/shelves/:id` are mobile-only routes.** Shelf delete, add-books, and the member sort control have no web E2E coverage by design — see [rule 04](../.claude/rules/04-playwright.md).
+- **`frontend/src/offline/` is mobile-gated** (`#[cfg(feature = "mobile")]`) and never compiles for web. It backs the Android shell; see [rule 08](../.claude/rules/08-offline-writes.md).


### PR DESCRIPTION
## Summary
- Adds `docs/feature-map-web.md` and `docs/feature-map-ios.md` — one row per user-visible feature, listing every file it spans, so an agent (or a person) can go from "where does read status live" to the answer without grepping five crates and stitching the results together.
- The existing `docs/architecture.md` already contains every one of those facts, but it is indexed by *directory* — it answers "what does this module do", never "which files make up this feature". These maps are the other direction, and deliberately duplicate no rationale: paths only, with `architecture.md` still the single place that explains *why* a module is shaped the way it is.
- The web map covers the full stack per feature (`shared/` → `db/` → `server/` → `frontend/`) plus the Playwright spec that covers it, in six sections: library & browse, editing, reading & listening, personal shelf data, getting books off the server, and accounts & administration. Paths are relative to each column's crate root so the cells stay scannable.
- The iOS map covers the native SwiftUI client with views, service, REST route, and test per feature, plus an **Offline** column recording each write's rule-08 contract (`queued` / `direct` / `cached` / `local`). That column is framed as a constraint rather than a description, because the interesting failure mode is someone "improving" a deliberately-direct write into the outbox without re-running the four tests.
- The Android `mobile/` crate renders the same `frontend/` markup in a WebView, so it is covered by the web map rather than getting a third file — stated at the top of that map instead of left implicit.
- Both maps end with a "coverage gaps worth knowing" section recording where testing genuinely stops: OPDS has no E2E spec at all, the Kobo sync API is a manual runbook only, `/shelves` is a mobile-only route with several controls that have no web coverage by design, and `omnibusUITests` is a single smoke file. An agent that knows a surface is untested behaves differently from one that assumes it is.
- `CLAUDE.md` gains a `## Finding code` section placed immediately after the intro and before `## Rules`, so it is the first thing read. It points at both maps and then says plainly that they are a starting point rather than a complete index, with a numbered fall-through to `architecture.md` and then `grep`, and an instruction to trust the code over either document and fix the map in the same change when it is found stale.
- `AGENTS.md` gets the same pointer, kept to the thin-redirect shape that file requires.
- Rule 98 gains a section on the maps rotting the same way skills do, with a table of which cell to update for each kind of change, and a standing instruction to keep them paths-only so they do not drift back into prose. Rule 99's docs-sync step gains a matching bullet.

## Test plan
- [x] Every cited path verified **column-aware** by script — each backticked path resolved against its own column's crate root rather than against any root, so a path that exists under the wrong crate would fail. 357 paths checked, 0 wrong.
- [x] All relative markdown links across both new maps, `CLAUDE.md`, `AGENTS.md`, and the two touched rules resolve — 0 broken.
- [x] Line-count cap holds: `CLAUDE.md` is 133 lines and rule 98 is 60, both well under the ~200 the repo enforces. The maps live in `docs/`, which the cap does not cover.
- [x] No Rust, TypeScript, or CSS changed, so `just lint` and `just test` have nothing to exercise here — the diff is six markdown files.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — this PR touches only `*.md` and `docs/`, so the release job skips it automatically; no label needed.

## Notes
- The maps are hand-maintained, which is the honest trade-off: they are far cheaper to read than the 474-line `architecture.md` and far more likely to lag a rename. The rule-98 entry and the "trust the code over either document" line in `CLAUDE.md` are both there to make that lag safe rather than pretend it will not happen.
- Cells name the module that owns a concern rather than always the exact file, and only user-visible features get rows — infrastructure like the rate limiter or the conditional-request layer appears only where a feature depends on it. Both limits are stated in each map's preamble so a reader knows when to fall through.
- One genuine error and about forty-five ambiguous entries were caught by the verification pass rather than by review: `shelf_rule_builder` is a file rather than a directory, and a batch of iOS cells originally used bare sibling filenames like `ComicArchive.swift` that read fine but could not be pasted into an editor. Those were rewritten to full paths or collapsed to the owning directory.
