### PR TITLE
fix: keep the iOS reader's chrome off the keyboard's safe area (#2220)

### DIFF
--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -183,6 +183,12 @@ struct ReaderView: View {
             }
             .animation(Motion.glide, value: audio.isActive)
         }
+        // The page ignores the safe area outright, so a keyboard inset lifts
+        // the chrome alone and parks it mid-prose. Nothing types here, but
+        // `NoteComposer` autofocuses and SwiftUI hands the presenter that inset
+        // too (#2220). On the modified view, never the inset's content, which
+        // the keyboard has already shrunk (#2102).
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .statusBarHidden(!chromeVisible)
         .persistentSystemOverlays(chromeVisible ? .automatic : .hidden)
         // The status bar sits on the page, so it has to read against the


### PR DESCRIPTION
- Closes #2220 — after the note composer closes, every native control in the iOS EPUB reader (close button, both indicator labels, the menu button) parks itself in the vertical middle of the page and stays there, with the prose running underneath it
- The cause is a keyboard bottom safe-area inset landing on `ReaderView`. `ReaderWebView` opts out of the safe area entirely (`.ignoresSafeArea(edges: .all)`), so the epub.js page is unaffected and only the SwiftUI chrome lifts — which is exactly the reported symptom
- Fixed with `.ignoresSafeArea(.keyboard, edges: .bottom)` on the reader's body. The reader has no inline text entry of its own; every field it can reach lives in a sheet that keeps its own keyboard avoidance, so opting the reader out costs nothing
- Placement follows the lesson #2102 already recorded in `MainTabView`: the modifier goes on the view the `safeAreaInset` was applied to, never on the inset's content, because the keyboard shrinks the host and an `ignoresSafeArea` on the child is a no-op

## How the inset was identified

Measured off the reporter's screenshots (iPhone 16 Pro, 874pt tall):

- The top indicator label sits at 88.6pt, which is exactly `topInset(62) + Spacing.xs(4) + ReaderMenu.buttonSize/2(23)` — the top edge is correct
- The bottom label sits at 511pt, putting the layout container's bottom edge at 538pt instead of 840pt
- The missing 336pt is the iPhone portrait keyboard height including the QuickType bar

That number is what identifies the culprit as a keyboard rather than the audio dock (`MiniPlayerBar.reservedHeight` is 71pt) or the tab shell's inset, neither of which is anywhere near 336pt.

## Where the keyboard comes from

`NoteComposer` is presented as a `.sheet` from `ReaderView`, sets `focused = true` in `onAppear`, and both Cancel and Save call `dismiss()` with the field still first responder. SwiftUI applies the window's keyboard safe area to the presenting view as well as the sheet, and the reader never opted out.

#2102 considered this call site and left it alone on the premise that `ReaderView` "carr[ies] no text field or `.searchable`, so no keyboard can come up on them". That is true of the reader's own body but not of the sheet it presents, which is the gap this closes. The premise does still hold for the other two immersive surfaces, so they are deliberately untouched — `PlayerView`'s sheets are Chapters, Bookmarks, Speed and Sleep, and `ComicReaderView` presents only the player. None carries text entry.

Worth noting the fix does not depend on that attribution being the whole story: it makes the reader immune to a keyboard inset from any source, and the 336pt measurement establishes the inset is a keyboard regardless of which surface raised it.

## Regression coverage

None, and deliberately so. `omnibusTests` is a pure-logic suite — no view hosting, no ViewInspector — and this invariant only exists once a live keyboard inset reaches a hosted `ReaderView`, which needs a server, a book and a WKWebView behind it.

The XCUITest form of the assertion is the one `.claude/rules/04-playwright.md` bans outright: `ShellChromeTests` asserted exactly this contract for the tab bar in #2102 and was deleted as flaky, because with the keyboard in the accessibility tree any query blows XCUITest's *internal* snapshot budget, which no test-side timeout can extend. The rule records that a replacement must be a layout-level test in `omnibusTests` without a live keyboard in the tree; there is no machinery for that today, and inventing it is out of scope for a one-line fix.

Verified by `just ios-build` and `just ios-test` (both green, full suite passing). Not reproduced end-to-end on a device — that needs the note-composer round trip inside a live reading session.