### PR TITLE
chore: rename the widget profile secret to IOS_WIDGETS_PROVISIONING_PROFILE_BASE64

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -27,7 +27,7 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 #     ASC_ISSUER_ID                     App Store Connect API issuer ID
 #   Per-app (a profile is bound to one bundle ID):
 #     IOS_PROVISIONING_PROFILE_BASE64   App Store profile for com.omnibus.mobile
-#     IOS_WIDGET_PROVISIONING_PROFILE_BASE64
+#     IOS_WIDGETS_PROVISIONING_PROFILE_BASE64
 #                                       App Store profile for
 #                                       com.omnibus.mobile.OmnibusWidgets
 #
@@ -128,7 +128,7 @@ jobs:
           cert-p12-base64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
           cert-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
           profile-base64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
-          extension-profile-base64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64 }}
+          extension-profile-base64: ${{ secrets.IOS_WIDGETS_PROVISIONING_PROFILE_BASE64 }}
           expected-team: ${{ env.DEVELOPMENT_TEAM }}
 
       # Archive unsigned. Signing settings passed on the xcodebuild command line
@@ -178,7 +178,7 @@ jobs:
           # the cause rather than letting -exportArchive report the appex as
           # simply unprovisioned.
           if [ -z "$WIDGET_PROFILE_NAME" ]; then
-            echo "::error::IOS_WIDGET_PROVISIONING_PROFILE_BASE64 is not set. The app embeds $WIDGET_BUNDLE_ID, and manual signing needs a profile per embedded bundle."
+            echo "::error::IOS_WIDGETS_PROVISIONING_PROFILE_BASE64 is not set. The app embeds $WIDGET_BUNDLE_ID, and manual signing needs a profile per embedded bundle."
             exit 1
           fi
           pb "Add :provisioningProfiles:$WIDGET_BUNDLE_ID string $WIDGET_PROFILE_NAME"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -430,7 +430,7 @@ books.
 
 **TestFlight release requires a second provisioning profile.** A profile is
 bound to one bundle ID and the app now embeds `com.omnibus.mobile.OmnibusWidgets`,
-so `IOS_WIDGET_PROVISIONING_PROFILE_BASE64` sits alongside
+so `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` sits alongside
 `IOS_PROVISIONING_PROFILE_BASE64` and `ExportOptions.plist` carries a
 `provisioningProfiles` entry per embedded bundle. Both App IDs must also carry
 the App Groups capability for `group.com.omnibus.mobile` — which means the

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -119,7 +119,7 @@ force quit.
 
 > **Releasing needs a second provisioning profile.** One profile covers one
 > bundle ID, and the app now embeds `com.omnibus.mobile.OmnibusWidgets`, so
-> TestFlight wants `IOS_WIDGET_PROVISIONING_PROFILE_BASE64` beside the existing
+> TestFlight wants `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` beside the existing
 > secret — and both App IDs need the App Groups capability, so the app's own
 > profile must be *regenerated* rather than reused. `just ios-build` and
 > `just ios-test` cannot catch a mistake here: simulator builds sign ad-hoc.


### PR DESCRIPTION
## Summary
- Renames the widget's provisioning-profile secret from `IOS_WIDGET_PROVISIONING_PROFILE_BASE64` to **`IOS_WIDGETS_PROVISIONING_PROFILE_BASE64`**, matching the target and the bundle id it provisions — both of which are plural (`OmnibusWidgets`, `com.omnibus.mobile.OmnibusWidgets`).
- Three references move together: the `secrets.` lookup feeding the `ios-signing` action, the missing-secret error message, and the required-secrets list in the workflow header. The prose in `omnibus-ios/README.md` and `docs/architecture.md` follows.
- The composite action is deliberately untouched: its input is `extension-profile-base64`, which names the *role* rather than the secret, so it stays correct for any future extension without a rename.
- **Only free to do right now.** The secret does not exist yet — #2187 introduced the reference but nobody has created the value, so this is a rename on paper. Once it holds a profile, changing the name means re-uploading one.

## Test plan
- [x] `.github/workflows/testflight.yml` still parses as YAML.
- [x] No reference to the old name survives anywhere in the repo (`grep -rn IOS_WIDGET_PROVISIONING`).
- [ ] **Not verifiable before merge:** the TestFlight lane is `workflow_dispatch`-only and has never run with an embedded extension, so the first dispatch after the secrets exist is what proves the two-profile export. A missing or misnamed secret now fails with an error naming the bundle it could not provision, rather than an opaque `-exportArchive` failure.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — touches only `.github/` and `*.md`, which the release workflow skips automatically. Ticked to say that is intended rather than overlooked.

## Notes
- Follow-up to #2187, which merged while this was being prepared — so it targets `main` directly rather than stacking.
- Nothing else needs doing after merging: the name is only read at TestFlight dispatch time, and no build artifact embeds it.
