### PR TITLE
[OMNI-2200] Give Each Exploration Agent Its Own Browser

### DIFF
--- a/.claude/rules/04-playwright.md
+++ b/.claude/rules/04-playwright.md
@@ -16,7 +16,7 @@ The Playwright project (`ui_tests/playwright`) uses **pnpm** as its package mana
 
 The `playwright-driver.browsers` package in [flake.nix](../../flake.nix) provides the browser bundle, and the shellHook exports `PLAYWRIGHT_BROWSERS_PATH` into the Nix store. Do **not** run `pnpm exec playwright install` — it would re-download Chromium into `~/Library/Caches/ms-playwright/` and diverge from the flake.
 
-`@playwright/test` is pinned with a tilde range (`~1.59.0`) so pnpm stays on the same minor as nixpkgs. When bumping the version, update both together since each Playwright minor expects a specific Chromium build number.
+`@playwright/test` is pinned with a tilde range (`~1.61.0`) so pnpm stays on the same minor as the Chromium bundle. The bundle comes from a **dedicated** flake input, `nixpkgs-playwright`, pinned to a rev where `playwright-driver` is 1.61.1 — separate from `nixpkgs-unstable` so moving the browser does not also move the Rust toolchain, `dioxus-cli` and node. Each Playwright minor expects a specific Chromium build number, so **three things move together or not at all**: that flake input's rev, this tilde range, and the `overrides` in [`scripts/explore/driver/package.json`](../../scripts/explore/driver/package.json), which pins the agentic-exploration driver's transitive `playwright` to the same version so it shares the one bundle rather than downloading a second Chromium.
 
 ## Reporters — `list` + `junit`
 

--- a/.claude/skills/agentic-exploration/SKILL.md
+++ b/.claude/skills/agentic-exploration/SKILL.md
@@ -98,7 +98,23 @@ One journal per run, shared by every agent. Six transcripts is something nobody
 reads; one timestamped timeline is what lets the report correlate an agent's
 500 with another agent's merge two seconds earlier.
 
-## 6. Fan out
+## 6. Start the browsers
+
+```bash
+scripts/explore/driver.sh up <N>      # one server, session and browser per agent
+scripts/explore/driver.sh status
+```
+
+**One browser per agent is not a nicety.** Run `r-20260828-01` died because
+three subagents shared a single browser tab: they shared a cookie jar, three
+different users collapsed into one, and two agents correctly aborted rather than
+write journal entries under a wrong actor. The driver makes that impossible.
+
+Agents drive their browser with `driver.sh run <n> "<command>"`, which prints
+`{"text": ..., "isError": ...}`. Tear down with `driver.sh down` when the run
+ends, whatever the outcome.
+
+## 7. Fan out
 
 One subagent per actor, in parallel, each given **only**:
 
@@ -106,7 +122,8 @@ One subagent per actor, in parallel, each given **only**:
 - its `actor`, `surface: web`, the base URL, and its own username and password;
 - its sampled sequence — hand over **one flow document at a time**, never the list;
 - the corpus path, and the journal path;
-- the run id.
+- the run id;
+- **its agent number**, for `driver.sh run <n>` — never another agent's.
 
 Tell each agent, verbatim in the brief:
 
@@ -121,7 +138,7 @@ to replay from, and **anything wrong or ambiguous in the flow documents
 themselves**. That last one has been the most valuable output of every run so
 far — the catalog is as much under test as the app.
 
-## 7. Report back
+## 8. Report back
 
 Until #2203 lands there is no report generator, so summarise by hand from the
 journal — not from agent prose, which is unverified:

--- a/docs/qa/agentic_exploration/flows/adding_book.md
+++ b/docs/qa/agentic_exploration/flows/adding_book.md
@@ -46,12 +46,20 @@ goes in through the front door* in [start.md](../start.md).
    takes a single file, an audiobook takes several at once.
 3. Choose a file from the corpus, by dropping it on the drop zone or through
    the file chooser. Journal the filename **before** you upload it.
-4. The app extracts the file's metadata and shows a **review form** — Title,
-   Author, Series, Series index — under "Review the details, then add to your
-   library." Read it against what you know the book to be. Real library files
-   frequently carry garbled, swapped, or filename-derived metadata, and this
-   form is where a person would fix it before committing. Correct it when it is
-   wrong, and journal both what the app offered and what you changed.
+4. The app extracts the file's metadata and shows a **review form** under
+   "Review the details, then add to your library." Read it against what you know
+   the book to be. Real library files frequently carry garbled, swapped, or
+   filename-derived metadata, and this form is where a person would fix it
+   before committing. Correct it when it is wrong, and journal both what the app
+   offered and what you changed.
+
+   Three things to expect rather than report as bugs. The form may come back
+   **entirely empty** — audiobooks often carry no container tags at all, and
+   there is then nothing to review; fill in Title and Author yourself, since the
+   required-field guard will otherwise block the save. The **audiobook form has
+   no Series fields**, unlike the ebook one. And the form offers a single Author
+   field even when the file names several creators — check the detail page
+   afterwards to see whether the others survived, and journal the answer.
 5. Click **Add to library**.
 6. Wait for the book to appear in the library. Indexing is asynchronous — give
    it time and re-check rather than reporting it missing straight away.

--- a/docs/qa/agentic_exploration/flows/adding_journal.md
+++ b/docs/qa/agentic_exploration/flows/adding_journal.md
@@ -7,16 +7,24 @@
 | **Surfaces** | web, iOS |
 | **Actions** | `journal.create`, `journal.update`, `journal.delete` |
 
