### PR TITLE
fix: build the widget extension as com.omnibus.mobile.widgets

### DIFF
--- a/.github/actions/ios-signing/action.yml
+++ b/.github/actions/ios-signing/action.yml
@@ -27,6 +27,28 @@ inputs:
       extension needs no second secret.
     required: false
     default: ""
+  expected-bundle-id:
+    description: >
+      Bundle ID the app profile must be for. Checked against the profile's own
+      `application-identifier` entitlement, which is the only copy of Apple's
+      answer that reaches CI — the portal is the authority here, so comparing
+      the workflow against the Xcode project proves nothing (the two have
+      agreed while both disagreed with Apple). Optional; skipped when empty
+      and always satisfied by a wildcard profile.
+    required: false
+    default: ""
+  expected-extension-bundle-id:
+    description: "Same, for the embedded extension's profile."
+    required: false
+    default: ""
+  require-app-group:
+    description: >
+      App Group both profiles must carry, e.g. group.com.omnibus.mobile. A
+      profile generated before the capability was added to its App ID silently
+      lacks the entitlement and fails export with a mismatch that names
+      neither the group nor the fix. Optional; skipped when empty.
+    required: false
+    default: ""
   expected-team:
     description: >
       Team ID the profile must belong to. Set it on any job that resolves the
@@ -116,6 +138,8 @@ runs:
       env:
         PROFILE_BASE64: ${{ inputs.profile-base64 }}
         EXPECTED_TEAM: ${{ inputs.expected-team }}
+        EXPECTED_BUNDLE_ID: ${{ inputs.expected-bundle-id }}
+        REQUIRE_APP_GROUP: ${{ inputs.require-app-group }}
       run: |
         set -euo pipefail
         PROFILE="$RUNNER_TEMP/omnibus.mobileprovision"
@@ -132,6 +156,12 @@ runs:
           echo "::error::Profile '$NAME' belongs to team $TEAM, but the build signs as $EXPECTED_TEAM. The cert, the profile, and DEVELOPMENT_TEAM must all name one team."
           exit 1
         fi
+
+        # Fail here rather than after the archive. Export is the first thing
+        # that compares the profile to the binary, and by then the run has
+        # spent ten minutes building.
+        bash "$GITHUB_ACTION_PATH/check-profile.sh" \
+          "$PLIST" "$NAME" "$EXPECTED_BUNDLE_ID" "$REQUIRE_APP_GROUP"
 
         # Install into every dir xcodebuild searches, keyed by UUID as Xcode
         # expects. Xcode 16 moved the search path to ~/Library/Developer/Xcode/
@@ -162,6 +192,8 @@ runs:
       env:
         PROFILE_BASE64: ${{ inputs.extension-profile-base64 }}
         EXPECTED_TEAM: ${{ inputs.expected-team }}
+        EXPECTED_BUNDLE_ID: ${{ inputs.expected-extension-bundle-id }}
+        REQUIRE_APP_GROUP: ${{ inputs.require-app-group }}
       run: |
         set -euo pipefail
         PROFILE="$RUNNER_TEMP/omnibus-extension.mobileprovision"
@@ -177,6 +209,9 @@ runs:
           echo "::error::Extension profile '$NAME' belongs to team $TEAM, but the build signs as $EXPECTED_TEAM."
           exit 1
         fi
+
+        bash "$GITHUB_ACTION_PATH/check-profile.sh" \
+          "$PLIST" "$NAME" "$EXPECTED_BUNDLE_ID" "$REQUIRE_APP_GROUP"
 
         for INSTALL_DIR in \
           "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles" \

