### PR TITLE
fix: revise the site copy and stop the framed shots cropping

### DIFF
--- a/site/src/index.html
+++ b/site/src/index.html
@@ -59,11 +59,10 @@
       <div class="sec-inner themes-in">
         <div class="themes-copy">
           <p class="kick" data-anim>Themes</p>
-          <h2 class="h2" data-anim style="--d:70ms">The same shelf, four ways.</h2>
-          <p class="lede" data-anim style="--d:130ms">Dark, black, white, sepia. Pick one and it follows you everywhere — library, reader, player, phone.</p>
+          <h2 class="h2" data-anim style="--d:70ms">Four cozy styles</h2>
         </div>
         <div class="themes-vis" data-anim style="--d:200ms">
-          <figure class="frame frame--fill" style="--ar:1442/1002">
+          <figure class="frame" style="--ar:1442/1002">
             <img class="shot" src="shots/dark/omnibus-themes-strip.webp" width="1442" height="1002" alt="One library screen sliced diagonally into four colour themes: dark, black, white and sepia.">
           </figure>
         </div>
@@ -76,15 +75,11 @@
         <div class="split">
           <div class="split-copy">
             <p class="kick" data-anim>Read</p>
-            <h2 class="h2" data-anim style="--d:70ms">A reader that keeps your place.</h2>
+            <h2 class="h2" data-anim style="--d:70ms">Saves your progress</h2>
             <ul class="pts" data-anim style="--d:130ms">
               <li><span><b>Progress lives on the server.</b> The page you left on the laptop is the page your phone opens.</span></li>
               <li><span><b>Highlight a passage</b> and share it as a quote card in a tap.</span></li>
-              <li><span><b>Send to your device.</b> Push any book to a Kobo or Kindle — no Calibre round-trip.</span></li>
             </ul>
-            <div class="cta" data-anim style="--d:190ms">
-              <a class="sbtn ghost" href="https://github.com/seamus-sloan/omnibus" target="_blank" rel="noreferrer">See the reader code</a>
-            </div>
           </div>
           <div class="split-vis" data-anim style="--d:230ms">
             <figure class="frame" style="--ar:1442/982">
@@ -106,7 +101,7 @@
           </div>
           <div class="split-copy">
             <p class="kick" data-anim style="--d:80ms">Listen</p>
-            <h2 class="h2" data-anim style="--d:140ms">Audiobooks with a chapter map.</h2>
+            <h2 class="h2" data-anim style="--d:140ms">Play Any Audiobook Format</h2>
             <ul class="pts" data-anim style="--d:200ms">
               <li><span><b>Streamed, not downloaded.</b> HLS transcode on the fly — start on the commute, finish in the kitchen.</span></li>
               <li><span><b>Chapter map, speed, sleep timer.</b> The controls you actually reach for, one row deep.</span></li>
@@ -123,11 +118,11 @@
         <div class="split">
           <div class="split-copy">
             <p class="kick" data-anim>Format sync</p>
-            <h2 class="h2" data-anim style="--d:70ms">One book, two formats, one position.</h2>
+            <h2 class="h2" data-anim style="--d:70ms">Sync Ebook and Audiobook Positions</h2>
             <ul class="pts" data-anim style="--d:130ms">
-              <li><span><b>Link the EPUB to its audiobook</b> and the book keeps a single place: read to chapter 14, the player opens at 4:12:38.</span></li>
-              <li><span><b>Chapter anchors when the files have them,</b> percentage when they don’t — and it says which one it used, and how confident it is.</span></li>
-              <li><span><b>One resume card instead of two,</b> led by whichever format you touched last.</span></li>
+              <li><span>Manually link formats together. You decide whether or not to opt into the feature and how the sync will work.</span></li>
+              <li><span>Sync based off of chapters when ebook and audiobook have the same chapter count.</span></li>
+              <li><span>Sync based off of completion percentage when chapters don’t line up.</span></li>
             </ul>
           </div>
           <div class="split-vis" data-anim style="--d:210ms">
@@ -153,11 +148,11 @@
           </div>
           <div class="split-copy">
             <p class="kick" data-anim style="--d:80ms">Kobo</p>
-            <h2 class="h2" data-anim style="--d:140ms">Your shelves, on your Kobo.</h2>
+            <h2 class="h2" data-anim style="--d:140ms">Kobo Sync</h2>
             <ul class="pts" data-anim style="--d:200ms">