-A journal entry is a private piece of writing about a book. It is per-user
-content, it is rendered from markdown by the server, and it can carry images —
-three different things that can each break independently.
+A journal entry is a piece of writing about a book, rendered from markdown by
+the server, optionally carrying images — three things that can each break
+independently.
+
+**It is not private.** The app presents the journal as a shared, attributed
+per-book surface ("THE JOURNAL · 1 ENTRY FROM 1 READER", with a "· you" marker
+on your own byline). Seeing another reader's entry is therefore expected, not a
+leak. What *would* be a finding is an entry attributed to the wrong person, or
+your own entry appearing without the "you" marker.
 
 ## Steps
 
 1. From a book's detail page, find where entries about the book are written.
 2. Write something a person would write about a book — a paragraph, not a test
-   string. Include a **distinctive phrase** you can search for later, and
-   journal that phrase.
+   string. Include a **distinctive phrase** and journal it, so the audit can
+   match the entry later. Do **not** expect to find it via search: the command
+   palette's full-text section is marked "Coming soon" and journal text is not
+   indexed, so a search returning nothing is not a finding.
 3. Use at least one piece of formatting: bold, italic, a quote, or a list. Vary
    which one across runs.
 4. Occasionally embed an image from the corpus.
@@ -46,8 +54,9 @@ distinctive phrase, so the audit can tell a deliberate delete from a loss.
 - Text is truncated, reordered, or has characters mangled.
 - An image uploads but does not display, or displays on another entry.
 - The entry attaches to the wrong book.
-- Someone else's journal entry is visible to you. **High severity** — journals
-  are private per user.
+- An entry is attributed to the wrong reader, or your own entry renders without
+  the "you" marker. (Merely *seeing* another reader's entry is expected — the
+  journal is a shared surface.)
 - An edit silently discards the previous content.
 
 ## Sharp edges

--- a/docs/qa/agentic_exploration/flows/browsing_book_details.md
+++ b/docs/qa/agentic_exploration/flows/browsing_book_details.md
@@ -15,7 +15,9 @@ turn up something cosmetic that no assertion would catch.
 
 1. Reach a book's detail page from wherever you happen to be.
 2. Actually read the page. Cover, title, author, series, description, formats,
-   page count, dates, tags, genres, ratings, saved passages, suggestions.
+   dates, identifiers, tags, genres, ratings, saved passages, suggestions.
+   There is **no page or chapter count** on this page — do not go looking for
+   one, and do not report its absence.
 3. Ask of each thing: is this plausible? A negative page count, a date in 1900,
    an author of "Unknown, Unknown", a description that is raw HTML, a cover
    that belongs to another book — all findings.
@@ -24,11 +26,19 @@ turn up something cosmetic that no assertion would catch.
    - **Rate it.** Set a rating, confirm it takes, reload and confirm it stuck.
      Then clear it, confirm the clear sticks, and set it once more — leave a
      rating behind, because the audit reconciles against one.
-   - **Set a read status.** Move it between want, reading, and finished, and
-     watch what the home page does in response.
-   - **Follow a link out** — to the author, the series, a tag, or a genre — and
-     confirm the destination is about the thing you clicked.
-   - **Look at the suggestions** and follow one.
+   - **Set a read status.** The three states are **Unread**, **Reading** and
+     **Finished** — there is no "want" here; the wishlist is a separate thing
+     reached through Check in. Move between them and watch the home page.
+   - **Follow a link out** and confirm the destination is about the thing you
+     clicked. **Series is the only one reliably present.** Tag and genre chips
+     on a book page are inert, and some books show their author as plain text
+     with no link. A missing author link *is* worth journalling — but as an
+     observation about that book, not as a failure of this step.
+   - **Look at the suggestions.** These come from Hardcover and need a
+     server-wide API key. If the panel offers an "Add a Hardcover API key" CTA
+     instead of books, the feature is switched off — that is **not** a finding,
+     and you must not go to Settings to enable it. Note it and follow the
+     sibling "More by <author>" panel instead.
 5. Come back to the book and confirm the page is as you left it.
 
 ## Journal
@@ -61,5 +71,7 @@ clicked and where you landed.
   slow. An empty suggestions panel is not a finding; an error in it is.
 - **Another agent may have edited this book's metadata a moment ago.** Fields
   changing between two visits is expected in a shared library.
-- Read status changes here **do** move the book on and off the home page's
-  continue surface. That is the feature.
+- Read status changes move a book **off** the continue surface (Finished
+  removes it) but do not necessarily put one **on**: marking a never-opened book
+  as Reading adds nothing, because the surface is driven by reading progress.
+  Both directions are correct.

--- a/docs/qa/agentic_exploration/flows/creating_a_shelf.md
+++ b/docs/qa/agentic_exploration/flows/creating_a_shelf.md
@@ -63,7 +63,12 @@ the book uuids — those are what the audit reconciles.
 - The shelf saves under a different name, visibility, or kind.
 - It does not appear, or disappears after a reload.
 - Selecting it shows books that do not belong to it.
-- Another user's shelves are visible to you.
+- Another user's shelf is visible **and you are not an admin**. Admins see every
+  shelf by design, and the exploration accounts are currently all admins — so on
+  this instance the criterion is undecidable and you should journal `uncertain`
+  rather than guess. (Worth reporting separately: another user's private shelf
+  renders in the rail with no owner attribution, while the wishlists beside it
+  do show owner names.)
 - **On iOS:** removing a book from a shelf deletes the book. High severity.
 
 ## Sharp edges
@@ -72,6 +77,6 @@ the book uuids — those are what the audit reconciles.
   change. Correct.
 - A **Smart** shelf fills by rule, so being unable to add a book to it by hand
   is correct on every surface.
-- Your display name is denormalised into the wishlist shelf's name, so that one
-  may carry an older name than your profile does. Journal it `uncertain` rather
-  than deciding.
+- Your display name is denormalised into the wishlist shelf's name. It has been
+  observed updating in the same render as a profile save, so a *stale* name
+  there is worth journalling as a real observation rather than shrugging off.

