### PR TITLE
fix: render the real release version in the auth page footers

### DIFF
--- a/frontend/src/pages/auth/login.rs
+++ b/frontend/src/pages/auth/login.rs
@@ -346,10 +346,7 @@ fn LoginForm(props: LoginFormProps) -> Element {
                     Link { to: Route::Register {}, "Register" }
                 }
             }
-            div { class: "auth-footer-note",
-                "omnibus · v"
-                {env!("CARGO_PKG_VERSION")}
-            }
+            div { class: "auth-footer-note", {crate::version::version_line()} }
         }
     }
 }

--- a/frontend/src/pages/auth/mod.rs
+++ b/frontend/src/pages/auth/mod.rs
@@ -24,10 +24,7 @@ pub(crate) fn m_auth_shell(tagline: &str, children: Element) -> Element {
                 p { class: "m-auth-tagline", "{tagline}" }
             }
             div { class: "m-auth-body", {children} }
-            div { class: "m-auth-foot mono",
-                "omnibus · v"
-                {env!("CARGO_PKG_VERSION")}
-            }
+            div { class: "m-auth-foot mono", {crate::version::version_line()} }
         }
     }
 }

--- a/frontend/src/version.rs
+++ b/frontend/src/version.rs
@@ -4,6 +4,8 @@
 //! crate version, pinned at `0.1.0`) so `dx serve` / `cargo build` keep
 //! compiling and rendering a version string without the env var set.
 
+use std::sync::OnceLock;
+
 /// This build's own version string, always with a single leading `v` (e.g.
 /// `v0.8.9`; `v0.1.0` for a local dev build with no `OMNIBUS_VERSION` set —
 /// AC6). Docker's build-arg carries the full release tag (already
@@ -23,11 +25,13 @@ pub fn app_version() -> String {
     normalize(raw)
 }
 
-/// The `omnibus · v0.8.9` line the auth-page footers render (the web login
-/// form and the mobile auth shell), kept here so the two can't drift — and
-/// so neither re-adds the literal `v` that [`app_version`] already carries.
-pub fn version_line() -> String {
-    format!("omnibus · {}", app_version())
+/// The `omnibus · v0.8.9` line both auth-page footers render.
+///
+/// [`app_version`] already carries the leading `v`, so a caller must not add
+/// one. Computed once — the login form re-renders on every keystroke.
+pub fn version_line() -> &'static str {
+    static LINE: OnceLock<String> = OnceLock::new();
+    LINE.get_or_init(|| format!("omnibus · {}", app_version()))
 }
 
 /// Ensure `raw` has exactly one leading `v`, trimming whitespace and
@@ -51,7 +55,7 @@ mod tests {
     #[test]
     fn version_line_renders_one_v_and_no_literal_prefix() {
         let line = version_line();
-        assert_eq!(line, format!("omnibus · v{}", env!("CARGO_PKG_VERSION")));
+        assert_eq!(line, concat!("omnibus · v", env!("CARGO_PKG_VERSION")));
         assert!(!line.contains("vv"), "doubled v in {line:?}");
     }
 

--- a/frontend/src/version.rs
+++ b/frontend/src/version.rs
@@ -23,6 +23,13 @@ pub fn app_version() -> String {
     normalize(raw)
 }
 
+/// The `omnibus · v0.8.9` line the auth-page footers render (the web login
+/// form and the mobile auth shell), kept here so the two can't drift — and
+/// so neither re-adds the literal `v` that [`app_version`] already carries.
+pub fn version_line() -> String {
+    format!("omnibus · {}", app_version())
+}
+
 /// Ensure `raw` has exactly one leading `v`, trimming whitespace and
 /// collapsing any number of existing leading `v` characters (e.g. a doubled
 /// `"vv0.8.9"`) down to one.
@@ -39,6 +46,13 @@ mod tests {
         // OMNIBUS_VERSION isn't set for `cargo test`, so this pins the local
         // dev fallback (AC6): "v" + CARGO_PKG_VERSION, currently "v0.1.0".
         assert_eq!(app_version(), format!("v{}", env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn version_line_renders_one_v_and_no_literal_prefix() {
+        let line = version_line();
+        assert_eq!(line, format!("omnibus · v{}", env!("CARGO_PKG_VERSION")));
+        assert!(!line.contains("vv"), "doubled v in {line:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The web login form and the mobile auth shell interpolated `env!("CARGO_PKG_VERSION")` straight into their footers, so every deployed build read `omnibus · v0.1.0` — the crate version is pinned at `0.1.0` and the release tag only reaches the build through `OMNIBUS_VERSION`. Confirmed live on the v0.28.7 image: `/api/_health` reported `"version":"v0.28.7"` while the login footer showed v0.1.0.
- Both footers now render `version::version_line()`, a new one-line wrapper over the existing `app_version()` (added in #1055 for exactly this). The literal `"v"` prefix is dropped at both sites since `app_version()` already carries one.
- `version_line()` lives next to `app_version()` rather than in either page so the two footers — which render the identical string — can't drift, and neither can re-introduce the doubled `vv`.
- Left alone deliberately: `client_version` on the mobile login/register payloads (`frontend/src/data/auth.rs`) has the same `CARGO_PKG_VERSION` shape, but it's a stored wire field rendered in no UI, and the only build that sends it (the Android hybrid) never sets `OMNIBUS_VERSION` — switching it would just turn `0.1.0` into `v0.1.0` while diverging from the bare format the iOS client sends.

## Test plan
- [x] `cargo nextest run -p omnibus-frontend --features server` — 925 passed
- [x] `cargo nextest run -p omnibus-frontend --features mobile` — 783 passed
- [x] New `version_line_renders_one_v_and_no_literal_prefix` pins the exact string and asserts no doubled `v`
- [x] `cargo clippy` clean on both feature legs (`-D warnings`); `cargo fmt --check` clean
- [x] Compile-time plumbing proven end to end: rebuilding with `OMNIBUS_VERSION=v0.28.7` makes both version tests fail with `left: "v0.28.7"` against the pinned dev expectation of `v0.1.0`

## Version
- [x] **Patch** — the default.

## Notes
- No E2E coverage of the footer text exists today (nothing in `ui_tests/playwright` asserts it), so the footer string is guarded by the Rust test alone.