### PR TITLE
feat: make the Continue widget a one-book call to action

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,10 +399,9 @@ are the other half of a second target:
 OmnibusShared/      — source compiled into *both* the app and the widget
                       extension (a filesystem-synchronized group listed in two
                       targets' `fileSystemSynchronizedGroups`): WidgetSnapshot
-                      (the wire form, plus the cursor arithmetic the one-book
-                      families walk their rail with), WidgetStore (the App
-                      Group container's layout, the only encoder either side
-                      uses, and where that cursor is kept), DeepLink
+                      (the wire form, plus which book a pinned widget resolves
+                      to), WidgetStore (the App Group container's layout, and
+                      the only encoder either side uses), DeepLink
                       (the `omnibus://book/<uuid>` URLs the widget mints and
                       the app parses back) and OKLCH (the OKLCH↔sRGB
                       conversion for server-provided accents — shared so the
@@ -414,8 +413,11 @@ OmnibusWidgets/     — the WidgetKit extension (`com.omnibus.mobile.widgets`,
                       else, so it renders in Airplane Mode with the app force
                       quit), its three family layouts and the three distinct
                       empty states, ContinueIntents (a widget cannot be swiped,
-                      so small and medium each show one book and carry an
-                      `AppIntent` that flips to the next), and WidgetTheme —
+                      so small and medium each show *one* book and the widget
+                      is an `AppIntentConfiguration` — one copy per book,
+                      stacked, and the swipe is the stack's; `relevance()`
+                      publishes one configuration per book in progress so a
+                      Smart Stack has something to rotate), and WidgetTheme —
                       colours derived entirely from the book's own tone,
                       because the reader's chosen
                       theme lives in the app's `UserDefaults`, which the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,9 +399,10 @@ are the other half of a second target:
 OmnibusShared/      — source compiled into *both* the app and the widget
                       extension (a filesystem-synchronized group listed in two
                       targets' `fileSystemSynchronizedGroups`): WidgetSnapshot
-                      (the wire form, plus which book a pinned widget resolves
-                      to), WidgetStore (the App Group container's layout, and
-                      the only encoder either side uses), DeepLink
+                      (the wire form, plus the cursor arithmetic the medium
+                      card flips its rail with), WidgetStore (the App Group
+                      container's layout, the only encoder either side uses,
+                      and where that cursor is kept), DeepLink
                       (the `omnibus://book/<uuid>` URLs the widget mints and
                       the app parses back) and OKLCH (the OKLCH↔sRGB
                       conversion for server-provided accents — shared so the
@@ -413,13 +414,12 @@ OmnibusWidgets/     — the WidgetKit extension (`com.omnibus.mobile.widgets`,
                       else, so it renders in Airplane Mode with the app force
                       quit), its three family layouts and the three distinct
                       empty states, ContinueIntents (a widget cannot be swiped,
-                      so small and medium each show *one* book and the widget
-                      is an `AppIntentConfiguration` — one copy per book,
-                      stacked, and the swipe is the stack's; `relevance()`
-                      publishes one configuration per book in progress so a
-                      Smart Stack has something to rotate), and WidgetTheme —
-                      colours derived entirely from the book's own tone,
-                      because the reader's chosen
+                      so the medium card shows one book and carries an
+                      `AppIntent` that flips to the next — capped at three,
+                      and absent from the small card, which answers with
+                      whichever book you touched last and nothing else), and
+                      WidgetTheme — colours derived entirely from the book's
+                      own tone, because the reader's chosen
                       theme lives in the app's `UserDefaults`, which the
                       extension cannot read
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,8 +399,10 @@ are the other half of a second target:
 OmnibusShared/      — source compiled into *both* the app and the widget
                       extension (a filesystem-synchronized group listed in two
                       targets' `fileSystemSynchronizedGroups`): WidgetSnapshot
-                      (the wire form), WidgetStore (the App Group container's
-                      layout, and the only encoder either side uses), DeepLink
+                      (the wire form, plus the cursor arithmetic the one-book
+                      families walk their rail with), WidgetStore (the App
+                      Group container's layout, the only encoder either side
+                      uses, and where that cursor is kept), DeepLink
                       (the `omnibus://book/<uuid>` URLs the widget mints and
                       the app parses back) and OKLCH (the OKLCH↔sRGB
                       conversion for server-provided accents — shared so the
@@ -411,8 +413,11 @@ OmnibusWidgets/     — the WidgetKit extension (`com.omnibus.mobile.widgets`,
                       `TimelineProvider` that reads the App Group and nothing
                       else, so it renders in Airplane Mode with the app force
                       quit), its three family layouts and the three distinct
-                      empty states, and WidgetTheme — colours derived entirely
-                      from the book's own tone, because the reader's chosen
+                      empty states, ContinueIntents (a widget cannot be swiped,
+                      so small and medium each show one book and carry an
+                      `AppIntent` that flips to the next), and WidgetTheme —
+                      colours derived entirely from the book's own tone,
+                      because the reader's chosen
                       theme lives in the app's `UserDefaults`, which the
                       extension cannot read
 ```

--- a/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
+++ b/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
@@ -92,19 +92,43 @@ struct WidgetSnapshot: Codable, Sendable, Equatable {
         WidgetSnapshot(state: state, generatedAt: .distantPast)
     }
 
-    /// The book a one-book card should draw, given what its widget is pinned to.
+    /// The most the medium card's control will flip through.
     ///
-    /// The selection names a *book*, never an index. The rail is rewritten on
-    /// every position save, so an index means "whatever is third today" — the
+    /// Five is what the large family *lists*, and listing is cheap. Flipping is
+    /// not: every book past the front costs a tap and a redraw to reach, and
+    /// past three the control stops meaning "the other book I'm in" and starts
+    /// meaning "page my library" — which is the app's job, not a widget's.
+    static let maxFlipped = 3
+
+    /// The books that control walks. The front of the rail, capped.
+    var flipRail: [WidgetBook] {
+        Array(books.prefix(Self.maxFlipped))
+    }
+
+    /// Which book the medium card is showing, and where it sits in that rail.
+    ///
+    /// The cursor names a *book*, never an index. The rail is rewritten on
+    /// every position save, so an index means "whatever is second today" — the
     /// next save that reorders it would move the card out from under the
     /// reader. Naming the book lets it hold its place, and gives an honest
-    /// answer once it drops off the rail: a widget pinned to a book the reader
-    /// has since finished falls back to whatever they are reading now, rather
-    /// than sitting on a finished book until they think to reconfigure it.
+    /// answer once it drops off: it is gone, so the front book takes over.
     /// Same rule as the app's `ContinueHero.selected`.
-    func showing(selected: String?) -> WidgetBook? {
-        guard let first = books.first else { return nil }
-        guard let selected else { return first }
-        return books.first { $0.id == selected } ?? first
+    func showing(cursor: String?) -> (book: WidgetBook, index: Int)? {
+        let rail = flipRail
+        guard let first = rail.first else { return nil }
+        guard let cursor, let index = rail.firstIndex(where: { $0.id == cursor }) else {
+            return (first, 0)
+        }
+        return (rail[index], index)
+    }
+
+    /// The book after the cursor's, wrapping at the end — where the card's
+    /// advance control moves to. It wraps because that control is the only way
+    /// through the rail: dead-ending on the last book would leave no way back
+    /// to the one the reader is actually in the middle of.
+    func next(after cursor: String?) -> WidgetBook? {
+        let rail = flipRail
+        guard let (_, index) = showing(cursor: cursor) else { return nil }
+        return rail[(index + 1) % rail.count]
     }
 }

--- a/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
+++ b/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
@@ -1,10 +1,15 @@
 //  WidgetSnapshot.swift
-//  What the app hands the Home Screen, and the only thing a widget reads.
+//  What the app hands the Home Screen: every book a card could draw, and
+//  everything it draws about one.
 //
 //  A timeline render gets a tight memory and time budget, so the extension is
 //  given a finished answer rather than a second reader on `OfflineStore` — no
-//  SQLite, no decoding of the full `Book` payloads, no network. Everything a
-//  card draws is resolved app-side and written here.
+//  SQLite, no decoding of the full `Book` payloads, no network.
+//
+//  *Which* of those books a one-book card shows is the one thing not resolved
+//  app-side: the reader flips it from the Home Screen, so the extension keeps
+//  that cursor in the App Group's defaults and resolves it against this list —
+//  see `showing(cursor:)` and `WidgetStore.cursor()`.
 
 import Foundation
 

--- a/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
+++ b/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
@@ -91,4 +91,29 @@ struct WidgetSnapshot: Codable, Sendable, Equatable {
     static func empty(_ state: State = .signedOut) -> WidgetSnapshot {
         WidgetSnapshot(state: state, generatedAt: .distantPast)
     }
+
+    /// Which book a one-book card is showing, and where it sits in the rail.
+    ///
+    /// The cursor names a *book*, never an index. The rail is rewritten on
+    /// every position save, so an index means "whatever is third today" — the
+    /// next save that reorders the fan would move the card out from under the
+    /// reader. Naming the book lets it hold its place, and gives an honest
+    /// answer once it drops off the rail: it is gone, so the front book takes
+    /// over. Same rule as the app's `ContinueHero.selected`.
+    func showing(cursor: String?) -> (book: WidgetBook, index: Int)? {
+        guard let first = books.first else { return nil }
+        guard let cursor, let index = books.firstIndex(where: { $0.id == cursor }) else {
+            return (first, 0)
+        }
+        return (books[index], index)
+    }
+
+    /// The book after the cursor's, wrapping at the end — where the card's
+    /// advance control moves to. It wraps because that control is the only way
+    /// through the rail: dead-ending on the last book would leave no way back
+    /// to the one the reader is actually in the middle of.
+    func next(after cursor: String?) -> WidgetBook? {
+        guard let (_, index) = showing(cursor: cursor) else { return nil }
+        return books[(index + 1) % books.count]
+    }
 }

--- a/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
+++ b/omnibus-ios/OmnibusShared/WidgetSnapshot.swift
@@ -92,28 +92,19 @@ struct WidgetSnapshot: Codable, Sendable, Equatable {
         WidgetSnapshot(state: state, generatedAt: .distantPast)
     }
 
-    /// Which book a one-book card is showing, and where it sits in the rail.
+    /// The book a one-book card should draw, given what its widget is pinned to.
     ///
-    /// The cursor names a *book*, never an index. The rail is rewritten on
+    /// The selection names a *book*, never an index. The rail is rewritten on
     /// every position save, so an index means "whatever is third today" — the
-    /// next save that reorders the fan would move the card out from under the
+    /// next save that reorders it would move the card out from under the
     /// reader. Naming the book lets it hold its place, and gives an honest
-    /// answer once it drops off the rail: it is gone, so the front book takes
-    /// over. Same rule as the app's `ContinueHero.selected`.
-    func showing(cursor: String?) -> (book: WidgetBook, index: Int)? {
+    /// answer once it drops off the rail: a widget pinned to a book the reader
+    /// has since finished falls back to whatever they are reading now, rather
+    /// than sitting on a finished book until they think to reconfigure it.
+    /// Same rule as the app's `ContinueHero.selected`.
+    func showing(selected: String?) -> WidgetBook? {
         guard let first = books.first else { return nil }
-        guard let cursor, let index = books.firstIndex(where: { $0.id == cursor }) else {
-            return (first, 0)
-        }
-        return (books[index], index)
-    }
-
-    /// The book after the cursor's, wrapping at the end — where the card's
-    /// advance control moves to. It wraps because that control is the only way
-    /// through the rail: dead-ending on the last book would leave no way back
-    /// to the one the reader is actually in the middle of.
-    func next(after cursor: String?) -> WidgetBook? {
-        guard let (_, index) = showing(cursor: cursor) else { return nil }
-        return books[(index + 1) % books.count]
+        guard let selected else { return first }
+        return books.first { $0.id == selected } ?? first
     }
 }

--- a/omnibus-ios/OmnibusShared/WidgetStore.swift
+++ b/omnibus-ios/OmnibusShared/WidgetStore.swift
@@ -63,6 +63,33 @@ enum WidgetStore {
         try decoder.decode(WidgetSnapshot.self, from: data)
     }
 
+    // MARK: - Which book the medium card is showing
+
+    /// The book the medium card last advanced to, by `WidgetBook.id`.
+    ///
+    /// In the App Group's defaults rather than the snapshot file: the app owns
+    /// that file and rewrites it wholesale on every position save, so a cursor
+    /// kept there would be erased by the next sync. This is the one piece of
+    /// widget state the *extension* writes.
+    static func cursor() -> String? {
+        groupDefaults?.string(forKey: cursorKey)
+    }
+
+    static func setCursor(_ id: String?) {
+        guard let defaults = groupDefaults else { return }
+        if let id {
+            defaults.set(id, forKey: cursorKey)
+        } else {
+            defaults.removeObject(forKey: cursorKey)
+        }
+    }
+
+    private static let cursorKey = "continue.cursor"
+
+    private static var groupDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupID)
+    }
+
     // MARK: - Cover art
 
     /// The extensions a pre-rendered cover can carry. Covers with alpha are

--- a/omnibus-ios/OmnibusShared/WidgetStore.swift
+++ b/omnibus-ios/OmnibusShared/WidgetStore.swift
@@ -63,6 +63,33 @@ enum WidgetStore {
         try decoder.decode(WidgetSnapshot.self, from: data)
     }
 
+    // MARK: - Which book the card is showing
+
+    /// The book a one-book card last advanced to, by `WidgetBook.id`.
+    ///
+    /// In the App Group's defaults rather than the snapshot file: the app owns
+    /// that file and rewrites it wholesale on every position save, so a cursor
+    /// kept there would be erased by the next sync. This is the one piece of
+    /// widget state the *extension* writes.
+    static func cursor() -> String? {
+        groupDefaults?.string(forKey: cursorKey)
+    }
+
+    static func setCursor(_ id: String?) {
+        guard let defaults = groupDefaults else { return }
+        if let id {
+            defaults.set(id, forKey: cursorKey)
+        } else {
+            defaults.removeObject(forKey: cursorKey)
+        }
+    }
+
+    private static let cursorKey = "continue.cursor"
+
+    private static var groupDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupID)
+    }
+
     // MARK: - Cover art
 
     /// The extensions a pre-rendered cover can carry. Covers with alpha are

--- a/omnibus-ios/OmnibusShared/WidgetStore.swift
+++ b/omnibus-ios/OmnibusShared/WidgetStore.swift
@@ -63,33 +63,6 @@ enum WidgetStore {
         try decoder.decode(WidgetSnapshot.self, from: data)
     }
 
-    // MARK: - Which book the card is showing
-
-    /// The book a one-book card last advanced to, by `WidgetBook.id`.
-    ///
-    /// In the App Group's defaults rather than the snapshot file: the app owns
-    /// that file and rewrites it wholesale on every position save, so a cursor
-    /// kept there would be erased by the next sync. This is the one piece of
-    /// widget state the *extension* writes.
-    static func cursor() -> String? {
-        groupDefaults?.string(forKey: cursorKey)
-    }
-
-    static func setCursor(_ id: String?) {
-        guard let defaults = groupDefaults else { return }
-        if let id {
-            defaults.set(id, forKey: cursorKey)
-        } else {
-            defaults.removeObject(forKey: cursorKey)
-        }
-    }
-
-    private static let cursorKey = "continue.cursor"
-
-    private static var groupDefaults: UserDefaults? {
-        UserDefaults(suiteName: appGroupID)
-    }
-
     // MARK: - Cover art
 
     /// The extensions a pre-rendered cover can carry. Covers with alpha are

--- a/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
@@ -1,0 +1,33 @@
+//  ContinueIntents.swift
+//  Moving the one-book card along the rail without leaving the Home Screen.
+//
+//  A widget cannot be swiped — the system renders it as a snapshot, and the
+//  only interaction it offers is a tap: a `widgetURL`/`Link` that opens the
+//  app, or an `AppIntent` that runs in the extension. So the card flips rather
+//  than scrolls, and this is the flip.
+
+import AppIntents
+import WidgetKit
+
+struct ShowNextBook: AppIntent {
+    static let title: LocalizedStringResource = "Show the next book"
+    static let description = IntentDescription(
+        "Moves the Continue widget on to the next book you have in progress."
+    )
+
+    /// The whole point is that the rail can be walked from the Home Screen.
+    /// Launching the app to answer a tap would make the control slower than
+    /// just opening the book it is trying to skip past.
+    static let openAppWhenRun = false
+
+    func perform() async throws -> some IntentResult {
+        let snapshot = WidgetStore.load() ?? .empty()
+        WidgetStore.setCursor(snapshot.next(after: WidgetStore.cursor())?.id)
+        // WidgetKit reloads after an intent on its own, but only for the
+        // widget whose button was tapped. Naming the kind refreshes a second
+        // Continue widget on the same screen, which is otherwise left showing
+        // a cursor that has already moved.
+        WidgetCenter.shared.reloadTimelines(ofKind: WidgetKind.continueReading)
+        return .result()
+    }
+}

--- a/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
@@ -1,71 +1,33 @@
 //  ContinueIntents.swift
-//  What makes one Continue widget different from the next one beside it.
+//  Moving the medium card along the rail without leaving the Home Screen.
 //
-//  A widget cannot be swiped — the system renders it as a snapshot and only
-//  routes taps — so the rail is walked by *stacking* widgets and swiping the
-//  stack. That only shows different books if each copy can be configured to a
-//  different one, which is what this is: the book parameter the Home Screen's
-//  edit sheet offers, and the entity query behind it.
+//  A widget cannot be swiped — the system renders it as a snapshot, and the
+//  only interaction it offers is a tap: a `widgetURL`/`Link` that opens the
+//  app, or an `AppIntent` that runs in the extension. So the card flips rather
+//  than scrolls, and this is the flip.
 
 import AppIntents
+import WidgetKit
 
-/// A book the widget can be pinned to, named by `WidgetBook.id` so the
-/// selection survives the rail being rewritten around it.
-struct BookEntity: AppEntity {
-    let id: String
-    let title: String
-    let author: String
-
-    init(_ book: WidgetBook) {
-        id = book.id
-        title = book.title
-        author = book.author
-    }
-
-    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Book"
-    static let defaultQuery = BookQuery()
-
-    var displayRepresentation: DisplayRepresentation {
-        DisplayRepresentation(title: "\(title)", subtitle: "\(author)")
-    }
-}
-
-/// Answers the configuration sheet out of the App Group snapshot.
-///
-/// The books in progress are the only ones offered. Pinning a widget to
-/// something the reader is not currently reading would be a widget that says
-/// "Continue" about a book they never started — and the snapshot is all the
-/// extension can see anyway.
-struct BookQuery: EntityQuery {
-    func entities(for identifiers: [BookEntity.ID]) async throws -> [BookEntity] {
-        books.filter { identifiers.contains($0.id) }
-    }
-
-    func suggestedEntities() async throws -> [BookEntity] {
-        books
-    }
-
-    private var books: [BookEntity] {
-        (WidgetStore.load() ?? .empty()).books.map(BookEntity.init)
-    }
-}
-
-struct SelectBookIntent: WidgetConfigurationIntent {
-    static let title: LocalizedStringResource = "Choose a book"
+struct ShowNextBook: AppIntent {
+    static let title: LocalizedStringResource = "Show the next book"
     static let description = IntentDescription(
-        "Pick the book this widget shows. Left empty it follows whichever book you read last."
+        "Moves the Continue widget on to the next book you have in progress."
     )
 
-    /// Optional on purpose, and the empty case is the default: a widget added
-    /// without a thought should track the reader rather than pin to whatever
-    /// happened to be on top the day they added it. Pinning is what you do to
-    /// the *second* copy, once you are building a stack.
-    @Parameter(title: "Book")
-    var book: BookEntity?
+    /// The whole point is that the rail can be walked from the Home Screen.
+    /// Launching the app to answer a tap would make the control slower than
+    /// just opening the book it is trying to skip past.
+    static let openAppWhenRun = false
 
-    init() {}
-
-    init(book: BookEntity?) {
-        self.book = book
+    func perform() async throws -> some IntentResult {
+        let snapshot = WidgetStore.load() ?? .empty()
+        WidgetStore.setCursor(snapshot.next(after: WidgetStore.cursor())?.id)
+        // WidgetKit reloads after an intent on its own, but only for the
+        // widget whose button was tapped. Naming the kind refreshes a second
+        // Continue widget on the same screen, which is otherwise left showing
+        // a cursor that has already moved.
+        WidgetCenter.shared.reloadTimelines(ofKind: WidgetKind.continueReading)
+        return .result()
     }
 }

--- a/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueIntents.swift
@@ -1,33 +1,71 @@
 //  ContinueIntents.swift
-//  Moving the one-book card along the rail without leaving the Home Screen.
+//  What makes one Continue widget different from the next one beside it.
 //
-//  A widget cannot be swiped — the system renders it as a snapshot, and the
-//  only interaction it offers is a tap: a `widgetURL`/`Link` that opens the
-//  app, or an `AppIntent` that runs in the extension. So the card flips rather
-//  than scrolls, and this is the flip.
+//  A widget cannot be swiped — the system renders it as a snapshot and only
+//  routes taps — so the rail is walked by *stacking* widgets and swiping the
+//  stack. That only shows different books if each copy can be configured to a
+//  different one, which is what this is: the book parameter the Home Screen's
+//  edit sheet offers, and the entity query behind it.
 
 import AppIntents
-import WidgetKit
 
-struct ShowNextBook: AppIntent {
-    static let title: LocalizedStringResource = "Show the next book"
+/// A book the widget can be pinned to, named by `WidgetBook.id` so the
+/// selection survives the rail being rewritten around it.
+struct BookEntity: AppEntity {
+    let id: String
+    let title: String
+    let author: String
+
+    init(_ book: WidgetBook) {
+        id = book.id
+        title = book.title
+        author = book.author
+    }
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Book"
+    static let defaultQuery = BookQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(title)", subtitle: "\(author)")
+    }
+}
+
+/// Answers the configuration sheet out of the App Group snapshot.
+///
+/// The books in progress are the only ones offered. Pinning a widget to
+/// something the reader is not currently reading would be a widget that says
+/// "Continue" about a book they never started — and the snapshot is all the
+/// extension can see anyway.
+struct BookQuery: EntityQuery {
+    func entities(for identifiers: [BookEntity.ID]) async throws -> [BookEntity] {
+        books.filter { identifiers.contains($0.id) }
+    }
+
+    func suggestedEntities() async throws -> [BookEntity] {
+        books
+    }
+
+    private var books: [BookEntity] {
+        (WidgetStore.load() ?? .empty()).books.map(BookEntity.init)
+    }
+}
+
+struct SelectBookIntent: WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Choose a book"
     static let description = IntentDescription(
-        "Moves the Continue widget on to the next book you have in progress."
+        "Pick the book this widget shows. Left empty it follows whichever book you read last."
     )
 
-    /// The whole point is that the rail can be walked from the Home Screen.
-    /// Launching the app to answer a tap would make the control slower than
-    /// just opening the book it is trying to skip past.
-    static let openAppWhenRun = false
+    /// Optional on purpose, and the empty case is the default: a widget added
+    /// without a thought should track the reader rather than pin to whatever
+    /// happened to be on top the day they added it. Pinning is what you do to
+    /// the *second* copy, once you are building a stack.
+    @Parameter(title: "Book")
+    var book: BookEntity?
 
-    func perform() async throws -> some IntentResult {
-        let snapshot = WidgetStore.load() ?? .empty()
-        WidgetStore.setCursor(snapshot.next(after: WidgetStore.cursor())?.id)
-        // WidgetKit reloads after an intent on its own, but only for the
-        // widget whose button was tapped. Naming the kind refreshes a second
-        // Continue widget on the same screen, which is otherwise left showing
-        // a cursor that has already moved.
-        WidgetCenter.shared.reloadTimelines(ofKind: WidgetKind.continueReading)
-        return .result()
+    init() {}
+
+    init(book: BookEntity?) {
+        self.book = book
     }
 }

--- a/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
@@ -11,6 +11,10 @@ import WidgetKit
 struct ContinueEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot
+    /// Which book the one-book families are showing. Resolved at timeline time
+    /// rather than inside the view, so a render stays a pure function of its
+    /// entry and a `#Preview` can pose any card in the rail.
+    var cursor: String?
 }
 
 struct ContinueProvider: TimelineProvider {
@@ -34,11 +38,20 @@ struct ContinueProvider: TimelineProvider {
         // the same fabricated card the placeholder does — a real-looking
         // widget is what someone is choosing between in that list.
         let snapshot = context.isPreview ? .preview : (WidgetStore.load() ?? .empty())
-        completion(ContinueEntry(date: .now, snapshot: snapshot))
+        // The gallery always shows the front of the rail: someone choosing a
+        // widget has not flipped it anywhere yet, and a stored cursor from a
+        // widget already on their Home Screen would pose this one on a book
+        // they didn't pick.
+        let cursor = context.isPreview ? nil : WidgetStore.cursor()
+        completion(ContinueEntry(date: .now, snapshot: snapshot, cursor: cursor))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<ContinueEntry>) -> Void) {
-        let entry = ContinueEntry(date: .now, snapshot: WidgetStore.load() ?? .empty())
+        let entry = ContinueEntry(
+            date: .now,
+            snapshot: WidgetStore.load() ?? .empty(),
+            cursor: WidgetStore.cursor()
+        )
         completion(
             Timeline(entries: [entry], policy: .after(.now + Self.refreshInterval))
         )
@@ -48,7 +61,7 @@ struct ContinueProvider: TimelineProvider {
 struct ContinueWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: WidgetKind.continueReading, provider: ContinueProvider()) { entry in
-            ContinueWidgetView(snapshot: entry.snapshot)
+            ContinueWidgetView(snapshot: entry.snapshot, cursor: entry.cursor)
         }
         .configurationDisplayName("Continue")
         .description("Pick up the book you were last in.")

--- a/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
@@ -1,9 +1,10 @@
 //  ContinueWidget.swift
 //  The Home Screen equivalent of the landing Continue stack.
 //
-//  Reads nothing but the App Group snapshot, so it renders identically in
-//  Airplane Mode with the app force-quit — which is most of the time a widget
-//  is actually looked at.
+//  Reads nothing outside the App Group — the snapshot the app writes, and the
+//  cursor the extension keeps beside it — so it renders identically in Airplane
+//  Mode with the app force-quit, which is most of the time a widget is actually
+//  looked at.
 
 import SwiftUI
 import WidgetKit

--- a/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
@@ -5,19 +5,20 @@
 //  Airplane Mode with the app force-quit — which is most of the time a widget
 //  is actually looked at.
 
+import AppIntents
 import SwiftUI
 import WidgetKit
 
 struct ContinueEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot
-    /// Which book the one-book families are showing. Resolved at timeline time
-    /// rather than inside the view, so a render stays a pure function of its
-    /// entry and a `#Preview` can pose any card in the rail.
-    var cursor: String?
+    /// Which book this copy of the widget is pinned to, by `WidgetBook.id`.
+    /// Resolved at timeline time rather than inside the view, so a render stays
+    /// a pure function of its entry and a `#Preview` can pose any book.
+    var selected: String?
 }
 
-struct ContinueProvider: TimelineProvider {
+struct ContinueProvider: AppIntentTimelineProvider {
     /// How long a timeline stands before WidgetKit asks for another.
     ///
     /// The app pushes a reload whenever the snapshot changes, so this is only
@@ -33,38 +34,74 @@ struct ContinueProvider: TimelineProvider {
         ContinueEntry(date: .now, snapshot: .preview)
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (ContinueEntry) -> Void) {
+    func snapshot(for configuration: SelectBookIntent, in context: Context) async -> ContinueEntry {
         // The gallery preview has no App Group content to show yet, so it gets
         // the same fabricated card the placeholder does — a real-looking
         // widget is what someone is choosing between in that list.
         let snapshot = context.isPreview ? .preview : (WidgetStore.load() ?? .empty())
-        // The gallery always shows the front of the rail: someone choosing a
-        // widget has not flipped it anywhere yet, and a stored cursor from a
-        // widget already on their Home Screen would pose this one on a book
-        // they didn't pick.
-        let cursor = context.isPreview ? nil : WidgetStore.cursor()
-        completion(ContinueEntry(date: .now, snapshot: snapshot, cursor: cursor))
+        return ContinueEntry(
+            date: .now,
+            snapshot: snapshot,
+            selected: context.isPreview ? nil : configuration.book?.id
+        )
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<ContinueEntry>) -> Void) {
+    func timeline(for configuration: SelectBookIntent, in context: Context) async -> Timeline<ContinueEntry> {
         let entry = ContinueEntry(
             date: .now,
             snapshot: WidgetStore.load() ?? .empty(),
-            cursor: WidgetStore.cursor()
+            selected: configuration.book?.id
         )
-        completion(
-            Timeline(entries: [entry], policy: .after(.now + Self.refreshInterval))
+        return Timeline(entries: [entry], policy: .after(.now + Self.refreshInterval))
+    }
+
+    /// One configuration per book in progress, so a Smart Stack has something
+    /// to rotate between rather than one card that never changes.
+    ///
+    /// Grouped rather than loose: these are alternative views of one widget,
+    /// not five widgets someone asked for, and an ungrouped set can stack up as
+    /// five separate faces of the same thing.
+    func relevance() async -> WidgetRelevance<SelectBookIntent> {
+        let books = (WidgetStore.load() ?? .empty()).books.prefix(WidgetSnapshot.maxBooks)
+        return WidgetRelevance(
+            books.map {
+                WidgetRelevanceAttribute(
+                    configuration: SelectBookIntent(book: BookEntity($0)),
+                    group: .named(WidgetKind.continueReading)
+                )
+            }
         )
+    }
+
+    /// What the widget gallery offers when the reader is adding one. The
+    /// unpinned card leads: it is the one that keeps working without being
+    /// revisited, and the pinned ones are what a stack is built out of
+    /// afterwards.
+    func recommendations() -> [AppIntentRecommendation<SelectBookIntent>] {
+        let books = (WidgetStore.load() ?? .empty()).books.prefix(WidgetSnapshot.maxBooks)
+        return [AppIntentRecommendation(intent: SelectBookIntent(), description: Text("Most recent"))]
+            + books.map {
+                AppIntentRecommendation(
+                    intent: SelectBookIntent(book: BookEntity($0)),
+                    description: Text($0.title)
+                )
+            }
     }
 }
 
 struct ContinueWidget: Widget {
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: WidgetKind.continueReading, provider: ContinueProvider()) { entry in
-            ContinueWidgetView(snapshot: entry.snapshot, cursor: entry.cursor)
+        AppIntentConfiguration(
+            kind: WidgetKind.continueReading,
+            intent: SelectBookIntent.self,
+            provider: ContinueProvider()
+        ) { entry in
+            ContinueWidgetView(snapshot: entry.snapshot, selected: entry.selected)
         }
         .configurationDisplayName("Continue")
-        .description("Pick up the book you were last in.")
+        // Says the stack out loud: the card shows one book, and the way to see
+        // the others is to add a second copy and stack them.
+        .description("Pick up a book you're in the middle of. Add one per book and stack them to swipe between.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
         // The card is a full-bleed wash in the book's own colour with cover
         // art laid on it, so it owns its insets: the system's default margins

--- a/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidget.swift
@@ -5,20 +5,19 @@
 //  Airplane Mode with the app force-quit — which is most of the time a widget
 //  is actually looked at.
 
-import AppIntents
 import SwiftUI
 import WidgetKit
 
 struct ContinueEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot
-    /// Which book this copy of the widget is pinned to, by `WidgetBook.id`.
-    /// Resolved at timeline time rather than inside the view, so a render stays
-    /// a pure function of its entry and a `#Preview` can pose any book.
-    var selected: String?
+    /// Which book the medium card is showing, by `WidgetBook.id`. Read at
+    /// timeline time rather than inside the view, so a render stays a pure
+    /// function of its entry and a `#Preview` can pose any card in the rail.
+    var cursor: String?
 }
 
-struct ContinueProvider: AppIntentTimelineProvider {
+struct ContinueProvider: TimelineProvider {
     /// How long a timeline stands before WidgetKit asks for another.
     ///
     /// The app pushes a reload whenever the snapshot changes, so this is only
@@ -34,74 +33,38 @@ struct ContinueProvider: AppIntentTimelineProvider {
         ContinueEntry(date: .now, snapshot: .preview)
     }
 
-    func snapshot(for configuration: SelectBookIntent, in context: Context) async -> ContinueEntry {
+    func getSnapshot(in context: Context, completion: @escaping (ContinueEntry) -> Void) {
         // The gallery preview has no App Group content to show yet, so it gets
         // the same fabricated card the placeholder does — a real-looking
         // widget is what someone is choosing between in that list.
         let snapshot = context.isPreview ? .preview : (WidgetStore.load() ?? .empty())
-        return ContinueEntry(
-            date: .now,
-            snapshot: snapshot,
-            selected: context.isPreview ? nil : configuration.book?.id
-        )
+        // The gallery always shows the front of the rail: someone choosing a
+        // widget has not flipped it anywhere yet, and a stored cursor from a
+        // widget already on their Home Screen would pose this one on a book
+        // they didn't pick.
+        let cursor = context.isPreview ? nil : WidgetStore.cursor()
+        completion(ContinueEntry(date: .now, snapshot: snapshot, cursor: cursor))
     }
 
-    func timeline(for configuration: SelectBookIntent, in context: Context) async -> Timeline<ContinueEntry> {
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ContinueEntry>) -> Void) {
         let entry = ContinueEntry(
             date: .now,
             snapshot: WidgetStore.load() ?? .empty(),
-            selected: configuration.book?.id
+            cursor: WidgetStore.cursor()
         )
-        return Timeline(entries: [entry], policy: .after(.now + Self.refreshInterval))
-    }
-
-    /// One configuration per book in progress, so a Smart Stack has something
-    /// to rotate between rather than one card that never changes.
-    ///
-    /// Grouped rather than loose: these are alternative views of one widget,
-    /// not five widgets someone asked for, and an ungrouped set can stack up as
-    /// five separate faces of the same thing.
-    func relevance() async -> WidgetRelevance<SelectBookIntent> {
-        let books = (WidgetStore.load() ?? .empty()).books.prefix(WidgetSnapshot.maxBooks)
-        return WidgetRelevance(
-            books.map {
-                WidgetRelevanceAttribute(
-                    configuration: SelectBookIntent(book: BookEntity($0)),
-                    group: .named(WidgetKind.continueReading)
-                )
-            }
+        completion(
+            Timeline(entries: [entry], policy: .after(.now + Self.refreshInterval))
         )
-    }
-
-    /// What the widget gallery offers when the reader is adding one. The
-    /// unpinned card leads: it is the one that keeps working without being
-    /// revisited, and the pinned ones are what a stack is built out of
-    /// afterwards.
-    func recommendations() -> [AppIntentRecommendation<SelectBookIntent>] {
-        let books = (WidgetStore.load() ?? .empty()).books.prefix(WidgetSnapshot.maxBooks)
-        return [AppIntentRecommendation(intent: SelectBookIntent(), description: Text("Most recent"))]
-            + books.map {
-                AppIntentRecommendation(
-                    intent: SelectBookIntent(book: BookEntity($0)),
-                    description: Text($0.title)
-                )
-            }
     }
 }
 
 struct ContinueWidget: Widget {
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(
-            kind: WidgetKind.continueReading,
-            intent: SelectBookIntent.self,
-            provider: ContinueProvider()
-        ) { entry in
-            ContinueWidgetView(snapshot: entry.snapshot, selected: entry.selected)
+        StaticConfiguration(kind: WidgetKind.continueReading, provider: ContinueProvider()) { entry in
+            ContinueWidgetView(snapshot: entry.snapshot, cursor: entry.cursor)
         }
         .configurationDisplayName("Continue")
-        // Says the stack out loud: the card shows one book, and the way to see
-        // the others is to add a second copy and stack them.
-        .description("Pick up a book you're in the middle of. Add one per book and stack them to swipe between.")
+        .description("Pick up the book you were last in.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
         // The card is a full-bleed wash in the book's own colour with cover
         // art laid on it, so it owns its insets: the system's default margins

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -1,35 +1,41 @@
 //  ContinueWidgetView.swift
 //  One card per family, plus the three ways the card can be empty.
 //
-//  The families are not the same layout at three sizes: small and medium each
-//  answer "what am I in the middle of" with a single book, and large answers
-//  "and when did I last touch each" with all of them. A widget cannot be
-//  swiped, so the one-book families are each pinned to a book instead and the
-//  rail is walked by stacking them — see `ContinueIntents`.
+//  The families are not the same layout at three sizes: small answers "what am
+//  I in the middle of" with the one book that is, medium answers "which of my
+//  two or three" with one book and a control that flips between them, and large
+//  answers "and when did I last touch each" with all of them. A widget cannot
+//  be swiped, so the flip is a tap — see `ContinueIntents`.
 
+import AppIntents
 import SwiftUI
 import WidgetKit
 
 struct ContinueWidgetView: View {
     let snapshot: WidgetSnapshot
-    /// Which book this copy is pinned to, by `WidgetBook.id`.
-    var selected: String?
+    /// Which book the medium card is showing, by `WidgetBook.id`.
+    var cursor: String?
 
     @Environment(\.widgetFamily) private var family
     @Environment(\.colorScheme) private var scheme
 
-    /// The whole card takes its colour from the book it is about, the way the
-    /// book-detail hero takes its wash from the book it is about. For the one
-    /// book families that is the pinned book; large is a list, so it stays with
-    /// the book leading it.
-    private var theme: WidgetTheme {
-        WidgetTheme(tone: (isRail ? snapshot.books.first : shown)?.tone, scheme: scheme)
+    private var isMedium: Bool { family != .systemSmall && family != .systemLarge }
+
+    private var flipped: (book: WidgetBook, index: Int)? {
+        snapshot.showing(cursor: cursor)
     }
 
-    private var isRail: Bool { family == .systemLarge }
+    /// The book the card is about. Only medium follows the cursor: small is the
+    /// "what am I in the middle of" card and answers with the book that is,
+    /// full stop, and large is a list led by the same one.
+    private var lead: WidgetBook? {
+        isMedium ? flipped?.book : snapshot.books.first
+    }
 
-    private var shown: WidgetBook? {
-        snapshot.showing(selected: selected)
+    /// The whole card takes its colour from the book it is about, the way the
+    /// book-detail hero takes its wash from the book it is about.
+    private var theme: WidgetTheme {
+        WidgetTheme(tone: lead?.tone, scheme: scheme)
     }
 
     var body: some View {
@@ -43,8 +49,8 @@ struct ContinueWidgetView: View {
     /// behind it.
     @ViewBuilder
     private var background: some View {
-        if family == .systemSmall, let shown {
-            WidgetHeroBackdrop(book: shown, theme: theme)
+        if family == .systemSmall, let lead {
+            WidgetHeroBackdrop(book: lead, theme: theme)
         } else {
             theme.ground
         }
@@ -52,11 +58,19 @@ struct ContinueWidgetView: View {
 
     @ViewBuilder
     private var content: some View {
-        if let shown {
+        if let lead {
             switch family {
-            case .systemSmall: SmallCard(book: shown, theme: theme)
+            case .systemSmall: SmallCard(book: lead, theme: theme)
             case .systemLarge: LargeCard(books: snapshot.books, theme: theme)
-            default: MediumCard(book: shown, theme: theme)
+            default:
+                MediumCard(
+                    book: lead,
+                    theme: theme,
+                    rail: RailPosition(
+                        index: flipped?.index ?? 0,
+                        count: snapshot.flipRail.count
+                    )
+                )
             }
         } else {
             EmptyCard(state: snapshot.state, theme: theme, family: family)
@@ -68,10 +82,25 @@ private enum Layout {
     static let margin: CGFloat = 14
 }
 
+/// Where the shown book sits in the medium card's flip rail — what the dots
+/// draw, and what tells the advance control whether there is anywhere to go.
+private struct RailPosition {
+    let index: Int
+    let count: Int
+
+    var hasOthers: Bool { count > 1 }
+}
+
 // MARK: - Small
 
-/// One book, given the whole card: its own artwork blurred into the ground, the
-/// cover sharp on top, and where you are along the bottom edge.
+/// The one book you are in the middle of, given the whole card: its own artwork
+/// blurred into the ground, the cover sharp on top, and where you are along the
+/// bottom edge.
+///
+/// No flip control, deliberately. This is 130pt square — the smallest surface
+/// the app has — and a chevron on it would spend the card's only spare corner
+/// arguing with the artwork to answer a question this family isn't asking.
+/// Whichever book you touched last is the whole answer here.
 ///
 /// The sizes here are a budget, not a preference. A `systemSmall` is 130pt of
 /// content on a 6.3" phone, and the cover, the spacings and the position line
@@ -148,11 +177,12 @@ private struct BleedBar: View {
 ///
 /// The old three-across fan answered "which of my two or three" by shrinking
 /// all three to a thumbnail and a truncated title. This answers it by showing
-/// one book properly, with the resume actually reachable from the Home Screen —
-/// and leaves "which of them" to a stack of these.
+/// one book properly, with the resume actually reachable from the Home Screen,
+/// and letting the reader flip to the others.
 private struct MediumCard: View {
     let book: WidgetBook
     let theme: WidgetTheme
+    let rail: RailPosition
 
     private var isAudio: Bool { book.format == .audio }
 
@@ -177,13 +207,20 @@ private struct MediumCard: View {
             .frame(maxHeight: .infinity)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(isAudio ? "Continue listening" : "Continue reading")
-                    .font(.system(size: 9.5, weight: .semibold))
-                    .tracking(0.6)
-                    .textCase(.uppercase)
-                    .foregroundStyle(theme.rule)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.85)
+                HStack(alignment: .center, spacing: 6) {
+                    Text(isAudio ? "Continue listening" : "Continue reading")
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .tracking(0.6)
+                        .textCase(.uppercase)
+                        .foregroundStyle(theme.rule)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+
+                    Spacer(minLength: 0)
+
+                    RailDots(theme: theme, rail: rail)
+                    AdvanceButton(theme: theme, rail: rail)
+                }
 
                 Text(book.title)
                     .font(.system(size: 17, weight: .semibold, design: .serif))
@@ -253,6 +290,52 @@ private struct ResumePill: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(Capsule().fill(theme.pillFill))
+        }
+    }
+}
+
+// MARK: - Flipping through the rail
+
+/// Moves the card on to the next book without leaving the Home Screen.
+///
+/// Hidden when the rail is one book, where it would be a control that does
+/// nothing — and drawn as a chevron rather than a pair of arrows because the
+/// intent wraps, so forward is the only direction there needs to be.
+private struct AdvanceButton: View {
+    let theme: WidgetTheme
+    let rail: RailPosition
+
+    var body: some View {
+        if rail.hasOthers {
+            Button(intent: ShowNextBook()) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(theme.ink1)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(theme.track))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Next book")
+        }
+    }
+}
+
+/// Where the shown book sits in the rail. Drawn from the resolved index rather
+/// than from a count of its own, so it cannot disagree with the card above it.
+private struct RailDots: View {
+    let theme: WidgetTheme
+    let rail: RailPosition
+
+    var body: some View {
+        if rail.hasOthers {
+            HStack(spacing: 4) {
+                ForEach(0..<rail.count, id: \.self) { position in
+                    Capsule()
+                        .fill(position == rail.index ? theme.rule : theme.ink2.opacity(0.35))
+                        .frame(width: position == rail.index ? 10 : 4, height: 4)
+                }
+            }
+            .accessibilityHidden(true)
         }
     }
 }

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -98,6 +98,10 @@ private enum Layout {
     static var mediumBloomOffset: CGFloat {
         margin + mediumCoverWidth / 2 - mediumBloom / 2
     }
+
+    /// Width the eyebrow row keeps clear for the dots and the chevron, which
+    /// are drawn over it rather than in it.
+    static let mediumControls: CGFloat = 58
 }
 
 /// Where the shown book sits in the medium card's flip rail — what the dots
@@ -219,7 +223,7 @@ private struct MediumCard: View {
             .frame(maxHeight: .infinity)
 
             VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .center, spacing: 6) {
+                HStack(spacing: 6) {
                     Text(isAudio ? "Continue listening" : "Continue reading")
                         .font(.system(size: 9.5, weight: .semibold))
                         .tracking(0.6)
@@ -228,10 +232,13 @@ private struct MediumCard: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.85)
 
-                    Spacer(minLength: 0)
-
-                    RailDots(theme: theme, rail: rail)
-                    AdvanceButton(theme: theme, rail: rail)
+                    // Holds the corner the dots and the chevron are drawn in.
+                    // They are an overlay rather than members of this row
+                    // because the chevron's tap target has to be far bigger
+                    // than the chevron, and a row as tall as that target costs
+                    // the title its second line on a 6.3" phone. A spacer
+                    // reserves the width without owning the height.
+                    Spacer(minLength: Layout.mediumControls)
                 }
 
                 Text(book.title)
@@ -269,6 +276,18 @@ private struct MediumCard: View {
             }
         }
         .padding(Layout.margin)
+        .overlay(alignment: .topTrailing) {
+            HStack(spacing: 2) {
+                RailDots(theme: theme, rail: rail)
+                AdvanceButton(theme: theme, rail: rail)
+            }
+            // The button carries `slop` of its own padding, so its frame
+            // overhangs the chevron by that much on every side. Backing the
+            // inset off by the same amount lands the drawn chip on the card's
+            // margin rather than the invisible frame around it.
+            .padding(.top, Layout.margin - AdvanceButton.slop)
+            .padding(.trailing, Layout.margin - AdvanceButton.slop)
+        }
         .background(alignment: .leading) {
             theme.bloom(diameter: Layout.mediumBloom)
                 .offset(x: Layout.mediumBloomOffset)
@@ -318,18 +337,22 @@ private struct AdvanceButton: View {
     let theme: WidgetTheme
     let rail: RailPosition
 
-    /// How far past the drawn chip a tap still counts.
+    /// How far past the drawn chip a tap still counts, taking the target to
+    /// 40pt around a 22pt chevron.
     ///
-    /// The chip stays 22pt because the card's height budget is tuned around it
-    /// — the eyebrow row is as tall as this control, and the title's second
-    /// line is what pays for any growth. But 22pt is half Apple's minimum, and
-    /// this is the one control on the card whose *miss* does something other
-    /// than what a hit does: every other target here resolves to the same
-    /// `book.deepLink`, while the margin around this one is the card-wide
-    /// `widgetURL`, so a tap a few points off cold-launches the reader instead
-    /// of flipping. The padding buys the hit area, the negative padding hands
-    /// the layout its 22pt back.
-    private static let slop: CGFloat = 8
+    /// 22pt alone is half Apple's minimum, and this is the one control on the
+    /// card whose *miss* does something other than what a hit does: every other
+    /// target here resolves to the same `book.deepLink`, while the space around
+    /// this one is the card-wide `widgetURL`, so a tap a few points off
+    /// cold-launches the reader instead of flipping.
+    ///
+    /// Plain padding, and the caller draws this in an overlay. Padding the
+    /// button and then cancelling it with negative padding also shrinks the
+    /// bounds hit-testing uses, which would leave the target the 22pt it
+    /// started at; growing the row instead costs the title its second line at
+    /// 158pt. An overlay is the only one of the three that buys the area
+    /// without spending layout.
+    static let slop: CGFloat = 9
 
     var body: some View {
         if rail.hasOthers {
@@ -343,7 +366,6 @@ private struct AdvanceButton: View {
                     .contentShape(Circle())
             }
             .buttonStyle(.plain)
-            .padding(-Self.slop)
             .accessibilityLabel("Next book")
         }
     }

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -291,6 +291,11 @@ private struct ResumePill: View {
             HStack(spacing: 5) {
                 Image(systemName: book.format == .audio ? "play.fill" : "book.fill")
                     .font(.system(size: 9, weight: .bold))
+                    // Decorative — the word beside it already says what this
+                    // does, and VoiceOver reads a bare system image as its
+                    // symbol name, so leaving it in makes the control announce
+                    // as "play.fill Play".
+                    .accessibilityHidden(true)
                 Text(book.format == .audio ? "Play" : "Read")
                     .font(.system(size: 11.5, weight: .semibold))
             }
@@ -313,6 +318,19 @@ private struct AdvanceButton: View {
     let theme: WidgetTheme
     let rail: RailPosition
 
+    /// How far past the drawn chip a tap still counts.
+    ///
+    /// The chip stays 22pt because the card's height budget is tuned around it
+    /// — the eyebrow row is as tall as this control, and the title's second
+    /// line is what pays for any growth. But 22pt is half Apple's minimum, and
+    /// this is the one control on the card whose *miss* does something other
+    /// than what a hit does: every other target here resolves to the same
+    /// `book.deepLink`, while the margin around this one is the card-wide
+    /// `widgetURL`, so a tap a few points off cold-launches the reader instead
+    /// of flipping. The padding buys the hit area, the negative padding hands
+    /// the layout its 22pt back.
+    private static let slop: CGFloat = 8
+
     var body: some View {
         if rail.hasOthers {
             Button(intent: ShowNextBook()) {
@@ -321,8 +339,11 @@ private struct AdvanceButton: View {
                     .foregroundStyle(theme.ink1)
                     .frame(width: 22, height: 22)
                     .background(Circle().fill(theme.track))
+                    .padding(Self.slop)
+                    .contentShape(Circle())
             }
             .buttonStyle(.plain)
+            .padding(-Self.slop)
             .accessibilityLabel("Next book")
         }
     }

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -80,6 +80,24 @@ struct ContinueWidgetView: View {
 
 private enum Layout {
     static let margin: CGFloat = 14
+
+    /// The medium card's cover, sized by width rather than height.
+    /// `WidgetCover` fits a 2:3 box into whatever it is proposed, and an
+    /// `HStack` proposes width to a flexible child before it knows the row's
+    /// height — so left to fill, the cover took half the card across and hung
+    /// off the bottom of it. 86pt puts its derived height just inside the 6.3"
+    /// card's 130.
+    static let mediumCoverWidth: CGFloat = 86
+
+    /// Kept close to the card's own height. A bloom much larger than the card
+    /// is clipped top and bottom into a full-height band, which reads as a slab
+    /// of colour behind the artwork rather than as a glow around it.
+    static let mediumBloom: CGFloat = 170
+
+    /// Puts the bloom's centre on the cover's centre.
+    static var mediumBloomOffset: CGFloat {
+        margin + mediumCoverWidth / 2 - mediumBloom / 2
+    }
 }
 
 /// Where the shown book sits in the medium card's flip rail — what the dots
@@ -189,14 +207,8 @@ private struct MediumCard: View {
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             OptionalLink(destination: book.deepLink) {
-                // Sized by width, not height. `WidgetCover` fits a 2:3 box into
-                // whatever it is proposed, and an `HStack` proposes width to a
-                // flexible child before it knows the row's height — so left to
-                // fill, the cover took half the card across and hung off the
-                // bottom of it. 86pt puts its derived height just inside the
-                // 6.3" card's 130.
                 WidgetCover(book: book, theme: theme, cornerRadius: 7)
-                    .frame(width: 86)
+                    .frame(width: Layout.mediumCoverWidth)
                     // Tighter than the small card's, which is laid on a blur of
                     // itself and needs the separation. Here the ground is a
                     // pale wash, and a soft shadow on one spreads 10pt of grey
@@ -258,12 +270,8 @@ private struct MediumCard: View {
         }
         .padding(Layout.margin)
         .background(alignment: .leading) {
-            // Centred on the cover: the offset puts the bloom's middle at the
-            // margin plus half the cover's width. Kept close to the card's own
-            // height, too — a circle much larger than the card is clipped top
-            // and bottom into a full-height band, which reads as a slab of
-            // colour behind the artwork rather than as a glow around it.
-            theme.bloom(diameter: 170).offset(x: Layout.margin + 43 - 85)
+            theme.bloom(diameter: Layout.mediumBloom)
+                .offset(x: Layout.mediumBloomOffset)
         }
         // Everything a `Link` or a `Button` doesn't cover — the margins, the
         // gap between the cover and the text, the text itself. Without it a tap

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -102,6 +102,10 @@ private enum Layout {
     /// Width the eyebrow row keeps clear for the dots and the chevron, which
     /// are drawn over it rather than in it.
     static let mediumControls: CGFloat = 58
+
+    /// The drawn chevron chip, and so also the height the eyebrow row holds
+    /// open beneath it — see the row's own note.
+    static let mediumChip: CGFloat = 22
 }
 
 /// Where the shown book sits in the medium card's flip rail — what the dots
@@ -167,6 +171,12 @@ private struct SmallCard: View {
         // The bar bleeds the full width of the card rather than sitting inside
         // the margins: it is the one element that reads at arm's length, and
         // the card has no vertical room left to give it a band of its own.
+        //
+        // Known and accepted: the widget is masked to a ~21.5pt rounded rect,
+        // so the leading corner of the fill is clipped and a book under about
+        // 7% draws no visible fill at all. Insetting the bar to clear the mask
+        // was tried and rejected — a bar floating above the edge is a worse
+        // card than one whose first few percent don't show.
         .overlay(alignment: .bottom) { BleedBar(book: book, theme: theme) }
         .widgetURL(book.deepLink)
     }
@@ -236,10 +246,16 @@ private struct MediumCard: View {
                     // They are an overlay rather than members of this row
                     // because the chevron's tap target has to be far bigger
                     // than the chevron, and a row as tall as that target costs
-                    // the title its second line on a 6.3" phone. A spacer
-                    // reserves the width without owning the height.
+                    // the title its second line on a 6.3" phone.
                     Spacer(minLength: Layout.mediumControls)
                 }
+                // The row still has to be as tall as the *chip*, even though it
+                // no longer contains it. Left to the 9.5pt eyebrow alone the row
+                // collapsed and pulled the title up under the control — so the
+                // end of a long first line sat inside the chevron's tap circle,
+                // and tapping a word of the title flipped the book instead of
+                // opening it.
+                .frame(height: Layout.mediumChip)
 
                 Text(book.title)
                     .font(.system(size: 17, weight: .semibold, design: .serif))
@@ -360,9 +376,15 @@ private struct AdvanceButton: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 10, weight: .bold))
                     .foregroundStyle(theme.ink1)
-                    .frame(width: 22, height: 22)
+                    .frame(width: Layout.mediumChip, height: Layout.mediumChip)
                     .background(Circle().fill(theme.track))
-                    .padding(Self.slop)
+                    // Grown up and outwards, into the card's own margin, and
+                    // barely downwards — below the chip is the title, and a
+                    // target that reaches into it turns a tap on the last word
+                    // of a line into a flip.
+                    .padding(.top, Self.slop)
+                    .padding(.horizontal, Self.slop)
+                    .padding(.bottom, Self.slop / 2)
                     .contentShape(Circle())
             }
             .buttonStyle(.plain)

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -3,34 +3,33 @@
 //
 //  The families are not the same layout at three sizes: small and medium each
 //  answer "what am I in the middle of" with a single book, and large answers
-//  "and when did I last touch each" with all of them. The one-book families
-//  carry a control that flips to the next book, because a widget cannot be
-//  swiped — see `ContinueIntents`.
+//  "and when did I last touch each" with all of them. A widget cannot be
+//  swiped, so the one-book families are each pinned to a book instead and the
+//  rail is walked by stacking them — see `ContinueIntents`.
 
-import AppIntents
 import SwiftUI
 import WidgetKit
 
 struct ContinueWidgetView: View {
     let snapshot: WidgetSnapshot
-    /// Which book the one-book families are showing, by `WidgetBook.id`.
-    var cursor: String?
+    /// Which book this copy is pinned to, by `WidgetBook.id`.
+    var selected: String?
 
     @Environment(\.widgetFamily) private var family
     @Environment(\.colorScheme) private var scheme
 
     /// The whole card takes its colour from the book it is about, the way the
     /// book-detail hero takes its wash from the book it is about. For the one
-    /// book families that is whichever the reader has flipped to; large is a
-    /// list, so it stays with the book leading it.
+    /// book families that is the pinned book; large is a list, so it stays with
+    /// the book leading it.
     private var theme: WidgetTheme {
-        WidgetTheme(tone: (isRail ? snapshot.books.first : shown?.book)?.tone, scheme: scheme)
+        WidgetTheme(tone: (isRail ? snapshot.books.first : shown)?.tone, scheme: scheme)
     }
 
     private var isRail: Bool { family == .systemLarge }
 
-    private var shown: (book: WidgetBook, index: Int)? {
-        snapshot.showing(cursor: cursor)
+    private var shown: WidgetBook? {
+        snapshot.showing(selected: selected)
     }
 
     var body: some View {
@@ -44,8 +43,8 @@ struct ContinueWidgetView: View {
     /// behind it.
     @ViewBuilder
     private var background: some View {
-        if family == .systemSmall, let book = shown?.book {
-            WidgetHeroBackdrop(book: book, theme: theme)
+        if family == .systemSmall, let shown {
+            WidgetHeroBackdrop(book: shown, theme: theme)
         } else {
             theme.ground
         }
@@ -53,12 +52,11 @@ struct ContinueWidgetView: View {
 
     @ViewBuilder
     private var content: some View {
-        if let shown, !snapshot.books.isEmpty {
-            let rail = RailPosition(index: shown.index, count: snapshot.books.count)
+        if let shown {
             switch family {
-            case .systemSmall: SmallCard(book: shown.book, theme: theme, rail: rail)
+            case .systemSmall: SmallCard(book: shown, theme: theme)
             case .systemLarge: LargeCard(books: snapshot.books, theme: theme)
-            default: MediumCard(book: shown.book, theme: theme, rail: rail)
+            default: MediumCard(book: shown, theme: theme)
             }
         } else {
             EmptyCard(state: snapshot.state, theme: theme, family: family)
@@ -68,15 +66,6 @@ struct ContinueWidgetView: View {
 
 private enum Layout {
     static let margin: CGFloat = 14
-}
-
-/// Where the shown book sits in the rail — what the dots draw and what tells
-/// the advance control whether there is anywhere to go.
-private struct RailPosition {
-    let index: Int
-    let count: Int
-
-    var hasOthers: Bool { count > 1 }
 }
 
 // MARK: - Small
@@ -92,7 +81,6 @@ private struct RailPosition {
 private struct SmallCard: View {
     let book: WidgetBook
     let theme: WidgetTheme
-    let rail: RailPosition
 
     var body: some View {
         // Centred as a column. A 2:3 cover is far narrower than the card, so
@@ -129,9 +117,6 @@ private struct SmallCard: View {
         // the margins: it is the one element that reads at arm's length, and
         // the card has no vertical room left to give it a band of its own.
         .overlay(alignment: .bottom) { BleedBar(book: book, theme: theme) }
-        .overlay(alignment: .topTrailing) {
-            AdvanceButton(theme: theme, rail: rail).padding(6)
-        }
         .widgetURL(book.deepLink)
     }
 }
@@ -163,12 +148,11 @@ private struct BleedBar: View {
 ///
 /// The old three-across fan answered "which of my two or three" by shrinking
 /// all three to a thumbnail and a truncated title. This answers it by showing
-/// one book properly and letting the reader flip — which is the same question
-/// with the resume actually reachable from the Home Screen.
+/// one book properly, with the resume actually reachable from the Home Screen —
+/// and leaves "which of them" to a stack of these.
 private struct MediumCard: View {
     let book: WidgetBook
     let theme: WidgetTheme
-    let rail: RailPosition
 
     private var isAudio: Bool { book.format == .audio }
 
@@ -193,20 +177,13 @@ private struct MediumCard: View {
             .frame(maxHeight: .infinity)
 
             VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .center, spacing: 6) {
-                    Text(isAudio ? "Continue listening" : "Continue reading")
-                        .font(.system(size: 9.5, weight: .semibold))
-                        .tracking(0.6)
-                        .textCase(.uppercase)
-                        .foregroundStyle(theme.rule)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.85)
-
-                    Spacer(minLength: 0)
-
-                    RailDots(theme: theme, rail: rail)
-                    AdvanceButton(theme: theme, rail: rail)
-                }
+                Text(isAudio ? "Continue listening" : "Continue reading")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .tracking(0.6)
+                    .textCase(.uppercase)
+                    .foregroundStyle(theme.rule)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
 
                 Text(book.title)
                     .font(.system(size: 17, weight: .semibold, design: .serif))
@@ -276,52 +253,6 @@ private struct ResumePill: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(Capsule().fill(theme.pillFill))
-        }
-    }
-}
-
-// MARK: - Flipping through the rail
-
-/// Moves the card on to the next book without leaving the Home Screen.
-///
-/// Hidden on a rail of one, where it would be a control that does nothing —
-/// and drawn as a chevron rather than a pair of arrows because the intent
-/// wraps, so forward is the only direction there needs to be.
-private struct AdvanceButton: View {
-    let theme: WidgetTheme
-    let rail: RailPosition
-
-    var body: some View {
-        if rail.hasOthers {
-            Button(intent: ShowNextBook()) {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(theme.ink1)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(theme.track))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Next book")
-        }
-    }
-}
-
-/// Where the shown book sits in the rail. Drawn from the resolved index rather
-/// than from a count of its own, so it cannot disagree with the card above it.
-private struct RailDots: View {
-    let theme: WidgetTheme
-    let rail: RailPosition
-
-    var body: some View {
-        if rail.hasOthers {
-            HStack(spacing: 4) {
-                ForEach(0..<rail.count, id: \.self) { position in
-                    Capsule()
-                        .fill(position == rail.index ? theme.rule : theme.ink2.opacity(0.35))
-                        .frame(width: position == rail.index ? 10 : 4, height: 4)
-                }
-            }
-            .accessibilityHidden(true)
         }
     }
 }

--- a/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
+++ b/omnibus-ios/OmnibusWidgets/ContinueWidgetView.swift
@@ -1,148 +1,328 @@
 //  ContinueWidgetView.swift
 //  One card per family, plus the three ways the card can be empty.
 //
-//  The families are not the same layout at three sizes: small answers "what am
-//  I in the middle of", medium "which of my two or three", large "and when did
-//  I last touch each". Each is sized around the one question it answers.
+//  The families are not the same layout at three sizes: small and medium each
+//  answer "what am I in the middle of" with a single book, and large answers
+//  "and when did I last touch each" with all of them. The one-book families
+//  carry a control that flips to the next book, because a widget cannot be
+//  swiped — see `ContinueIntents`.
 
+import AppIntents
 import SwiftUI
 import WidgetKit
 
 struct ContinueWidgetView: View {
     let snapshot: WidgetSnapshot
+    /// Which book the one-book families are showing, by `WidgetBook.id`.
+    var cursor: String?
 
     @Environment(\.widgetFamily) private var family
     @Environment(\.colorScheme) private var scheme
 
-    /// The whole card takes its colour from whichever book leads it, the way
-    /// the book-detail hero takes its wash from the book it is about.
+    /// The whole card takes its colour from the book it is about, the way the
+    /// book-detail hero takes its wash from the book it is about. For the one
+    /// book families that is whichever the reader has flipped to; large is a
+    /// list, so it stays with the book leading it.
     private var theme: WidgetTheme {
-        WidgetTheme(tone: snapshot.books.first?.tone, scheme: scheme)
+        WidgetTheme(tone: (isRail ? snapshot.books.first : shown?.book)?.tone, scheme: scheme)
+    }
+
+    private var isRail: Bool { family == .systemLarge }
+
+    private var shown: (book: WidgetBook, index: Int)? {
+        snapshot.showing(cursor: cursor)
     }
 
     var body: some View {
         content
-            .padding(Layout.margin)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .containerBackground(for: .widget) { theme.ground }
+            .containerBackground(for: .widget) { background }
+    }
+
+    /// Small spends the book's own artwork on its ground; the others keep the
+    /// tone wash, which is what a card with room for the cover *sharp* wants
+    /// behind it.
+    @ViewBuilder
+    private var background: some View {
+        if family == .systemSmall, let book = shown?.book {
+            WidgetHeroBackdrop(book: book, theme: theme)
+        } else {
+            theme.ground
+        }
     }
 
     @ViewBuilder
     private var content: some View {
-        if snapshot.books.isEmpty {
-            EmptyCard(state: snapshot.state, theme: theme, family: family)
-        } else {
+        if let shown, !snapshot.books.isEmpty {
+            let rail = RailPosition(index: shown.index, count: snapshot.books.count)
             switch family {
-            case .systemSmall: SmallCard(book: snapshot.books[0], theme: theme)
+            case .systemSmall: SmallCard(book: shown.book, theme: theme, rail: rail)
             case .systemLarge: LargeCard(books: snapshot.books, theme: theme)
-            default: MediumCard(books: snapshot.books, theme: theme)
+            default: MediumCard(book: shown.book, theme: theme, rail: rail)
             }
+        } else {
+            EmptyCard(state: snapshot.state, theme: theme, family: family)
         }
     }
 }
 
 private enum Layout {
     static let margin: CGFloat = 14
-    /// The most a `systemMedium` fits across without the titles becoming two
-    /// truncated words each.
-    static let mediumColumns = 3
+}
+
+/// Where the shown book sits in the rail — what the dots draw and what tells
+/// the advance control whether there is anywhere to go.
+private struct RailPosition {
+    let index: Int
+    let count: Int
+
+    var hasOthers: Bool { count > 1 }
 }
 
 // MARK: - Small
 
-/// One book, given the whole card: cover, title, and where you are in it.
+/// One book, given the whole card: its own artwork blurred into the ground, the
+/// cover sharp on top, and where you are along the bottom edge.
 ///
-/// The sizes here are a budget, not a preference. A `systemSmall` is 134pt of
-/// content on a 6.3" phone, and the cover, the two spacings, and the footer are
-/// all fixed — so whatever they don't claim is what the title gets, and
-/// `layoutPriority` cannot conjure more. At a 74pt cover and 8pt spacings the
-/// title was left 15pt, which is one line, so every title longer than the card
-/// is wide truncated mid-word. Sized to fit two lines instead: nothing on this
-/// card matters more than which book it is.
+/// The sizes here are a budget, not a preference. A `systemSmall` is 130pt of
+/// content on a 6.3" phone, and the cover, the spacings and the position line
+/// are all fixed — so whatever they don't claim is what the title gets, and
+/// `layoutPriority` cannot conjure more. Sized so the title keeps two lines:
+/// nothing on this card matters more than which book it is.
 private struct SmallCard: View {
     let book: WidgetBook
     let theme: WidgetTheme
+    let rail: RailPosition
 
     var body: some View {
         // Centred as a column. A 2:3 cover is far narrower than the card, so
         // ranged left it sat off in one corner — and centring the cover over a
         // left-ranged title just moves the mismatch onto the type.
-        VStack(alignment: .center, spacing: 6) {
-            WidgetCover(book: book, theme: theme, cornerRadius: 5)
-                .frame(height: 60)
-                .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
-                // Also what holds the column at the card's full width: with no
-                // bar to draw (a CFI-only EPUB save has no percentage) nothing
-                // else here is greedy, and the stack would shrink to the
-                // title's width and be pinned to the leading edge — centred
-                // within itself, off-centre on the card.
+        VStack(alignment: .center, spacing: 0) {
+            WidgetCover(book: book, theme: theme, cornerRadius: 6)
+                .frame(height: 74)
+                // Deeper than the flat card's, because here the cover is laid
+                // on a blur of itself: without a shadow to separate them the
+                // sharp edge reads as an artefact of the blur rather than as a
+                // second object in front of it.
+                .shadow(color: .black.opacity(0.42), radius: 10, y: 5)
                 .frame(maxWidth: .infinity)
+
+            Spacer(minLength: 4)
 
             Text(book.title)
                 .font(.system(size: 13, weight: .semibold, design: .serif))
                 .foregroundStyle(theme.ink0)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
-                // Claims its two lines ahead of the spacer below it.
+                // Claims its two lines ahead of the spacer above it.
                 .layoutPriority(1)
 
-            Spacer(minLength: 0)
-
-            PositionFooter(book: book, theme: theme)
+            Text(PositionLabel.text(for: book))
+                .font(.system(size: 9.5, weight: .medium))
+                .foregroundStyle(theme.ink1)
+                .lineLimit(1)
+                .padding(.top, 2)
+        }
+        .padding(Layout.margin)
+        // The bar bleeds the full width of the card rather than sitting inside
+        // the margins: it is the one element that reads at arm's length, and
+        // the card has no vertical room left to give it a band of its own.
+        .overlay(alignment: .bottom) { BleedBar(book: book, theme: theme) }
+        .overlay(alignment: .topTrailing) {
+            AdvanceButton(theme: theme, rail: rail).padding(6)
         }
         .widgetURL(book.deepLink)
     }
 }
 
-// MARK: - Medium
-
-/// Three across — the shape of "which of the two or three am I picking up".
-private struct MediumCard: View {
-    let books: [WidgetBook]
+/// The position bar, run edge to edge along the bottom of the small card.
+private struct BleedBar: View {
+    let book: WidgetBook
     let theme: WidgetTheme
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            ForEach(books.prefix(Layout.mediumColumns)) { book in
-                OptionalLink(destination: book.deepLink) {
-                    // Centred as a column, for the same reason as the small
-                    // card's — see `SmallCard`.
-                    VStack(alignment: .center, spacing: 6) {
-                        WidgetCover(book: book, theme: theme)
-                            .frame(height: 80)
-                            .shadow(color: .black.opacity(0.28), radius: 5, y: 3)
-                            .frame(maxWidth: .infinity)
-
-                        Text(book.title)
-                            .font(.system(size: 11.5, weight: .semibold, design: .serif))
-                            .foregroundStyle(theme.ink0)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.center)
-
-                        Spacer(minLength: 0)
-
-                        if let fraction = book.fraction {
-                            WidgetProgressBar(fraction: fraction, theme: theme, height: 2.5)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .center)
+        if let fraction = book.fraction {
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Rectangle().fill(theme.track)
+                    Rectangle()
+                        .fill(theme.rule)
+                        .frame(width: geometry.size.width * min(1, max(0, fraction)))
                 }
             }
-            // A single book must not stretch to the full width — the column is
-            // sized by the cover's aspect, and a lone one would draw a cover
-            // three times the height of the card.
-            if books.count < Layout.mediumColumns {
-                ForEach(books.count..<Layout.mediumColumns, id: \.self) { _ in
-                    Color.clear.frame(maxWidth: .infinity)
+            .frame(height: 3)
+        }
+    }
+}
+
+// MARK: - Medium
+
+/// One book as a call to action: the cover at full card height, the title set
+/// large beside it, and a pill that resumes it.
+///
+/// The old three-across fan answered "which of my two or three" by shrinking
+/// all three to a thumbnail and a truncated title. This answers it by showing
+/// one book properly and letting the reader flip — which is the same question
+/// with the resume actually reachable from the Home Screen.
+private struct MediumCard: View {
+    let book: WidgetBook
+    let theme: WidgetTheme
+    let rail: RailPosition
+
+    private var isAudio: Bool { book.format == .audio }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            OptionalLink(destination: book.deepLink) {
+                // Sized by width, not height. `WidgetCover` fits a 2:3 box into
+                // whatever it is proposed, and an `HStack` proposes width to a
+                // flexible child before it knows the row's height — so left to
+                // fill, the cover took half the card across and hung off the
+                // bottom of it. 86pt puts its derived height just inside the
+                // 6.3" card's 130.
+                WidgetCover(book: book, theme: theme, cornerRadius: 7)
+                    .frame(width: 86)
+                    // Tighter than the small card's, which is laid on a blur of
+                    // itself and needs the separation. Here the ground is a
+                    // pale wash, and a soft shadow on one spreads 10pt of grey
+                    // past every edge — which reads as the cover being bigger
+                    // and hanging off the card rather than as depth.
+                    .shadow(color: .black.opacity(0.26), radius: 6, y: 3)
+            }
+            .frame(maxHeight: .infinity)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .center, spacing: 6) {
+                    Text(isAudio ? "Continue listening" : "Continue reading")
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .tracking(0.6)
+                        .textCase(.uppercase)
+                        .foregroundStyle(theme.rule)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+
+                    Spacer(minLength: 0)
+
+                    RailDots(theme: theme, rail: rail)
+                    AdvanceButton(theme: theme, rail: rail)
+                }
+
+                Text(book.title)
+                    .font(.system(size: 17, weight: .semibold, design: .serif))
+                    .foregroundStyle(theme.ink0)
+                    .lineLimit(2)
+                    // The card's height is fixed, so a stack with nothing left
+                    // to give takes it from the title — a two-line one silently
+                    // becomes one truncated line the moment anything below asks
+                    // for space.
+                    .layoutPriority(1)
+
+                Text(book.author)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.ink2)
+                    .lineLimit(1)
+
+                Spacer(minLength: 2)
+
+                if let fraction = book.fraction {
+                    WidgetProgressBar(fraction: fraction, theme: theme, height: 3)
+                        .padding(.bottom, 4)
+                }
+
+                HStack(spacing: 8) {
+                    Text(PositionLabel.text(for: book))
+                        .font(.system(size: 10.5, weight: .medium))
+                        .foregroundStyle(theme.ink1)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+
+                    ResumePill(book: book, theme: theme)
                 }
             }
         }
-        // Everything a `Link` doesn't cover — the container margins, the gaps
-        // between columns, and the filler columns padding a one- or two-book
-        // fan, which can be two thirds of the card. Without it a tap there
-        // launches the app with no URL at all, which is the failure `DeepLink`
-        // exists to describe.
-        .widgetURL(books.first?.deepLink)
+        .padding(Layout.margin)
+        .background(alignment: .leading) {
+            // Centred on the cover: the offset puts the bloom's middle at the
+            // margin plus half the cover's width. Kept close to the card's own
+            // height, too — a circle much larger than the card is clipped top
+            // and bottom into a full-height band, which reads as a slab of
+            // colour behind the artwork rather than as a glow around it.
+            theme.bloom(diameter: 170).offset(x: Layout.margin + 43 - 85)
+        }
+        // Everything a `Link` or a `Button` doesn't cover — the margins, the
+        // gap between the cover and the text, the text itself. Without it a tap
+        // there launches the app with no URL at all, which is the failure
+        // `DeepLink` exists to describe.
+        .widgetURL(book.deepLink)
+    }
+}
+
+/// The card's one solid shape, and the only control on it that resumes.
+private struct ResumePill: View {
+    let book: WidgetBook
+    let theme: WidgetTheme
+
+    var body: some View {
+        OptionalLink(destination: book.deepLink) {
+            HStack(spacing: 5) {
+                Image(systemName: book.format == .audio ? "play.fill" : "book.fill")
+                    .font(.system(size: 9, weight: .bold))
+                Text(book.format == .audio ? "Play" : "Read")
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundStyle(theme.pillInk)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(theme.pillFill))
+        }
+    }
+}
+
+// MARK: - Flipping through the rail
+
+/// Moves the card on to the next book without leaving the Home Screen.
+///
+/// Hidden on a rail of one, where it would be a control that does nothing —
+/// and drawn as a chevron rather than a pair of arrows because the intent
+/// wraps, so forward is the only direction there needs to be.
+private struct AdvanceButton: View {
+    let theme: WidgetTheme
+    let rail: RailPosition
+
+    var body: some View {
+        if rail.hasOthers {
+            Button(intent: ShowNextBook()) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(theme.ink1)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(theme.track))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Next book")
+        }
+    }
+}
+
+/// Where the shown book sits in the rail. Drawn from the resolved index rather
+/// than from a count of its own, so it cannot disagree with the card above it.
+private struct RailDots: View {
+    let theme: WidgetTheme
+    let rail: RailPosition
+
+    var body: some View {
+        if rail.hasOthers {
+            HStack(spacing: 4) {
+                ForEach(0..<rail.count, id: \.self) { position in
+                    Capsule()
+                        .fill(position == rail.index ? theme.rule : theme.ink2.opacity(0.35))
+                        .frame(width: position == rail.index ? 10 : 4, height: 4)
+                }
+            }
+            .accessibilityHidden(true)
+        }
     }
 }
 
@@ -180,6 +360,7 @@ private struct LargeCard: View {
                     .frame(maxHeight: .infinity)
             }
         }
+        .padding(Layout.margin)
         // The kicker, the container margins and the row hairlines are all
         // dead zones otherwise — see `MediumCard`.
         .widgetURL(books.first?.deepLink)
@@ -243,30 +424,13 @@ private struct LargeRow: View {
 
 // MARK: - Shared pieces
 
-/// The bar and the one line under it — percent for a book, time left for an
-/// audiobook. The small card's footer; medium draws a bare bar and large has
-/// its own row shape.
-private struct PositionFooter: View {
-    let book: WidgetBook
-    let theme: WidgetTheme
-
-    var body: some View {
-        VStack(alignment: .center, spacing: 5) {
-            if let fraction = book.fraction {
-                WidgetProgressBar(fraction: fraction, theme: theme)
-            }
-            Text(label)
-                .font(.system(size: 10.5, weight: .medium))
-                .foregroundStyle(theme.ink1)
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity)
-    }
-
+/// The one line describing where you are — percent for a book, time left for an
+/// audiobook. Large has its own row shape and doesn't use it.
+private enum PositionLabel {
     /// Percent and time-left together when the book has both — the two answer
     /// different questions ("how far in", "how much longer"), and an audiobook
     /// is the only thing that can say the second.
-    private var label: String {
+    static func text(for book: WidgetBook) -> String {
         var parts: [String] = []
         if let fraction = book.fraction {
             parts.append("\(Int((fraction * 100).rounded()))%")
@@ -312,6 +476,7 @@ private struct EmptyCard: View {
 
             Spacer(minLength: 0)
         }
+        .padding(Layout.margin)
         .frame(maxWidth: .infinity, alignment: .leading)
         .widgetURL(DeepLink.appRoot)
     }

--- a/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
+++ b/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
@@ -42,6 +42,32 @@ struct WidgetTheme {
 
     var track: Color { ink2.opacity(0.28) }
 
+    /// The Read/Play pill — the card's one solid, saturated shape. Everything
+    /// else on a hero card is a wash or a hairline, so this is what the eye
+    /// lands on and the reason the card reads as something to act on.
+    var pillFill: Color { OKLCH(isLight ? 0.52 : 0.82, tone.c * 1.0, tone.h).color }
+    var pillInk: Color { OKLCH(isLight ? 0.99 : 0.16, tone.c * 0.06, tone.h).color }
+
+    /// A bloom of the book's own colour behind its cover, lifting the artwork
+    /// off the wash instead of letting it sit on a flat panel. Same
+    /// construction as the app's `HeroCard.cardGround`.
+    func bloom(diameter: CGFloat) -> some View {
+        RadialGradient(
+            // Far weaker on a light ground. `plusLighter` on something already
+            // near white has nowhere to go but grey, so the strength the app's
+            // dark hero uses reads here as a smudge rather than as a glow.
+            colors: [OKLCH(0.62, tone.c * 0.9, tone.h).color.opacity(isLight ? 0.16 : 0.40), .clear],
+            center: .center,
+            startRadius: 0,
+            // Must land inside the frame's half-width, or the frame clips the
+            // gradient while it still has colour and the bloom shows a hard
+            // seam.
+            endRadius: diameter / 2
+        )
+        .frame(width: diameter, height: diameter)
+        .blendMode(.plusLighter)
+    }
+
     /// The plate a coverless book gets, so a shelf of them doesn't read as
     /// grey noise. A pared-back `GeneratedCoverPlate`: the app sets the title
     /// into the artwork, which a widget draws at 34pt wide in the large family
@@ -92,11 +118,66 @@ struct WidgetCover: View {
             .accessibilityLabel(book.title)
     }
 
-    private var image: UIImage? {
+    private var image: UIImage? { WidgetArt.image(for: book) }
+}
+
+/// The one place a card decodes a book's pre-rendered cover.
+///
+/// Shared because the small hero draws the same bytes twice — once blurred as
+/// the card's ground and once sharp on top of it — and two decodes of one file
+/// on a render budget as tight as a widget's is a cost for nothing.
+enum WidgetArt {
+    static func image(for book: WidgetBook) -> UIImage? {
         guard let name = book.thumb,
               let url = WidgetStore.thumbURL(named: name)
         else { return nil }
         return UIImage(contentsOfFile: url.path)
+    }
+}
+
+/// The book's own artwork, blown up and blurred into the card's ground.
+///
+/// Falls back to the tone wash when there is no art — which is not a
+/// degradation so much as the same idea by a cheaper route, since the tone was
+/// extracted from that cover in the first place.
+struct WidgetHeroBackdrop: View {
+    let book: WidgetBook
+    let theme: WidgetTheme
+
+    var body: some View {
+        ZStack {
+            theme.ground
+            if let image = WidgetArt.image(for: book) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    // Blurred hard enough that the crop is no longer legible
+                    // as a crop. A 2:3 cover filling a square loses a third of
+                    // its height, and at any gentler radius what shows is
+                    // recognisably the middle of the artwork with its title
+                    // sliced off.
+                    .blur(radius: 24, opaque: true)
+                    // A blur this heavy is an average of the whole cover, and
+                    // the average of any artwork is closer to grey than any
+                    // part of it was. Pushing the chroma back up is what keeps
+                    // the ground reading as *this book's* colour.
+                    .saturation(1.4)
+                    // Graded, not flat. A single veil strong enough to carry
+                    // the title at the bottom of the card washes the top of it
+                    // out too, and the top is the half with the artwork's
+                    // colour in it — which is the whole reason for using the
+                    // cover as a ground rather than the tone.
+                    .overlay {
+                        LinearGradient(
+                            colors: theme.isLight
+                                ? [.white.opacity(0.08), .white.opacity(0.66)]
+                                : [.black.opacity(0.12), .black.opacity(0.72)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    }
+            }
+        }
     }
 }
 

--- a/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
+++ b/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
@@ -178,25 +178,46 @@ struct WidgetHeroBackdrop: View {
         ZStack {
             theme.ground
             if let image = WidgetArt.image(for: book) {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    // Blurred hard enough that the crop is no longer legible
-                    // as a crop. A 2:3 cover filling a square loses a third of
-                    // its height, and at any gentler radius what shows is
-                    // recognisably the middle of the artwork with its title
-                    // sliced off.
-                    // Not `opaque: true`. Covers with alpha are filed as PNG on
-                    // purpose (`WidgetStore.thumbExtensions`), and telling the
-                    // blur its input has no alpha pulls black in around every
-                    // transparent edge — on exactly the covers the store goes
-                    // out of its way to keep unflattened.
-                    .blur(radius: 24, opaque: false)
-                    // A blur this heavy is an average of the whole cover, and
-                    // the average of any artwork is closer to grey than any
-                    // part of it was. Pushing the chroma back up is what keeps
-                    // the ground reading as *this book's* colour.
-                    .saturation(1.4)
+                // Held in a container that cannot grow, the same way
+                // `WidgetCover` holds its own: an aspect-fill image *reports* a
+                // size larger than the box it fills, so anything hung on it is
+                // laid out against that larger box. With the veil attached to
+                // the image directly, a 2:3 cover on a square card put the
+                // card's edges at 17% and 83% of the ramp — 0.22 of black at
+                // the top where 0.12 was asked for, and 0.62 at the bottom
+                // where 0.72 was. The gradient has to grade the *card*.
+                Color.clear
+                    .overlay {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            // Overfilled a little, because the blur below fades
+                            // to transparent at the image's own edges and the
+                            // fill is flush with the card across its width.
+                            // Without this the ground shows through as a
+                            // 24pt vignette down both sides.
+                            .scaleEffect(1.2)
+                            // Blurred hard enough that the crop is no longer
+                            // legible as a crop. A 2:3 cover filling a square
+                            // loses a third of its height, and at any gentler
+                            // radius what shows is recognisably the middle of
+                            // the artwork with its title sliced off.
+                            //
+                            // Not `opaque: true`. Covers with alpha are filed
+                            // as PNG on purpose (`WidgetStore.thumbExtensions`),
+                            // and telling the blur its input has no alpha pulls
+                            // black in around every transparent edge — on
+                            // exactly the covers the store goes out of its way
+                            // to keep unflattened.
+                            .blur(radius: 24, opaque: false)
+                            // A blur this heavy is an average of the whole
+                            // cover, and the average of any artwork is closer
+                            // to grey than any part of it was. Pushing the
+                            // chroma back up is what keeps the ground reading
+                            // as *this book's* colour.
+                            .saturation(1.4)
+                    }
+                    .clipped()
                     // Graded, not flat. A single veil strong enough to carry
                     // the title at the bottom of the card washes the top of it
                     // out too, and the top is the half with the artwork's

--- a/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
+++ b/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
@@ -128,32 +128,39 @@ struct WidgetCover: View {
 /// then sharp on top of it — and two decodes of one file on a render budget as
 /// tight as a widget's is a cost for nothing.
 ///
-/// Keyed on the file's modification date as well as its name, because the app
-/// rewrites a cover in place under the same name when the artwork changes: a
-/// name-only key would pin a live extension process to the bytes it happened to
-/// decode first. `@MainActor` rather than locked — SwiftUI evaluates a body
-/// there, which is the only place this is reached from.
+/// Entries are keyed by name and carry the file's modification date, because
+/// the app rewrites a cover in place under the same name when the artwork
+/// changes. Keying on the *pair* would leave the superseded bytes behind, one
+/// entry per revision; keying on the name and comparing the date replaces them.
+/// `@MainActor` rather than locked — SwiftUI evaluates a body there, which is
+/// the only place this is reached from.
 @MainActor
 enum WidgetArt {
-    private struct Key: Hashable {
-        let name: String
+    private struct Entry {
         let modified: Date?
+        let image: UIImage
     }
 
-    private static var memo: [Key: UIImage] = [:]
+    private static var memo: [String: Entry] = [:]
 
     static func image(for book: WidgetBook) -> UIImage? {
         guard let name = book.thumb,
               let url = WidgetStore.thumbURL(named: name)
         else { return nil }
 
-        let key = Key(name: name, modified: WidgetStore.thumbModified(named: name))
-        if let cached = memo[key] { return cached }
+        let modified = WidgetStore.thumbModified(named: name)
+        if let hit = memo[name], hit.modified == modified { return hit.image }
 
         guard let image = UIImage(contentsOfFile: url.path) else { return nil }
-        // Bounded by the snapshot, which is bounded by `WidgetSnapshot.maxBooks`
-        // — so this cannot grow with the reader's library.
-        memo[key] = image
+        // One entry per name bounds this against a single snapshot, but not
+        // against a process that outlives several: the rail turns over as books
+        // are finished and started, and each new one is a name this has never
+        // seen. Dropping the lot at the ceiling costs one re-decode per visible
+        // card, which is the same cost this memo exists to save once.
+        if memo[name] == nil, memo.count >= WidgetSnapshot.maxBooks {
+            memo.removeAll(keepingCapacity: true)
+        }
+        memo[name] = Entry(modified: modified, image: image)
         return image
     }
 }

--- a/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
+++ b/omnibus-ios/OmnibusWidgets/WidgetTheme.swift
@@ -121,17 +121,40 @@ struct WidgetCover: View {
     private var image: UIImage? { WidgetArt.image(for: book) }
 }
 
-/// The one place a card decodes a book's pre-rendered cover.
+/// The one place a card decodes a book's pre-rendered cover, and the memo that
+/// keeps it to once per file.
 ///
-/// Shared because the small hero draws the same bytes twice — once blurred as
-/// the card's ground and once sharp on top of it — and two decodes of one file
-/// on a render budget as tight as a widget's is a cost for nothing.
+/// The small hero draws the same bytes twice — blurred as the card's ground,
+/// then sharp on top of it — and two decodes of one file on a render budget as
+/// tight as a widget's is a cost for nothing.
+///
+/// Keyed on the file's modification date as well as its name, because the app
+/// rewrites a cover in place under the same name when the artwork changes: a
+/// name-only key would pin a live extension process to the bytes it happened to
+/// decode first. `@MainActor` rather than locked — SwiftUI evaluates a body
+/// there, which is the only place this is reached from.
+@MainActor
 enum WidgetArt {
+    private struct Key: Hashable {
+        let name: String
+        let modified: Date?
+    }
+
+    private static var memo: [Key: UIImage] = [:]
+
     static func image(for book: WidgetBook) -> UIImage? {
         guard let name = book.thumb,
               let url = WidgetStore.thumbURL(named: name)
         else { return nil }
-        return UIImage(contentsOfFile: url.path)
+
+        let key = Key(name: name, modified: WidgetStore.thumbModified(named: name))
+        if let cached = memo[key] { return cached }
+
+        guard let image = UIImage(contentsOfFile: url.path) else { return nil }
+        // Bounded by the snapshot, which is bounded by `WidgetSnapshot.maxBooks`
+        // — so this cannot grow with the reader's library.
+        memo[key] = image
+        return image
     }
 }
 
@@ -156,7 +179,12 @@ struct WidgetHeroBackdrop: View {
                     // its height, and at any gentler radius what shows is
                     // recognisably the middle of the artwork with its title
                     // sliced off.
-                    .blur(radius: 24, opaque: true)
+                    // Not `opaque: true`. Covers with alpha are filed as PNG on
+                    // purpose (`WidgetStore.thumbExtensions`), and telling the
+                    // blur its input has no alpha pulls black in around every
+                    // transparent edge — on exactly the covers the store goes
+                    // out of its way to keep unflattened.
+                    .blur(radius: 24, opaque: false)
                     // A blur this heavy is an average of the whole cover, and
                     // the average of any artwork is closer to grey than any
                     // part of it was. Pushing the chroma back up is what keeps

--- a/omnibus-ios/README.md
+++ b/omnibus-ios/README.md
@@ -75,9 +75,10 @@ compiles into two binaries without a framework.
 
 ## Widgets
 
-The Home Screen gets **Continue** in all three system families — one book,
-three across, or five with last-read timestamps. It is the landing Continue
-stack, and like the rest of the app it is local-first: the widget reads the
+The Home Screen gets **Continue** in all three system families — the book you
+are in, that book with a control that flips through the next two, or five with
+last-read timestamps. It is the landing Continue stack, and like the rest of the
+app it is local-first: apart from the one write below, the widget reads the
 shared container and nothing else, so it draws in Airplane Mode with the app
 force quit.
 
@@ -106,6 +107,20 @@ force quit.
   next opened, while the app's own rail had already healed. `refreshRail` owns
   it now so a new call site can't reintroduce the split. Gated on reachability:
   offline the pass stays a pure replica read.
+- **A widget cannot be swiped, so the medium card flips.** The system renders a
+  widget as a snapshot and routes only taps — a `widgetURL`/`Link` that opens
+  the app, or an `AppIntent` that runs in the extension. So the medium family
+  shows one book and a chevron backed by `ShowNextBook`, which advances a cursor
+  and reloads the timeline in place. That cursor is the **one piece of widget
+  state the extension writes**: it lives in the App Group's `UserDefaults`
+  rather than in the snapshot file, because the app owns that file and rewrites
+  it wholesale on every position save, so a cursor kept there would be erased by
+  the next sync. It names a book rather than an index — the rail is reordered by
+  those same saves — and falls back to the front when its book leaves. The flip
+  caps at three (`WidgetSnapshot.maxFlipped`): the large family *lists* five,
+  and listing is cheap, but every book past the front of a flip costs a tap.
+  The small family carries no control at all; it answers with the book you
+  touched last and nothing else.
 - **The three empty states are three different screens.** "Not signed in",
   "no books yet" and "nothing open" want three different next steps; a bare
   empty list can't tell them apart, and a blank tile tells the reader nothing.

--- a/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
+++ b/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
@@ -118,6 +118,78 @@ struct WidgetSnapshotCodableTests {
     }
 }
 
+/// The cursor the one-book families flip through the rail with. A widget cannot
+/// be swiped, so this is the whole of "show the next book" — and it resolves
+/// against a rail the app rewrites on every position save.
+@Suite("Widget rail cursor")
+struct WidgetRailCursorTests {
+    private static func rail(_ uuids: [String]) -> WidgetSnapshot {
+        WidgetSnapshot(
+            state: .ready,
+            books: uuids.map { entry(uuid: $0) },
+            generatedAt: Date(timeIntervalSince1970: 1_724_500_000)
+        )
+    }
+
+    @Test
+    func showing_starts_at_the_front_when_the_reader_has_not_flipped_yet() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: nil))
+        #expect(shown.book.bookUUID == "a")
+        #expect(shown.index == 0)
+    }
+
+    @Test
+    func showing_holds_the_book_the_reader_flipped_to() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "b")
+        #expect(shown.index == 1)
+    }
+
+    /// Why the cursor names a book rather than an index: a save that reorders
+    /// the rail must not move the card out from under the reader.
+    @Test
+    func showing_follows_its_book_when_the_rail_is_reordered_around_it() throws {
+        let shown = try #require(Self.rail(["c", "a", "b"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "b")
+        #expect(shown.index == 2)
+    }
+
+    @Test
+    func showing_falls_back_to_the_front_when_its_book_leaves_the_rail() throws {
+        let shown = try #require(Self.rail(["a", "c"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "a")
+        #expect(shown.index == 0)
+    }
+
+    @Test
+    func showing_is_nil_when_there_is_nothing_to_continue() {
+        #expect(WidgetSnapshot.empty(.nothingInProgress).showing(cursor: "b:epub") == nil)
+    }
+
+    @Test
+    func next_walks_the_rail_in_order() {
+        #expect(Self.rail(["a", "b", "c"]).next(after: "a:epub")?.bookUUID == "b")
+    }
+
+    /// The advance control is the only way through the rail, so it has to come
+    /// back round — dead-ending on the last book would strand a reader away
+    /// from the one they are actually in the middle of.
+    @Test
+    func next_wraps_past_the_end_of_the_rail() {
+        #expect(Self.rail(["a", "b", "c"]).next(after: "c:epub")?.bookUUID == "a")
+    }
+
+    @Test
+    func next_on_a_rail_of_one_stays_where_it_is() {
+        #expect(Self.rail(["a"]).next(after: "a:epub")?.bookUUID == "a")
+    }
+
+    @Test
+    func next_is_nil_when_there_is_nothing_to_continue() {
+        #expect(WidgetSnapshot.empty().next(after: nil) == nil)
+    }
+}
+
 @Suite("Widget deep links")
 struct WidgetDeepLinkTests {
     @Test

--- a/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
+++ b/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
@@ -118,11 +118,11 @@ struct WidgetSnapshotCodableTests {
     }
 }
 
-/// The cursor the one-book families flip through the rail with. A widget cannot
-/// be swiped, so this is the whole of "show the next book" — and it resolves
+/// Which book a pinned copy of the widget draws. A widget cannot be swiped, so
+/// each copy is configured to a book and the rail is walked by stacking them —
 /// against a rail the app rewrites on every position save.
-@Suite("Widget rail cursor")
-struct WidgetRailCursorTests {
+@Suite("Widget book selection")
+struct WidgetBookSelectionTests {
     private static func rail(_ uuids: [String]) -> WidgetSnapshot {
         WidgetSnapshot(
             state: .ready,
@@ -132,61 +132,51 @@ struct WidgetRailCursorTests {
     }
 
     @Test
-    func showing_starts_at_the_front_when_the_reader_has_not_flipped_yet() throws {
-        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: nil))
-        #expect(shown.book.bookUUID == "a")
-        #expect(shown.index == 0)
+    func showing_follows_the_most_recent_book_when_the_widget_is_unpinned() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(selected: nil))
+        #expect(shown.bookUUID == "a")
     }
 
     @Test
-    func showing_holds_the_book_the_reader_flipped_to() throws {
-        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: "b:epub"))
-        #expect(shown.book.bookUUID == "b")
-        #expect(shown.index == 1)
+    func showing_draws_the_book_the_widget_is_pinned_to() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(selected: "b:epub"))
+        #expect(shown.bookUUID == "b")
     }
 
-    /// Why the cursor names a book rather than an index: a save that reorders
-    /// the rail must not move the card out from under the reader.
+    /// Why the selection names a book rather than an index: a save that
+    /// reorders the rail must not repoint a pinned widget at a different book.
     @Test
     func showing_follows_its_book_when_the_rail_is_reordered_around_it() throws {
-        let shown = try #require(Self.rail(["c", "a", "b"]).showing(cursor: "b:epub"))
-        #expect(shown.book.bookUUID == "b")
-        #expect(shown.index == 2)
+        let shown = try #require(Self.rail(["c", "a", "b"]).showing(selected: "b:epub"))
+        #expect(shown.bookUUID == "b")
     }
 
+    /// A widget pinned to a book the reader has since finished falls back to
+    /// what they are reading now, rather than sitting on a dead card until they
+    /// think to reconfigure it.
     @Test
     func showing_falls_back_to_the_front_when_its_book_leaves_the_rail() throws {
-        let shown = try #require(Self.rail(["a", "c"]).showing(cursor: "b:epub"))
-        #expect(shown.book.bookUUID == "a")
-        #expect(shown.index == 0)
+        let shown = try #require(Self.rail(["a", "c"]).showing(selected: "b:epub"))
+        #expect(shown.bookUUID == "a")
     }
 
     @Test
     func showing_is_nil_when_there_is_nothing_to_continue() {
-        #expect(WidgetSnapshot.empty(.nothingInProgress).showing(cursor: "b:epub") == nil)
+        #expect(WidgetSnapshot.empty(.nothingInProgress).showing(selected: "b:epub") == nil)
+        #expect(WidgetSnapshot.empty().showing(selected: nil) == nil)
     }
 
+    /// The two formats of a dual-format book are two cards, so a widget pinned
+    /// to the audiobook must not be answered with the ebook.
     @Test
-    func next_walks_the_rail_in_order() {
-        #expect(Self.rail(["a", "b", "c"]).next(after: "a:epub")?.bookUUID == "b")
-    }
-
-    /// The advance control is the only way through the rail, so it has to come
-    /// back round — dead-ending on the last book would strand a reader away
-    /// from the one they are actually in the middle of.
-    @Test
-    func next_wraps_past_the_end_of_the_rail() {
-        #expect(Self.rail(["a", "b", "c"]).next(after: "c:epub")?.bookUUID == "a")
-    }
-
-    @Test
-    func next_on_a_rail_of_one_stays_where_it_is() {
-        #expect(Self.rail(["a"]).next(after: "a:epub")?.bookUUID == "a")
-    }
-
-    @Test
-    func next_is_nil_when_there_is_nothing_to_continue() {
-        #expect(WidgetSnapshot.empty().next(after: nil) == nil)
+    func showing_separates_the_two_formats_of_one_book() throws {
+        let snapshot = WidgetSnapshot(
+            state: .ready,
+            books: [entry(uuid: "a", format: .epub), entry(uuid: "a", format: .audio)],
+            generatedAt: Date(timeIntervalSince1970: 1_724_500_000)
+        )
+        let shown = try #require(snapshot.showing(selected: "a:audio"))
+        #expect(shown.format == .audio)
     }
 }
 

--- a/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
+++ b/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
@@ -118,11 +118,11 @@ struct WidgetSnapshotCodableTests {
     }
 }
 
-/// Which book a pinned copy of the widget draws. A widget cannot be swiped, so
-/// each copy is configured to a book and the rail is walked by stacking them —
+/// The cursor the medium card flips through its rail with. A widget cannot be
+/// swiped, so this is the whole of "show the next book" — and it resolves
 /// against a rail the app rewrites on every position save.
-@Suite("Widget book selection")
-struct WidgetBookSelectionTests {
+@Suite("Widget rail cursor")
+struct WidgetRailCursorTests {
     private static func rail(_ uuids: [String]) -> WidgetSnapshot {
         WidgetSnapshot(
             state: .ready,
@@ -132,42 +132,86 @@ struct WidgetBookSelectionTests {
     }
 
     @Test
-    func showing_follows_the_most_recent_book_when_the_widget_is_unpinned() throws {
-        let shown = try #require(Self.rail(["a", "b", "c"]).showing(selected: nil))
-        #expect(shown.bookUUID == "a")
+    func showing_starts_at_the_front_when_the_reader_has_not_flipped_yet() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: nil))
+        #expect(shown.book.bookUUID == "a")
+        #expect(shown.index == 0)
     }
 
     @Test
-    func showing_draws_the_book_the_widget_is_pinned_to() throws {
-        let shown = try #require(Self.rail(["a", "b", "c"]).showing(selected: "b:epub"))
-        #expect(shown.bookUUID == "b")
+    func showing_holds_the_book_the_reader_flipped_to() throws {
+        let shown = try #require(Self.rail(["a", "b", "c"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "b")
+        #expect(shown.index == 1)
     }
 
-    /// Why the selection names a book rather than an index: a save that
-    /// reorders the rail must not repoint a pinned widget at a different book.
+    /// Why the cursor names a book rather than an index: a save that reorders
+    /// the rail must not move the card out from under the reader.
     @Test
     func showing_follows_its_book_when_the_rail_is_reordered_around_it() throws {
-        let shown = try #require(Self.rail(["c", "a", "b"]).showing(selected: "b:epub"))
-        #expect(shown.bookUUID == "b")
+        let shown = try #require(Self.rail(["c", "a", "b"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "b")
+        #expect(shown.index == 2)
     }
 
-    /// A widget pinned to a book the reader has since finished falls back to
-    /// what they are reading now, rather than sitting on a dead card until they
-    /// think to reconfigure it.
     @Test
     func showing_falls_back_to_the_front_when_its_book_leaves_the_rail() throws {
-        let shown = try #require(Self.rail(["a", "c"]).showing(selected: "b:epub"))
-        #expect(shown.bookUUID == "a")
+        let shown = try #require(Self.rail(["a", "c"]).showing(cursor: "b:epub"))
+        #expect(shown.book.bookUUID == "a")
+        #expect(shown.index == 0)
     }
 
     @Test
     func showing_is_nil_when_there_is_nothing_to_continue() {
-        #expect(WidgetSnapshot.empty(.nothingInProgress).showing(selected: "b:epub") == nil)
-        #expect(WidgetSnapshot.empty().showing(selected: nil) == nil)
+        #expect(WidgetSnapshot.empty(.nothingInProgress).showing(cursor: "b:epub") == nil)
     }
 
-    /// The two formats of a dual-format book are two cards, so a widget pinned
-    /// to the audiobook must not be answered with the ebook.
+    @Test
+    func next_walks_the_rail_in_order() {
+        #expect(Self.rail(["a", "b", "c"]).next(after: "a:epub")?.bookUUID == "b")
+    }
+
+    /// The advance control is the only way through the rail, so it has to come
+    /// back round — dead-ending on the last book would strand a reader away
+    /// from the one they are actually in the middle of.
+    @Test
+    func next_wraps_past_the_end_of_the_rail() {
+        #expect(Self.rail(["a", "b", "c"]).next(after: "c:epub")?.bookUUID == "a")
+    }
+
+    @Test
+    func next_on_a_rail_of_one_stays_where_it_is() {
+        #expect(Self.rail(["a"]).next(after: "a:epub")?.bookUUID == "a")
+    }
+
+    @Test
+    func next_is_nil_when_there_is_nothing_to_continue() {
+        #expect(WidgetSnapshot.empty().next(after: nil) == nil)
+    }
+
+    /// The large family lists five; the medium card flips through three. A
+    /// reader with more books in progress than that must not be able to tap
+    /// their way past the cap.
+    @Test
+    func flip_rail_stops_at_three_however_many_books_are_in_progress() {
+        let snapshot = Self.rail(["a", "b", "c", "d", "e"])
+        #expect(snapshot.books.count == 5)
+        #expect(snapshot.flipRail.map(\.bookUUID) == ["a", "b", "c"])
+        #expect(snapshot.next(after: "c:epub")?.bookUUID == "a")
+    }
+
+    /// A cursor left on a book that the cap has since pushed off the rail —
+    /// a fourth book arriving in front of it — reads as gone, not as an index
+    /// past the end.
+    @Test
+    func showing_falls_back_when_a_new_book_pushes_its_book_past_the_cap() throws {
+        let shown = try #require(Self.rail(["d", "a", "b", "c"]).showing(cursor: "c:epub"))
+        #expect(shown.book.bookUUID == "d")
+        #expect(shown.index == 0)
+    }
+
+    /// The two formats of a dual-format book are two cards, so a cursor on the
+    /// audiobook must not be answered with the ebook.
     @Test
     func showing_separates_the_two_formats_of_one_book() throws {
         let snapshot = WidgetSnapshot(
@@ -175,8 +219,8 @@ struct WidgetBookSelectionTests {
             books: [entry(uuid: "a", format: .epub), entry(uuid: "a", format: .audio)],
             generatedAt: Date(timeIntervalSince1970: 1_724_500_000)
         )
-        let shown = try #require(snapshot.showing(selected: "a:audio"))
-        #expect(shown.format == .audio)
+        let shown = try #require(snapshot.showing(cursor: "a:audio"))
+        #expect(shown.book.format == .audio)
     }
 }
 


### PR DESCRIPTION
## Summary
- Rebuilds the Continue widget's `systemSmall` and `systemMedium` families as a one-book call to action; `systemLarge` is untouched and still lists five.
- Medium becomes the app's `ContinueHero` translated to a widget: the cover at full card height, a `CONTINUE READING` / `CONTINUE LISTENING` eyebrow, the title at 17pt serif instead of 11.5pt, author, progress bar, position readout, and a Read/Play pill that resumes the book straight from the Home Screen. It replaces the three-across fan, which showed three thumbnails and three truncated titles with nothing on the card to act on.
- Small draws the book's own artwork blurred and saturated into its ground, the sharp cover on top under a graded scrim, and runs the progress bar edge to edge along the bottom of the card.
- A widget cannot be swiped — the system renders it as a snapshot and only routes taps — so the rest of the rail is reached by a chevron backed by `ShowNextBook`, an `AppIntent` that moves a cursor kept in the App Group's defaults and reloads the timeline. Dots beside the eyebrow show where you are.
- The flip rail caps at three (`WidgetSnapshot.flipRail`). Five is what the large family *lists*, and listing is cheap; every book past the front of a flip costs a tap and a redraw to reach, and past three the control stops meaning "the other book I'm in" and starts meaning "page my library".
- Small carries no flip control at all. It is 130pt square on a 6.3" phone, a chevron there spends the card's only spare corner arguing with the artwork, and "what am I in the middle of" is answered by whichever book you touched last.
- The cursor names a **book** (`WidgetBook.id`), never an index. The rail is rewritten on every position save, so an index would mean "whatever is second today" and the next save that reordered it would move the card out from under the reader. A cursor whose book has left the rail — finished, or pushed past the three-book cap by a newer one — falls back to the front rather than resolving to a stale position.

## Test plan
- [x] `just ios-build` — app plus widget extension compile clean.
- [x] `just ios-test` — 544 tests pass, including 11 new `WidgetRailCursorTests` covering cursor resolution, reorder stability, the fall-back when a book leaves the rail, wrap-around, the three-book cap, and the dual-format case where `a:epub` and `a:audio` must not resolve to each other.
- [ ] **Not verified on a real Home Screen.** Every screenshot below is an offline render harness that compiles the extension's view sources for the simulator and draws the cards; it does not run the widget process. So the chevron is drawn but never tapped, and `ShowNextBook`'s round trip (cursor write → timeline reload → card advances) is covered by unit tests on `next(after:)` and by nothing else. `containerBackground` is supplied by the harness rather than by WidgetKit. Worth adding the widget by hand via `just ios-sim` before or after merge.

## Version
- [x] **Patch** — the default; leave unlabeled.

## Notes
- Layout numbers on both cards are budgets rather than preferences, and the binding constraint is the 6.3" phone: `systemSmall` is 130pt of content there, and the medium card's dial and title compete for the same 130. Both families lost the title's second line to an oversized element at least once during this work, and the regression is invisible on a 6.9" phone — which is why the render sheet poses every card at both point sizes and in both colour schemes.
- The middle commit builds a Smart Stack approach (`AppIntentConfiguration`, a per-book `SelectBookIntent`, `relevance()`) and the third removes it. Reaching the rail that way meant hand-pinning one widget per book and stacking them, which is setup most readers will never do; the chevron does it in one tap with none. Squash-merge hides the round trip, but it is in the commit list.
- Known rough edges, deliberately left: long titles still truncate on medium at 17pt serif, and `systemLarge` is still the five-row list rather than being reworked to match the one-book direction.