--- a/docs/qa/agentic_exploration/flows/editing_metadata.md
+++ b/docs/qa/agentic_exploration/flows/editing_metadata.md
@@ -23,7 +23,11 @@ content.
 3. Change one or two fields. Good candidates: title suffix, subtitle, series
    name or number, publisher, tags, genres, description. Append rather than
    replace where you can — `Foo (ed. agent-3)` beats overwriting `Foo`.
-4. Occasionally replace the cover image instead, using a file from the corpus.
+4. Occasionally replace the cover image instead. Use **that book's own**
+   `cover.jpg` sidecar from the corpus — another book's cover would make the
+   shared library worse, which this flow tells you not to do. Note that the
+   cover is written **immediately** on picking it, before you press Save, and
+   the editor's Discard link cannot undo it.
 5. Save. Watch for a confirmation and for the edited-field count to match what
    you actually changed.
 6. Return to the detail page and confirm the new values are shown.

--- a/docs/qa/agentic_exploration/flows/listening_to_audiobook.md
+++ b/docs/qa/agentic_exploration/flows/listening_to_audiobook.md
@@ -7,13 +7,19 @@
 | **Surfaces** | web, iOS |
 | **Actions** | `book.open`, `player.play`, `player.seek`, `player.rate`, `player.close` |
 
-Listen to roughly a tenth of an audiobook. Playback position, like reading
+Listen to roughly a tenth of an audiobook **by position** — a tenth of a ten-hour
+book is an hour of playback you should skip through, not an hour of real time
+you sit and wait. Playback position, like reading
 position, is written constantly and missed immediately when lost.
 
 ## Preconditions
 
 A book with an audiobook format. Multi-file audiobooks are more interesting
-than single-file ones — prefer them when you can tell.
+than single-file ones, but **the library gives you no way to tell before you
+open the player** — the FORMATS column shows only `M4B`, and the file count
+appears nowhere until you are inside. Open one, see what you got, and say which
+in the journal. A single-file M4B can still expose many chapter markers, so
+chapter seams are testable even when file seams are not.
 
 ## Steps
 
@@ -26,8 +32,11 @@ than single-file ones — prefer them when you can tell.
    watch what happens at the seam.
 5. Occasionally set a sleep timer and watch it count down; you need not wait
    for it to fire.
-6. Leave the player through the app's own way out, then check the book's detail
-   page reflects where you got to.
+6. Leave the player and check the book's detail page reflects where you got to.
+   There is no single "exit" control: the book title links back to the detail
+   page, and once you are elsewhere the persistent mini-player offers "Stop and
+   close player". Leaving via the title does **not** stop playback — the
+   mini-player keeps going, which is intended.
 
 ## Journal
 

--- a/docs/qa/agentic_exploration/flows/merging_books.md
+++ b/docs/qa/agentic_exploration/flows/merging_books.md
@@ -49,9 +49,16 @@ detectable.
 - The merge summary names the two books you actually chose.
 - Afterwards there is one book carrying both formats.
 - The other book is gone from the library, search, author pages, and shelves.
-- Reading position, highlights, bookmarks, ratings, and read status from both
-  sides are present on the survivor.
-- An undo, if taken, restores both books with their data.
+- Highlights and bookmarks from both sides are present on the survivor — these
+  accumulate, so "both" is literal.
+- For the **scalar** values that cannot merge — rating, read status, reading
+  position — the survivor keeps a coherent single value, and you journal which
+  side it came from. There is no documented conflict rule, so either side
+  winning is acceptable; what is not acceptable is a value belonging to neither,
+  or one side's value landing on the wrong book.
+- An undo, if taken, restores both books with **their own** data — each book
+  carrying the rating, read status and identifiers it had before the merge, not
+  the other's. Check both books, not just the survivor.
 
 ## Fail
 

--- a/docs/qa/agentic_exploration/flows/reading_a_book.md
+++ b/docs/qa/agentic_exploration/flows/reading_a_book.md
@@ -22,7 +22,8 @@ starting.
 1. Reach the book from the library, an author page, a search, or the continue
    surface on the home page. Vary this between runs.
 2. Open it to read. Note where it opened — at the start, or where you left off.
-3. Read forward through roughly 10% of the book. Turn pages the way a person
+3. Read forward through roughly 10% of the book **by position**, not by time
+   spent. Turn pages the way a person
    does: some quickly, some slowly. Do not spam the page-forward control.
    **If page-turning itself is broken**, that is a `fail` and you should journal
    it as one — but do not abandon the flow. Reaching a position through the

--- a/docs/qa/agentic_exploration/flows/updating_profile.md
+++ b/docs/qa/agentic_exploration/flows/updating_profile.md
@@ -21,8 +21,9 @@ never change anyone's permissions, and never delete a user.
    include your actor id and a counter, so a stale copy elsewhere is obvious.
 3. Save, and confirm the new name appears in the app's own chrome — wherever
    your name is shown while you are signed in.
-4. Occasionally replace your picture with an image from the corpus instead, and
-   confirm it appears everywhere your avatar does.
+4. Occasionally replace your picture instead, and confirm it appears everywhere
+   your avatar does. The corpus is book files, but many author folders carry a
+   `cover.jpg` sidecar — use one of those.
 5. Navigate away, come back, and confirm both stuck.
 6. Reload the page and confirm again.
 

--- a/docs/qa/agentic_exploration/flows/wishlist.md
+++ b/docs/qa/agentic_exploration/flows/wishlist.md
@@ -19,8 +19,10 @@ fail.
 
 1. Start checking in a book.
 2. Identify a book you do **not** already have. Either enter an ISBN or search
-   by title and author. Prefer a real, well-known book — the lookup has a better
-   chance and a wrong answer is easier to spot.
+   by title. **There is no author field** — the search takes a title only, and
+   adding the author to it measurably degrades the results, so do not. Prefer a
+   real, well-known book: the lookup has a better chance and a wrong answer is
+   easier to spot.
 3. Read what comes back. Does the result match what you asked for? Journal the
    candidates you were shown.
 4. Pick the right one, or say none of them match if none do.