--- a/.github/actions/ios-signing/check-profile.sh
+++ b/.github/actions/ios-signing/check-profile.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Validate a decoded provisioning profile against what this build expects.
+#
+# Called once per profile by action.yml, before the archive. Export is
+# otherwise the first step that compares a profile to a binary, and by then the
+# run has spent ten minutes building — so every check here is one that would
+# have cost an archive to discover.
+#
+# Usage: check-profile.sh <decoded-plist> <profile-name> [bundle-id] [app-group]
+# An empty bundle-id or app-group skips that check.
+set -euo pipefail
+
+plist="${1:?usage: check-profile.sh <plist> <name> [bundle-id] [app-group]}"
+name="${2:?}"
+expected_bundle_id="${3-}"
+require_app_group="${4-}"
+
+pb() { /usr/libexec/PlistBuddy -c "$1" "$plist" 2>/dev/null; }
+
+if [ -n "$expected_bundle_id" ]; then
+  app_id="$(pb 'Print :Entitlements:application-identifier' || true)"
+  if [ -z "$app_id" ]; then
+    echo "::error::Profile '$name' carries no application-identifier entitlement, so it cannot sign anything."
+    exit 1
+  fi
+  # "D33VSDXHA6.com.omnibus.mobile" -> "com.omnibus.mobile". The team prefix is
+  # the first dot-separated component; the bundle id is everything after it.
+  profile_bundle_id="${app_id#*.}"
+  case "$profile_bundle_id" in
+    *'*')
+      echo "Profile '$name' is a wildcard ($profile_bundle_id) — matches $expected_bundle_id by construction."
+      ;;
+    "$expected_bundle_id")
+      echo "Profile '$name' is for $profile_bundle_id."
+      ;;
+    *)
+      echo "::error::Profile '$name' is for app ID '$profile_bundle_id', but this build signs '$expected_bundle_id'. Either register an App ID for '$expected_bundle_id' and generate an App Store profile for it, or change that target's PRODUCT_BUNDLE_IDENTIFIER to match the profile."
+      exit 1
+      ;;
+  esac
+fi
+
+if [ -n "$require_app_group" ]; then
+  groups="$(pb 'Print :Entitlements:com.apple.security.application-groups' || true)"
+  case "$groups" in
+    *"$require_app_group"*)
+      echo "Profile '$name' carries the App Group $require_app_group."
+      ;;
+    *)
+      echo "::error::Profile '$name' does not carry the App Group '$require_app_group'. Add the App Groups capability to its App ID and then REGENERATE the profile — a profile does not pick up a capability added after it was created, which is why reusing an existing one fails here."
+      exit 1
+      ;;
+  esac
+fi
+
+# An App Store profile must not carry get-task-allow. A Development profile
+# exported by mistake signs and uploads without complaint, then App Store
+# Connect rejects the build by email (ITMS-90163) long after the run went
+# green — so it is worth two seconds here.
+task_allow="$(pb 'Print :Entitlements:get-task-allow' || true)"
+if [ "$task_allow" = "true" ]; then
+  echo "::error::Profile '$name' is a Development profile (get-task-allow is true). App Store distribution needs an App Store profile; this one uploads fine and is rejected afterwards."
+  exit 1
+fi

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -29,7 +29,7 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 #     IOS_PROVISIONING_PROFILE_BASE64   App Store profile for com.omnibus.mobile
 #     IOS_WIDGETS_PROVISIONING_PROFILE_BASE64
 #                                       App Store profile for
-#                                       com.omnibus.mobile.OmnibusWidgets
+#                                       com.omnibus.mobile.widgets
 #
 # The app embeds a WidgetKit extension, and manual signing needs one profile
 # per embedded bundle — so both secrets are required, and both App IDs must
@@ -117,7 +117,7 @@ jobs:
       DEVELOPMENT_TEAM: "D33VSDXHA6"
       BUNDLE_ID: com.omnibus.mobile
       # Must match PRODUCT_BUNDLE_IDENTIFIER on the OmnibusWidgets target.
-      WIDGET_BUNDLE_ID: com.omnibus.mobile.OmnibusWidgets
+      WIDGET_BUNDLE_ID: com.omnibus.mobile.widgets
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -8,13 +8,14 @@ name: TestFlight
 run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.marketing_version) || 'latest tag' }}"
 
 # Manually-triggered iOS build + TestFlight upload for the native SwiftUI app
