### PR TITLE
fix: pull the Continue rail before publishing a widget snapshot

### DIFF
--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -96,6 +96,16 @@ force quit.
   only `CoverIdentity.tone`, resolved app-side and carried in the snapshot as
   OKLCH. That is also why `OKLCH.swift` is shared rather than copied: two copies
   could drift, and one book would show up in two different colours.
+- **A snapshot pass pulls the Continue rail before it composes anything.** The
+  extension is local-first but the *pass* is not, and it cannot be: the reader
+  saves a CFI and the server derives the whole-book percent off the request
+  path, so the row this device just wrote carries no percent and a card built
+  from it draws no bar. Half the passes used to pull first and half didn't, and
+  the ones that didn't were the two that run right after a write — a close, a
+  backgrounding — so the Home Screen kept a barless snapshot until the app was
+  next opened, while the app's own rail had already healed. `refreshRail` owns
+  it now so a new call site can't reintroduce the split. Gated on reachability:
+  offline the pass stays a pure replica read.
 - **The three empty states are three different screens.** "Not signed in",
   "no books yet" and "nothing open" want three different next steps; a bare
   empty list can't tell them apart, and a blank tile tells the reader nothing.
@@ -476,6 +486,12 @@ carries a TODO to harden it; this does that.
   derives from journal entries at 100% progress — marking a book Finished via
   read status alone does not populate it. The server also caches stats for 60s,
   so a fresh entry takes up to a minute to appear.
+- **A widget card loses its bar for an EPUB read offline.** The whole-book
+  percent is derived server-side and the device cannot compute one, so a
+  position written with no connection has none to show until the next online
+  snapshot pass — the card falls back to its "Reading" label. The same pass can
+  also, rarely, outrun the server's own derivation, which is spawned after the
+  write's response is composed; that heals on the following pass.
 - Author photo editing, book merging, and the admin log viewer are not ported.
 - Test coverage is limited to the pure logic worth pinning — the offline layer
   (`omnibusTests/OfflineSyncTests.swift`), the player's chapter arithmetic

--- a/omnibus-ios/omnibus/Offline/LifecycleSync.swift
+++ b/omnibus-ios/omnibus/Offline/LifecycleSync.swift
@@ -77,10 +77,9 @@ final class LifecycleSync {
         await Connectivity.shared.refreshPendingCount()
 
         // The replica entries a returning reader is most likely to be looking
-        // at. Everything else refreshes when its screen asks.
-        async let mirror: Void = LibraryIndex.shared.sync()
-        async let resume: Void = refreshResumePoints()
-        _ = await (mirror, resume)
+        // at. Everything else refreshes when its screen asks — the Continue
+        // rail included, which the snapshot pass below pulls for itself.
+        await LibraryIndex.shared.sync()
 
         await WidgetSnapshotWriter.shared.refresh()
     }
@@ -156,13 +155,6 @@ final class LifecycleSync {
         }
     }
 
-    /// Pull the Continue-reading rail through its live read so the replica is
-    /// current before any screen asks. The values themselves are the caller's
-    /// business — this is here for the write into the cache the read performs.
-    private func refreshResumePoints() async {
-        for await _ in UserDataService.recentProgress().values() {}
-    }
-
     // MARK: - Background refresh
 
     /// Register the background handler. Must run before the app finishes