--- a/docs/qa/agentic_exploration/pitfalls.md
+++ b/docs/qa/agentic_exploration/pitfalls.md
@@ -33,11 +33,13 @@ rather than pressing on with unreliable evidence.
 
 ## Your driver, not the app
 
-- **A command that returns `"Done"` did not fail.** The driver only prints a
-  value for *expression-shaped* commands. `page.evaluate(async () => { … return
-  x })` yields `"Done"`; the same thing written without braces —
-  `page.evaluate(() => fetch(…).then(r => r.status))` — yields the value.
-  Getting `"Done"` means rewrite the command, not that the app is broken.
+- **A command that returns `"Done"` did not fail.** The driver swallows the
+  result whenever the command contains a semicolon — **including one inside a
+  string literal**: `page.evaluate(() => "a; b")` yields `"Done"` while
+  `page.evaluate(() => "a b")` yields `"a b"`. Brace-bodied arrows
+  (`async () => { … return x }`) hit it for the same reason. Rewrite without
+  semicolons — chain with `.then()` and drop statement separators. `"Done"`
+  means rewrite the command, not that the app is broken.
 - **A file input cannot be clicked.** Clicking one opens a native dialog nothing
   can see. Upload with
   `page.getByTestId("add-books-file-input").setInputFiles("/abs/path.epub")`

--- a/docs/qa/agentic_exploration/pitfalls.md
+++ b/docs/qa/agentic_exploration/pitfalls.md
@@ -31,6 +31,21 @@ A pane that keeps failing is a note about the harness, not a finding about the
 app. Say so in the journal, and if it becomes unworkable, stop and report that
 rather than pressing on with unreliable evidence.
 
+## Your driver, not the app
+
+- **A command that returns `"Done"` did not fail.** The driver only prints a
+  value for *expression-shaped* commands. `page.evaluate(async () => { … return
+  x })` yields `"Done"`; the same thing written without braces —
+  `page.evaluate(() => fetch(…).then(r => r.status))` — yields the value.
+  Getting `"Done"` means rewrite the command, not that the app is broken.
+- **A file input cannot be clicked.** Clicking one opens a native dialog nothing
+  can see. Upload with
+  `page.getByTestId("add-books-file-input").setInputFiles("/abs/path.epub")`
+  and then read the review form's fields.
+- **You have your own browser.** If you ever see another actor's session, that
+  is a harness fault of the first order — journal it `high` and stop, exactly as
+  start.md says. Do not log back in and continue.
+
 ## Deliberate app behaviour
 
 Each of these is intended, and each has been mistaken for a defect before:

--- a/docs/qa/agentic_exploration/pitfalls.md
+++ b/docs/qa/agentic_exploration/pitfalls.md
@@ -48,6 +48,26 @@ rather than pressing on with unreliable evidence.
   is a harness fault of the first order — journal it `high` and stop, exactly as
   start.md says. Do not log back in and continue.
 
+## Things that look broken in the DOM and are not
+
+Each of these was nearly filed as a defect by an agent that checked first.
+
+- **`3 wk ago` beside LONGEST SIT is a sparkline axis label**, not part of the
+  stat. Flattened `innerText` reads "LONGEST SIT / 9m / Aug 28 / 3 wk ago",
+  which looks like today's date being called three weeks old. It lives in
+  `.rx-spark-axis`.
+- **The mini-player's speed and sleep panels are always in the DOM**, at
+  `opacity: 0; pointer-events: none`. They appear in `document.body.innerText`
+  on any book page and read as two expanded panels drawn over the page. Check
+  computed style before believing a panel is open.
+- **The persistent mini-player lives outside `<main>`.** Audio playing with "no
+  visible transport" usually means you only looked inside `main`.
+- **The journal composer is a CodeMirror contenteditable.** `locator.fill()`
+  silently strips every newline, collapsing a multi-paragraph entry to one line
+  — which looks exactly like the app truncating your text. Use
+  `keyboard.type`. `ControlOrMeta+End` also does not move the caret to the end
+  there, so an "append" can land mid-document.
+
 ## Deliberate app behaviour
 
 Each of these is intended, and each has been mistaken for a defect before:

--- a/docs/qa/agentic_exploration/start.md
+++ b/docs/qa/agentic_exploration/start.md
@@ -95,7 +95,7 @@ transcripts are thrown away.
 | Field | Meaning |
 |---|---|
 | `ts` | UTC, ms precision. The report correlates agents on this alone — never batch entries and stamp them later. |
-| `seq` | Your own monotonic counter, from 1, for the run. |
+| `seq` | Your own counter, monotonic and unique **per actor**. Derive it from the journal filtered to your own `actor`, never from the line count — the journal is shared, so counting all lines numbers you by other agents' work. Starting above 1 is acceptable; going backwards or repeating is not. |
 | `action` | Dotted verb — `book.open`, `highlight.create`, `metadata.save`, `shelf.add`. |
 | `target` | The book uuid or other entity id, **in full** — never abbreviated. Ownership is looked up on this exact string, so a truncated uuid loses the book forever. `null` when there isn't one. |
 | `params` | **Everything a replayer needs to redo this.** Under-filling it is the commonest way a real bug becomes an anecdote. |