-              <li><span><b>A shelf becomes a collection.</b> Flip sync on and the device sees that shelf — reading state comes back the same way.</span></li>
+              <li><span>Choose shelves to sync. Omnibus hosts Kobo endpoints for your device to talk to.</span></li>
               <li><span><b>KEPUB, not just EPUB.</b> Files convert through kepubify at sync time and stay cached until the book changes.</span></li>
-              <li><span><b>Kindle by email, OPDS for the rest,</b> and an OPF export of your metadata for the day you want out.</span></li>
+              <li><span>Progress, annotations, and reading stats sync directly to your server when your Kobo syncs.</span></li>
             </ul>
           </div>
         </div>
@@ -170,11 +165,9 @@
         <div class="split">
           <div class="split-copy">
             <p class="kick" data-anim>Kindle</p>
-            <h2 class="h2" data-anim style="--d:70ms">And the Kindle in your bag.</h2>
+            <h2 class="h2" data-anim style="--d:70ms">Sending to Kindle</h2>
             <ul class="pts" data-anim style="--d:130ms">
-              <li><span><b>The EPUB itself gets sent.</b></span></li>
               <li><span><b>Set SMTP once.</b> The admin configures it in settings, each reader saves their own send-to address, and every book page grows a Send button.</span></li>
-              <li><span><b>Sends run in the background.</b> The job queues on the worker, so the page never waits and the file on disk is never touched.</span></li>
             </ul>
           </div>
           <div class="split-vis" data-anim style="--d:210ms">
@@ -186,13 +179,38 @@
       </div>
     </section>
 
-    <!-- 8 · check-in -->
+    <!-- 8 · mobile -->
+    <section class="pane" id="mobile" data-label="Mobile">
+      <div class="sec-inner sec-inner--stack">
+        <div class="center-copy" style="max-width:680px">
+          <p class="kick" data-anim>Mobile</p>
+          <h2 class="h2" data-anim style="--d:70ms">Native iOS App with Swift</h2>
+          <p class="lede" data-anim style="--d:130ms;max-width:54ch;margin:0 auto">Native Swift iOS app open for testing. WebView shell on Android. Access your library wherever you go.</p>
+        </div>
+        <div class="phones">
+          <div>
+            <div class="phone" data-anim style="--ar:404/876;--d:190ms">
+              <img class="shot" src="shots/dark/omnibus-ios-book-detail.webp" width="404" height="876" alt="A book page in the native iOS app, resuming at chapter four.">
+            </div>
+            <p class="phone-cap" data-anim style="--d:250ms">iOS · native SwiftUI</p>
+          </div>
+          <div>
+            <div class="phone" data-anim style="--ar:382/802;--d:280ms">
+              <img class="shot" src="shots/dark/omnibus-android-library.webp" width="382" height="802" alt="The library on Android, with a continue card and a wall of covers.">
+            </div>
+            <p class="phone-cap" data-anim style="--d:340ms">Android · WebView shell</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 9 · check-in -->
     <section class="pane" id="checkin" data-label="Check-in">
       <div class="sec-inner sec-inner--stack">
         <div class="center-copy" style="max-width:720px">
           <p class="kick" data-anim>Check-in</p>
-          <h2 class="h2" data-anim style="--d:70ms">The shelf you can actually touch.</h2>
-          <p class="lede" data-anim style="--d:130ms;max-width:58ch;margin:0 auto">Scan the barcode of a physical book. Omnibus matches it against your library — ISBN first, then title and author. Own it in print? Check the copy in. Don’t own it yet? It lands on the wishlist with the day you found it, and no invented progress.</p>
+          <h2 class="h2" data-anim style="--d:70ms">Track your Physical Books</h2>
+          <p class="lede" data-anim style="--d:130ms;max-width:58ch;margin:0 auto">Scan an ISBN to say that you own the book or add it to your wishlist to buy later.</p>
         </div>
         <div class="trio">
           <div>
@@ -217,38 +235,13 @@
       </div>
     </section>
 