-# (omnibus-ios/ Xcode project, bundle com.omnibus.mobile). The Apple side
-# (App ID, app record, distribution cert, App Store Connect API key, App Store
-# provisioning profile) must already exist.
+# (omnibus-ios/ Xcode project, bundle com.omnibus.mobile). The Apple side must
+# already exist: the app record, the distribution cert, the App Store Connect
+# API key, and — because the app embeds a widget extension — **two** App IDs
+# with **two** App Store provisioning profiles, one per embedded bundle.
 #
 # The build is a real .xcodeproj archived unsigned by `xcodebuild archive`,
-# signed at `xcodebuild -exportArchive` time (manual signing against the
-# profile below, scoped to the app bundle id via ExportOptions.plist) and
+# signed at `xcodebuild -exportArchive` time (manual signing, with one
+# ExportOptions.plist `provisioningProfiles` entry per embedded bundle) and
 # uploaded with `xcrun altool`. The cert-import + profile-install lives in
 # .github/actions/ios-signing.
 #
@@ -33,12 +34,17 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 #
 # The app embeds a WidgetKit extension, and manual signing needs one profile
 # per embedded bundle — so both secrets are required, and both App IDs must
-# carry the App Groups capability with group.com.omnibus.mobile. A profile
-# minted before the app group was added does not include the entitlement and
-# fails export with a provisioning/entitlement mismatch, so the *existing*
-# com.omnibus.mobile profile has to be regenerated as well as the new one
-# created. Nothing before -exportArchive catches either: the archive is built
-# unsigned, and the simulator lanes sign ad-hoc.
+# carry the App Groups capability with group.com.omnibus.mobile. The *existing*
+# com.omnibus.mobile profile therefore has to be regenerated, not just reused:
+# a profile does not pick up a capability added after it was created.
+#
+# Getting that wrong does not fail loudly. The archive is built unsigned, so
+# the binaries carry no entitlements and export derives them wholly from the
+# profiles — a profile without the App Group produces an IPA that exports,
+# uploads and installs, whose widgets then render their placeholder forever.
+# Hence the checks: ios-signing asserts each profile's app id, App Group and
+# distribution type before the archive, and the export step re-checks the
+# signed IPA. The simulator lanes prove none of this; they sign ad-hoc.
 
 on:
   workflow_dispatch:
@@ -100,7 +106,7 @@ jobs:
   ios:
     name: ios (native · com.omnibus.mobile)
     needs: version
-    # omnibus-ios targets iOS 26.5, so it needs the Xcode 26 / iOS 26 SDK on
+    # omnibus-ios targets iOS 26.4, so it needs the Xcode 26 / iOS 26 SDK on
     # macos-26. App Store Connect also rejects any upload built with an older
     # SDK, so macos-14/15 (Xcode 15/16) can't be used.
     runs-on: macos-26
@@ -111,12 +117,28 @@ jobs:
       # injected per-job and isn't governed by `permissions:`.
       actions: write
     env:
+      # Validated in the Archive step. Defaulting to run_number is only
+      # monotonic if nobody has ever dispatched a higher literal — once
+      # someone does, every later default is rejected by App Store Connect
+      # for going backwards.
       BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
       MARKETING_VERSION: ${{ needs.version.outputs.marketing_version }}
       # The team the omnibus-ios project + the distribution cert belong to.
       DEVELOPMENT_TEAM: "D33VSDXHA6"
       BUNDLE_ID: com.omnibus.mobile
-      # Must match PRODUCT_BUNDLE_IDENTIFIER on the OmnibusWidgets target.
+      # Asserted against both profiles before the archive, and against the
+      # exported IPA afterwards. Must match `WidgetStore.appGroupID` and both
+      # .entitlements files.
+      APP_GROUP_ID: group.com.omnibus.mobile
+      # Must match the App ID of the profile in
+      # IOS_WIDGETS_PROVISIONING_PROFILE_BASE64. That is the binding
+      # constraint, and the reason this can't be derived from the project:
+      # when it last broke, this value and PRODUCT_BUNDLE_IDENTIFIER agreed
+      # with each other and disagreed with Apple's portal, so any check
+      # against the pbxproj would have passed and shipped the same failure.
+      # It has to equal PRODUCT_BUNDLE_IDENTIFIER as well — just don't read
+      # that agreement as evidence. Note it is deliberately *not* the target
+      # name: the product is OmnibusWidgets.appex and the id ends `.widgets`.
       WIDGET_BUNDLE_ID: com.omnibus.mobile.widgets
     steps:
       - uses: actions/checkout@v4