--- a/flake.lock
+++ b/flake.lock
@@ -55,6 +55,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-playwright": {
+      "locked": {
+        "lastModified": 1787814960,
+        "narHash": "sha256-PYZq1qzCJXC2zGI0mH07vrZBsw6DRBAOX0jN1pPtqOQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1779508470,
@@ -76,6 +92,7 @@
         "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-playwright": "nixpkgs-playwright",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,17 +5,24 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Pinned solely for `playwright-driver.browsers`. Kept separate from
+    # nixpkgs-unstable so moving the Chromium bundle does not also move the
+    # Rust toolchain, dioxus-cli and node — the browser version has to track
+    # the npm @playwright/test pin, and nothing else should be dragged along
+    # for that. Bump this rev and `@playwright/test` together, never apart.
+    nixpkgs-playwright.url = "github:NixOS/nixpkgs/c27cdad491a991b11ed731760aa2ef8db0cb0410";
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, fenix }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-playwright, flake-utils, fenix }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         pkgs-unstable = import nixpkgs-unstable { inherit system; };
+        pkgs-playwright = import nixpkgs-playwright { inherit system; };
 
         # Slim core Rust toolchain. wasm32 rust-std is kept here because it's
         # small (single-digit MB) and lets rust-analyzer / `cargo check` exercise
@@ -184,7 +191,7 @@
         # E2E extras layer on top of webExtras: Playwright's Nix-provided
         # Chromium bundle. The PLAYWRIGHT_BROWSERS_PATH export below pins it.
         e2eExtras = [
-          pkgs-unstable.playwright-driver.browsers
+          pkgs-playwright.playwright-driver.browsers
         ];
 
         # Mobile extras: JDK for the Android NDK toolchain. Mobile rust
@@ -309,9 +316,16 @@
         '';
 
         # `e2e` shell pins Playwright's Chromium to the Nix store. The npm
-        # @playwright/test version must match this bundle's version.
+        # @playwright/test version must match this bundle's version — each
+        # Playwright minor expects a specific Chromium build number, so the
+        # `nixpkgs-playwright` rev and the `@playwright/test` range move
+        # together or not at all.
+        #
+        # The agentic-exploration driver (scripts/explore/driver/) pins its own
+        # transitive `playwright` to the same version for the same reason, so
+        # it shares this bundle instead of downloading a second Chromium.
         playwrightHook = ''
-          export PLAYWRIGHT_BROWSERS_PATH="${pkgs-unstable.playwright-driver.browsers}"
+          export PLAYWRIGHT_BROWSERS_PATH="${pkgs-playwright.playwright-driver.browsers}"
           export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
         '';
 

--- a/scripts/explore/driver.sh
+++ b/scripts/explore/driver.sh
@@ -11,9 +11,9 @@
 # Why one server per agent rather than one shared browser:
 #   Run r-20260828-01 died because three subagents shared a single browser tab.
 #   They shared a cookie jar, so "three different users" collapsed into one and
-#   two agents correctly aborted rather than journal entries under a wrong
-#   actor. A server per agent gives a browser per agent, which makes that class
-#   of failure impossible rather than merely unlikely.
+#   two agents correctly aborted rather than write journal entries under a
+#   wrong actor. A server per agent gives a browser per agent, which makes that
+#   class of failure impossible rather than merely unlikely.
 #
 # Why not playwright-repl's own MCP mode:
 #   N MCP clients against one server land back in a shared browser. The HTTP
@@ -47,7 +47,12 @@ driver::ensure_deps() {
   fi
   if [ ! -x "$DRIVER/node_modules/.bin/playwright-repl" ]; then
     echo "installing driver deps (first run)…" >&2
-    (cd "$DRIVER" && npm install --no-audit --no-fund >/dev/null 2>&1)
+    # `npm ci` from the committed lockfile: reproducible across machines, and
+    # it cannot rewrite package-lock.json, so `driver.sh up` never dirties the
+    # worktree. The pinned playwright version is the whole point — an install
+    # free to resolve differently would silently stop sharing the flake's
+    # Chromium.
+    (cd "$DRIVER" && npm ci --no-audit --no-fund >/dev/null 2>&1)
   fi
 }
 
@@ -91,11 +96,20 @@ case "$cmd" in
     ;;
 
   run)
-    n="${2:?usage: driver.sh run <n> <command>}"
+    n="${2:?usage: driver.sh run <n> \"<command>\"}"
+    [[ "$n" =~ ^[0-9]+$ ]] && [ "$n" -ge 1 ] \
+      || { echo "agent number must be a positive integer (got: $n)" >&2; exit 2; }
     shift 2
+    # Exactly one argument, so an unquoted command cannot be silently
+    # reassembled with collapsed whitespace — which would change the JS being
+    # evaluated without anyone noticing.
+    [ "$#" -eq 1 ] || {
+      echo "expected exactly one command argument — quote it: driver.sh run $n \"<command>\"" >&2
+      exit 2
+    }
     port="$(driver::port "$n")"
     driver::alive "$port" || { echo "agent-$n has no server on $port — run driver.sh up first" >&2; exit 1; }
-    body="$(python3 -c 'import json,sys; print(json.dumps({"command": sys.argv[1]}))' "$*")"
+    body="$(python3 -c 'import json,sys; print(json.dumps({"command": sys.argv[1]}))' "$1")"
     curl -sS --max-time 180 -X POST "http://127.0.0.1:$port/run" \
       -H 'Content-Type: application/json' -d "$body"
     echo
@@ -111,8 +125,20 @@ for e in json.load(open(sys.argv[1])): print(e["actor"], e["port"])' "$MANIFEST"
     ;;
 
   down)
+    # Stop exactly what `up` recorded. A fixed port window would strand
+    # servers whenever the run had more agents than the window covers, and the
+    # manifest is deleted here, so nothing would ever find them again.
+    ports=""
+    if [ -f "$MANIFEST" ]; then
+      ports="$(python3 -c 'import json,sys
+for e in json.load(open(sys.argv[1])): print(e["port"])' "$MANIFEST")"
+    else
+      # No manifest (a crashed run, or `down` before `up`): fall back to the
+      # default window so stray servers are still reachable.
+      ports="$(seq "$PORT_BASE" $((PORT_BASE + 31)))"
+    fi
     stopped=0
