### PR TITLE
fix: give every completion metric one liveness definition

### DIFF
--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -13,7 +13,7 @@ works in production.
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
    number after the highest existing file (latest is
-   `0076_cross_format_follow.sql`). The number is the version
+   `0079_merge_orphan_user_data.sql`). The number is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere
@@ -61,6 +61,16 @@ a bare `SELECT id FROM books WHERE uuid = ?`. Durable user-data tables
 should soft-reference `book_uuid TEXT` (no FK, no cascade), like
 `metadata_overrides` — not a cascading `book_id` FK that wipes user data
 on reindex.
+
+**A soft-referencing table must also be added to `RETARGET_TABLES` in
+`db/src/merge/transaction.rs`** — that list is the other half of the
+contract. Merge deletes the source `books` row, so a table missing from it
+strands the reader's rows on a uuid no book carries: invisible to every
+query that joins `books`, still counted by every query that doesn't, which
+is how the Finished tile and the trailing-12 chart came to disagree
+(migration `0079` heals the rows, the list stops new ones). If the table
+carries a `UNIQUE` key the retarget would collide on, add it to
+`DEDUPE_TABLES` beside it and the shared latest-wins helper resolves it.
 
 ## Testing
 

--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -62,15 +62,22 @@ should soft-reference `book_uuid TEXT` (no FK, no cascade), like
 `metadata_overrides` — not a cascading `book_id` FK that wipes user data
 on reindex.
 
-**A soft-referencing table must also be added to `RETARGET_TABLES` in
-`db/src/merge/transaction.rs`** — that list is the other half of the
-contract. Merge deletes the source `books` row, so a table missing from it
-strands the reader's rows on a uuid no book carries: invisible to every
-query that joins `books`, still counted by every query that doesn't, which
-is how the Finished tile and the trailing-12 chart came to disagree
-(migration `0079` heals the rows, the list stops new ones). If the table
-carries a `UNIQUE` key the retarget would collide on, add it to
-`DEDUPE_TABLES` beside it and the shared latest-wins helper resolves it.
+**A new table holding per-reader state keyed on `book_uuid` must also be
+added to `RETARGET_TABLES` in `db/src/merge/transaction.rs`** — that list is
+the other half of the contract. Merge deletes the source `books` row, so a
+table missing from it strands the reader's rows on a uuid no book carries:
+invisible to every query that joins `books`, still counted by every query
+that doesn't. Migration `0079` heals the rows already stranded that way; the
+list is what stops new ones. If the table carries a `UNIQUE` key the retarget
+would collide on, add it to `DEDUPE_TABLES` beside it and the shared
+latest-wins helper resolves it.
+
+The list is deliberately **not** every table with a `book_uuid` column.
+Library-wide tables (`shelf_books`, `physical_copies`, `wishlist_entries`,
+`cross_format_links`, the suggestion caches) are out of scope here and are
+handled — or deliberately not — by their own owners; adding one to
+`RETARGET_TABLES` without understanding its merge semantics is a change in
+its own right, not a box to tick.
 
 ## Testing
 

--- a/db/migrations/0079_merge_orphan_user_data.sql
+++ b/db/migrations/0079_merge_orphan_user_data.sql
@@ -1,0 +1,80 @@
+-- Repoint per-user rows that a past merge stranded on a deleted book.
+--
+-- `merge::transaction::move_progress_and_history` retargeted seven soft-ref
+-- tables onto the surviving book but not `journal_entries`, `book_read_status`
+-- or `user_ratings`, and `finalize_merge` then deleted the source `books` row.
+-- Those rows are still on disk under a uuid no book carries, which makes them
+-- invisible wherever a query joins `books` (the book page, the Finished tile,
+-- the finished rail) and still countable wherever one doesn't (the trailing-12
+-- chart, the vs-previous delta, the average-rating mean). The merge path is
+-- fixed alongside this file; this heals the rows it already stranded.
+--
+-- Forward-only and self-limiting: `merged_uuids.uuid` is the primary key, so
+-- each orphan resolves to exactly one survivor, and a database that has never
+-- merged builds an empty map and no-ops through every statement below.
+
+-- Orphans only: a uuid the attach ledger maps to a live book, that no `books`
+-- row carries itself. The `<>` guard keeps a book that merely records its own
+-- uuid in the ledger out of the map.
+CREATE TEMP TABLE merge_orphan_map AS
+SELECT mu.uuid AS orphan_uuid, b.uuid AS live_uuid
+  FROM merged_uuids mu
+  JOIN books b ON b.id = mu.book_id
+ WHERE mu.uuid <> b.uuid
+   AND NOT EXISTS (SELECT 1 FROM books o WHERE o.uuid = mu.uuid);
+
+-- `book_read_status` and `user_ratings` are UNIQUE (user_id, book_uuid), so a
+-- reader who rated (or finished) both sides of a merge has two rows that the
+-- retarget would collide on. Resolve latest-wins, ties to the surviving book —
+-- the same rule `dedupe_latest_wins` applies at merge time.
+--
+-- Two passes, in this order: drop the orphan rows the live row already beats,
+-- then drop the live rows whose orphan counterpart outlived that first pass.
+DELETE FROM book_read_status
+ WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
+   AND EXISTS (SELECT 1 FROM book_read_status live
+                 JOIN merge_orphan_map m ON m.live_uuid = live.book_uuid
+                WHERE m.orphan_uuid = book_read_status.book_uuid
+                  AND live.user_id = book_read_status.user_id
+                  AND live.updated_at >= book_read_status.updated_at);
+
+DELETE FROM book_read_status
+ WHERE book_uuid IN (SELECT live_uuid FROM merge_orphan_map)
+   AND EXISTS (SELECT 1 FROM book_read_status orph
+                 JOIN merge_orphan_map m ON m.orphan_uuid = orph.book_uuid
+                WHERE m.live_uuid = book_read_status.book_uuid
+                  AND orph.user_id = book_read_status.user_id);
+
+DELETE FROM user_ratings
+ WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
+   AND EXISTS (SELECT 1 FROM user_ratings live
+                 JOIN merge_orphan_map m ON m.live_uuid = live.book_uuid
+                WHERE m.orphan_uuid = user_ratings.book_uuid
+                  AND live.user_id = user_ratings.user_id
+                  AND live.updated_at >= user_ratings.updated_at);
+
+DELETE FROM user_ratings
+ WHERE book_uuid IN (SELECT live_uuid FROM merge_orphan_map)
+   AND EXISTS (SELECT 1 FROM user_ratings orph
+                 JOIN merge_orphan_map m ON m.orphan_uuid = orph.book_uuid
+                WHERE m.live_uuid = user_ratings.book_uuid
+                  AND orph.user_id = user_ratings.user_id);
+
+-- `journal_entries` has no per-book uniqueness (a reader keeps many entries on
+-- one book), so every stranded row moves without a collision pass.
+UPDATE journal_entries
+   SET book_uuid = (SELECT m.live_uuid FROM merge_orphan_map m
+                     WHERE m.orphan_uuid = journal_entries.book_uuid)
+ WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map);
+
+UPDATE book_read_status
+   SET book_uuid = (SELECT m.live_uuid FROM merge_orphan_map m
+                     WHERE m.orphan_uuid = book_read_status.book_uuid)
+ WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map);
+
+UPDATE user_ratings
+   SET book_uuid = (SELECT m.live_uuid FROM merge_orphan_map m
+                     WHERE m.orphan_uuid = user_ratings.book_uuid)
+ WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map);
+
+DROP TABLE merge_orphan_map;