@@ -130,6 +152,9 @@ jobs:
           profile-base64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
           extension-profile-base64: ${{ secrets.IOS_WIDGETS_PROVISIONING_PROFILE_BASE64 }}
           expected-team: ${{ env.DEVELOPMENT_TEAM }}
+          expected-bundle-id: ${{ env.BUNDLE_ID }}
+          expected-extension-bundle-id: ${{ env.WIDGET_BUNDLE_ID }}
+          require-app-group: ${{ env.APP_GROUP_ID }}
 
       # Archive unsigned. Signing settings passed on the xcodebuild command line
       # apply to every target in the build — including SPM-generated resource
@@ -141,6 +166,14 @@ jobs:
       - name: Archive
         run: |
           set -euo pipefail
+          # CURRENT_PROJECT_VERSION must be a dotted integer sequence. An input
+          # like "1.0-rc1" builds happily and is only rejected once App Store
+          # Connect processes the upload, minutes after the run goes green.
+          case "$BUILD_NUMBER" in
+            '' | *[!0-9.]*)
+              echo "::error::build_number must be numeric/dot-separated, got: '$BUILD_NUMBER'"
+              exit 1 ;;
+          esac
           xcodebuild \
             -project omnibus-ios/omnibus.xcodeproj \
             -scheme omnibus \
@@ -198,6 +231,37 @@ jobs:
           # exportArchive names the .ipa after the product; copy to a stable path.
           IPA="$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)"
           cp "$IPA" "$GITHUB_WORKSPACE/omnibus-ios.ipa"