-    <!-- 9 · mobile -->
-    <section class="pane" id="mobile" data-label="Mobile">
-      <div class="sec-inner sec-inner--stack">
-        <div class="center-copy" style="max-width:680px">
-          <p class="kick" data-anim>Mobile</p>
-          <h2 class="h2" data-anim style="--d:70ms">In your pocket, on your server.</h2>
-          <p class="lede" data-anim style="--d:130ms;max-width:54ch;margin:0 auto">A native SwiftUI app on iOS and a WebView shell on Android, both speaking to the same backend. Same library, same progress, same theme.</p>
-        </div>
-        <div class="phones">
-          <div>
-            <div class="phone" data-anim style="--ar:404/876;--d:190ms">
-              <img class="shot" src="shots/dark/omnibus-ios-book-detail.webp" width="404" height="876" alt="A book page in the native iOS app, resuming at chapter four.">
-            </div>
-            <p class="phone-cap" data-anim style="--d:250ms">iOS · native SwiftUI</p>
-          </div>
-          <div>
-            <div class="phone" data-anim style="--ar:382/802;--d:280ms">
-              <img class="shot" src="shots/dark/omnibus-android-library.webp" width="382" height="802" alt="The library on Android, with a continue card and a wall of covers.">
-            </div>
-            <p class="phone-cap" data-anim style="--d:340ms">Android · WebView shell</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
     <!-- 10 · scanning -->
     <section class="pane" id="scan" data-label="Scanning">
       <div class="sec-inner sec-inner--stack">
         <div class="center-copy" style="max-width:900px">
           <p class="kick" data-anim>Scanning</p>
-          <h2 class="h2" data-anim style="--d:70ms">Point it at a folder. It walks the rest.</h2>
-          <p class="lede" data-anim style="--d:130ms;max-width:74ch;margin:0 auto">The scanner recurses through whatever you already have — nested author and series trees, loose files, mixed formats — and reads each book’s metadata out of the file itself. What you then edit lives in the database, not in your books: originals are never rewritten, and the current values ride along on anything you export or send to a device.</p>
+          <h2 class="h2" data-anim style="--d:70ms">Your Files; Untouched</h2>
+          <p class="lede" data-anim style="--d:130ms;max-width:74ch;margin:0 auto">The scanner recurses through whatever you already have — nested author and series trees, loose files, mixed formats — and reads each book’s metadata out of the file itself. Your metadata edits live in the Omnibus database and will be written to exported media.</p>
         </div>
         <div class="duo">
           <div>
@@ -283,7 +276,7 @@
             <p class="faq-a">Point Omnibus at the folder you already have. The <code>Author/Title</code> layout scans as-is, metadata is read from inside each EPUB rather than Calibre’s <code>metadata.opf</code> sidecar, and nothing on disk is moved or renamed.</p>
           </div>
           <div data-anim style="--d:220ms">
-            <p class="faq-q">Do I need a beefy server?</p>
+            <p class="faq-q">Do I need a high-end server?</p>
             <p class="faq-a">No. A 4GB Raspberry Pi is more than enough. One Rust binary, SQLite, and a bind-mount — it runs on the machine you already own. Audio is transcoded on demand, so leave a little CPU headroom if the whole house listens at once.</p>
           </div>
           <div data-anim style="--d:290ms">
@@ -303,7 +296,7 @@
       <div class="sec-inner">
         <div class="close-in">
           <p class="kick" data-anim>Open source</p>
-          <h2 class="h1" data-anim style="--d:70ms;max-width:20ch">Your books. Your machine. Your call.</h2>
+          <h2 class="h1" data-anim style="--d:70ms;max-width:20ch">Your book collection in one place.</h2>
           <p class="lede" data-anim style="--d:130ms;text-align:center;max-width:52ch">Point Omnibus at your existing digital library and try it out; Omnibus doesn’t tamper with any of your files or folder structure.</p>
           <p class="cmd" data-anim style="--d:190ms"><s>$</s>docker compose up -d</p>
           <div class="cta" data-anim style="--d:240ms;justify-content:center">

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -98,14 +98,19 @@ body.flow{overflow:auto}
 .cue.hide{opacity:0;pointer-events:none}
 
 /* ── framed screenshots ───────────────────────────────────────────
-   Every framed box declares its shot's aspect as --ar, so the BOX owns the
-   sizing and the image just fills it. Letting the image size itself instead
-   is the bug this replaced: `max-width` binds first, the height that implies
-   wins over `height:100%`, and a tall phone shot overflows its row. */
-.frame,.phone{aspect-ratio:var(--ar);height:100%;width:auto;max-width:100%;margin:0 auto}
-.frame{position:relative;border:1px solid var(--pg-line);border-radius:14px;overflow:hidden;background:var(--pg-panel);box-shadow:var(--pg-shadow)}
-.shot{display:block;width:100%;height:100%;object-fit:cover;object-position:center top}
-.frame--fill{width:100%;height:100%}
+   The IMAGE is the sized element and carries the frame's border: on a
+   replaced element, `max-width` + `max-height` with both dimensions `auto` is
+   the one construction that fits inside a box on BOTH axes while preserving
+   aspect. Sizing the wrapper instead pins both axes, which overrides the
+   declared aspect-ratio and lets `object-fit:cover` crop in silence — that
+   cost 78% of the sync inset and 40% of the theme strip before it was
+   measured. The wrapper now only positions and centres. */
+/* flex, not grid: a grid container's implicit row is auto-sized, so it grows
+   to the image and the image's own max-height:100% then resolves against
+   that row rather than the slot — constraining nothing. A flex item's
+   percentage max-height resolves against the container's real height. */
+.frame,.phone{position:relative;display:flex;align-items:center;justify-content:center;width:100%;height:100%;min-width:0;min-height:0;margin:0}
+.shot{display:block;max-width:100%;max-height:100%;width:auto;height:auto;border:1px solid var(--pg-line);border-radius:14px;background:var(--pg-panel);box-shadow:var(--pg-shadow)}
 
 /* hero — the one screen shown in perspective, bleeding off the right edge */
 .hero{display:grid;grid-template-columns:minmax(360px,42%) 1fr;align-items:center;gap:clamp(24px,4vw,72px)}