@@ -197,8 +189,9 @@ final class LifecycleSync {
     ///
     /// Deliberately narrow. The system grants seconds, not minutes, and killing
     /// the app for overrunning costs future grants — so this drains the outbox
-    /// and refreshes the resume rail, and leaves the library mirror to a real
-    /// foreground where there's time to page through it.
+    /// and refreshes the resume rail (inside the snapshot pass, which pulls it),
+    /// and leaves the library mirror to a real foreground where there's time to
+    /// page through it.
     private func runBackgroundRefresh(_ task: BGAppRefreshTask) async {
         // Re-arm first: an early return past this point would otherwise end the
         // chain and the app would never be woken again.
@@ -206,7 +199,6 @@ final class LifecycleSync {
 
         let work = Task {
             await SyncEngine.shared.drain()
-            await refreshResumePoints()
             await Connectivity.shared.refreshPendingCount()
             // The whole reason a widget can be right about a session that
             // ended on another device: this pass runs without the app ever

--- a/omnibus-ios/omnibus/Offline/LifecycleSync.swift
+++ b/omnibus-ios/omnibus/Offline/LifecycleSync.swift
@@ -78,7 +78,8 @@ final class LifecycleSync {
 
         // The replica entries a returning reader is most likely to be looking
         // at. Everything else refreshes when its screen asks — the Continue
-        // rail included, which the snapshot pass below pulls for itself.
+        // rail included, which the snapshot pass below pulls for itself when
+        // there is a session and a network to pull with.
         await LibraryIndex.shared.sync()
 
         await WidgetSnapshotWriter.shared.refresh()
@@ -189,9 +190,9 @@ final class LifecycleSync {
     ///
     /// Deliberately narrow. The system grants seconds, not minutes, and killing
     /// the app for overrunning costs future grants — so this drains the outbox
-    /// and refreshes the resume rail (inside the snapshot pass, which pulls it),
-    /// and leaves the library mirror to a real foreground where there's time to
-    /// page through it.
+    /// and refreshes the resume rail (inside the snapshot pass, which pulls it
+    /// when online), and leaves the library mirror to a real foreground where
+    /// there's time to page through it.
     private func runBackgroundRefresh(_ task: BGAppRefreshTask) async {
         // Re-arm first: an early return past this point would otherwise end the
         // chain and the app would never be woken again.

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -20,6 +20,12 @@ actor WidgetSnapshotWriter {
     /// in a container both processes have to page in.
     private static let thumbMaxPixels: CGFloat = 300
 
+    /// How long a pass waits on the Continue rail before composing from the
+    /// replica instead. Longer than the reader's `PositionSync.openDeadline`
+    /// — nobody is watching a snapshot pass the way they are watching a book
+    /// open — but short enough to leave the background assertion its time.
+    private static let railDeadline: Duration = .seconds(3)
+
     /// The pass currently running or queued behind one.
     private var pass: Task<Void, Never>?
 
@@ -62,6 +68,7 @@ actor WidgetSnapshotWriter {
     private static func build() async -> WidgetSnapshot {
         guard await APIClient.shared.hasToken() else { return .empty(.signedOut) }
 
+        await refreshRail()
         let points: [ResumePoint] = await Cache.cachedOnly(CacheKey.recentProgress) ?? []
         guard !points.isEmpty else {
             // Two different things to say, and the mirror is what tells them
@@ -80,6 +87,38 @@ actor WidgetSnapshotWriter {
             books.append(await entry(for: point))
         }
         return WidgetSnapshot(state: .ready, books: books, generatedAt: Date())
+    }
+
+    /// Pull the Continue rail through its live read, for the write into the
+    /// cache the read performs — the values are `build`'s business.
+    ///
+    /// A position this device just wrote is deliberately incomplete: the
+    /// reader saves a CFI and the server derives the whole-book percent off
+    /// the request path, so the optimistic row carries no percent and a card
+    /// built from it draws no bar. Half the passes used to pull first and half
+    /// didn't, and the ones that didn't are the two that run right after a
+    /// write — a close, a backgrounding — so the Home Screen kept the barless
+    /// snapshot until the app was next opened. Owning the pull here is what
+    /// stops the next call site from reintroducing that.
+    ///
+    /// Gated on reachability like the cover fetch below: offline this stays a
+    /// pure replica read rather than paying a request timeout inside a
+    /// background assertion that cancels the whole pass when it runs out.
+    ///
+    /// Bounded for the same reason, and the bound is not a timeout — the read
+    /// carries on and still writes the cache, so a pull that misses this pass
+    /// serves the next one. Waiting on it unbounded would put a hung request
+    /// in front of the publish on the way to the background, and a pass the
+    /// expiration handler cancels writes no snapshot at all: the Home Screen
+    /// would keep an older one rather than the replica's, which is the
+    /// outcome this whole change is about avoiding.
+    private static func refreshRail() async {
+        guard await Connectivity.shared.isOnline else { return }
+        let pull = Task { () -> Bool? in
+            for await _ in UserDataService.recentProgress().values() {}
+            return true
+        }
+        _ = await firstResult(of: pull, within: railDeadline)
     }
 
     private static func entry(for point: ResumePoint) async -> WidgetBook {

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -129,18 +129,20 @@ actor WidgetSnapshotWriter {
     /// after a sign-out. Cancelling costs only a request that hadn't answered,
     /// since `Cache.live` caches whatever it has already fetched regardless.
     private static func refreshRail(hasToken: Bool) async {
-        guard await shouldPullRail(hasToken: hasToken, isOnline: Connectivity.shared.isOnline)
-        else { return }
+        // Bound separately: `shouldPullRail` is synchronous, so an `await` in
+        // front of it would name the wrong thing as the suspension point.
+        let isOnline = await Connectivity.shared.isOnline
+        guard shouldPullRail(hasToken: hasToken, isOnline: isOnline) else { return }
         let pull = Task {
             for await _ in UserDataService.recentProgress().values() {}
         }
-        // `try`, not `try?`: cancelling the deadline has to *skip* the cancel,
-        // and a swallowed `CancellationError` would fall through to it instead.
-        // Harmless in this order — the pull has already finished by then — but
-        // it reads as a guard it isn't, and one swapped line would make it a
-        // real spurious cancel.
+        // Cancelling the deadline has to *skip* the cancel, so the sleep's
+        // `CancellationError` returns rather than falling through — `try?`
+        // here would swallow it and cancel a pull that had just succeeded.
+        // Catching keeps the task non-throwing, matching the timer in
+        // `firstResult`.
         let deadline = Task {
-            try await Task.sleep(for: railDeadline)
+            do { try await Task.sleep(for: railDeadline) } catch { return }
             pull.cancel()
         }
         await pull.value

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -134,8 +134,13 @@ actor WidgetSnapshotWriter {
         let pull = Task {
             for await _ in UserDataService.recentProgress().values() {}
         }
+        // `try`, not `try?`: cancelling the deadline has to *skip* the cancel,
+        // and a swallowed `CancellationError` would fall through to it instead.
+        // Harmless in this order — the pull has already finished by then — but
+        // it reads as a guard it isn't, and one swapped line would make it a
+        // real spurious cancel.
         let deadline = Task {
-            try? await Task.sleep(for: railDeadline)
+            try await Task.sleep(for: railDeadline)
             pull.cancel()
         }
         await pull.value

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -105,20 +105,27 @@ actor WidgetSnapshotWriter {
     /// pure replica read rather than paying a request timeout inside a
     /// background assertion that cancels the whole pass when it runs out.
     ///
-    /// Bounded for the same reason, and the bound is not a timeout — the read
-    /// carries on and still writes the cache, so a pull that misses this pass
-    /// serves the next one. Waiting on it unbounded would put a hung request
-    /// in front of the publish on the way to the background, and a pass the
-    /// expiration handler cancels writes no snapshot at all: the Home Screen
-    /// would keep an older one rather than the replica's, which is the
-    /// outcome this whole change is about avoiding.
+    /// Bounded for the same reason, and the bound **cancels** rather than
+    /// abandons. Waiting unbounded would put a hung request in front of the
+    /// publish on the way to the background, where a pass the expiration
+    /// handler cancels writes no snapshot at all and the Home Screen keeps an
+    /// older one. Letting the read run on past the bound — `firstResult`'s
+    /// shape — would break this actor's one guarantee, that the last caller is
+    /// the last writer: a pull outliving its pass still carries the bearer it
+    /// went out with, so it can land the previous account's rail in the replica
+    /// after a sign-out. Cancelling costs only a request that hadn't answered,
+    /// since `Cache.live` caches whatever it has already fetched regardless.
     private static func refreshRail() async {
         guard await Connectivity.shared.isOnline else { return }
-        let pull = Task { () -> Bool? in
+        let pull = Task {
             for await _ in UserDataService.recentProgress().values() {}
-            return true
         }
-        _ = await firstResult(of: pull, within: railDeadline)
+        let deadline = Task {
+            try? await Task.sleep(for: railDeadline)
+            pull.cancel()
+        }
+        await pull.value
+        deadline.cancel()
     }
 
     private static func entry(for point: ResumePoint) async -> WidgetBook {

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -115,28 +115,27 @@ actor WidgetSnapshotWriter {
     /// - **Bounded**, so a hung request can't sit in front of the publish on
     ///   the way to the background — a pass the expiration handler cancels
     ///   writes no snapshot at all.
-    /// - **The bound cancels rather than abandons.** A pull outliving its pass
-    ///   still carries the bearer it went out with, and would break this
-    ///   actor's one guarantee that the last caller is the last writer.
+    /// - **The bound cancels rather than abandons, and stays structured.** A
+    ///   pull outliving its pass still carries the bearer it went out with,
+    ///   and would break this actor's one guarantee that the last caller is
+    ///   the last writer.
     private static func refreshRail(hasToken: Bool) async {
         // Bound separately: `shouldPullRail` is synchronous, so an `await` in
         // front of it would name the wrong thing as the suspension point.
         let isOnline = await Connectivity.shared.isOnline
         guard shouldPullRail(hasToken: hasToken, isOnline: isOnline) else { return }
-        let pull = Task {
-            for await _ in UserDataService.recentProgress().values() {}
+        // A group rather than two unstructured `Task`s: a group's children
+        // inherit cancellation, so the expiration handler that cancels a
+        // background pass stops the read with it. Two unstructured tasks do
+        // not, and would have carried a read into suspension for as long as
+        // the deadline had left to run. Whichever child lands first — the
+        // read, or the deadline — `cancelAll` retires the other.
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { for await _ in UserDataService.recentProgress().values() {} }
+            group.addTask { try? await Task.sleep(for: railDeadline) }
+            await group.next()
+            group.cancelAll()
         }
-        // Cancelling the deadline has to *skip* the cancel, so the sleep's
-        // `CancellationError` returns rather than falling through — `try?`
-        // here would swallow it and cancel a pull that had just succeeded.
-        // Catching keeps the task non-throwing, matching the timer in
-        // `firstResult`.
-        let deadline = Task {
-            do { try await Task.sleep(for: railDeadline) } catch { return }
-            pull.cancel()
-        }
-        await pull.value
-        deadline.cancel()
     }
 
     private static func entry(for point: ResumePoint) async -> WidgetBook {

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -66,9 +66,10 @@ actor WidgetSnapshotWriter {
     }
 
     private static func build() async -> WidgetSnapshot {
-        guard await APIClient.shared.hasToken() else { return .empty(.signedOut) }
+        let hasToken = await APIClient.shared.hasToken()
+        guard hasToken else { return .empty(.signedOut) }
 
-        await refreshRail()
+        await refreshRail(hasToken: hasToken)
         let points: [ResumePoint] = await Cache.cachedOnly(CacheKey.recentProgress) ?? []
         guard !points.isEmpty else {
             // Two different things to say, and the mirror is what tells them
@@ -87,6 +88,18 @@ actor WidgetSnapshotWriter {
             books.append(await entry(for: point))
         }
         return WidgetSnapshot(state: .ready, books: books, generatedAt: Date())
+    }
+
+    /// Whether a pass should spend a rail pull: a session to read with, and a
+    /// network to read over. `internal` so the rule is testable.
+    ///
+    /// The token is a parameter rather than an ordering assumption. `build`
+    /// guards on it above, so passing it here reads redundant — but that guard
+    /// is the only thing standing between a sign-out pass and an authenticated
+    /// read, and an ordering property holds only until someone moves a line.
+    /// As a term of the rule it cannot be lost that way.
+    static func shouldPullRail(hasToken: Bool, isOnline: Bool) -> Bool {
+        hasToken && isOnline
     }
 
     /// Pull the Continue rail through its live read, for the write into the
@@ -115,8 +128,9 @@ actor WidgetSnapshotWriter {
     /// went out with, so it can land the previous account's rail in the replica
     /// after a sign-out. Cancelling costs only a request that hadn't answered,
     /// since `Cache.live` caches whatever it has already fetched regardless.
-    private static func refreshRail() async {
-        guard await Connectivity.shared.isOnline else { return }
+    private static func refreshRail(hasToken: Bool) async {
+        guard await shouldPullRail(hasToken: hasToken, isOnline: Connectivity.shared.isOnline)
+        else { return }
         let pull = Task {
             for await _ in UserDataService.recentProgress().values() {}
         }

--- a/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
+++ b/omnibus-ios/omnibus/Widgets/WidgetSnapshotWriter.swift
@@ -103,31 +103,21 @@ actor WidgetSnapshotWriter {
     }
 
     /// Pull the Continue rail through its live read, for the write into the
-    /// cache the read performs — the values are `build`'s business.
+    /// cache the read performs — the values are `build`'s business. A position
+    /// this device just wrote carries no percent, so a card composed from the
+    /// replica alone draws no bar; see the widget section of
+    /// `omnibus-ios/README.md` for why that is and what it cost.
     ///
-    /// A position this device just wrote is deliberately incomplete: the
-    /// reader saves a CFI and the server derives the whole-book percent off
-    /// the request path, so the optimistic row carries no percent and a card
-    /// built from it draws no bar. Half the passes used to pull first and half
-    /// didn't, and the ones that didn't are the two that run right after a
-    /// write — a close, a backgrounding — so the Home Screen kept the barless
-    /// snapshot until the app was next opened. Owning the pull here is what
-    /// stops the next call site from reintroducing that.
+    /// Three invariants an edit here has to keep:
     ///
-    /// Gated on reachability like the cover fetch below: offline this stays a
-    /// pure replica read rather than paying a request timeout inside a
-    /// background assertion that cancels the whole pass when it runs out.
-    ///
-    /// Bounded for the same reason, and the bound **cancels** rather than
-    /// abandons. Waiting unbounded would put a hung request in front of the
-    /// publish on the way to the background, where a pass the expiration
-    /// handler cancels writes no snapshot at all and the Home Screen keeps an
-    /// older one. Letting the read run on past the bound — `firstResult`'s
-    /// shape — would break this actor's one guarantee, that the last caller is
-    /// the last writer: a pull outliving its pass still carries the bearer it
-    /// went out with, so it can land the previous account's rail in the replica
-    /// after a sign-out. Cancelling costs only a request that hadn't answered,
-    /// since `Cache.live` caches whatever it has already fetched regardless.
+    /// - **Signed in and online only.** Offline this stays a pure replica read
+    ///   rather than paying a request timeout inside a background assertion.
+    /// - **Bounded**, so a hung request can't sit in front of the publish on
+    ///   the way to the background — a pass the expiration handler cancels
+    ///   writes no snapshot at all.
+    /// - **The bound cancels rather than abandons.** A pull outliving its pass
+    ///   still carries the bearer it went out with, and would break this
+    ///   actor's one guarantee that the last caller is the last writer.
     private static func refreshRail(hasToken: Bool) async {
         // Bound separately: `shouldPullRail` is synchronous, so an `await` in
         // front of it would name the wrong thing as the suspension point.

--- a/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
+++ b/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
@@ -253,6 +253,24 @@ struct WidgetSnapshotWriterTests {
 
         #expect(WidgetSnapshotWriter.secondsRemaining(for: unmeasured, format: .audio) == nil)
     }
+
+    @Test(arguments: [
+        (true, true, true),
+        (true, false, false),
+        (false, true, false),
+        (false, false, false),
+    ])
+    func a_pass_pulls_the_rail_only_with_a_session_and_a_network(
+        hasToken: Bool, isOnline: Bool, pulls: Bool
+    ) {
+        // Signed out the read would go out under a bearer a sign-out is in the
+        // middle of revoking; offline it would pay a request timeout inside a
+        // background assertion. Both are terms of the rule rather than an
+        // ordering the next edit to `build` could quietly lose.
+        #expect(
+            WidgetSnapshotWriter.shouldPullRail(hasToken: hasToken, isOnline: isOnline) == pulls
+        )
+    }
 }
 
 @Suite("Widget labels track the app's own")


### PR DESCRIPTION
- The Continue widget dropped its progress bar for an EPUB after a reading session, falling back to the bare "Reading" label, then got it back the next time the app foregrounded — while the in-app Continue hero showed the right bar the whole time.
- The bar needs `progress_percent`, and the iOS reader never sends one: `ReaderView.persist` saves a CFI, and the server derives the whole-book percent off the request path in `spawn_epub_percent_derivation`. So every page turn leaves the replica holding a percent-less optimistic row, and `ResumePoint.fraction` is nil for it.
- `WidgetSnapshotWriter.build` reads `Cache.cachedOnly(CacheKey.recentProgress)` — the replica, never the network. Two of the four sites that publish a snapshot refreshed the rail first (`didEnterForeground`, `runBackgroundRefresh`) and two did not (`didCloseBook`, `didEnterBackground`) — and the two that did not are exactly the ones that run right after a write, so they were the ones that mattered.
- The app's own rail heals a moment later through `LibraryView`'s `onChange(of: presentation.progressToken)`, but that never re-triggers a widget pass, which is why the Home Screen and the app disagreed.
- Moves the pull into the writer as `refreshRail`, after the `hasToken()` guard so a sign-out pass cannot issue an authenticated read, and gated on `Connectivity.shared.isOnline` like the existing cover fetch so an offline pass stays a pure replica read. One owner means a new call site cannot reintroduce the split.
- Drops the now-duplicated `refreshResumePoints()` from the two sites that had it; `didCloseBook` and `didEnterBackground` get the pull for free.
- The pull is bounded at 3s inside a `withTaskGroup`, and the bound **cancels** rather than abandons. Waiting unbounded would put a hung request in front of the publish inside `didEnterBackground`'s background assertion, where a pass the expiration handler cancels writes no snapshot at all and the Home Screen keeps an older one. Letting the read run on past the bound instead — `firstResult`'s shape, which an earlier revision of this PR used — would break the one guarantee `WidgetSnapshotWriter` makes, that the last caller is the last writer: a pull outliving its pass still carries the bearer it went out with, so a slow one racing `AppState.signOut` could land the previous account's rail in the replica after the sign-out pass had already published. The group is what makes both hold: unstructured `Task {}` inherits actor context and priority but *not* cancellation, so `work.cancel()` from the expiration handler would not have reached the read — a group's children do inherit it, and nothing outlives the function.
- Considered and rejected: having iOS send epub.js's own `pct`. It would make `spawn_epub_percent_derivation` no-op for iOS writes, so the stored percent — which Kobo sync-out echoes and cross-format falls back to when a CFI cannot be anchored — would use a different ruler depending on which client wrote last. Also rejected: carrying the previously-held percent forward through a percent-less write, which shows a stale bar rather than the accurate one the server already has.

## Testing

- `just ios-build` and `just ios-test` green.
- No new unit test. `LifecycleSync` and the writer's orchestration have no existing coverage, and `omnibus-ios/README.md` already records that nothing drives a widget in CI — a test here would assert against mocks of the two singletons the change is about, which would pin the mock rather than the behaviour. Verified by hand instead, on the repro below.
- Manual repro (deterministic): scroll the library grid past page one — this trips `hasPaginated` and stands down the 60s poll that otherwise heals the replica mid-session — then open an EPUB, turn a page, and swipe to the Home Screen from inside the reader. Before: bar gone, "Reading" label. After: bar intact, showing the same percentage as the app. That 60-second poll, which keeps running under the reader's full-screen cover, is why the bug presented as intermittent.

## Known residuals

Both documented in `omnibus-ios/README.md`:

- An EPUB read entirely offline has no derivable percent — the device cannot compute one — so the card keeps its "Reading" label until the next online pass.
- A pull can rarely outrun the server's own derivation, which is spawned after the write's response is composed. Heals on the following pass.

Closes #2216