--- a/db/migrations/0079_merge_orphan_user_data.sql
+++ b/db/migrations/0079_merge_orphan_user_data.sql
@@ -23,42 +23,65 @@ SELECT mu.uuid AS orphan_uuid, b.uuid AS live_uuid
  WHERE mu.uuid <> b.uuid
    AND NOT EXISTS (SELECT 1 FROM books o WHERE o.uuid = mu.uuid);
 
--- `book_read_status` and `user_ratings` are UNIQUE (user_id, book_uuid), so a
--- reader who rated (or finished) both sides of a merge has two rows that the
--- retarget would collide on. Resolve latest-wins, ties to the surviving book —
--- the same rule `dedupe_latest_wins` applies at merge time.
+-- `book_read_status` and `user_ratings` are UNIQUE (user_id, book_uuid), so
+-- every row that will land on the same surviving book for the same reader has
+-- to be resolved down to one before the retarget runs.
 --
--- Two passes, in this order: drop the orphan rows the live row already beats,
--- then drop the live rows whose orphan counterpart outlived that first pass.
-DELETE FROM book_read_status
- WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
-   AND EXISTS (SELECT 1 FROM book_read_status live
-                 JOIN merge_orphan_map m ON m.live_uuid = live.book_uuid
-                WHERE m.orphan_uuid = book_read_status.book_uuid
-                  AND live.user_id = book_read_status.user_id
-                  AND live.updated_at >= book_read_status.updated_at);
+-- Note the plural: a chain of merges (A into B, then B into C) leaves *several*
+-- orphan uuids pointing at one live book, so this is not merely orphan-vs-live.
+-- A reader who rated two books that were later merged into the same third one
+-- has two orphan rows plus possibly a live one, and repointing them all would
+-- violate the UNIQUE constraint and abort the upgrade. Resolving pairwise is
+-- what the runtime `dedupe_latest_wins` can afford to do — it only ever moves
+-- one source onto one target — and is not enough here.
+--
+-- So: resolve each candidate row to the uuid it will end up on, then delete
+-- every row that has a strictly better sibling in that final group. Latest
+-- `updated_at` wins; ties go to the row already on the surviving book, then to
+-- the lowest id, so the outcome is deterministic and exactly one row survives
+-- per (user, surviving book).
+CREATE TEMP TABLE merge_orphan_resolved AS
+SELECT 'book_read_status' AS src, r.id AS id, r.user_id AS user_id,
+       r.updated_at AS updated_at,
+       COALESCE(m.live_uuid, r.book_uuid) AS target_uuid,
+       (m.live_uuid IS NULL) AS on_live
+  FROM book_read_status r
+  LEFT JOIN merge_orphan_map m ON m.orphan_uuid = r.book_uuid
+ WHERE r.book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
+    OR r.book_uuid IN (SELECT live_uuid FROM merge_orphan_map)
+UNION ALL
+SELECT 'user_ratings', r.id, r.user_id, r.updated_at,
+       COALESCE(m.live_uuid, r.book_uuid), (m.live_uuid IS NULL)
+  FROM user_ratings r
+  LEFT JOIN merge_orphan_map m ON m.orphan_uuid = r.book_uuid
+ WHERE r.book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
+    OR r.book_uuid IN (SELECT live_uuid FROM merge_orphan_map);
 
 DELETE FROM book_read_status
- WHERE book_uuid IN (SELECT live_uuid FROM merge_orphan_map)
-   AND EXISTS (SELECT 1 FROM book_read_status orph
-                 JOIN merge_orphan_map m ON m.orphan_uuid = orph.book_uuid
-                WHERE m.live_uuid = book_read_status.book_uuid
-                  AND orph.user_id = book_read_status.user_id);
+ WHERE id IN (
+   SELECT x.id FROM merge_orphan_resolved x
+    WHERE x.src = 'book_read_status'
+      AND EXISTS (SELECT 1 FROM merge_orphan_resolved o
+                   WHERE o.src = x.src AND o.user_id = x.user_id
+                     AND o.target_uuid = x.target_uuid AND o.id <> x.id
+                     AND (o.updated_at > x.updated_at
+                       OR (o.updated_at = x.updated_at AND o.on_live > x.on_live)
+                       OR (o.updated_at = x.updated_at AND o.on_live = x.on_live
+                           AND o.id < x.id))));
 
 DELETE FROM user_ratings
- WHERE book_uuid IN (SELECT orphan_uuid FROM merge_orphan_map)
-   AND EXISTS (SELECT 1 FROM user_ratings live
-                 JOIN merge_orphan_map m ON m.live_uuid = live.book_uuid
-                WHERE m.orphan_uuid = user_ratings.book_uuid
-                  AND live.user_id = user_ratings.user_id
-                  AND live.updated_at >= user_ratings.updated_at);
+ WHERE id IN (
+   SELECT x.id FROM merge_orphan_resolved x
+    WHERE x.src = 'user_ratings'
+      AND EXISTS (SELECT 1 FROM merge_orphan_resolved o
+                   WHERE o.src = x.src AND o.user_id = x.user_id
+                     AND o.target_uuid = x.target_uuid AND o.id <> x.id
+                     AND (o.updated_at > x.updated_at
+                       OR (o.updated_at = x.updated_at AND o.on_live > x.on_live)
+                       OR (o.updated_at = x.updated_at AND o.on_live = x.on_live
+                           AND o.id < x.id))));
 
-DELETE FROM user_ratings
- WHERE book_uuid IN (SELECT live_uuid FROM merge_orphan_map)
-   AND EXISTS (SELECT 1 FROM user_ratings orph
-                 JOIN merge_orphan_map m ON m.orphan_uuid = orph.book_uuid
-                WHERE m.live_uuid = user_ratings.book_uuid
-                  AND orph.user_id = user_ratings.user_id);
+DROP TABLE merge_orphan_resolved;
 
 -- `journal_entries` has no per-book uniqueness (a reader keeps many entries on
 -- one book), so every stranded row moves without a collision pass.

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -1318,3 +1318,109 @@ async fn migration_0079_is_a_no_op_on_a_database_that_never_merged() {
             .unwrap();
     assert_eq!(ratings, vec![("uuid-live".to_string(), 7)]);
 }