@@ -117,21 +122,22 @@ body.flow{overflow:auto}
    a top offset instead leaves it hanging: the slot has no height of its
    own (the frame is absolute), so a narrower viewport shrinks the frame
    and drops all the slack below it. */
+.hero-shot .shot{width:100%;height:100%;max-width:none;max-height:none;object-fit:cover;object-position:center top;border-bottom:0;border-radius:14px 14px 0 0;background:transparent}
 .hero-shot{position:absolute;left:44%;right:calc(var(--pad) * -1.1);top:0;bottom:0;display:grid;align-content:center;perspective:2200px}
-.hero-shot .frame{position:relative;width:100%;height:auto;max-width:none;margin:0;aspect-ratio:1440/900;background:transparent;border-bottom:0;border-radius:14px 14px 0 0;transform:rotateX(5deg) rotateY(-11deg) rotateZ(0.6deg) scale(1.04);transform-origin:left center;-webkit-mask-image:linear-gradient(to bottom,#000 0,#000 68%,rgba(0,0,0,.5) 87%,transparent 100%);mask-image:linear-gradient(to bottom,#000 0,#000 68%,rgba(0,0,0,.5) 87%,transparent 100%)}
+.hero-shot .frame{position:relative;display:block;width:100%;height:auto;aspect-ratio:1440/900;transform:rotateX(5deg) rotateY(-11deg) rotateZ(0.6deg) scale(1.04);transform-origin:left center;-webkit-mask-image:linear-gradient(to bottom,#000 0,#000 68%,rgba(0,0,0,.5) 87%,transparent 100%);mask-image:linear-gradient(to bottom,#000 0,#000 68%,rgba(0,0,0,.5) 87%,transparent 100%)}
 
 /* two-up: copy beside a screen */
 .split{display:grid;grid-template-columns:minmax(300px,34%) 1fr;gap:clamp(24px,3.6vw,64px);align-items:center;height:100%;padding:clamp(70px,11vh,120px) 0 clamp(48px,8vh,90px)}
 .split--flip{grid-template-columns:1fr minmax(300px,33%)}
 .split-copy{display:grid;gap:clamp(12px,2vh,24px);align-content:center}
 .split-vis{position:relative;height:100%;min-height:0;display:grid;place-items:center}
-.inset-shot{position:absolute;left:-5%;bottom:-4%;width:46%;z-index:5}
+.inset-shot{position:absolute;left:-5%;bottom:-4%;width:46%;height:auto;z-index:5}
 
 /* the theme strip is one image; its four labels are baked in */
 .themes-in{grid-template-rows:auto 1fr;align-content:stretch;padding:clamp(78px,12vh,124px) 0 clamp(26px,4.5vh,58px);gap:clamp(14px,2.4vh,30px)}
-.themes-copy{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1.1fr);gap:6px clamp(28px,4.5vw,80px);align-items:end}
-.themes-copy .kick{grid-column:1/-1}
-.themes-copy .lede{max-width:52ch;align-self:end}
+/* one column: the two-column split existed to seat a lede beside the heading,
+   and there is no lede on this panel any more */
+.themes-copy{display:grid;gap:6px}
 .themes-vis{position:relative;min-height:0;display:grid;place-items:center}
 
 /* phone rows */
@@ -140,8 +146,7 @@ body.flow{overflow:auto}
 .phones>div,.trio>div{min-width:0;height:100%;display:grid;grid-template-rows:1fr auto}
 .trio>div{flex:0 1 320px}
 .phones>div{flex:0 1 440px}
-.phone{min-height:0;overflow:hidden;border-radius:22px}
-.phone .shot{object-fit:contain;object-position:center}
+.phone .shot{border-radius:22px}
 .phone-cap{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--pg-ink3);text-align:center;margin-top:16px;min-height:2.4em}
 
 /* side-by-side desktop screens */
@@ -191,6 +196,7 @@ body.flow .themes-copy{grid-template-columns:1fr}
 body.flow .phones,body.flow .trio,body.flow .duo{flex-direction:column;height:auto;gap:36px}
 body.flow .phones>div,body.flow .trio>div,body.flow .duo>div{height:auto;flex:none;width:100%;max-width:380px;margin:0 auto}
 body.flow .frame,body.flow .phone{height:auto;width:100%}
+body.flow .shot{max-height:none}
 body.flow .duo>div{max-width:640px}
 body.flow .duo .frame{height:auto;width:100%}
 body.flow .faq{grid-template-columns:1fr}

--- a/site/src/site.css
+++ b/site/src/site.css
@@ -187,7 +187,12 @@ body.flow [data-anim]{opacity:1;transform:none;transition:none}
 body.flow .site-top{position:sticky;background:color-mix(in oklch,var(--pg-bg) 88%,transparent);backdrop-filter:blur(10px)}
 body.flow .hero{grid-template-columns:1fr}
 body.flow .hero-shot{position:static;display:block;perspective:none;margin-top:28px}
-body.flow .hero-shot .frame{transform:none;mask-image:none;-webkit-mask-image:none;border-bottom:1px solid var(--pg-line);border-radius:14px;background:var(--pg-panel)}
+/* The wrapper is only ever transform + mask; the border and radius live on
+   the image, so flow mode has to close the hero's frame there too — the
+   deck variant leaves it deliberately open at the bottom to bleed under
+   the mask, and there is no mask here to hide a squared-off edge. */
+body.flow .hero-shot .frame{transform:none;mask-image:none;-webkit-mask-image:none;aspect-ratio:auto}
+body.flow .hero-shot .shot{width:100%;height:auto;object-fit:fill;border:1px solid var(--pg-line);border-radius:14px;background:var(--pg-panel)}
 body.flow .split,body.flow .split--flip{grid-template-columns:1fr;height:auto;padding:0;gap:28px}
 body.flow .split--flip .split-vis{order:2}
 body.flow .split-vis,body.flow .themes-vis{height:auto}


### PR DESCRIPTION
## Summary
Copy pass across every panel of the marketing site, plus a real layout bug behind the framed screenshots.

- Headings and feature bullets rewritten to say what each thing does rather than how it is built; several bullets and the reader/Kobo/Kindle asides dropped outright. The themes panel loses its lede, so its two-column grid collapses to one. Mobile now sits above Check-in.
- **The framed shots were cropping, invisibly.** The frame pinned both axes (`height:100%` + `max-width:100%`), which overrides the declared `aspect-ratio`, and `object-fit:cover` trimmed the overflow: 78% off the Format Sync inset, 40% off the theme strip, 4% off each Scanning shot.
- The image is now the sized element and carries the frame's border — `max-width` + `max-height` with both dimensions `auto` is the one construction that fits a replaced element inside a box on both axes while preserving aspect. The wrapper only centres, and it centres with flex: a grid container's implicit row is auto-sized, so it grows to the image and the image's `max-height:100%` then resolves against that row rather than the slot, constraining nothing.

Site-only change; no shipped-app code is touched.

## Test plan
- [x] `stylelint` clean on `site/src/site.css`.
- [x] Measured all 15 shots at 1440x900 after the change: **0% crop, 0px overflow**, against 78% / 40% / 4% / 4% before. The hero's 4% is its intentional `scale(1.04)` bleed.
- [x] Format Sync inset renders 375x101 (was 375x453) — short and wide, as designed.
- [x] Scanning panel shows both screens full-width, no side trim.
- [x] Hero still bleeds 130px past the right edge under its mask, and its centre stays within 2px of the copy's.
- [x] Panel order verified `hero,themes,read,listen,sync,kobo,kindle,mobile,checkin,scan,faq,close`; the rail is generated from the panes so it follows.

## Version
- [x] **No release** — the site and its stylesheet are the whole diff.