-    for port in $(seq "$PORT_BASE" $((PORT_BASE + 31))); do
+    for port in $ports; do
       pid="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
       [ -n "$pid" ] && { kill $pid 2>/dev/null || true; stopped=$((stopped + 1)); }
     done

--- a/scripts/explore/driver.sh
+++ b/scripts/explore/driver.sh
@@ -19,12 +19,13 @@
 #   N MCP clients against one server land back in a shared browser. The HTTP
 #   surface, one server per port, is what keeps them apart.
 #
-# Why a private browser directory:
-#   playwright-repl bundles Playwright 1.62.1 (Chromium build 1234) while the
-#   flake pins ~1.59 (build 1217) for the E2E suite. They cannot share
-#   PLAYWRIGHT_BROWSERS_PATH, and running `playwright install` inside
-#   ui_tests/playwright would diverge the suite from the flake — see
-#   .claude/rules/04-playwright.md.
+# Why it shares the flake's Chromium:
+#   playwright-repl declares `playwright: ^1.59.1`, which npm would float to
+#   whatever is newest — a build the flake's bundle does not contain. The
+#   driver's package.json pins that transitive dependency to the same version
+#   as the flake's playwright-driver.browsers, so one Nix Chromium serves the
+#   E2E suite and the driver alike and nothing ever downloads a browser. Bump
+#   the two together; see .claude/rules/04-playwright.md.
 
 set -euo pipefail
 
@@ -36,14 +37,17 @@ STATE="$ROOT/.claude/runtime/explore/driver"
 MANIFEST="$STATE/ports.json"
 
 driver::ensure_deps() {
-  export PLAYWRIGHT_BROWSERS_PATH="$DRIVER/browsers"
+  # The browser comes from the flake, so the driver must run inside a shell
+  # that provides it. Failing here beats a confusing "Executable doesn't
+  # exist" from deep inside Playwright.
+  if [ -z "${PLAYWRIGHT_BROWSERS_PATH-}" ]; then
+    echo "PLAYWRIGHT_BROWSERS_PATH is unset — run inside 'nix develop .#e2e'" >&2
+    echo "(or via scripts/with-dev-env.sh e2e …), which pins the Chromium bundle." >&2
+    return 1
+  fi
   if [ ! -x "$DRIVER/node_modules/.bin/playwright-repl" ]; then
     echo "installing driver deps (first run)…" >&2
     (cd "$DRIVER" && npm install --no-audit --no-fund >/dev/null 2>&1)
-  fi
-  if [ ! -d "$DRIVER/browsers" ]; then
-    echo "downloading the driver's own chromium (kept out of the flake)…" >&2
-    (cd "$DRIVER" && ./node_modules/.bin/playwright install chromium >/dev/null 2>&1)
   fi
 }
 
@@ -72,7 +76,7 @@ case "$cmd" in
       if driver::alive "$port"; then
         echo "  agent-$i: reusing server on $port" >&2
       else
