### PR TITLE
fix: decode the App Store Connect key the way that works

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -157,12 +157,24 @@ jobs:
           # the same path explicitly, so one file serves both.
           KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
           # Created empty and locked down *before* any key material lands in
-          # it, so the bytes are never briefly world-readable. `printf %s`
-          # rather than `echo`, which mangles a value beginning with `-` and
-          # interprets backslashes in some shells.
+          # it, so the bytes are never briefly world-readable.
           : > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
-          printf '%s' "$ASC_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
+          # `echo`, not `printf '%s'`. base64 wraps at 76 columns, and this
+          # secret is stored wrapped; dropping the trailing newline left the
+          # final line unterminated and `base64 -D` decoded a truncated key,
+          # which xcodebuild reported as "Authentication failed ... bearer
+          # token" rather than as a malformed file.
+          echo "$ASC_API_KEY_BASE64" | base64 -D > "$KEY_PATH"
+
+          # Prove the decode produced a key before spending ten minutes on an
+          # archive that can only fail. Deliberately tests the PEM header
+          # only — never the contents.
+          if ! grep -q -- "-----BEGIN PRIVATE KEY-----" "$KEY_PATH"; then
+            echo "::error::ASC_API_KEY_BASE64 did not decode to a PEM private key. Re-store it as the base64 of the AuthKey_*.p8 file itself, e.g. base64 -i AuthKey_XXXX.p8 | gh secret set ASC_API_KEY_BASE64."
+            exit 1
+          fi
+          echo "App Store Connect key decoded ($(wc -c < "$KEY_PATH") bytes)."
 
       # Archive with **automatic** signing, letting Xcode fetch what it needs
       # from App Store Connect via the API key.


### PR DESCRIPTION
## Summary
- Run [33022284261](https://github.com/seamus-sloan/omnibus/actions/runs/33022284261) failed the archive with `Authentication failed: Make sure a bearer token was provided, it is properly configured and signed, and it has not expired`, followed by `No profiles for 'com.omnibus.mobile.widgets' were found`. The second is a consequence of the first — unable to authenticate, Xcode fell back to looking for a locally installed profile, and automatic signing installs none.
- **The cause was mine, introduced in #2205.** Hardening the key write swapped `echo` for `printf '%s'`. `base64` wraps at 76 columns and this secret is stored wrapped, so dropping the trailing newline left the final line unterminated and `base64 -D` decoded a truncated key. `echo` is what every previous successful release used.
- Keeps the half of that change that was sound: the file is still created empty and `chmod 600` before any key material lands in it.
- Adds a PEM-header check on the decoded file, so a bad decode fails in seconds with a message naming the secret rather than ten minutes later as an opaque auth error. It greps for `-----BEGIN PRIVATE KEY-----` and reports a byte count — never any key content.

## Test plan
- [x] `.github/workflows/testflight.yml` parses as YAML.
- [x] No Swift or build-setting changes — `just ios-build` / `just ios-test` unaffected.
- [ ] **Proven only by dispatching.** This is the next iteration on getting the first widget build to TestFlight; the check added here is what will distinguish a decode problem from an authority problem if it fails again.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — touches only `.github/`, which the release workflow skips automatically.

## Notes
- If the next dispatch still reports an authentication failure *after* the PEM check passes, the key decoded fine and the remaining explanation is authority: an App Store Connect key needs the App Manager or Admin role to create or update provisioning profiles, and a Developer-role key can upload builds but not manage signing assets. That would be a key to re-issue in App Store Connect, not a change in this repo.