+
+#[tokio::test]
+async fn migration_0079_resolves_two_orphans_landing_on_the_same_book() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    // A chain of merges (A into B, then B into C) leaves several orphan uuids
+    // pointing at one live book, so a reader can hold rows on two of them.
+    // Repointing both without resolving them first violates
+    // UNIQUE (user_id, book_uuid) and aborts the upgrade at startup.
+    sqlx::raw_sql(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path)
+              VALUES ('uuid-gone-2', 1, 'EPUB', '/books');
+         INSERT INTO book_read_status (user_id, book_uuid, status, updated_at, finished_at)
+              VALUES (1, 'uuid-gone', 'finished', 1000, 1000),
+                     (1, 'uuid-gone-2', 'reading', 2000, NULL);
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-gone', 4, 1000),
+                     (1, 'uuid-gone-2', 9, 2000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    // One row each, on the survivor, carrying the newer orphan's values.
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![("uuid-live".to_string(), 9)]);
+
+    let status: Vec<(String, String)> =
+        sqlx::query_as("SELECT book_uuid, status FROM book_read_status")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        status,
+        vec![("uuid-live".to_string(), "reading".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn migration_0079_resolves_two_orphans_against_a_live_row_too() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    // Three-way: two orphans plus a row already on the survivor. The newest
+    // wins across the whole group, not just pairwise.
+    sqlx::raw_sql(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path)
+              VALUES ('uuid-gone-2', 1, 'EPUB', '/books');
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-gone', 2, 1000),
+                     (1, 'uuid-gone-2', 6, 3000),
+                     (1, 'uuid-live', 4, 2000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![("uuid-live".to_string(), 6)]);
+}
+
+#[tokio::test]
+async fn migration_0079_keeps_each_readers_own_row_when_orphans_collide() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    // The dedupe groups by (user, surviving book) — one reader's rows must
+    // never delete another's.
+    sqlx::raw_sql(
+        "INSERT INTO users (id, username, password_hash, is_admin) VALUES (2, 'v', 'x', 0);
+         INSERT INTO merged_uuids (uuid, book_id, format, library_path)
+              VALUES ('uuid-gone-2', 1, 'EPUB', '/books');
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-gone', 4, 1000),
+                     (1, 'uuid-gone-2', 9, 2000),
+                     (2, 'uuid-gone', 3, 1500);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    let ratings: Vec<(i64, String, i64)> =
+        sqlx::query_as("SELECT user_id, book_uuid, half_stars FROM user_ratings ORDER BY user_id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        ratings,
+        vec![
+            (1, "uuid-live".to_string(), 9),
+            (2, "uuid-live".to_string(), 3),
+        ]
+    );
+}

--- a/db/src/merge/tests.rs
+++ b/db/src/merge/tests.rs
@@ -1007,3 +1007,314 @@ fn map_settings_error_returns_other_for_non_db_variants() {
         "expected Other, got {json:?}"
     );
 }