-        (cd "$DRIVER" && PLAYWRIGHT_BROWSERS_PATH="$DRIVER/browsers" \
+        (cd "$DRIVER" && \
           nohup ./node_modules/.bin/playwright-repl --silent --http \
             --http-port "$port" -s "agent-$i" \
             >"$STATE/agent-$i.log" 2>&1 &)

--- a/scripts/explore/driver.sh
+++ b/scripts/explore/driver.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Browser driver for the agentic-exploration swarm: one playwright-repl server
+# per agent, each with its own session, port, and browser process.
+#
+# Usage:
+#   driver.sh up <agent-count>     start N servers, print the port manifest
+#   driver.sh run <n> <command>    send one command to agent n, print the result
+#   driver.sh status               show which agents are up
+#   driver.sh down                 stop every server
+#
+# Why one server per agent rather than one shared browser:
+#   Run r-20260828-01 died because three subagents shared a single browser tab.
+#   They shared a cookie jar, so "three different users" collapsed into one and
+#   two agents correctly aborted rather than journal entries under a wrong
+#   actor. A server per agent gives a browser per agent, which makes that class
+#   of failure impossible rather than merely unlikely.
+#
+# Why not playwright-repl's own MCP mode:
+#   N MCP clients against one server land back in a shared browser. The HTTP
+#   surface, one server per port, is what keeps them apart.
+#
+# Why a private browser directory:
+#   playwright-repl bundles Playwright 1.62.1 (Chromium build 1234) while the
+#   flake pins ~1.59 (build 1217) for the E2E suite. They cannot share
+#   PLAYWRIGHT_BROWSERS_PATH, and running `playwright install` inside
+#   ui_tests/playwright would diverge the suite from the flake — see
+#   .claude/rules/04-playwright.md.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+DRIVER="$HERE/driver"
+PORT_BASE="${OMNIBUS_EXPLORE_PORT_BASE:-9223}"
+STATE="$ROOT/.claude/runtime/explore/driver"
+MANIFEST="$STATE/ports.json"
+
+driver::ensure_deps() {
+  export PLAYWRIGHT_BROWSERS_PATH="$DRIVER/browsers"
+  if [ ! -x "$DRIVER/node_modules/.bin/playwright-repl" ]; then
+    echo "installing driver deps (first run)…" >&2
+    (cd "$DRIVER" && npm install --no-audit --no-fund >/dev/null 2>&1)
+  fi
+  if [ ! -d "$DRIVER/browsers" ]; then
+    echo "downloading the driver's own chromium (kept out of the flake)…" >&2
+    (cd "$DRIVER" && ./node_modules/.bin/playwright install chromium >/dev/null 2>&1)
+  fi
+}
+
+driver::port() { echo $((PORT_BASE + $1 - 1)); }
+
+driver::alive() {
+  # 000 means nothing accepted the connection; any HTTP code means a server is
+  # there. `/` is deliberately not a route, so 404 is the healthy answer.
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:$1/" 2>/dev/null)" || true
+  [ -n "$code" ] && [ "$code" != "000" ]
+}
+
+cmd="${1:?usage: driver.sh up <n> | run <n> <command> | status | down}"
+
+case "$cmd" in
+  up)
+    count="${2:?usage: driver.sh up <agent-count>}"
+    [[ "$count" =~ ^[0-9]+$ ]] && [ "$count" -ge 1 ] \
+      || { echo "agent-count must be a positive integer" >&2; exit 2; }
+    driver::ensure_deps
+    mkdir -p "$STATE"
+    entries=""
+    for i in $(seq 1 "$count"); do
+      port="$(driver::port "$i")"
+      if driver::alive "$port"; then
+        echo "  agent-$i: reusing server on $port" >&2
+      else
+        (cd "$DRIVER" && PLAYWRIGHT_BROWSERS_PATH="$DRIVER/browsers" \
+          nohup ./node_modules/.bin/playwright-repl --silent --http \
+            --http-port "$port" -s "agent-$i" \
+            >"$STATE/agent-$i.log" 2>&1 &)
+        for _ in $(seq 1 40); do driver::alive "$port" && break; sleep 1; done
+        driver::alive "$port" \
+          || { echo "agent-$i failed to start on $port — see $STATE/agent-$i.log" >&2; exit 1; }
+        echo "  agent-$i: started on $port" >&2
+      fi
+      entries="$entries{\"actor\":\"agent-$i\",\"port\":$port},"
+    done
+    printf '[%s]\n' "${entries%,}" | tee "$MANIFEST"
+    ;;
+
+  run)
+    n="${2:?usage: driver.sh run <n> <command>}"
+    shift 2
+    port="$(driver::port "$n")"
+    driver::alive "$port" || { echo "agent-$n has no server on $port — run driver.sh up first" >&2; exit 1; }
+    body="$(python3 -c 'import json,sys; print(json.dumps({"command": sys.argv[1]}))' "$*")"
+    curl -sS --max-time 180 -X POST "http://127.0.0.1:$port/run" \
+      -H 'Content-Type: application/json' -d "$body"
+    echo
+    ;;
+
+  status)
+    [ -f "$MANIFEST" ] || { echo "no manifest — nothing started"; exit 0; }
+    while read -r actor port; do
+      if driver::alive "$port"; then state=up; else state=DOWN; fi
+      printf '  %-9s port %s  %s\n' "$actor" "$port" "$state"
+    done < <(python3 -c 'import json,sys
+for e in json.load(open(sys.argv[1])): print(e["actor"], e["port"])' "$MANIFEST")
+    ;;
+
+  down)
+    stopped=0
+    for port in $(seq "$PORT_BASE" $((PORT_BASE + 31))); do
+      pid="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+      [ -n "$pid" ] && { kill $pid 2>/dev/null || true; stopped=$((stopped + 1)); }
+    done
+    rm -f "$MANIFEST"
+    echo "stopped $stopped server(s)"
+    ;;
+
+  *) echo "unknown command: $cmd" >&2; exit 2 ;;
+esac

--- a/scripts/explore/driver/.gitignore
+++ b/scripts/explore/driver/.gitignore
@@ -1,0 +1,5 @@
+# Installed on first `driver.sh up`. Never commit either: node_modules is
+# reproducible from package.json, and browsers/ is ~600 MB of Chromium that
+# must stay OUT of the flake's PLAYWRIGHT_BROWSERS_PATH.
+node_modules/
+browsers/

--- a/scripts/explore/driver/.gitignore
+++ b/scripts/explore/driver/.gitignore
@@ -1,5 +1,8 @@
-# Installed on first `driver.sh up`. Never commit either: node_modules is
-# reproducible from package.json, and browsers/ is ~600 MB of Chromium that
-# must stay OUT of the flake's PLAYWRIGHT_BROWSERS_PATH.
+# node_modules is reproducible from package.json + package-lock.json.
 node_modules/
+
+# Should never exist: the driver shares the flake's Chromium via
+# PLAYWRIGHT_BROWSERS_PATH. If this appears, something ran `playwright install`
+# and the driver has silently stopped testing on the same browser as the E2E
+# suite — delete it and check the version pins in package.json.
 browsers/

--- a/scripts/explore/driver/package-lock.json
+++ b/scripts/explore/driver/package-lock.json
@@ -1,0 +1,159 @@
+{
+  "name": "omnibus-explore-driver",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omnibus-explore-driver",
+      "dependencies": {
+        "playwright-repl": "0.27.3"
+      }
+    },
+    "node_modules/@playwright-repl/core": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@playwright-repl/core/-/core-0.27.3.tgz",
+      "integrity": "sha512-CshcbKPVH+J3QmmcUiYD+Nqqr9eM804FIgdV7QfDX84vqHBcmukdsmH0vUJrkcLPF57e5NLBz2WyQ0ACFMJF/w==",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.8",
+        "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-repl": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/playwright-repl/-/playwright-repl-0.27.3.tgz",
+      "integrity": "sha512-A9s111kG3B7Ki8KDwV691f/EHiW/ZvMIRTfQ4n8b3Q5pPpXeLC9FADEEESYWM5oLZhIQbgMP+mijiSx0gMOnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@playwright-repl/core": "0.27.3",
+        "@playwright/test": "^1.59.1",
+        "playwright": "^1.59.1",
+        "playwright-core": "^1.59.1"
+      },
+      "bin": {
+        "playwright-repl": "dist/playwright-repl.js",
+        "pw-cli": "dist/pw-cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/explore/driver/package.json
+++ b/scripts/explore/driver/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "omnibus-explore-driver",
+  "private": true,
+  "description": "Browser driver for the agentic-exploration swarm. Deliberately separate from ui_tests/playwright: playwright-repl bundles its own Playwright, whose Chromium build differs from the flake's, and the two must never share a browser directory.",
+  "dependencies": {
+    "playwright-repl": "0.27.3"
+  }
+}

