### PR TITLE
fix: validate the IPA before uploading it to TestFlight

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -270,12 +270,30 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           set -euo pipefail
+          # An empty secret otherwise writes a zero-byte .p8 and surfaces as an
+          # opaque altool authentication error rather than a named cause.
+          if [ -z "$ASC_API_KEY_BASE64" ] || [ -z "$ASC_KEY_ID" ] || [ -z "$ASC_ISSUER_ID" ]; then
+            echo "::error::One of ASC_API_KEY_BASE64 / ASC_KEY_ID / ASC_ISSUER_ID is unset."
+            exit 1
+          fi
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
           echo "$ASC_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
+          trap 'rm -f "$KEY_PATH"' EXIT
+
+          # Validate before uploading. `--upload-app` only proves the bytes
+          # arrived: everything appex-specific — entitlement validity, asset
+          # catalogue completeness, device-family and MinimumOSVersion
+          # agreement between the app and its extension — is checked
+          # asynchronously afterwards and reported by email. Without this the
+          # run goes green and the build simply never appears in TestFlight,
+          # which is indistinguishable from success right up until someone
+          # goes looking for it.
+          xcrun altool --validate-app -f "$GITHUB_WORKSPACE/omnibus-ios.ipa" -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
           xcrun altool --upload-app -f "$GITHUB_WORKSPACE/omnibus-ios.ipa" -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
-          rm -f "$KEY_PATH"
 
       - name: Upload .ipa artifact
         if: always()


### PR DESCRIPTION
## Summary
- `xcrun altool --upload-app` only confirms the bytes arrived. Everything appex-specific — entitlement validity, asset-catalogue completeness, device-family and `MinimumOSVersion` agreement between the app and its extension — is validated **asynchronously** by App Store Connect afterwards and reported by email, so a rejected build leaves the workflow **green** while the build never appears in TestFlight. That is indistinguishable from success until someone goes looking, and this app has an embedded extension for the first time — precisely what that asynchronous pass scrutinises.
- Adds `altool --validate-app` with the same arguments immediately before the upload, so a rejection fails the run that produced it.
- Guards the three ASC secrets: an empty one previously wrote a zero-byte `.p8` and surfaced as an opaque "unable to authenticate" rather than a named cause — the same guard shape the widget-profile check already uses.
- Moves the private-key cleanup to a `trap`, so the key is removed even when validation or upload fails.

## Test plan
- [x] `.github/workflows/testflight.yml` parses as YAML.
- [x] No Swift or build-setting changes, so `just ios-build` / `just ios-test` are unaffected.
- [ ] **Provable only on a real dispatch**, which is currently blocked: run 33019659916 stopped at profile validation because `Omnibus Widgets Prov Prof` carries no App Group. This PR is queued behind that Apple-side fix.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — touches only `.github/`, which the release workflow skips automatically.

## Notes
- From the release-path review of #2196; deferred there to keep that PR to the identifier fix.
- The remaining known gap is dSYMs: `destination: export` plus a bare `.ipa` means App Store Connect gets no symbols for either Mach-O, so crash reports for the app and the widget stay unsymbolicated. Not a failure, and left alone deliberately — it wants either `destination: upload` or archiving the `.xcarchive`, both of which change more of the release path than is wise while the first widget build is still unproven.