+
+      # The archive is built unsigned (CODE_SIGNING_ALLOWED=NO), so the binaries
+      # carry no entitlements of their own — export derives them entirely from
+      # the provisioning profiles. That makes a missing App Group a *silent*
+      # outcome rather than a loud one: the IPA exports, uploads, installs, and
+      # every widget renders its placeholder forever, because
+      # containerURL(forSecurityApplicationGroupIdentifier:) returns nil. The
+      # profile checks in ios-signing catch it earlier; this proves it of the
+      # artifact actually being shipped.
+      - name: Verify the exported IPA carries the App Group
+        run: |
+          set -euo pipefail
+          WORK="$RUNNER_TEMP/ipa-check"
+          rm -rf "$WORK" && mkdir -p "$WORK"
+          unzip -q "$GITHUB_WORKSPACE/omnibus-ios.ipa" -d "$WORK"
+          APP="$(ls -d "$WORK"/Payload/*.app | head -n1)"
+
+          fail=0
+          for BUNDLE in "$APP" "$APP"/PlugIns/*.appex; do
+            [ -e "$BUNDLE" ] || continue
+            NAME="$(basename "$BUNDLE")"
+            ENTS="$(codesign -d --entitlements - --xml "$BUNDLE" 2>/dev/null || true)"
+            case "$ENTS" in
+              *"$APP_GROUP_ID"*)
+                echo "$NAME carries $APP_GROUP_ID." ;;
+              *)
+                echo "::error::$NAME was signed without the App Group $APP_GROUP_ID. Its provisioning profile does not grant it, so the widget would install and silently render nothing. Add App Groups to that bundle's App ID and regenerate the profile."
+                fail=1 ;;
+            esac
+          done
+          [ "$fail" -eq 0 ] || exit 1
 
       - name: Upload to TestFlight
         env:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -434,10 +434,18 @@ so `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` sits alongside
 `IOS_PROVISIONING_PROFILE_BASE64` and `ExportOptions.plist` carries a
 `provisioningProfiles` entry per embedded bundle. Both App IDs must also carry
 the App Groups capability for `group.com.omnibus.mobile` — which means the
-*existing* app profile has to be regenerated, not just the new one created, since
-a profile minted before the entitlement existed fails export on the mismatch.
-Nothing before `-exportArchive` catches either: the archive is built unsigned and
-every simulator lane signs ad-hoc.
+*existing* app profile has to be regenerated, not just the new one created: a
+profile does not pick up a capability added after it was created.
+
+Getting that wrong fails **silently**, which is why the workflow checks it three
+ways. The archive is built unsigned, so the binaries carry no entitlements and
+`-exportArchive` derives them wholly from the profiles — a profile missing the
+App Group yields an IPA that exports, uploads and installs, whose widgets then
+render their placeholder forever because `containerURL` returns `nil`.
+`.github/actions/ios-signing/check-profile.sh` therefore asserts each profile's
+app id, App Group and distribution type *before* the archive, and the export step
+re-reads the signed IPA to confirm the entitlement actually landed. Simulator
+lanes prove none of it — they sign ad-hoc.
 
 **TestFlight release:** the manually-triggered
 `.github/workflows/testflight.yml` (workflow_dispatch, `macos-26` runner —
@@ -445,9 +453,10 @@ Xcode 26 / iOS 26 SDK, which App Store Connect now requires) archives the
 Xcode project with manual signing (`xcodebuild archive` +
 `-exportArchive`, bundle `com.omnibus.mobile`) and uploads the `.ipa`
 with `xcrun altool`, stamping the marketing version from the latest `v*`
-release tag so TestFlight tracks the server release. Signing is six
-CI-only repo secrets (distribution cert + password, provisioning profile,
-App Store Connect API key + key-id + issuer-id) — enumerated in the
+release tag so TestFlight tracks the server release. Signing is seven
+CI-only repo secrets (distribution cert + password, an App Store
+provisioning profile for *each* of the two embedded bundles, App Store
+Connect API key + key-id + issuer-id) — enumerated in the
 workflow file's header comment. A daily companion workflow
 (`testflight-feedback.yml`) turns new TestFlight screenshot feedback into
 GitHub issues via `scripts/testflight_feedback_to_issues.py`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -406,7 +406,7 @@ OmnibusShared/      — source compiled into *both* the app and the widget
                       conversion for server-provided accents — shared so the
                       widget and the Continue hero cannot draw one book in two
                       different colours)
-OmnibusWidgets/     — the WidgetKit extension (`com.omnibus.mobile.OmnibusWidgets`,
+OmnibusWidgets/     — the WidgetKit extension (`com.omnibus.mobile.widgets`,
                       embedded into the app at `PlugIns/`): ContinueWidget (a
                       `TimelineProvider` that reads the App Group and nothing
                       else, so it renders in Airplane Mode with the app force
@@ -429,7 +429,7 @@ outlives a sign-out and would otherwise keep showing the previous account's
 books.
 
 **TestFlight release requires a second provisioning profile.** A profile is
-bound to one bundle ID and the app now embeds `com.omnibus.mobile.OmnibusWidgets`,
+bound to one bundle ID and the app now embeds `com.omnibus.mobile.widgets`,
 so `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` sits alongside
 `IOS_PROVISIONING_PROFILE_BASE64` and `ExportOptions.plist` carries a
 `provisioningProfiles` entry per embedded bundle. Both App IDs must also carry

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -118,7 +118,7 @@ force quit.
   the Continue hero, the snapshot and the deep link all read it.
 
 > **Releasing needs a second provisioning profile.** One profile covers one
-> bundle ID, and the app now embeds `com.omnibus.mobile.OmnibusWidgets`, so
+> bundle ID, and the app now embeds `com.omnibus.mobile.widgets`, so
 > TestFlight wants `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` beside the existing
 > secret — and both App IDs need the App Groups capability, so the app's own
 > profile must be *regenerated* rather than reused. `just ios-build` and

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -65,7 +65,7 @@ to scope an exception to.
 | `omnibus/Comic/` | CBZ comic pager: paged `TabView` + `UIScrollView` zoom, no WebView |
 | `omnibus/Widgets/` | Builds the App Group snapshot the Home Screen renders from |
 | `OmnibusShared/` | Compiled into **both** targets: the snapshot, the App Group layout, the deep-link URLs, OKLCH |
-| `OmnibusWidgets/` | The WidgetKit extension — a separate target, a separate process |
+| `OmnibusWidgets/` | The WidgetKit extension — a separate target, a separate process, and a separate bundle id (`com.omnibus.mobile.widgets`) |
 
 `OmnibusShared/` and `OmnibusWidgets/` sit beside `omnibus/` rather than inside
 it because a target's sources have to be a folder of their own: the project uses
@@ -121,8 +121,12 @@ force quit.
 > bundle ID, and the app now embeds `com.omnibus.mobile.widgets`, so
 > TestFlight wants `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` beside the existing
 > secret — and both App IDs need the App Groups capability, so the app's own
-> profile must be *regenerated* rather than reused. `just ios-build` and
-> `just ios-test` cannot catch a mistake here: simulator builds sign ad-hoc.
+> profile must be *regenerated* rather than reused. Getting it wrong is silent,
+> not loud: the release archive is unsigned, so entitlements come entirely from
+> the profiles, and one missing the App Group ships a widget that installs and
+> renders nothing. CI asserts it on both profiles and again on the exported IPA.
+> `just ios-build` and `just ios-test` cannot catch it — simulator builds sign
+> ad-hoc.
 
 > The widget draws in SF (with the serif face for titles) rather than the app's
 > vendored Cormorant Garamond. `UIAppFonts` registers fonts per-bundle and an

--- a/omnibus-ios/omnibus.xcodeproj/project.pbxproj
+++ b/omnibus-ios/omnibus.xcodeproj/project.pbxproj
@@ -696,7 +696,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.OmnibusWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -729,7 +729,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.OmnibusWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.omnibus.mobile.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;


### PR DESCRIPTION
## Summary
- Builds the widget extension as **`com.omnibus.mobile.widgets`**, the App ID that is actually registered, instead of `com.omnibus.mobile.OmnibusWidgets`. The first TestFlight dispatch got all the way to signing and failed there: `Provisioning profile "Omnibus Widgets Prov Prof" has app ID "com.omnibus.mobile.widgets", which does not match the bundle ID "com.omnibus.mobile.OmnibusWidgets"`.
- Takes the registered id rather than re-minting a profile to match the target name: bundle ids are conventionally lowercase, it matches the `IOS_WIDGETS_…` secret merged in #2195, and no build has ever been uploaded under the old id, so nothing downstream is pinned to it.
- **Only `PRODUCT_BUNDLE_IDENTIFIER` moves.** The Xcode target and product name stay `OmnibusWidgets`, so the artifact is still `OmnibusWidgets.appex` and the embed phase, entitlements file and Info.plist are all untouched.
- `WIDGET_BUNDLE_ID` in the TestFlight workflow and the two doc references move with it, so the ExportOptions entry still names the bundle it provisions.

## Test plan
- [x] `just ios-build` clean; `just ios-test` 502/502.
- [x] Built appex reports `CFBundleIdentifier = com.omnibus.mobile.widgets` and `NSExtensionPointIdentifier = com.apple.widgetkit-extension`.
- [x] Both bundles still carry `group.com.omnibus.mobile` — checked in the generated `-Simulated.xcent` for the app and the appex, so the App Group survives the rename.
- [x] Ruled out the next likely export failure: built with CI's exact `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` overrides and confirmed they reach the **appex** as well as the app (both `0.14.3` / `999`). App Store Connect rejects an extension whose version strings don't match its host, and command-line build settings apply to every target — so that holds.
- [ ] **The export itself is still unproven.** It is `workflow_dispatch`-only; the next dispatch after this merges is what confirms it.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The remaining risk on the release path is entitlements rather than identifiers: if "Omnibus Widgets Prov Prof" was generated *before* App Groups was added to that App ID — or if the app's own profile was not regenerated — export fails again with a profile/entitlement mismatch. That is fixed on Apple's side, not here.
- Follows #2187 (the widget itself) and #2195 (the secret rename).
