### PR TITLE
fix: sign the release archive so entitlements survive to the IPA

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -156,13 +156,26 @@ jobs:
           expected-extension-bundle-id: ${{ env.WIDGET_BUNDLE_ID }}
           require-app-group: ${{ env.APP_GROUP_ID }}
 
-      # Archive unsigned. Signing settings passed on the xcodebuild command line
-      # apply to every target in the build — including SPM-generated resource
-      # bundles (ZIPFoundation_ZIPFoundation), which reject a manually specified
-      # profile and fail the archive. Signing happens at export instead, where
-      # ExportOptions.plist scopes the profile to the app's bundle id.
+      # Archive **signed**. This used to pass CODE_SIGNING_ALLOWED=NO and leave
+      # signing to export, on the reasoning that command-line signing settings
+      # apply to every target and the SPM resource bundles reject a profile.
+      # That is true, and the conclusion was wrong: a provisioning profile is a
+      # permission *ceiling*, not a source of entitlements. Entitlements come
+      # from each target's .entitlements file when the binary is signed, so an
+      # unsigned archive carries none and -exportArchive has nothing to carry
+      # through — it re-signed with only the four baseline entitlements and
+      # dropped the App Group, producing an IPA whose widget installs and
+      # renders nothing. Verified on the artifact from run 33024849469: the
+      # embedded profile granted group.com.omnibus.mobile, the binary never
+      # claimed it.
+      #
+      # The SPM problem is avoided by setting Manual signing per-target on the
+      # Release configuration in the project rather than on this command line,
+      # so the resource bundles keep their own defaults. Debug is untouched.
+      #
       # MARKETING_VERSION + CURRENT_PROJECT_VERSION are passed as build settings
-      # so the archive is stamped without editing the pbxproj.
+      # so the archive is stamped without editing the pbxproj, and apply to every
+      # target — the appex included, which App Store Connect requires to match.
       - name: Archive
         run: |
           set -euo pipefail
@@ -181,8 +194,6 @@ jobs:
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/omnibus.xcarchive" \
             archive \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -13,11 +13,13 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 # API key, and — because the app embeds a widget extension — **two** App IDs
 # with **two** App Store provisioning profiles, one per embedded bundle.
 #
-# The build is a real .xcodeproj archived unsigned by `xcodebuild archive`,
-# signed at `xcodebuild -exportArchive` time (manual signing, with one
-# ExportOptions.plist `provisioningProfiles` entry per embedded bundle) and
-# uploaded with `xcrun altool`. The cert-import + profile-install lives in
-# .github/actions/ios-signing.
+# The build is a real .xcodeproj archived **signed** by `xcodebuild archive`,
+# re-signed for distribution at `xcodebuild -exportArchive` (manual signing,
+# one ExportOptions.plist `provisioningProfiles` entry per embedded bundle)
+# and uploaded with `xcrun altool`. Signing at archive time is what applies
+# each target's .entitlements; it is configured per-target on the Release
+# configuration in the project, not here. The cert-import + profile-install
+# lives in .github/actions/ios-signing.
 #
 # Required repository secrets:
 #   Shared (team/account-scoped):
@@ -38,13 +40,12 @@ run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.mark
 # com.omnibus.mobile profile therefore has to be regenerated, not just reused:
 # a profile does not pick up a capability added after it was created.
 #
-# Getting that wrong does not fail loudly. The archive is built unsigned, so
-# the binaries carry no entitlements and export derives them wholly from the
-# profiles — a profile without the App Group produces an IPA that exports,
-# uploads and installs, whose widgets then render their placeholder forever.
-# Hence the checks: ios-signing asserts each profile's app id, App Group and
-# distribution type before the archive, and the export step re-checks the
-# signed IPA. The simulator lanes prove none of this; they sign ad-hoc.
+# Getting that wrong does not fail loudly, so it is checked twice: ios-signing
+# asserts each profile's app id, App Group and distribution type before the
+# archive, and the export step re-reads the signed IPA. Both are needed — a
+# profile only *permits* an entitlement, the binary has to claim it, and the
+# two failures look identical from the outside. The simulator lanes prove
+# none of this; they sign ad-hoc.
 
 on:
   workflow_dispatch:
@@ -229,9 +230,10 @@ jobs:
           pb "Add :uploadSymbols bool true"
           pb "Add :destination string export"
 
-      # Signs the (unsigned) archive: cert + profile come from ExportOptions.plist,
-      # and codesign finds the identity because the ios-signing action prepended
-      # the throwaway keychain to the user search list.
+      # Re-signs the already-signed archive for distribution, scoping a profile
+      # to each embedded bundle via ExportOptions.plist. codesign finds the
+      # identity because the ios-signing action prepended the throwaway keychain
+      # to the user search list.
       - name: Export .ipa
         run: |
           set -euo pipefail
