### PR TITLE
fix: apply iOS reader typography changed while the page is rebooting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -448,6 +448,23 @@ the pending queue. `webViewWebContentProcessDidTerminate` makes the recovery
 explicit, deferring the reload past a backgrounding rather than feeding a fresh
 process to the same reclaim.
 
+Typography is the third thing a boot carries, and it is shaped differently from
+the other two: it *is* a snapshot, because `bootScript` has to hand the glue one
+complete set of options in a single call. So the boot records what it handed over
+in `ReaderController.appliedSettings`, and `ready` re-syncs the difference. Both
+halves of the reboot window matter and each is carried by a different mechanism —
+a change made before the replacement announces `hostReady` rides the boot options
+(`bootScript` reads `settings` live), and one made after it announces but before
+it paints rides the re-sync. Dropping the second left the settings sheet showing
+one size while the page rendered another until the next reboot (#2191). A new
+`ReaderSettings` field therefore has to be added in three places, not one:
+`bootScript`'s options, `settingsScripts`' diff, and the tolerant decoder.
+
+`appliedSettings` is `nil` whenever no page is holding our typography, and the
+two page-death paths each clear only their own half of that — `prepareForReboot`
+drops `isReady` and leaves the view, `teardown` drops the view and leaves
+`isReady` — so the gate is `hasLivePage`, which asks both, never one alone.
+
 **The models are hand-mirrored, so they drift silently.** `Models/` restates the
 `shared/` wire DTOs in Swift with no generator and no compiler tying the two
 together, so a field added or renamed on the Rust side surfaces as a runtime 422

--- a/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
@@ -104,9 +104,11 @@ struct ReaderSettingsSheet: View {
     }
 
     /// The size is set in the face it controls, so the control previews itself.
-    /// The number carries what the preview can't: two adjacent sizes look alike,
-    /// so a change that didn't land is otherwise indistinguishable from one that
-    /// did — and it matches the line-height row directly beneath.
+    /// The number is there because the preview alone can't separate two adjacent
+    /// sizes — 19 and 20 render as the same "Aa" — and it matches the
+    /// line-height row directly beneath. Like every control here it shows what
+    /// the reader has *asked for*; whether the page took it is
+    /// `ReaderController.appliedSettings`, which is not a reader-facing fact.
     private var sizeRow: some View {
         PlateRow(label: "Size", isFirst: true) {
             HStack(spacing: Spacing.md) {
@@ -115,22 +117,37 @@ struct ReaderSettingsSheet: View {
                     .foregroundStyle(palette.ink1Color)
                     .frame(width: 46, alignment: .trailing)
                     .animation(Motion.snap, value: controller.settings.fontSize)
+                    .accessibilityHidden(true)
 
-                Text("\(controller.settings.fontSize)")
+                // `verbatim` rather than interpolation: the sibling row formats
+                // with `String(format:)`, which is locale-independent, and
+                // `Text("\(int)")` goes through `LocalizedStringKey` — the two
+                // adjacent readouts would render in different numeral systems.
+                Text(verbatim: String(controller.settings.fontSize))
                     .font(.monoUI(12))
                     .foregroundStyle(palette.ink2Color)
                     .contentTransition(.numericText())
                     // The row is tight enough that the number is what SwiftUI
                     // compresses first — without this it wraps to a digit per
-                    // line rather than pushing on anything else.
+                    // line rather than pushing on anything else. Horizontal
+                    // only: the height is not in question, and pinning it
+                    // fights the numeric roll.
                     .lineLimit(1)
-                    .fixedSize()
+                    .fixedSize(horizontal: true, vertical: false)
                     .animation(Motion.snap, value: controller.settings.fontSize)
+                    .accessibilityLabel("Size")
+                    .accessibilityValue("\(controller.settings.fontSize) point")
 
-                stepButton("minus", enabled: controller.settings.fontSize > 12) {
+                stepButton(
+                    "minus", label: "Decrease size",
+                    enabled: controller.settings.fontSize > 12
+                ) {
                     controller.settings.fontSize = max(12, controller.settings.fontSize - 1)
                 }
-                stepButton("plus", enabled: controller.settings.fontSize < 34) {
+                stepButton(
+                    "plus", label: "Increase size",
+                    enabled: controller.settings.fontSize < 34
+                ) {
                     controller.settings.fontSize = min(34, controller.settings.fontSize + 1)
                 }
             }
@@ -159,7 +176,7 @@ struct ReaderSettingsSheet: View {
     }
 
     private func stepButton(
-        _ icon: String, enabled: Bool, action: @escaping () -> Void
+        _ icon: String, label: String, enabled: Bool, action: @escaping () -> Void
     ) -> some View {
         Button {
             Haptics.tap()
@@ -174,6 +191,9 @@ struct ReaderSettingsSheet: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+        // Without this the row reads as an unattributed number followed by two
+        // unnamed buttons — the glyph name is all VoiceOver would otherwise have.
+        .accessibilityLabel(label)
     }
 
     private func group<Content: View>(

--- a/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
@@ -120,6 +120,11 @@ struct ReaderSettingsSheet: View {
                     .font(.monoUI(12))
                     .foregroundStyle(palette.ink2Color)
                     .contentTransition(.numericText())
+                    // The row is tight enough that the number is what SwiftUI
+                    // compresses first — without this it wraps to a digit per
+                    // line rather than pushing on anything else.
+                    .lineLimit(1)
+                    .fixedSize()
                     .animation(Motion.snap, value: controller.settings.fontSize)
 
                 stepButton("minus", enabled: controller.settings.fontSize > 12) {

--- a/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderSettingsSheet.swift
@@ -104,6 +104,9 @@ struct ReaderSettingsSheet: View {
     }
 
     /// The size is set in the face it controls, so the control previews itself.
+    /// The number carries what the preview can't: two adjacent sizes look alike,
+    /// so a change that didn't land is otherwise indistinguishable from one that
+    /// did — and it matches the line-height row directly beneath.
     private var sizeRow: some View {
         PlateRow(label: "Size", isFirst: true) {
             HStack(spacing: Spacing.md) {
@@ -111,6 +114,12 @@ struct ReaderSettingsSheet: View {
                     .font(.display(CGFloat(controller.settings.fontSize)))
                     .foregroundStyle(palette.ink1Color)
                     .frame(width: 46, alignment: .trailing)
+                    .animation(Motion.snap, value: controller.settings.fontSize)
+
+                Text("\(controller.settings.fontSize)")
+                    .font(.monoUI(12))
+                    .foregroundStyle(palette.ink2Color)
+                    .contentTransition(.numericText())
                     .animation(Motion.snap, value: controller.settings.fontSize)
 
                 stepButton("minus", enabled: controller.settings.fontSize > 12) {

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -298,9 +298,18 @@ final class ReaderController: NSObject {
         didSet {
             guard settings != oldValue else { return }
             settings.save()
-            applySettings(changedFrom: oldValue)
+            syncSettings()
         }
     }
+
+    /// The typography the page was last handed, or `nil` when no page is holding
+    /// ours — before the first boot, and after a teardown.
+    ///
+    /// This, rather than `didSet`'s `oldValue`, is what a sync diffs against. A
+    /// change made while the page is rebooting has to survive until there is a
+    /// page to receive it, and `oldValue` forgets it the moment the next change
+    /// lands (#2191).
+    private(set) var appliedSettings: ReaderSettings?
 
     fileprivate var webView: WKWebView?
     private var book: Book?
@@ -447,6 +456,10 @@ final class ReaderController: NSObject {
         run("OmnibusReader.destroy()")
         webView?.stopLoading()
         webView = nil
+        // Nothing is holding our typography any more. Left standing, the next
+        // change would diff against a page that no longer exists and mark
+        // itself applied without ever having been sent.
+        appliedSettings = nil
     }
 
     // MARK: - Page lifetime
@@ -493,29 +506,46 @@ final class ReaderController: NSObject {
         drawnHighlights = []
     }
 
-    private func applySettings(changedFrom old: ReaderSettings) {
-        guard isReady else { return }
-        if settings.fontSize != old.fontSize {
-            run("OmnibusReader.setFontSize(\(settings.fontSize))")
+    /// Bring the page up to the settings in force, if it isn't already there.
+    ///
+    /// Runs both when a setting changes and when a page reports ready. A boot
+    /// bakes a *snapshot* of the settings into its options (`bootScript`), so
+    /// anything changed between that snapshot and first paint is on disk and
+    /// nowhere else — dropping it left the sheet showing one size and the page
+    /// rendering another until the next reboot (#2191).
+    private func syncSettings() {
+        guard isReady, let shown = appliedSettings, shown != settings else { return }
+        for script in settingsScripts(from: shown) { run(script) }
+        appliedSettings = settings
+    }
+
+    /// The calls that bring a page showing `shown` up to the settings in force.
+    ///
+    /// Pure, so what a sync would send is assertable without a web view.
+    func settingsScripts(from shown: ReaderSettings) -> [String] {
+        var scripts: [String] = []
+        if settings.fontSize != shown.fontSize {
+            scripts.append("OmnibusReader.setFontSize(\(settings.fontSize))")
         }
-        if settings.theme != old.theme {
-            run("OmnibusReader.setTheme(\(settings.theme.jsQuoted))")
+        if settings.theme != shown.theme {
+            scripts.append("OmnibusReader.setTheme(\(settings.theme.jsQuoted))")
         }
-        if settings.fontFamily != old.fontFamily {
-            run("OmnibusReader.setFont(\(settings.fontFamily.jsQuoted))")
+        if settings.fontFamily != shown.fontFamily {
+            scripts.append("OmnibusReader.setFont(\(settings.fontFamily.jsQuoted))")
         }
-        if settings.lineHeight != old.lineHeight {
-            run("OmnibusReader.setLineHeight(\(settings.lineHeight))")
+        if settings.lineHeight != shown.lineHeight {
+            scripts.append("OmnibusReader.setLineHeight(\(settings.lineHeight))")
         }
-        if settings.margins != old.margins {
-            run("OmnibusReader.setMargins(\(settings.margins.css.jsQuoted))")
+        if settings.margins != shown.margins {
+            scripts.append("OmnibusReader.setMargins(\(settings.margins.css.jsQuoted))")
         }
-        if settings.justify != old.justify {
-            run("OmnibusReader.setJustify(\(settings.justify))")
+        if settings.justify != shown.justify {
+            scripts.append("OmnibusReader.setJustify(\(settings.justify))")
         }
-        if settings.spread != old.spread {
-            run("OmnibusReader.setSpread(\(settings.spread.css.jsQuoted))")
+        if settings.spread != shown.spread {
+            scripts.append("OmnibusReader.setSpread(\(settings.spread.css.jsQuoted))")
         }
+        return scripts
     }
 
     fileprivate func run(_ script: String) {
@@ -525,6 +555,10 @@ final class ReaderController: NSObject {
     fileprivate func bootReader() {
         guard let script = bootScript() else { return }
         run(script)
+        // `bootScript` baked the settings in force into its options, so the page
+        // answering this call is showing exactly these — and a change arriving
+        // before it reports ready is a diff against them.
+        appliedSettings = settings
     }
 
     /// The `OmnibusReader.init` call that boots the page, at `restoreCFI` and in
@@ -573,6 +607,10 @@ final class ReaderController: NSObject {
             case "ready":
                 isReady = true
                 failed = false
+                // A setting changed between this page's boot snapshot and its
+                // first paint reaches it here, or not at all until the next
+                // reboot (#2191).
+                syncSettings()
                 for highlight in pendingHighlights {
                     guard let cfiRange = highlight.epubCFIRange else { continue }
                     addAnnotation(

--- a/omnibus-ios/omnibus/Reader/ReaderWebView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderWebView.swift
@@ -311,7 +311,10 @@ final class ReaderController: NSObject {
     /// lands (#2191).
     private(set) var appliedSettings: ReaderSettings?
 
-    fileprivate var webView: WKWebView?
+    /// Internal rather than fileprivate so a test can stand a controller up with
+    /// a real page attached — `hasLivePage` gates the settings handover on it,
+    /// so a controller without one can't be driven through that path at all.
+    var webView: WKWebView?
     private var book: Book?
     /// Where a boot of the page picks up — the position the book opened at,
     /// then every position the reader reaches.
@@ -334,8 +337,11 @@ final class ReaderController: NSObject {
     /// same reclaim. Settled by `reloadIfNeeded` on the way back.
     private(set) var awaitingReload = false
 
-    override init() {
-        settings = ReaderSettings.load()
+    /// `settings` is a parameter so a test can pin the typography instead of
+    /// inheriting whatever the host's stored blob holds — every controller in a
+    /// suite otherwise reads one shared `UserDefaults` key.
+    init(settings: ReaderSettings = .load()) {
+        self.settings = settings
         super.init()
     }
 
@@ -506,6 +512,14 @@ final class ReaderController: NSObject {
         drawnHighlights = []
     }
 
+    /// Whether a page is up and holding our typography.
+    ///
+    /// Both halves are needed and each is dropped by a different path — a
+    /// reclaimed process clears `isReady` and leaves the view, a teardown clears
+    /// the view and leaves `isReady`. Asking one is how a half-dead page gets
+    /// treated as live.
+    private var hasLivePage: Bool { webView != nil && isReady }
+
     /// Bring the page up to the settings in force, if it isn't already there.
     ///
     /// Runs both when a setting changes and when a page reports ready. A boot
@@ -514,46 +528,69 @@ final class ReaderController: NSObject {
     /// nowhere else — dropping it left the sheet showing one size and the page
     /// rendering another until the next reboot (#2191).
     private func syncSettings() {
-        guard isReady, let shown = appliedSettings, shown != settings else { return }
-        for script in settingsScripts(from: shown) { run(script) }
+        guard hasLivePage, let shown = appliedSettings, shown != settings else { return }
+        for script in Self.settingsScripts(from: shown, to: settings) { run(script) }
         appliedSettings = settings
     }
 
-    /// The calls that bring a page showing `shown` up to the settings in force.
+    /// The calls that bring a page showing `shown` up to `wanted`.
     ///
-    /// Pure, so what a sync would send is assertable without a web view.
-    func settingsScripts(from shown: ReaderSettings) -> [String] {
+    /// Static, so it is genuinely a function of its two arguments — no
+    /// controller, no stored settings, and nothing to build in order to assert
+    /// what a sync would send.
+    static func settingsScripts(
+        from shown: ReaderSettings, to wanted: ReaderSettings
+    ) -> [String] {
         var scripts: [String] = []
-        if settings.fontSize != shown.fontSize {
-            scripts.append("OmnibusReader.setFontSize(\(settings.fontSize))")
+        if wanted.fontSize != shown.fontSize {
+            scripts.append("OmnibusReader.setFontSize(\(wanted.fontSize))")
         }
-        if settings.theme != shown.theme {
-            scripts.append("OmnibusReader.setTheme(\(settings.theme.jsQuoted))")
+        if wanted.theme != shown.theme {
+            scripts.append("OmnibusReader.setTheme(\(wanted.theme.jsQuoted))")
         }
-        if settings.fontFamily != shown.fontFamily {
-            scripts.append("OmnibusReader.setFont(\(settings.fontFamily.jsQuoted))")
+        if wanted.fontFamily != shown.fontFamily {
+            scripts.append("OmnibusReader.setFont(\(wanted.fontFamily.jsQuoted))")
         }
-        if settings.lineHeight != shown.lineHeight {
-            scripts.append("OmnibusReader.setLineHeight(\(settings.lineHeight))")
+        if wanted.lineHeight != shown.lineHeight {
+            scripts.append("OmnibusReader.setLineHeight(\(wanted.lineHeight))")
         }
-        if settings.margins != shown.margins {
-            scripts.append("OmnibusReader.setMargins(\(settings.margins.css.jsQuoted))")
+        if wanted.margins != shown.margins {
+            scripts.append("OmnibusReader.setMargins(\(wanted.margins.css.jsQuoted))")
         }
-        if settings.justify != shown.justify {
-            scripts.append("OmnibusReader.setJustify(\(settings.justify))")
+        if wanted.justify != shown.justify {
+            scripts.append("OmnibusReader.setJustify(\(wanted.justify))")
         }
-        if settings.spread != shown.spread {
-            scripts.append("OmnibusReader.setSpread(\(settings.spread.css.jsQuoted))")
+        if wanted.spread != shown.spread {
+            scripts.append("OmnibusReader.setSpread(\(wanted.spread.css.jsQuoted))")
         }
         return scripts
     }
 
+    #if DEBUG
+    /// Scripts handed to the page, newest last — a test seam, read by nothing in
+    /// the app. Capped, because a reading session evaluates one of these per page
+    /// turn and an unbounded log would be a leak in every debug build.
+    ///
+    /// It exists because a settings sync's whole job is the JS it emits, and
+    /// asserting only the bookkeeping that follows leaves the emission itself
+    /// free to be deleted with the suite still green.
+    private(set) var evaluatedScripts: [String] = []
+    private static let evaluatedScriptsCap = 64
+    #endif
+
     fileprivate func run(_ script: String) {
+        #if DEBUG
+        evaluatedScripts.append(script)
+        if evaluatedScripts.count > Self.evaluatedScriptsCap { evaluatedScripts.removeFirst() }
+        #endif
         webView?.evaluateJavaScript(script)
     }
 
     fileprivate func bootReader() {
-        guard let script = bootScript() else { return }
+        // No page means nothing received the boot, so nothing may be recorded as
+        // holding it — a `hostReady` still in flight when the reader tore down
+        // would otherwise re-arm the diff base against a page that is gone.
+        guard webView != nil, let script = bootScript() else { return }
         run(script)
         // `bootScript` baked the settings in force into its options, so the page
         // answering this call is showing exactly these — and a change arriving
@@ -607,10 +644,6 @@ final class ReaderController: NSObject {
             case "ready":
                 isReady = true
                 failed = false
-                // A setting changed between this page's boot snapshot and its
-                // first paint reaches it here, or not at all until the next
-                // reboot (#2191).
-                syncSettings()
                 for highlight in pendingHighlights {
                     guard let cfiRange = highlight.epubCFIRange else { continue }
                     addAnnotation(
@@ -621,6 +654,19 @@ final class ReaderController: NSObject {
                 }
                 drawnHighlights = pendingHighlights.filter { $0.epubCFIRange != nil }
                 pendingHighlights = []
+                // A setting changed between this page's boot snapshot and its
+                // first paint reaches it here, or not at all until the next
+                // reboot (#2191).
+                //
+                // After the marks, not before: a size or spread change reflows
+                // the page, and this fork of the glue has no annotation repaint
+                // (the web one's `scheduleAnnotationRepaint` was never ported),
+                // so marks laid into a reflow that is still settling keep the
+                // rects they were given. Painting first makes this the same
+                // order as changing a setting with the book already open —
+                // which has the same repaint gap (#2193), but is at least the
+                // one path the reader already exercises.
+                syncSettings()
             case "error":
                 failed = true
             default:

--- a/omnibus-ios/omnibusTests/ReaderRebootTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderRebootTests.swift
@@ -5,8 +5,9 @@
 //  web-content process of an app that has been in the background a while, and
 //  `reader.html` is loaded again when the reader comes back. Every one of those
 //  boots reads the same state, so these pin what it has to be — the position the
-//  reader actually reached rather than the one the book was opened at, and the
-//  marks the outgoing page was holding (#1656).
+//  reader actually reached rather than the one the book was opened at (#1656),
+//  the marks the outgoing page was holding, and the typography in force by the
+//  time the replacement paints rather than when it started booting (#2191).
 
 import Foundation
 import Testing
@@ -203,5 +204,73 @@ struct ReaderRebootTests {
         // Otherwise the resume hook loads the page a second time, throwing away
         // the one that just came back and re-reading the book to do it.
         #expect(!controller.awaitingReload)
+    }
+
+    // MARK: - Typography handover
+
+    /// The bug. A boot bakes a *snapshot* of the settings into its options, and
+    /// a page rebooting after a backgrounding is not ready for seconds — long
+    /// enough for the reader to change a setting in a sheet that is still open
+    /// over it. Dropped, the change sat on disk while the page went on
+    /// rendering the snapshot, so the sheet read 26 and the page read 19.
+    @Test("a size changed while the page was rebooting reaches it when the page comes back")
+    func settingsChangedDuringARebootAreAppliedOnReady() {
+        withCleanReaderSettings {
+            let controller = openReader(at: openedAt)
+            // WebKit reclaimed the process: this is the replacement's snapshot.
+            controller.handle(message: ["type": "hostReady"])
+
+            controller.settings.fontSize = 26
+
+            // Nothing can take it yet — the replacement page hasn't painted.
+            #expect(controller.appliedSettings?.fontSize == ReaderSettings().fontSize)
+
+            controller.handle(message: ["type": "status", "payload": "ready"])
+
+            #expect(controller.appliedSettings?.fontSize == 26)
+        }
+    }
+
+    @Test("a size changed while the page is up is handed over as it happens")
+    func settingsChangedWhileReadyAreAppliedImmediately() {
+        withCleanReaderSettings {
+            let controller = openReader(at: openedAt)
+
+            controller.settings.fontSize = 26
+
+            #expect(controller.appliedSettings?.fontSize == 26)
+        }
+    }
+
+    /// A sync is a diff, not a replay: re-sending a setting the page already has
+    /// costs a re-pagination for nothing.
+    @Test("a sync sends only what the page is not already showing")
+    func syncSendsOnlyTheDifference() {
+        withCleanReaderSettings {
+            let controller = ReaderController()
+            controller.settings.fontSize = 26
+
+            #expect(
+                controller.settingsScripts(from: ReaderSettings())
+                    == ["OmnibusReader.setFontSize(26)"]
+            )
+            #expect(controller.settingsScripts(from: controller.settings).isEmpty)
+        }
+    }
+
+    @Test("a torn-down page stops being a diff base")
+    func teardownDropsTheDiffBase() {
+        withCleanReaderSettings {
+            let controller = openReader(at: openedAt)
+            #expect(controller.appliedSettings != nil)
+
+            controller.teardown()
+
+            // Left standing, the next change would diff against a page that is
+            // gone and mark itself applied without ever having been sent.
+            #expect(controller.appliedSettings == nil)
+            controller.settings.fontSize = 26
+            #expect(controller.appliedSettings == nil)
+        }
     }
 }

--- a/omnibus-ios/omnibusTests/ReaderRebootTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderRebootTests.swift
@@ -12,6 +12,7 @@
 import Foundation
 import Testing
 import UIKit
+import WebKit
 
 @testable import omnibus
 
@@ -19,7 +20,10 @@ import UIKit
 private func openReader(at cfi: String?, holding highlights: [Highlight] = [])
     -> ReaderController
 {
-    let controller = ReaderController()
+    // Explicit settings, so nothing here depends on the host's stored blob — and
+    // a real web view, because the settings handover is gated on a live page.
+    let controller = ReaderController(settings: ReaderSettings())
+    controller.webView = WKWebView()
     controller.configure(
         book: Book(
             id: 1, filename: "hound.epub", title: "The Hound of the Baskervilles",
@@ -70,6 +74,9 @@ private func mark(_ range: String) -> Highlight {
 
 private let openedAt = "epubcfi(/6/14[chap07]!/4/2/2,/1:0,/1:1)"
 private let readTo = "epubcfi(/6/14[chap07]!/4/2/58,/1:0,/1:1)"
+
+/// The call a page has to receive for a size change to have actually landed.
+private let setFontSize26 = "OmnibusReader.setFontSize(26)"
 
 @Suite("Reader page reboot")
 @MainActor
@@ -224,9 +231,14 @@ struct ReaderRebootTests {
 
             // Nothing can take it yet — the replacement page hasn't painted.
             #expect(controller.appliedSettings?.fontSize == ReaderSettings().fontSize)
+            #expect(!controller.evaluatedScripts.contains(setFontSize26))
 
             controller.handle(message: ["type": "status", "payload": "ready"])
 
+            // The bookkeeping is not the fix — the page being told is. Asserting
+            // only `appliedSettings` would let the emission be deleted outright
+            // with this test still green.
+            #expect(controller.evaluatedScripts.contains(setFontSize26))
             #expect(controller.appliedSettings?.fontSize == 26)
         }
     }
@@ -238,7 +250,26 @@ struct ReaderRebootTests {
 
             controller.settings.fontSize = 26
 
+            #expect(controller.evaluatedScripts.contains(setFontSize26))
             #expect(controller.appliedSettings?.fontSize == 26)
+        }
+    }
+
+    /// The other half of the window, carried by `bootScript` reading the settings
+    /// live rather than by the sync on ready — a different mechanism, and the
+    /// more commonly hit one. Hoisting the boot options into a value captured at
+    /// `configure` time (the mistake #1656 fixed for `restoreCFI`) would
+    /// reintroduce the reported symptom with every other test still passing.
+    @Test("a size changed before the replacement page boots rides its boot options")
+    func settingsChangedBeforeHostReadyRideTheBootSnapshot() throws {
+        try withCleanReaderSettings {
+            let controller = openReader(at: openedAt)
+            controller.webContentProcessDidTerminate(state: .active)
+
+            controller.settings.fontSize = 26
+
+            let options = try bootOptions(controller)
+            #expect(options["fontSize"] as? Int == 26)
         }
     }
 
@@ -246,16 +277,14 @@ struct ReaderRebootTests {
     /// costs a re-pagination for nothing.
     @Test("a sync sends only what the page is not already showing")
     func syncSendsOnlyTheDifference() {
-        withCleanReaderSettings {
-            let controller = ReaderController()
-            controller.settings.fontSize = 26
+        var wanted = ReaderSettings()
+        wanted.fontSize = 26
 
-            #expect(
-                controller.settingsScripts(from: ReaderSettings())
-                    == ["OmnibusReader.setFontSize(26)"]
-            )
-            #expect(controller.settingsScripts(from: controller.settings).isEmpty)
-        }
+        #expect(
+            ReaderController.settingsScripts(from: ReaderSettings(), to: wanted)
+                == [setFontSize26]
+        )
+        #expect(ReaderController.settingsScripts(from: wanted, to: wanted).isEmpty)
     }
 
     @Test("a torn-down page stops being a diff base")
@@ -270,6 +299,23 @@ struct ReaderRebootTests {
             // gone and mark itself applied without ever having been sent.
             #expect(controller.appliedSettings == nil)
             controller.settings.fontSize = 26
+            #expect(controller.appliedSettings == nil)
+            #expect(!controller.evaluatedScripts.contains(setFontSize26))
+        }
+    }
+
+    /// The page posts `hostReady` before it goes away; the message lands on the
+    /// main queue after the reader has already torn down.
+    @Test("a hostReady arriving after teardown does not re-arm the diff base")
+    func lateHostReadyDoesNotRearmAfterTeardown() {
+        withCleanReaderSettings {
+            let controller = openReader(at: openedAt)
+            controller.teardown()
+
+            controller.handle(message: ["type": "hostReady"])
+
+            // Re-arming here would undo the teardown: a later change would diff
+            // against a page that does not exist and record itself as sent.
             #expect(controller.appliedSettings == nil)
         }
     }

--- a/omnibus-ios/omnibusTests/ReaderSettingsStore.swift
+++ b/omnibus-ios/omnibusTests/ReaderSettingsStore.swift
@@ -1,0 +1,38 @@
+//  ReaderSettingsStore.swift
+//  Test access to the one `UserDefaults` key the reader's typography lives in.
+//
+//  Two suites write it — the persistence tests and the reboot handover tests —
+//  and a suite's `.serialized` orders that suite's own tests and nothing else.
+//  Suites still run against each other, so the shared key needs a lock.
+
+import Foundation
+
+@testable import omnibus
+
+/// Serializes every test that touches `omnibus.readerSettings`, across suites.
+private let readerSettingsLock = NSLock()
+
+/// Runs `body` against an empty `omnibus.readerSettings`, then puts back
+/// whatever the test host held.
+///
+/// Held for the whole of `body`, not just the clear: a reader settings test
+/// that ran against another's half-written blob would fail on the other's
+/// values rather than its own.
+func withCleanReaderSettings(_ body: () throws -> Void) rethrows {
+    readerSettingsLock.lock()
+    // Registered first, so it runs last — the store is restored before the next
+    // test is let in.
+    defer { readerSettingsLock.unlock() }
+
+    let defaults = UserDefaults.standard
+    let held = defaults.data(forKey: ReaderSettings.storageKey)
+    defaults.removeObject(forKey: ReaderSettings.storageKey)
+    defer {
+        if let held {
+            defaults.set(held, forKey: ReaderSettings.storageKey)
+        } else {
+            defaults.removeObject(forKey: ReaderSettings.storageKey)
+        }
+    }
+    try body()
+}

--- a/omnibus-ios/omnibusTests/ReaderSettingsStore.swift
+++ b/omnibus-ios/omnibusTests/ReaderSettingsStore.swift
@@ -9,8 +9,11 @@ import Foundation
 
 @testable import omnibus
 
-/// Serializes every test that touches `omnibus.readerSettings`, across suites.
-private let readerSettingsLock = NSLock()
+/// Serializes the tests that read or write `omnibus.readerSettings`.
+///
+/// Recursive because a nested call is a deadlock rather than an assertion
+/// failure, and a helper that wraps itself is an easy mistake to make.
+private let readerSettingsLock = NSRecursiveLock()
 
 /// Runs `body` against an empty `omnibus.readerSettings`, then puts back
 /// whatever the test host held.
@@ -18,6 +21,15 @@ private let readerSettingsLock = NSLock()
 /// Held for the whole of `body`, not just the clear: a reader settings test
 /// that ran against another's half-written blob would fail on the other's
 /// values rather than its own.
+///
+/// `body` is deliberately **not** `async`. It runs synchronously on the caller's
+/// thread, so a holder can never suspend waiting on an actor — which is what
+/// would let a `@MainActor` suite blocked on this lock deadlock against a
+/// nonisolated one holding it. Keep it that way; a hang here has no assertion
+/// message and burns the whole CI job.
+///
+/// Only tests that touch the key need this. A controller built with explicit
+/// settings — `ReaderController(settings:)` — reads nothing and needs no guard.
 func withCleanReaderSettings(_ body: () throws -> Void) rethrows {
     readerSettingsLock.lock()
     // Registered first, so it runs last — the store is restored before the next

--- a/omnibus-ios/omnibusTests/ReaderSettingsTests.swift
+++ b/omnibus-ios/omnibusTests/ReaderSettingsTests.swift
@@ -38,23 +38,9 @@ private func decode(_ payload: [String: Any]) throws -> ReaderSettings {
     try JSONDecoder().decode(ReaderSettings.self, from: JSONSerialization.data(withJSONObject: payload))
 }
 
-/// Runs `body` against an empty `omnibus.readerSettings`, then puts back
-/// whatever the test host held.
-private func withCleanStore(_ body: () throws -> Void) rethrows {
-    let defaults = UserDefaults.standard
-    let held = defaults.data(forKey: ReaderSettings.storageKey)
-    defaults.removeObject(forKey: ReaderSettings.storageKey)
-    defer {
-        if let held {
-            defaults.set(held, forKey: ReaderSettings.storageKey)
-        } else {
-            defaults.removeObject(forKey: ReaderSettings.storageKey)
-        }
-    }
-    try body()
-}
-
-// Serialized: every test in here shares the one `UserDefaults` key.
+// Serialized: every test in here shares the one `UserDefaults` key. The store
+// is guarded by `withCleanReaderSettings`, which also holds off the reboot
+// suite — `.serialized` orders this suite's tests and nothing else.
 @Suite("Reader settings persistence", .serialized)
 struct ReaderSettingsTests {
     /// The regression itself: the payload shape a build before #2084 wrote.
@@ -135,7 +121,7 @@ struct ReaderSettingsTests {
 
     @Test("a saved blob round-trips through UserDefaults")
     func savedBlobRoundTrips() {
-        withCleanStore {
+        withCleanReaderSettings {
             stored.save()
 
             #expect(ReaderSettings.load() == stored)
@@ -146,7 +132,7 @@ struct ReaderSettingsTests {
     /// first launch after the update.
     @Test("an upgrade onto a build with a new field loads the reader's own theme")
     func upgradeLoadsTheStoredTheme() throws {
-        try withCleanStore {
+        try withCleanReaderSettings {
             var payload = fullPayload()
             payload.removeValue(forKey: "spread")
             UserDefaults.standard.set(
@@ -164,7 +150,7 @@ struct ReaderSettingsTests {
 
     @Test("nothing stored loads the defaults")
     func emptyStoreLoadsDefaults() {
-        withCleanStore {
+        withCleanReaderSettings {
             #expect(ReaderSettings.load() == ReaderSettings())
         }
     }


### PR DESCRIPTION
## Summary
- A boot bakes a *snapshot* of the reader's settings into the `OmnibusReader.init` options, and the page stays unready for seconds afterwards while it opens the archive, resolves locations, and settles a restored position — `applySettings` dropped anything changed in that window, and nothing re-asserted it once the page reported ready.
- The setting was therefore written to `UserDefaults` and never handed to the page: the sheet showed one size while the page went on rendering another, and it stayed that way until the next reboot happened to take a fresh snapshot. Reported as font size "not saving".
- That window opens on every backgrounding long enough for WebKit to reclaim the web-content process, which is exactly when a reader leaves the app and comes back with the settings sheet still up.
- `syncSettings` now diffs against `appliedSettings` — what the page was last *told* — rather than `didSet`'s `oldValue`, which forgets a pending change the moment the next one lands, and it runs on `ready` as well as on change.
- The handover is gated on `hasLivePage` (a web view **and** `isReady`). The two page-death paths each clear only their own half — `prepareForReboot` drops readiness and leaves the view, `teardown` drops the view and leaves readiness — so asking one of them is how a half-dead page gets treated as live. `bootReader` likewise refuses to arm the diff base with no web view, so a `hostReady` still in flight when the reader tore down can't re-arm it against a page that is gone.
- The font-size row gains a numeric readout matching the line-height row directly beneath it: 19 and 20 render as the same "Aa", so the preview alone can't separate two adjacent sizes.
- Distinct from #2117, which fixed the *persistence* half of this symptom (a stored blob missing a key reset all seven settings). That shipped in v0.24.13; this report is from 0.26, so the blob was decoding correctly and the loss was on the apply side.

## Test plan
- [x] `just ios-test` — full `omnibusTests` suite green.
- [x] Six tests in `ReaderRebootTests`, the suite that already owns what a boot hands the page that replaces it: both halves of the reboot window, the ready-path happy case, the send-only-the-difference contract, teardown dropping the diff base, and a late `hostReady` not re-arming it.
- [x] Mutation-checked twice. Removing the `syncSettings()` call from the `ready` handler fails the reboot-window test and nothing else. Removing the *emission* inside `syncSettings` fails both tests that assert the emitted call, while the boot-snapshot and teardown tests correctly stay green.
- [x] Rendered the sheet on an iPhone 17 Pro simulator, before and after the review changes. This caught a bug nothing else would have: the number is the most compressible view in a tight row, so it wrapped to a digit per line until it was pinned.

## Version
- [x] **Patch** — the default; a bug fix plus a small readout, no schema or wire change.

## Notes
- **Re-sync runs after the pending marks are painted, not before.** A size or spread change reflows the page, and this fork of the glue has no annotation repaint — the web fork's `scheduleAnnotationRepaint` has 11 call sites and was never ported, so marks laid into a reflow that is still settling keep the rects they were given. Painting first puts the reboot path on the same ordering as changing a setting with the book already open. That path has the same gap, which is pre-existing and filed as #2193.
- **`settingsScripts` is static.** It was documented "pure" while reading `self.settings` for one side of the comparison, which made the asymmetry a hidden argument; as a static it needs no controller, and so the diff test touches no `UserDefaults`.
- **The suite asserts the emitted JS, not just the bookkeeping.** `appliedSettings` is set whether or not the call went out, so the original tests would have stayed green with the emission deleted outright. `ReaderController` keeps a bounded, `#if DEBUG` record of what it handed the page; nothing in the app reads it.
- **`ReaderController.init` takes explicit settings**, so the reboot tests no longer read the shared `omnibus.readerSettings` key at all — ten of them did, via `ReaderController()`, outside any guard. `withCleanReaderSettings` now guards only the tests that write it, and its lock is recursive.
- Concurrency warnings on `UIApplication.shared.applicationState` at `ReaderWebView.swift:482`/`:494` are pre-existing on `main` and untouched by this branch.

>[!WARNING]
> The apply-side gap fixed here has the right timing signature for the report that prompted it, but it was not reproduced on the reporter's device. Because the value on disk was always correct, this defect alone predicts "I changed it and the page ignored me" rather than a permanent revert. If the symptom survives this build, the next diagnostic is whether the *sheet* still shows the reader's chosen size while the page renders a different one.

Closes #2191