--- a/scripts/explore/driver/package.json
+++ b/scripts/explore/driver/package.json
@@ -1,8 +1,12 @@
 {
   "name": "omnibus-explore-driver",
   "private": true,
-  "description": "Browser driver for the agentic-exploration swarm. Deliberately separate from ui_tests/playwright: playwright-repl bundles its own Playwright, whose Chromium build differs from the flake's, and the two must never share a browser directory.",
+  "description": "Browser driver for the agentic-exploration swarm. The transitive playwright dependency is pinned to the same version as the flake's playwright-driver.browsers bundle, so this shares the Nix Chromium instead of downloading its own. Bump both together.",
   "dependencies": {
     "playwright-repl": "0.27.3"
+  },
+  "overrides": {
+    "playwright": "1.61.1",
+    "playwright-core": "1.61.1"
   }
 }

--- a/ui_tests/playwright/package.json
+++ b/ui_tests/playwright/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",
-    "@playwright/test": "~1.59.0",
+    "@playwright/test": "~1.61.0",
     "@types/node": "^22.10.0",
     "jszip": "^3.10.1",
     "tsx": "^4.21.0",

--- a/ui_tests/playwright/pnpm-lock.yaml
+++ b/ui_tests/playwright/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.5.5
         version: 2.5.5
       '@playwright/test':
-        specifier: ~1.59.0
-        version: 1.59.1
+        specifier: ~1.61.0
+        version: 1.61.1
       '@types/node':
         specifier: ^22.10.0
         version: 22.20.1
@@ -242,8 +242,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -406,13 +406,13 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -562,9 +562,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.61.1
 
   '@types/node@22.20.1':
     dependencies:
@@ -686,11 +686,11 @@ snapshots:
 
   pako@1.0.11: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.59.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Summary
- Adds `scripts/explore/driver.sh`: one `playwright-repl` server per agent, each with its own port, session and browser process. Run `r-20260828-01` died because three subagents shared a single browser *tab* — they shared a cookie jar, three different users collapsed into one, and two agents correctly aborted rather than write journal entries under a wrong actor. This makes that failure impossible rather than unlikely.
- Verified three simultaneous sessions holding `explorer-1`, `explorer-2` and `explorer-3` at once. The follow-up run then completed **15 flows in 54 minutes with three agents and zero identity collisions**, against 4 flows in 45 minutes with one agent before.
- **Bumps Playwright to 1.61.1 so the driver shares the flake's Chromium.** `playwright-repl` declares `playwright: ^1.59.1`, which npm floats to a build the flake's bundle does not contain — forcing a second ~600 MB browser and putting the driver at odds with rule 04. Now one Nix Chromium (build 1228) serves the E2E suite and the driver alike, and `driver.sh` downloads nothing.
- Folds ~20 catalog defects the run surfaced back into the flow docs — see Notes.

Part of #2200

## Test plan
- [x] Three concurrent servers verified holding three distinct sessions simultaneously (`/api/auth/me` per port).
- [x] File upload works through the driver: `setInputFiles` on the Add-books input populated the review form with Title/Author from a real EPUB.
- [x] Full run `r-20260828-02` — 3 agents, 15 flows, 183 journal entries, no agent ever saw another actor's session.
- [x] After the bump, both `@playwright/test` and the driver resolve to 1.61.1 and the driver launches on the flake bundle (`chromium-1228`) with no `browsers/` directory.
- [x] Review fixes verified: non-integer agent number and unquoted command are both rejected; `driver.sh up` leaves the worktree clean.
- [ ] **The E2E suite has not been run locally against 1.61** — a Playwright minor bump under 54 specs. CI's path-gated Playwright lane is the check that matters here.

## Version
- [x] **No release** — tooling and docs only; no shipped code changes.

## Notes
**On the version pin.** The Chromium bundle comes from a **dedicated** `nixpkgs-playwright` flake input, not `nixpkgs-unstable`, so moving the browser does not also move the Rust toolchain, `dioxus-cli` and node. 1.62.1 — what npm would otherwise choose — is not obtainable from nixpkgs at all; 1.61.1 is the newest it offers and `playwright-repl`'s caret range accepts it natively. Rule 04 now states the invariant: the flake input's rev, the `@playwright/test` tilde range, and the driver's `overrides` move together or not at all.

**Bugs the run found**, filed separately: #2234 (merge undo moves read status to the wrong book — verified on the API), #2235 (some creators never get an author record — found independently by two agents), and #2240–#2259.

**Catalog fixes worth calling out**, because each would have produced a *wrong* finding rather than merely a slow one:

- `browsing_book_details` told agents to read a page count that `adding_book` explicitly says does not exist, and named a "want" read status the UI calls **Unread**.
- `adding_journal` described entries as private per user and made another reader's entry a high-severity fail. The app presents the journal as a shared attributed surface, so that criterion would have fired on correct behaviour.
- `merging_books` required ratings and read status "from both sides" on the survivor — impossible for scalars, and precisely the case that exposed #2234.
- `creating_a_shelf` made another user's shelf a hard fail, but `can_view` grants admins every shelf and all exploration accounts are admins, so no agent could ever decide it. **This is the first concrete cost of deferring role variation.**

`seq` is now defined per-actor and derived from the journal filtered on the actor — two agents counted all lines and were numbered by each other's work. `pitfalls.md` gains DOM false-positives the agents caught themselves, including `locator.fill()` silently stripping newlines in the CodeMirror journal composer.

Deliberately **not** using `playwright-repl`'s MCP mode: N clients against one server land back in a shared browser, and its relay mode drives the operator's real Chrome.