@@ -243,14 +245,13 @@ jobs:
           IPA="$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)"
           cp "$IPA" "$GITHUB_WORKSPACE/omnibus-ios.ipa"
 
-      # The archive is built unsigned (CODE_SIGNING_ALLOWED=NO), so the binaries
-      # carry no entitlements of their own — export derives them entirely from
-      # the provisioning profiles. That makes a missing App Group a *silent*
-      # outcome rather than a loud one: the IPA exports, uploads, installs, and
-      # every widget renders its placeholder forever, because
-      # containerURL(forSecurityApplicationGroupIdentifier:) returns nil. The
-      # profile checks in ios-signing catch it earlier; this proves it of the
-      # artifact actually being shipped.
+      # A profile only *permits* an entitlement; the binary has to claim it, and
+      # a binary that doesn't is indistinguishable from a correct one until the
+      # widget renders nothing on someone's Home Screen —
+      # containerURL(forSecurityApplicationGroupIdentifier:) just returns nil.
+      # The profile checks in ios-signing prove the permission exists; this
+      # proves the artifact being shipped actually used it. Run 33024849469 is
+      # why both are needed: profiles correct, binary bare.
       - name: Verify the exported IPA carries the App Group
         run: |
           set -euo pipefail

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,15 +437,18 @@ the App Groups capability for `group.com.omnibus.mobile` — which means the
 *existing* app profile has to be regenerated, not just the new one created: a
 profile does not pick up a capability added after it was created.
 