+
+/// Stamp a read status, a rating and a journal entry on `book_uuid`.
+async fn seed_reader_record(
+    pool: &sqlx::SqlitePool,
+    user: i64,
+    book_uuid: &str,
+    half_stars: i64,
+    body: &str,
+    ts: i64,
+) {
+    sqlx::query(
+        "INSERT INTO book_read_status (user_id, book_uuid, status, updated_at, finished_at)
+         VALUES (?, ?, 'finished', ?, ?)",
+    )
+    .bind(user)
+    .bind(book_uuid)
+    .bind(ts)
+    .bind(ts)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(user)
+    .bind(book_uuid)
+    .bind(half_stars)
+    .bind(ts)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO journal_entries (user_id, book_uuid, body_md, progress, created_at, updated_at)
+         VALUES (?, ?, ?, 100, ?, ?)",
+    )
+    .bind(user)
+    .bind(book_uuid)
+    .bind(body)
+    .bind(ts)
+    .bind(ts)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn merge_books_moves_read_status_ratings_and_journals_to_target() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool).await;
+    let target = seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "Stoker/Drakula.m4b", "Drakula", "Bram Stoker").await;
+
+    // Only the book about to be merged away carries the reader's record.
+    seed_reader_record(&pool, user, &source, 10, "what a book", 2_000).await;
+
+    merge_books(&pool, &source, &target, Some(user))
+        .await
+        .unwrap();
+
+    // All three follow the book rather than stranding on the deleted uuid.
+    let status: Vec<(String, String)> =
+        sqlx::query_as("SELECT book_uuid, status FROM book_read_status")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(status, vec![(target.clone(), "finished".to_string())]);
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![(target.clone(), 10)]);
+
+    let journals: Vec<(String, String)> =
+        sqlx::query_as("SELECT book_uuid, body_md FROM journal_entries")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(journals, vec![(target.clone(), "what a book".to_string())]);
+}
+
+#[tokio::test]
+async fn merge_books_keeps_the_newer_read_status_and_rating_on_collision() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool).await;
+    let target = seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "Stoker/Drakula.m4b", "Drakula", "Bram Stoker").await;
+
+    // Both sides rated and finished; the source's record is the newer one.
+    seed_reader_record(&pool, user, &target, 6, "the ebook", 1_000).await;
+    seed_reader_record(&pool, user, &source, 10, "the audiobook", 2_000).await;
+
+    merge_books(&pool, &source, &target, Some(user))
+        .await
+        .unwrap();
+
+    // One row each, on the target, carrying the newer side's values.
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![(target.clone(), 10)]);
+
+    let finished: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, finished_at FROM book_read_status")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(finished, vec![(target.clone(), 2_000)]);
+
+    // Journals have no per-book uniqueness, so both entries survive the move.
+    let journals: i64 = count(
+        &pool,
+        &format!("SELECT COUNT(*) FROM journal_entries WHERE book_uuid = '{target}'"),
+    )
+    .await;
+    assert_eq!(journals, 2);
+}
+
+#[tokio::test]
+async fn merge_books_keeps_the_target_rating_when_it_is_the_newer_one() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let user = seed_user(&pool).await;
+    let target = seed_ebook(&pool, "Stoker/Dracula.epub", "Dracula", "Bram Stoker").await;
+    let source = seed_audiobook(&pool, "Stoker/Drakula.m4b", "Drakula", "Bram Stoker").await;
+
+    // Mirror of the test above — this time the surviving book is newer.
+    seed_reader_record(&pool, user, &target, 6, "the ebook", 3_000).await;
+    seed_reader_record(&pool, user, &source, 10, "the audiobook", 2_000).await;
+
+    merge_books(&pool, &source, &target, Some(user))
+        .await
+        .unwrap();
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![(target.clone(), 6)]);
+}
+
+/// Version of `0079_merge_orphan_user_data.sql`.
+const MERGE_ORPHAN_VERSION: i64 = 79;
+
+/// A pool migrated to just *below* [`MERGE_ORPHAN_VERSION`] — the schema an
+/// install carrying merge-stranded rows sits at before the heal lands. One
+/// connection, so the in-memory database is a single shared one.
+async fn pool_before_merge_orphan_heal() -> sqlx::SqlitePool {
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    for m in MIGRATOR.iter().filter(|m| m.version < MERGE_ORPHAN_VERSION) {
+        sqlx::raw_sql(&m.sql).execute(&pool).await.unwrap();
+    }
+    pool
+}
+
+async fn apply_merge_orphan_migration(pool: &sqlx::SqlitePool) {
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+    let m = MIGRATOR
+        .iter()
+        .find(|m| m.version == MERGE_ORPHAN_VERSION)
+        .expect("0079 must exist");
+    sqlx::raw_sql(&m.sql).execute(pool).await.unwrap();
+}
+
+/// The state an old merge left behind: a surviving book, the merged-away uuid
+/// recorded in the attach ledger, and no `books` row carrying it.
+async fn seed_merge_orphan_state(pool: &sqlx::SqlitePool) {
+    sqlx::raw_sql(
+        "INSERT INTO users (id, username, password_hash, is_admin) VALUES (1, 'u', 'x', 1);
+         INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib');
+         INSERT INTO books (id, uuid, library_id, path, title)
+              VALUES (1, 'uuid-live', 1, '/lib/a.epub', 'Dracula');
+         INSERT INTO merged_uuids (uuid, book_id, format, library_path)
+              VALUES ('uuid-gone', 1, 'M4B', '/audio');",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn migration_0079_repoints_user_data_stranded_by_an_earlier_merge() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    // The reader's record sits entirely on the merged-away uuid, where the
+    // book page cannot see it and the trailing-12 chart still counts it.
+    sqlx::raw_sql(
+        "INSERT INTO book_read_status (user_id, book_uuid, status, updated_at, finished_at)
+              VALUES (1, 'uuid-gone', 'finished', 2000, 2000);
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-gone', 9, 2000);
+         INSERT INTO journal_entries (user_id, book_uuid, body_md, progress, created_at, updated_at)
+              VALUES (1, 'uuid-gone', 'finished it', 100, 2000, 2000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    for table in ["book_read_status", "user_ratings", "journal_entries"] {
+        let on_live = count(
+            &pool,
+            &format!("SELECT COUNT(*) FROM {table} WHERE book_uuid = 'uuid-live'"),
+        )
+        .await;
+        let stranded = count(
+            &pool,
+            &format!("SELECT COUNT(*) FROM {table} WHERE book_uuid = 'uuid-gone'"),
+        )
+        .await;
+        assert_eq!(on_live, 1, "{table} must follow the surviving book");
+        assert_eq!(stranded, 0, "{table} must leave nothing on the dead uuid");
+    }
+}
+
+#[tokio::test]
+async fn migration_0079_keeps_the_newer_row_when_both_sides_carry_one() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    // Both sides rated and finished — the stranded side is the newer one, so
+    // latest-wins must replace the surviving book's row rather than collide
+    // against UNIQUE (user_id, book_uuid).
+    sqlx::raw_sql(
+        "INSERT INTO book_read_status (user_id, book_uuid, status, updated_at, finished_at)
+              VALUES (1, 'uuid-live', 'reading', 1000, NULL),
+                     (1, 'uuid-gone', 'finished', 2000, 2000);
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-live', 4, 1000),
+                     (1, 'uuid-gone', 9, 2000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![("uuid-live".to_string(), 9)]);
+
+    let status: Vec<(String, String)> =
+        sqlx::query_as("SELECT book_uuid, status FROM book_read_status")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        status,
+        vec![("uuid-live".to_string(), "finished".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn migration_0079_keeps_the_surviving_books_row_when_it_is_newer() {
+    let pool = pool_before_merge_orphan_heal().await;
+    seed_merge_orphan_state(&pool).await;
+    sqlx::raw_sql(
+        "INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-live', 4, 3000),
+                     (1, 'uuid-gone', 9, 2000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![("uuid-live".to_string(), 4)]);
+}
+
+#[tokio::test]
+async fn migration_0079_is_a_no_op_on_a_database_that_never_merged() {
+    let pool = pool_before_merge_orphan_heal().await;
+    sqlx::raw_sql(
+        "INSERT INTO users (id, username, password_hash, is_admin) VALUES (1, 'u', 'x', 1);
+         INSERT INTO scan_roots (id, path, display_name) VALUES (1, '/lib', 'Lib');
+         INSERT INTO books (id, uuid, library_id, path, title)
+              VALUES (1, 'uuid-live', 1, '/lib/a.epub', 'Dracula');
+         INSERT INTO user_ratings (user_id, book_uuid, half_stars, updated_at)
+              VALUES (1, 'uuid-live', 7, 1000);",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    apply_merge_orphan_migration(&pool).await;
+
+    let ratings: Vec<(String, i64)> =
+        sqlx::query_as("SELECT book_uuid, half_stars FROM user_ratings")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(ratings, vec![("uuid-live".to_string(), 7)]);
+}

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -388,18 +388,48 @@ async fn move_links(
     Ok(())
 }
 
-/// Re-parent reading progress and playback preferences (with latest-wins
-/// dedupe) plus bookmarks, reading/listening sessions, and highlights from the
-/// source book onto the target. The F1 user-data tables soft-reference the
-/// durable `books.uuid`, so re-parenting is an `UPDATE … SET book_uuid =
+/// Every per-user table that soft-references `books.uuid` and must follow the
+/// book across a merge. Ordered so the [`DEDUPE_TABLES`] entries — which have
+/// already had their collisions resolved — retarget alongside the rest.
+///
+/// This list is the merge's half of the soft-reference contract: a table added
+/// here but not there silently strands a user's data on the deleted source
+/// uuid, where it is invisible to anything joining `books` and still visible to
+/// anything that doesn't.
+const RETARGET_TABLES: [&str; 10] = [
+    "reading_progress",
+    "audiobook_playback_preferences",
+    "bookmarks",
+    "reading_sessions",
+    "listening_sessions",
+    "annotations",
+    "kobo_annotations_sync",
+    "journal_entries",
+    "book_read_status",
+    "user_ratings",
+];
+
+/// The subset of [`RETARGET_TABLES`] carrying a `UNIQUE` key the retarget would
+/// collide on, with the extra key column beyond `(user_id, book_uuid)` where
+/// there is one. Resolved latest-wins by [`dedupe_latest_wins`] before the
+/// retarget runs.
+const DEDUPE_TABLES: [(&str, Option<&str>); 4] = [
+    ("reading_progress", Some("format")),
+    ("audiobook_playback_preferences", None),
+    ("book_read_status", None),
+    ("user_ratings", None),
+];
+
+/// Re-parent every per-user row from the source book onto the target: reading
+/// progress, playback preferences, bookmarks, sessions, highlights, journal
+/// entries, read status, and ratings. The F1 user-data tables soft-reference
+/// the durable `books.uuid`, so re-parenting is an `UPDATE … SET book_uuid =
 /// <target> WHERE book_uuid = <source>` (no FK cascade — a cascade would
 /// *delete* the children). The two canonical uuids are read from `books` while
 /// the source row still exists (it is deleted later in `finalize_merge`).
 ///
-/// Dedupe on `reading_progress` is necessary because `format` is the coarse
-/// `'epub' | 'audio'`, while the merge's format-collision check uses the real
-/// file formats — an M4B book merging with an MP3 book passes the check but
-/// both carry `'audio'` progress rows.
+/// Tables with a `UNIQUE` key the retarget would violate are deduped first;
+/// see [`DEDUPE_TABLES`] and [`dedupe_latest_wins`].
 async fn move_progress_and_history(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     source_id: i64,
@@ -414,12 +444,14 @@ async fn move_progress_and_history(
         .fetch_one(&mut **tx)
         .await?;
 
-    dedupe_reading_progress(tx, &source_uuid, &target_uuid).await?;
-    dedupe_playback_preferences(tx, &source_uuid, &target_uuid).await?;
-    // Per-device annotation sync state keys on (device_id, book_uuid); where a
-    // device tracks BOTH uuids, keep the target's row (the retarget below
-    // would collide) — the watermark is regenerable, and a moved fingerprint
-    // just re-reports the merged book once.
+    for (table, extra_key) in DEDUPE_TABLES {
+        dedupe_latest_wins(tx, table, extra_key, &source_uuid, &target_uuid).await?;
+    }
+    // Per-device annotation sync state keys on (device_id, book_uuid) rather
+    // than on a user, so it can't use the latest-wins helper. Where a device
+    // tracks BOTH uuids, keep the target's row (the retarget below would
+    // collide) — the watermark is regenerable, and a moved fingerprint just
+    // re-reports the merged book once.
     sqlx::query(
         "DELETE FROM kobo_annotations_sync
           WHERE book_uuid = ?2 AND EXISTS (
@@ -431,15 +463,7 @@ async fn move_progress_and_history(
     .bind(&source_uuid)
     .execute(&mut **tx)
     .await?;
-    for table in [
-        "reading_progress",
-        "audiobook_playback_preferences",
-        "bookmarks",
-        "reading_sessions",
-        "listening_sessions",
-        "annotations",
-        "kobo_annotations_sync",
-    ] {
+    for table in RETARGET_TABLES {
         let sql = format!("UPDATE {table} SET book_uuid = ?1 WHERE book_uuid = ?2");
         sqlx::query(&sql)
             .bind(&target_uuid)
@@ -450,72 +474,58 @@ async fn move_progress_and_history(
     Ok(())
 }
 
-/// Latest-wins dedupe of `reading_progress` rows that collide on
-/// `(user_id, format)` once the source's uuid retargets onto the target's —
-/// see [`move_progress_and_history`]'s doc for why the coarse `format`
-/// column makes this necessary.
-async fn dedupe_reading_progress(
+/// Latest-wins dedupe of the rows in `table` that would collide on its
+/// `UNIQUE (user_id, book_uuid[, extra_key])` once the source's uuid retargets
+/// onto the target's. The surviving row is whichever side has the newer
+/// `updated_at`, ties going to the target.
+///
+/// `extra_key` names the third column of that unique key where there is one:
+/// `reading_progress` needs it because `format` is the coarse `'epub' |
+/// 'audio'`, while the merge's format-collision check uses the real file
+/// formats — an M4B book merging with an MP3 book passes the check but both
+/// carry `'audio'` progress rows.
+///
+/// Two passes are required, and in this order: keeping the newest row means
+/// deleting a loser on whichever side it falls, and pass 2's blanket delete of
+/// colliding target rows is only correct once pass 1 has removed the source
+/// rows the target already beat.
+async fn dedupe_latest_wins(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
+    table: &str,
+    extra_key: Option<&str>,
     source_uuid: &str,
     target_uuid: &str,
 ) -> Result<(), sqlx::Error> {
-    // Losing source rows first (target is newer or equal) …
-    sqlx::query(
-        "DELETE FROM reading_progress WHERE book_uuid = ?2 AND EXISTS (
-            SELECT 1 FROM reading_progress t
-             WHERE t.book_uuid = ?1 AND t.user_id = reading_progress.user_id
-               AND t.format = reading_progress.format
-               AND t.updated_at >= reading_progress.updated_at)",
-    )
-    .bind(target_uuid)
-    .bind(source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    // … then losing target rows (a strictly newer source row survived).
-    sqlx::query(
-        "DELETE FROM reading_progress WHERE book_uuid = ?1 AND EXISTS (
-            SELECT 1 FROM reading_progress s
-             WHERE s.book_uuid = ?2 AND s.user_id = reading_progress.user_id
-               AND s.format = reading_progress.format)",
-    )
-    .bind(target_uuid)
-    .bind(source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    Ok(())
-}
+    // `table` / `extra_key` are fixed literals from the consts above, never
+    // user input.
+    let also = extra_key
+        .map(|k| format!(" AND o.{k} = {table}.{k}"))
+        .unwrap_or_default();
 
-/// Latest-wins dedupe of `audiobook_playback_preferences` rows that collide
-/// on `user_id` once the source's uuid retargets onto the target's. Same
-/// two-pass shape as [`dedupe_reading_progress`].
-async fn dedupe_playback_preferences(
-    tx: &mut Transaction<'_, sqlx::Sqlite>,
-    source_uuid: &str,
-    target_uuid: &str,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "DELETE FROM audiobook_playback_preferences
-          WHERE book_uuid = ?2 AND EXISTS (
-            SELECT 1 FROM audiobook_playback_preferences t
-             WHERE t.book_uuid = ?1
-               AND t.user_id = audiobook_playback_preferences.user_id
-               AND t.updated_at >= audiobook_playback_preferences.updated_at)",
-    )
-    .bind(target_uuid)
-    .bind(source_uuid)
-    .execute(&mut **tx)
-    .await?;
-    sqlx::query(
-        "DELETE FROM audiobook_playback_preferences
-          WHERE book_uuid = ?1 AND EXISTS (
-            SELECT 1 FROM audiobook_playback_preferences s
-             WHERE s.book_uuid = ?2
-               AND s.user_id = audiobook_playback_preferences.user_id)",
-    )
-    .bind(target_uuid)
-    .bind(source_uuid)
-    .execute(&mut **tx)
-    .await?;
+    // Losing source rows first (target is newer or equal) …
+    let sql = format!(
+        "DELETE FROM {table} WHERE book_uuid = ?2 AND EXISTS (
+            SELECT 1 FROM {table} o
+             WHERE o.book_uuid = ?1 AND o.user_id = {table}.user_id{also}
+               AND o.updated_at >= {table}.updated_at)"
+    );
+    sqlx::query(&sql)
+        .bind(target_uuid)
+        .bind(source_uuid)
+        .execute(&mut **tx)
+        .await?;
+
+    // … then losing target rows (a strictly newer source row survived).
+    let sql = format!(
+        "DELETE FROM {table} WHERE book_uuid = ?1 AND EXISTS (
+            SELECT 1 FROM {table} o
+             WHERE o.book_uuid = ?2 AND o.user_id = {table}.user_id{also})"
+    );
+    sqlx::query(&sql)
+        .bind(target_uuid)
+        .bind(source_uuid)
+        .execute(&mut **tx)
+        .await?;
     Ok(())
 }
 

--- a/db/src/merge/transaction.rs
+++ b/db/src/merge/transaction.rs
@@ -388,14 +388,22 @@ async fn move_links(
     Ok(())
 }
 
-/// Every per-user table that soft-references `books.uuid` and must follow the
-/// book across a merge. Ordered so the [`DEDUPE_TABLES`] entries — which have
-/// already had their collisions resolved — retarget alongside the rest.
+/// Every table that soft-references `books.uuid` and must follow the book
+/// across a merge. Mostly per-user; `kobo_annotations_sync` is the one
+/// per-device entry, which is why its collision is handled separately below
+/// rather than by [`dedupe_latest_wins`].
 ///
-/// This list is the merge's half of the soft-reference contract: a table added
-/// here but not there silently strands a user's data on the deleted source
-/// uuid, where it is invisible to anything joining `books` and still visible to
-/// anything that doesn't.
+/// This list is the merge's half of the soft-reference contract: a per-reader
+/// table added to the schema but not here silently strands its rows on the
+/// deleted source uuid, where they are invisible to anything joining `books`
+/// and still visible to anything that doesn't.
+///
+/// **Not exhaustive over every `book_uuid` column.** `shelf_books`,
+/// `wishlist_entries`, `cross_format_links` and `physical_copies` also
+/// soft-reference a book and do *not* follow a merge today — a shelved book
+/// merged into another drops off its shelf. That is a separate pre-existing
+/// bug with its own semantics to settle (which shelf wins, what an inherited
+/// wishlist entry means), deliberately not folded in here.
 const RETARGET_TABLES: [&str; 10] = [
     "reading_progress",
     "audiobook_playback_preferences",

--- a/db/src/stats/compute.rs
+++ b/db/src/stats/compute.rs
@@ -57,13 +57,9 @@ pub(super) const FINISHED_EVENTS: &str = "\
 /// the liveness filter **every** completion metric shares. Same
 /// `(book_uuid, finished_at)` shape, same two binds.
 ///
-/// A function rather than four hand-written `JOIN books` clauses because the
-/// metrics disagreed when it was four: the headline count, the rail and the
-/// pages estimate joined `books` while the trailing-12 chart and the
-/// vs-previous delta did not, so a single completion on a merged-away book
-/// made the Finished tile and the chart directly above it report different
-/// numbers for the same month. Deriving the filter from one place means a
-/// metric that opts out has to do so visibly.
+/// Derived once rather than spelled out per query: several of these metrics
+/// render on the same screen, so a metric that opts out of the filter has to
+/// do so visibly.
 fn live_finished_events() -> String {
     format!(
         "SELECT f.book_uuid AS book_uuid, f.finished_at AS finished_at \
@@ -76,9 +72,7 @@ fn live_finished_events() -> String {
 /// liveness rule [`live_finished_events`] applies to completions, for the
 /// star-rating metrics. Bind order is `user_id`.
 ///
-/// Without it the average rating is computed over rows the UI cannot show:
-/// a rating stranded on a merged-away book renders nowhere on the book page
-/// and still moves the mean on the stats page.
+/// A rating the book page cannot render must not move the mean.
 const LIVE_RATINGS: &str = "\
     SELECT r.user_id AS user_id, r.half_stars AS half_stars, r.updated_at AS updated_at \
     FROM user_ratings r \

--- a/db/src/stats/compute.rs
+++ b/db/src/stats/compute.rs
@@ -53,6 +53,38 @@ pub(super) const FINISHED_EVENTS: &str = "\
     SELECT book_uuid, finished_at FROM book_read_status \
         WHERE user_id = ? AND status = 'finished' AND finished_at IS NOT NULL";
 
+/// [`FINISHED_EVENTS`] narrowed to completions on a book that still exists —
+/// the liveness filter **every** completion metric shares. Same
+/// `(book_uuid, finished_at)` shape, same two binds.
+///
+/// A function rather than four hand-written `JOIN books` clauses because the
+/// metrics disagreed when it was four: the headline count, the rail and the
+/// pages estimate joined `books` while the trailing-12 chart and the
+/// vs-previous delta did not, so a single completion on a merged-away book
+/// made the Finished tile and the chart directly above it report different
+/// numbers for the same month. Deriving the filter from one place means a
+/// metric that opts out has to do so visibly.
+fn live_finished_events() -> String {
+    format!(
+        "SELECT f.book_uuid AS book_uuid, f.finished_at AS finished_at \
+         FROM ({FINISHED_EVENTS}) f \
+         JOIN books b ON b.uuid = f.book_uuid"
+    )
+}
+
+/// A rating on a book that still exists, scoped to one user — the same
+/// liveness rule [`live_finished_events`] applies to completions, for the
+/// star-rating metrics. Bind order is `user_id`.
+///
+/// Without it the average rating is computed over rows the UI cannot show:
+/// a rating stranded on a merged-away book renders nowhere on the book page
+/// and still moves the mean on the stats page.
+const LIVE_RATINGS: &str = "\
+    SELECT r.user_id AS user_id, r.half_stars AS half_stars, r.updated_at AS updated_at \
+    FROM user_ratings r \
+    JOIN books b ON b.uuid = r.book_uuid \
+    WHERE r.user_id = ?";
+
 /// Run every per-field query and assemble the [`StatsSummary`] for one user's
 /// window. This is the body [`super::user_stats_at`] caches.
 pub(super) async fn compute(
@@ -155,19 +187,18 @@ pub(super) async fn sum_seconds(
 /// Mean star rating over books the user rated within the window (keyed on
 /// `user_ratings.updated_at`), in stars — `half_stars` is 1..=10, so the
 /// SQL mean halves it. `None` when nothing was rated in the window.
+/// Live books only, per [`LIVE_RATINGS`].
 pub(super) async fn avg_stars(
     pool: &SqlitePool,
     user_id: i64,
     start: i64,
 ) -> Result<Option<f64>, StatsError> {
-    Ok(sqlx::query_scalar(
-        "SELECT AVG(half_stars) / 2.0 FROM user_ratings
-         WHERE user_id = ? AND updated_at >= ?",
-    )
-    .bind(user_id)
-    .bind(start)
-    .fetch_one(pool)
-    .await?)
+    let sql = format!("SELECT AVG(half_stars) / 2.0 FROM ({LIVE_RATINGS}) WHERE updated_at >= ?");
+    Ok(sqlx::query_scalar(&sql)
+        .bind(user_id)
+        .bind(start)
+        .fetch_one(pool)
+        .await?)
 }
 
 /// Sittings in the window, counted over [`sessionize::stitched`] groups
@@ -434,10 +465,8 @@ pub(super) async fn finished_count(
     start: i64,
 ) -> Result<i64, StatsError> {
     let sql = format!(
-        "SELECT COUNT(DISTINCT f.book_uuid)
-         FROM ({FINISHED_EVENTS}) f
-         JOIN books b ON b.uuid = f.book_uuid
-         WHERE f.finished_at >= ?"
+        "SELECT COUNT(DISTINCT f.book_uuid) FROM ({}) f WHERE f.finished_at >= ?",
+        live_finished_events()
     );
     Ok(sqlx::query_scalar(&sql)
         .bind(user_id)
@@ -595,19 +624,22 @@ async fn avg_stars_bounded(
     start: i64,
     end: i64,
 ) -> Result<Option<f64>, StatsError> {
-    Ok(sqlx::query_scalar(
-        "SELECT AVG(half_stars) / 2.0 FROM user_ratings
-         WHERE user_id = ? AND updated_at >= ? AND updated_at < ?",
-    )
-    .bind(user_id)
-    .bind(start)
-    .bind(end)
-    .fetch_one(pool)
-    .await?)
+    let sql = format!(
+        "SELECT AVG(half_stars) / 2.0 FROM ({LIVE_RATINGS}) \
+         WHERE updated_at >= ? AND updated_at < ?"
+    );
+    Ok(sqlx::query_scalar(&sql)
+        .bind(user_id)
+        .bind(start)
+        .bind(end)
+        .fetch_one(pool)
+        .await?)
 }
 
-/// Count of distinct books finished (either source, see [`FINISHED_EVENTS`])
-/// with the completion moment in `[start, end)`.
+/// Count of distinct live books finished (either source, see
+/// [`FINISHED_EVENTS`]) with the completion moment in `[start, end)`. Shares
+/// [`finished_count`]'s definition exactly, so the drill-in's delta compares
+/// two counts of the same thing.
 async fn finished_count_bounded(
     pool: &SqlitePool,
     user_id: i64,
@@ -615,8 +647,9 @@ async fn finished_count_bounded(
     end: i64,
 ) -> Result<i64, StatsError> {
     let sql = format!(
-        "SELECT COUNT(DISTINCT f.book_uuid) FROM ({FINISHED_EVENTS}) f
-         WHERE f.finished_at >= ? AND f.finished_at < ?"
+        "SELECT COUNT(DISTINCT f.book_uuid) FROM ({}) f
+         WHERE f.finished_at >= ? AND f.finished_at < ?",
+        live_finished_events()
     );
     Ok(sqlx::query_scalar(&sql)
         .bind(user_id)
@@ -661,7 +694,7 @@ pub(super) async fn rating_monthly(
     pool: &SqlitePool,
     user_id: i64,
 ) -> Result<Vec<TrendPoint>, StatsError> {
-    let rows = sqlx::query(
+    let sql = format!(
         "WITH RECURSIVE months(month) AS (
              SELECT strftime('%Y-%m', 'now', 'start of month', '-11 months')
              UNION ALL
@@ -671,15 +704,12 @@ pub(super) async fn rating_monthly(
          )
          SELECT months.month AS month, AVG(ur.half_stars) / 2.0 AS avg_stars
          FROM months
-         LEFT JOIN user_ratings ur
-                ON ur.user_id = ?
-               AND strftime('%Y-%m', ur.updated_at, 'unixepoch') = months.month
+         LEFT JOIN ({LIVE_RATINGS}) ur
+                ON strftime('%Y-%m', ur.updated_at, 'unixepoch') = months.month
          GROUP BY months.month
-         ORDER BY months.month",
-    )
-    .bind(user_id)
-    .fetch_all(pool)
-    .await?;
+         ORDER BY months.month"
+    );
+    let rows = sqlx::query(&sql).bind(user_id).fetch_all(pool).await?;
 
     Ok(rows
         .into_iter()
@@ -716,10 +746,11 @@ pub(super) async fn books_per_month(
          )
          SELECT months.month AS month, COUNT(DISTINCT f.book_uuid) AS books
          FROM months
-         LEFT JOIN ({FINISHED_EVENTS}) f
+         LEFT JOIN ({}) f
                ON strftime('%Y-%m', f.finished_at, 'unixepoch') = months.month
          GROUP BY months.month
-         ORDER BY months.month"
+         ORDER BY months.month",
+        live_finished_events()
     );
     let rows = sqlx::query(&sql)
         .bind(user_id)

--- a/db/src/stats/tests.rs
+++ b/db/src/stats/tests.rs
@@ -889,8 +889,11 @@ async fn drop_book_row(pool: &SqlitePool, uuid: &str) {
         .unwrap();
 }
 
-async fn now_secs_db(pool: &SqlitePool) -> i64 {
-    sqlx::query_scalar("SELECT CAST(strftime('%s','now') AS INTEGER)")
+/// A moment safely inside the current calendar month. Not `now - 60`: for the
+/// first minute of the 1st that lands in the *previous* month, while the
+/// trailing-12 series still ends on the current one.
+async fn this_month_secs(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT CAST(strftime('%s','now','start of month','+1 day') AS INTEGER)")
         .fetch_one(pool)
         .await
         .unwrap()
@@ -901,9 +904,9 @@ async fn finished_metrics_agree_when_a_completion_outlives_its_book() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 2).await;
     let user = seed_user(&pool, "alice").await;
-    let now = now_secs_db(&pool).await;
-    finish_read_status(&pool, user, "uuid-1", now - 60).await;
-    finish_read_status(&pool, user, "uuid-2", now - 60).await;
+    let at = this_month_secs(&pool).await;
+    finish_read_status(&pool, user, "uuid-1", at).await;
+    finish_read_status(&pool, user, "uuid-2", at).await;
     drop_book_row(&pool, "uuid-2").await;
 
     // The headline count, the rail and the trailing-12 chart are three reads
@@ -946,9 +949,9 @@ async fn avg_stars_excludes_a_rating_whose_book_is_gone() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 2).await;
     let user = seed_user(&pool, "alice").await;
-    let now = now_secs_db(&pool).await;
-    rate_book(&pool, user, "uuid-1", 10, now - 60).await;
-    rate_book(&pool, user, "uuid-2", 2, now - 60).await;
+    let at = this_month_secs(&pool).await;
+    rate_book(&pool, user, "uuid-1", 10, at).await;
+    rate_book(&pool, user, "uuid-2", 2, at).await;
     drop_book_row(&pool, "uuid-2").await;
 
     // The 1-star sits on a book the UI cannot render a rating for, so it must
@@ -961,9 +964,9 @@ async fn rating_monthly_excludes_a_rating_whose_book_is_gone() {
     let pool = init_db("sqlite::memory:").await.unwrap();
     seed_minimal_books(&pool, 2).await;
     let user = seed_user(&pool, "alice").await;
-    let now = now_secs_db(&pool).await;
-    rate_book(&pool, user, "uuid-1", 10, now - 60).await;
-    rate_book(&pool, user, "uuid-2", 2, now - 60).await;
+    let at = this_month_secs(&pool).await;
+    rate_book(&pool, user, "uuid-1", 10, at).await;
+    rate_book(&pool, user, "uuid-2", 2, at).await;
     drop_book_row(&pool, "uuid-2").await;
 
     let months = rating_monthly(&pool, user).await.unwrap();
@@ -973,4 +976,35 @@ async fn rating_monthly_excludes_a_rating_whose_book_is_gone() {
         (months.last().unwrap().value - 5.0).abs() < f64::EPSILON,
         "expected the current month to mean 5.0, got {months:?}"
     );
+}
+
+#[tokio::test]
+async fn previous_period_avg_stars_excludes_a_rating_whose_book_is_gone() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+    let prev = prev_period_start(&pool, StatsRange::Month).await;
+    rate_book(&pool, user, "uuid-1", 10, prev).await;
+    rate_book(&pool, user, "uuid-2", 2, prev).await;
+    drop_book_row(&pool, "uuid-2").await;
+
+    // `avg_stars_bounded` carries its own copy of the filter; without this the
+    // baseline mean could disagree with the current window's for the same books.
+    let previous = previous_period(&pool, user, StatsRange::Month)
+        .await
+        .unwrap();
+    assert_eq!(previous.avg_stars, Some(5.0));
+}
+
+/// First second of the period preceding `range`'s current one.
+async fn prev_period_start(pool: &SqlitePool, range: StatsRange) -> i64 {
+    sqlx::query_scalar(match range {
+        StatsRange::Month => {
+            "SELECT CAST(strftime('%s','now','start of month','-1 month') AS INTEGER)"
+        }
+        _ => unreachable!("only Month is used here"),
+    })
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }

--- a/db/src/stats/tests.rs
+++ b/db/src/stats/tests.rs
@@ -875,3 +875,102 @@ async fn finished_books_rail_is_capped_but_count_is_not() {
         format!("uuid-{}", FINISHED_BOOKS_LIMIT + 5)
     );
 }
+
+/// Drop a book row the way `merge::transaction::finalize_merge` used to,
+/// leaving its soft-referencing user-data rows behind. Migration `0079` heals
+/// the rows an old merge stranded and the merge path no longer strands new
+/// ones — but a completion can outlive its book by any route that drops a
+/// `books` row, and every metric must agree about that book either way.
+async fn drop_book_row(pool: &SqlitePool, uuid: &str) {
+    sqlx::query("DELETE FROM books WHERE uuid = ?")
+        .bind(uuid)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn now_secs_db(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT CAST(strftime('%s','now') AS INTEGER)")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn finished_metrics_agree_when_a_completion_outlives_its_book() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+    let now = now_secs_db(&pool).await;
+    finish_read_status(&pool, user, "uuid-1", now - 60).await;
+    finish_read_status(&pool, user, "uuid-2", now - 60).await;
+    drop_book_row(&pool, "uuid-2").await;
+
+    // The headline count, the rail and the trailing-12 chart are three reads
+    // of one definition; before the shared liveness filter the chart reported
+    // 2 while the tile above it reported 1, for the same month.
+    let headline = finished_count(&pool, user, 0).await.unwrap();
+    let rail = finished_books(&pool, user, 0).await.unwrap();
+    let months = books_per_month(&pool, user).await.unwrap();
+    assert_eq!(headline, 1);
+    assert_eq!(rail.len(), 1);
+    assert_eq!(months.last().unwrap().books, 1);
+}
+
+#[tokio::test]
+async fn previous_period_excludes_a_completion_whose_book_is_gone() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+    // Mid-previous-month, safely inside the Month range's previous window.
+    let prev: i64 = sqlx::query_scalar(
+        "SELECT CAST(strftime('%s','now','start of month','-1 month','+14 days') AS INTEGER)",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    finish_read_status(&pool, user, "uuid-1", prev).await;
+    finish_read_status(&pool, user, "uuid-2", prev).await;
+    drop_book_row(&pool, "uuid-2").await;
+
+    // The delta's baseline must count the same population the current window
+    // does, or the drill-in invents a drop the reader never had.
+    let previous = previous_period(&pool, user, StatsRange::Month)
+        .await
+        .unwrap();
+    assert_eq!(previous.books_finished, 1);
+}
+
+#[tokio::test]
+async fn avg_stars_excludes_a_rating_whose_book_is_gone() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+    let now = now_secs_db(&pool).await;
+    rate_book(&pool, user, "uuid-1", 10, now - 60).await;
+    rate_book(&pool, user, "uuid-2", 2, now - 60).await;
+    drop_book_row(&pool, "uuid-2").await;
+
+    // The 1-star sits on a book the UI cannot render a rating for, so it must
+    // not drag the mean the stats page shows.
+    assert_eq!(avg_stars(&pool, user, 0).await.unwrap(), Some(5.0));
+}
+
+#[tokio::test]
+async fn rating_monthly_excludes_a_rating_whose_book_is_gone() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_minimal_books(&pool, 2).await;
+    let user = seed_user(&pool, "alice").await;
+    let now = now_secs_db(&pool).await;
+    rate_book(&pool, user, "uuid-1", 10, now - 60).await;
+    rate_book(&pool, user, "uuid-2", 2, now - 60).await;
+    drop_book_row(&pool, "uuid-2").await;
+
+    let months = rating_monthly(&pool, user).await.unwrap();
+    assert_eq!(months.len(), 12);
+    // Same filter as `avg_stars`, so the tile and its trend agree.
+    assert!(
+        (months.last().unwrap().value - 5.0).abs() < f64::EPSILON,
+        "expected the current month to mean 5.0, got {months:?}"
+    );
+}

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -129,8 +129,9 @@ pub struct GenreShare {
     pub books: i64,
 }
 
-/// A book completed within the window — a journal entry recorded 100% progress
-/// on it. `finished_at` is the most recent such entry's timestamp (unix secs).
+/// A book completed within the window — a 100% journal entry or an explicit
+/// read-status `finished`. `finished_at` is the most recent such moment
+/// (unix secs).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FinishedBook {
     pub book_uuid: String,
@@ -177,10 +178,13 @@ pub struct PeriodComparison {
 
 /// The full aggregate payload for one user over one [`StatsRange`].
 ///
-/// Book completion is sourced from `journal_entries.progress = 100` (the only
-/// progress fraction persisted today) rather than the session tables, which
-/// carry duration but no progress; a future first-class read/unread state
-/// would feed the same field instead.
+/// Book completion is sourced from either a 100% `journal_entries` row or an
+/// explicit `book_read_status` of `finished`, never from the session tables
+/// (which carry duration but no progress). A book finished both ways counts
+/// once, and every completion metric on this struct — `books_finished`,
+/// `finished_books`, `books_per_month`, `pages_read` and `previous` — shares
+/// that one definition, live books only. They must not drift apart: two of
+/// them render on the same screen.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct StatsSummary {
     pub range: StatsRange,


### PR DESCRIPTION
## Summary
- The stats page read the same completion events through three different filters — the Finished tile, the finished rail and the pages estimate joined `books`, while the trailing-12-month chart and the vs-previous delta did not — so a completion on a book that no longer exists made the tile report 1 and the chart directly above it report 2, for the same month, plus a fabricated downward "vs last month" delta. `avg_stars` and `rating_monthly` had the same gap for ratings.
- The orphans came from merge: `move_progress_and_history` retargeted seven soft-ref tables onto the surviving book but not `journal_entries`, `book_read_status` or `user_ratings`, and `finalize_merge` then deleted the source `books` row — so merging an audiobook into its ebook silently lost the rating and finish date on the merged-away side, while those rows kept moving the stats totals from a place nothing could render them.
- Merge now retargets all ten per-user tables, resolving the two newly unique-constrained ones latest-wins (the rule already applied to a colliding reading position ten lines above).
- The two near-identical dedupe helpers collapse into one shared two-pass implementation, so the four call sites cannot drift; the existing merge tests pass unchanged against it.
- Migration `0079` heals rows earlier merges already stranded, resolving them through the `merged_uuids` ledger under the same latest-wins rule, and no-ops on a database that never merged.
- The stats liveness filter is now derived from one place for completions (`live_finished_events`) and one for ratings (`LIVE_RATINGS`), so a metric that opts out has to do so visibly.
- Records the `RETARGET_TABLES` half of the soft-reference contract in `.claude/rules/06-migrations.md`, and corrects two `StatsSummary` doc comments that still described completion as journal-only.
- Stacked — 1 of 3. #2225 and #2226 build on this branch.

## Test plan
- [x] `just test` — full matrix green (db 2530, server 912, frontend 928, frontend-mobile 783, shared 364).
- [x] `just lint` — fmt + clippy across the crate/feature matrix, incl. wasm32.
- [x] New merge tests cover source-only transfer, latest-wins on collision in both directions, and journal entries surviving without a uniqueness pass.
- [x] New migration tests apply `0079` to a pool migrated to `0078`, covering the repoint, both collision directions, and the never-merged no-op.
- [x] New stats tests pin the three completion reads to one answer, and the previous-window and rating metrics to live books.

## Version
- [x] **Patch** — bug fix, no schema-visible API change.

## Notes
- The collision rule only decides the case where a reader rated or finished *both* sides of a merge. The case that actually loses data today is the one where only the merged-away book carried a rating: nothing rendered it, and it still moved the average.
- `busiest_week` remains computed on every stats load and rendered by neither client. Left alone deliberately — dropping a field the shipped iOS build decodes is a compat change better made on its own.