-Getting that wrong fails **silently**, which is why the workflow checks it three
-ways. The archive is built unsigned, so the binaries carry no entitlements and
-`-exportArchive` derives them wholly from the profiles — a profile missing the
-App Group yields an IPA that exports, uploads and installs, whose widgets then
-render their placeholder forever because `containerURL` returns `nil`.
-`.github/actions/ios-signing/check-profile.sh` therefore asserts each profile's
-app id, App Group and distribution type *before* the archive, and the export step
-re-reads the signed IPA to confirm the entitlement actually landed. Simulator
-lanes prove none of it — they sign ad-hoc.
+Getting that wrong fails **silently**, so it is checked from both ends. A
+provisioning profile only *permits* an entitlement — the binary has to claim it,
+which happens when the target's `.entitlements` is applied at signing time. The
+release archive is therefore signed (manual signing, set per-target on the
+**Release** configuration and scoped to `iphoneos` so simulator builds need no
+distribution credentials); an unsigned archive carries no entitlements at all and
+`-exportArchive` re-signs it with only the baseline four, which is how a correct
+profile still yields a widget that renders nothing.
+`.github/actions/ios-signing/check-profile.sh` asserts each profile's app id, App
+Group and distribution type *before* the archive, and the export step re-reads
+the signed IPA to confirm the entitlement actually landed. Simulator lanes prove
+none of it — they sign ad-hoc.
 
 **TestFlight release:** the manually-triggered
 `.github/workflows/testflight.yml` (workflow_dispatch, `macos-26` runner —

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -122,9 +122,11 @@ force quit.
 > TestFlight wants `IOS_WIDGETS_PROVISIONING_PROFILE_BASE64` beside the existing
 > secret — and both App IDs need the App Groups capability, so the app's own
 > profile must be *regenerated* rather than reused. Getting it wrong is silent,
-> not loud: the release archive is unsigned, so entitlements come entirely from
-> the profiles, and one missing the App Group ships a widget that installs and
-> renders nothing. CI asserts it on both profiles and again on the exported IPA.
+> not loud: a profile only *permits* the App Group, and the binary has to claim
+> it — so the release archive is signed (per-target on Release, scoped to
+> device) to apply the entitlements files. CI asserts the group on both profiles
+> and again on the exported IPA, because those are two different failures that
+> look the same from outside.
 > `just ios-build` and `just ios-test` cannot catch it — simulator builds sign
 > ad-hoc.
 

--- a/omnibus-ios/omnibus.xcodeproj/project.pbxproj
+++ b/omnibus-ios/omnibus.xcodeproj/project.pbxproj
@@ -539,7 +539,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = omnibus.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				// Release signs manually against an explicit profile; Debug stays
+				// Automatic so local builds and the simulator test lanes are
+				// untouched. Set per-target here rather than on xcodebuild's
+				// command line, because a command-line setting applies to every
+				// target — including the SPM resource bundles, which reject a
+				// profile and fail the archive.
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "Omnibus App Store Connect Distribution Prov Prof";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D33VSDXHA6;
 				ENABLE_APP_SANDBOX = YES;
@@ -717,7 +725,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = OmnibusWidgets.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				// Release signs manually against an explicit profile; Debug stays
+				// Automatic so local builds and the simulator test lanes are
+				// untouched. Set per-target here rather than on xcodebuild's
+				// command line, because a command-line setting applies to every
+				// target — including the SPM resource bundles, which reject a
+				// profile and fail the archive.
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				PROVISIONING_PROFILE_SPECIFIER = "Omnibus Widgets Prov Prof";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D33VSDXHA6;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/omnibus-ios/omnibus.xcodeproj/project.pbxproj
+++ b/omnibus-ios/omnibus.xcodeproj/project.pbxproj
@@ -539,15 +539,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = omnibus.entitlements;
-				// Release signs manually against an explicit profile; Debug stays
-				// Automatic so local builds and the simulator test lanes are
-				// untouched. Set per-target here rather than on xcodebuild's
-				// command line, because a command-line setting applies to every
-				// target — including the SPM resource bundles, which reject a
-				// profile and fail the archive.
-				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "Omnibus App Store Connect Distribution Prov Prof";
+				/* Device Release signs manually against an explicit profile, so the
+				   .entitlements are applied at archive time. Scoped to iphoneos:
+				   a Release *simulator* build would otherwise demand distribution
+				   credentials nobody has locally. Set per-target here rather than
+				   on xcodebuild's command line, which applies to every target
+				   including the SPM resource bundles — they reject a profile. */
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Omnibus App Store Connect Distribution Prov Prof";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D33VSDXHA6;
 				ENABLE_APP_SANDBOX = YES;
@@ -725,15 +726,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = OmnibusWidgets.entitlements;
-				// Release signs manually against an explicit profile; Debug stays
-				// Automatic so local builds and the simulator test lanes are
-				// untouched. Set per-target here rather than on xcodebuild's
-				// command line, because a command-line setting applies to every
-				// target — including the SPM resource bundles, which reject a
-				// profile and fail the archive.
-				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Manual;
-				PROVISIONING_PROFILE_SPECIFIER = "Omnibus Widgets Prov Prof";
+				/* Device Release signs manually against an explicit profile, so the
+				   .entitlements are applied at archive time. Scoped to iphoneos:
+				   a Release *simulator* build would otherwise demand distribution
+				   credentials nobody has locally. Set per-target here rather than
+				   on xcodebuild's command line, which applies to every target
+				   including the SPM resource bundles — they reject a profile. */
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Omnibus Widgets Prov Prof";
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = D33VSDXHA6;
 				GENERATE_INFOPLIST_FILE = YES;


### PR DESCRIPTION
## Summary
- Run [33024849469](https://github.com/seamus-sloan/omnibus/actions/runs/33024849469) archived, exported, and then failed the App Group check on **both** bundles. That check was correct — I downloaded its IPA artifact to be sure:
  - the **embedded profile** grants `group.com.omnibus.mobile` ✅
  - the **signed binary** carries only `application-identifier`, `beta-reports-active`, `com.apple.developer.team-identifier`, `get-task-allow` ❌
- **A provisioning profile is a permission ceiling, not a source of entitlements.** Entitlements come from each target's `.entitlements` file at the moment the binary is signed. The archive was built `CODE_SIGNING_ALLOWED=NO`, so none were embedded and `-exportArchive` had nothing to carry through — it re-signed with the baseline set and silently dropped the App Group. The profiles were never the problem, which is why regenerating them didn't fix it.
- Archives are now **signed**, so the entitlements files are applied.
- Signing at archive time was originally avoided because command-line signing settings apply to *every* target and the SPM resource bundles reject a profile. That constraint is real, so signing is set **per-target on the Release configuration in the project** rather than on the command line — the resource bundles keep their own defaults.
- **Debug is untouched** and stays on Automatic signing, so local builds and the simulator test lanes need no profiles.

## Test plan
- [x] `just ios-build` clean and `just ios-test` 502/502 — confirming the Debug path is genuinely unaffected by the Release-only signing change.
- [x] `xcodebuild -list` parses the edited pbxproj.
- [x] Diagnosis verified against the real artifact rather than inferred: profile grants the group, binary does not.
- [ ] **The export itself is what this fixes**, and only a dispatch proves it. The post-export IPA check that caught this stays in place and will confirm it.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- The two profile **names** are now literals in the pbxproj. That is the trade for not putting them on the command line; if a profile is renamed on the portal, the archive fails with `No profile matching ... found`, which names the cause. The alternative — passing them as build settings — is exactly what breaks the SPM bundles.
- This is the failure the post-export check was added for. Without it, run 33024849469 would have uploaded a build whose widget installs and renders a blank placeholder forever, with nothing to point at.