### PR TITLE
[OMNI-2266] Distinguish Check-in Lookup Sources on iOS

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/WishlistSection.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/WishlistSection.swift
@@ -140,7 +140,8 @@ struct WishlistSection: View {
         switch source {
         case .scan: "a scan"
         case .detail: "this page"
-        case .manual: "manual entry"
+        case .manual: "an ISBN you entered"
+        case .search: "a title search"
         }
     }
 

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInFlow.swift
@@ -18,6 +18,21 @@ enum CheckInStage: Equatable {
     case success(CheckInSuccess)
 }
 
+/// Which of the check-in flow's three front doors reached the book on screen.
+///
+/// They are not interchangeable to a reader, so nothing downstream may assume
+/// a scan: a title search's ISBN came from the *provider*, and a typed one was
+/// entered rather than read off a cover (#2247). Carried into the copy above
+/// the resolved book and into the provenance a wishlist entry records.
+enum FoundVia: Equatable, Sendable {
+    /// An ISBN read off a barcode by the camera.
+    case barcodeScan
+    /// An ISBN typed into the lookup field.
+    case isbnEntry
+    /// A provider candidate picked out of a title search.
+    case titleSearch
+}
+
 /// Everything the terminal success screen needs to render.
 struct CheckInSuccess: Equatable {
     enum Tone: Equatable {
@@ -81,6 +96,34 @@ enum CheckInFlow {
             bookUUID: ref.bookUUID,
             cover: externalCover(meta)
         )
+    }
+
+    /// The eyebrow over the resolved book, naming the door the reader used.
+    /// It sat at a hardcoded "You scanned", which a typed ISBN and a title
+    /// search both made false.
+    static func foundLine(_ via: FoundVia) -> String {
+        switch via {
+        case .barcodeScan: "You scanned"
+        case .isbnEntry: "You entered"
+        case .titleSearch: "You picked"
+        }
+    }
+
+    /// The provenance a wishlist entry added down this path records. Only the
+    /// camera is a scan; a typed ISBN is manual, and a title search is neither.
+    static func wishlistSource(_ via: FoundVia) -> WishlistSource {
+        switch via {
+        case .barcodeScan: .scan
+        case .isbnEntry: .manual
+        case .titleSearch: .search
+        }
+    }
+
+    /// The wishlist request for an online-resolved book, stamped with the door
+    /// the reader actually came through. Mirrors the web flow's
+    /// `wishlist_request_for`.
+    static func wishlistRequest(meta: ExternalBookMeta, foundVia: FoundVia) -> WishlistAddRequest {
+        WishlistAddRequest(bookUUID: nil, meta: meta, source: wishlistSource(foundVia))
     }
 
     /// The edition note belongs on exactly one screen — the in-library

--- a/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
+++ b/omnibus-ios/omnibus/Features/CheckIn/CheckInView.swift
@@ -17,6 +17,9 @@ struct CheckInView: View {
 
     @State private var manualISBN = ""
     @State private var stage: CheckInStage = .scan
+    /// Which door reached the book the flow is holding. Set by whichever
+    /// control started the lookup, read by every screen downstream of it.
+    @State private var foundVia: FoundVia = .barcodeScan
     @State private var isResolving = false
     @State private var isWriting = false
     @State private var error: String?
@@ -108,7 +111,7 @@ struct CheckInView: View {
                     BarcodeScannerView { code in
                         guard !isResolving else { return }
                         Haptics.success()
-                        Task { await resolve(code) }
+                        Task { await resolve(code, via: .barcodeScan) }
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 300)
@@ -177,9 +180,9 @@ struct CheckInView: View {
                 .keyboardType(.numbersAndPunctuation)
                 .autocorrectionDisabled()
                 .submitLabel(.search)
-                .onSubmit { Task { await resolve(manualISBN) } }
+                .onSubmit { Task { await resolve(manualISBN, via: .isbnEntry) } }
             Button {
-                Task { await resolve(manualISBN) }
+                Task { await resolve(manualISBN, via: .isbnEntry) }
             } label: {
                 if isResolving {
                     ProgressView()
@@ -376,8 +379,9 @@ struct CheckInView: View {
         }
     }
 
-    /// What the scan itself resolved to, shown once above the candidates so the
-    /// reader can compare them against it.
+    /// What the lookup itself resolved to, shown once above the candidates so
+    /// the reader can compare them against it. Its eyebrow names the door used
+    /// rather than asserting a scan.
     private func scannedCard(_ scanned: ExternalBookMeta) -> some View {
         HStack(alignment: .top, spacing: Spacing.md) {
             if let cover = scanned.coverURL, CheckInFlow.isExternalURL(cover) {
@@ -387,7 +391,7 @@ struct CheckInView: View {
                     .clipShape(RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
             }
             VStack(alignment: .leading, spacing: 4) {
-                Text("You scanned")
+                Text(CheckInFlow.foundLine(foundVia))
                     .font(.ui(12, weight: .medium))
                     .foregroundStyle(palette.ink3Color)
                 Text(scanned.title)
@@ -613,12 +617,13 @@ struct CheckInView: View {
 
     // MARK: - Actions
 
-    private func resolve(_ raw: String) async {
+    private func resolve(_ raw: String, via: FoundVia) async {
         let isbn = raw.filter { $0.isNumber || $0 == "X" || $0 == "x" }
         guard isbn.count >= 10 else {
             error = "That doesn't look like an ISBN."
             return
         }
+        foundVia = via
         isResolving = true
         error = nil
         defer { isResolving = false }
@@ -642,6 +647,7 @@ struct CheckInView: View {
     private func restart() {
         withAnimation(Motion.settle) {
             stage = .scan
+            foundVia = .barcodeScan
             manualISBN = ""
             note = ""
             error = nil
@@ -681,6 +687,7 @@ struct CheckInView: View {
     /// which could miss on a book the search itself just surfaced.
     private func resolvePick(_ meta: ExternalBookMeta) async {
         guard !isResolving else { return }
+        foundVia = .titleSearch
         isResolving = true
         error = nil
         defer { isResolving = false }
@@ -750,7 +757,7 @@ struct CheckInView: View {
         do {
             let ref: BookRef = try await APIClient.shared.post(
                 "/api/scan/wishlist",
-                body: WishlistAddRequest(bookUUID: nil, meta: meta, source: .scan)
+                body: CheckInFlow.wishlistRequest(meta: meta, foundVia: foundVia)
             )
             Haptics.success()
             // The wishlist is a real shelf whose membership derives from these

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1828,8 +1828,8 @@ struct AddPhysicalOnlyRequest: Codable, Sendable {
 ///
 /// The check-in flow has three front doors and they are not interchangeable:
 /// a barcode read by the camera is `scan`, an ISBN typed by hand is `manual`,
-/// and a title search is `search` — there the ISBN came from the provider, not
-/// from the reader at all (#2247).
+/// and a title search is `search` — there any ISBN came from the provider,
+/// because the reader supplied a title rather than a number.
 enum WishlistSource: String, Codable, Sendable {
     case scan, detail, manual, search
 }

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -1825,8 +1825,13 @@ struct AddPhysicalOnlyRequest: Codable, Sendable {
 }
 
 /// `#[serde(rename_all = "lowercase")]` on the Rust side.
+///
+/// The check-in flow has three front doors and they are not interchangeable:
+/// a barcode read by the camera is `scan`, an ISBN typed by hand is `manual`,
+/// and a title search is `search` — there the ISBN came from the provider, not
+/// from the reader at all (#2247).
 enum WishlistSource: String, Codable, Sendable {
-    case scan, detail, manual
+    case scan, detail, manual, search
 }
 
 /// Names its target with either an existing `book_uuid` or resolved `meta`;

--- a/omnibus-ios/omnibusTests/CheckInFlowTests.swift
+++ b/omnibus-ios/omnibusTests/CheckInFlowTests.swift
@@ -205,6 +205,52 @@ struct CheckInFlowTests {
         )
     }
 
+    // MARK: - Which door the book came through (#2266)
+
+    @Test("a scanned barcode files its wishlist entry as a scan")
+    func barcodeScanRecordsAScanSource() {
+        #expect(CheckInFlow.wishlistSource(.barcodeScan) == .scan)
+        let request = CheckInFlow.wishlistRequest(meta: externalMeta(), foundVia: .barcodeScan)
+        #expect(request.source == .scan)
+        #expect(request.bookUUID == nil)
+        #expect(request.meta?.isbn13 == "9781250903440")
+    }
+
+    @Test("a hand-typed ISBN files as manual, not as a scan")
+    func typedISBNRecordsAManualSource() {
+        #expect(CheckInFlow.wishlistSource(.isbnEntry) == .manual)
+        #expect(
+            CheckInFlow.wishlistRequest(meta: externalMeta(), foundVia: .isbnEntry).source
+                == .manual
+        )
+    }
+
+    @Test("a title search files as search — the reader supplied no ISBN")
+    func titleSearchRecordsASearchSource() {
+        #expect(CheckInFlow.wishlistSource(.titleSearch) == .search)
+        #expect(
+            CheckInFlow.wishlistRequest(meta: externalMeta(), foundVia: .titleSearch).source
+                == .search
+        )
+    }
+
+    @Test("the three doors never share a provenance")
+    func everyDoorRecordsADistinctSource() {
+        let sources = [FoundVia.barcodeScan, .isbnEntry, .titleSearch]
+            .map(CheckInFlow.wishlistSource)
+        #expect(Set(sources).count == 3)
+    }
+
+    @Test("the resolved-book eyebrow never claims a scan the reader didn't make")
+    func foundLineNamesTheDoorActuallyUsed() {
+        #expect(CheckInFlow.foundLine(.barcodeScan) == "You scanned")
+        #expect(CheckInFlow.foundLine(.isbnEntry) == "You entered")
+        #expect(CheckInFlow.foundLine(.titleSearch) == "You picked")
+        for via in [FoundVia.isbnEntry, .titleSearch] {
+            #expect(!CheckInFlow.foundLine(via).contains("scan"))
+        }
+    }
+
     @Test func externalURLDetectionSplitsAbsoluteFromServerRelative() {
         #expect(CheckInFlow.isExternalURL("https://books.google.com/x.jpg"))
         #expect(CheckInFlow.isExternalURL("http://covers.openlibrary.org/x.jpg"))

--- a/omnibus-ios/omnibusTests/ScanCodecTests.swift
+++ b/omnibus-ios/omnibusTests/ScanCodecTests.swift
@@ -37,6 +37,21 @@ struct WishlistAddRequestCodecTests {
         #expect(object["source"] as? String == "scan")
     }
 
+    @Test("encodes every front door's wire value the server matches on")
+    func encodesEverySource() throws {
+        for (source, wire) in [
+            (WishlistSource.scan, "scan"),
+            (WishlistSource.detail, "detail"),
+            (WishlistSource.manual, "manual"),
+            (WishlistSource.search, "search"),
+        ] {
+            let object = try encodedObject(
+                WishlistAddRequest(bookUUID: nil, meta: meta(), source: source)
+            )
+            #expect(object["source"] as? String == wire)
+        }
+    }
+
     @Test("names an existing book with a snake_case book_uuid")
     func encodesBookUUIDKey() throws {
         let object = try encodedObject(

--- a/omnibus-ios/omnibusTests/WishlistSectionTests.swift
+++ b/omnibus-ios/omnibusTests/WishlistSectionTests.swift
@@ -29,7 +29,7 @@ struct WishlistSectionTests {
         #expect(WishlistSection.sourceLabel(.manual) == "an ISBN you entered")
     }
 
-    @Test("names a title search, which supplied no ISBN at all")
+    @Test("names a title search, where the reader supplied a title and not an ISBN")
     func labelsATitleSearch() {
         #expect(WishlistSection.sourceLabel(.search) == "a title search")
     }

--- a/omnibus-ios/omnibusTests/WishlistSectionTests.swift
+++ b/omnibus-ios/omnibusTests/WishlistSectionTests.swift
@@ -24,9 +24,14 @@ struct WishlistSectionTests {
         #expect(WishlistSection.sourceLabel(.detail) == "this page")
     }
 
-    @Test("names a hand-made entry")
+    @Test("names a typed ISBN rather than calling it a scan")
     func labelsManualEntry() {
-        #expect(WishlistSection.sourceLabel(.manual) == "manual entry")
+        #expect(WishlistSection.sourceLabel(.manual) == "an ISBN you entered")
+    }
+
+    @Test("names a title search, which supplied no ISBN at all")
+    func labelsATitleSearch() {
+        #expect(WishlistSection.sourceLabel(.search) == "a title search")
     }
 
     @Test("states what is tracked, when, and from where")


### PR DESCRIPTION
## Summary
- A `FoundVia` set by whichever front door started the lookup — camera, ISBN field, or a picked title-search result — now decides the wishlist provenance the SwiftUI check-in flow posts: `scan`, `manual`, and `search` respectively, where all three previously posted `scan`.
- The resolved-book card's eyebrow reads off the same value ("You scanned" / "You entered" / "You picked") instead of hardcoding a scan the reader may not have made.
- `WishlistSource` gains `search`, and the book-detail tracking line names a typed ISBN and a title search rather than lumping both under a scan.
- Mirrors the web flow's contract (`FoundVia`, `wishlist_request_for`) rather than its structure — the SwiftUI stage machine has one screen carrying all three doors at once, so the door is captured at the control that fires, not derived from the stage.

Closes #2266

## Test plan
- [ ] `just ios-test` — 591 unit tests pass, 0 failures, including five new `CheckInFlowTests` cases (one per door, one asserting the three never collide, one on the eyebrow copy) and a new `WishlistSectionTests` case for the `search` label.
- [ ] `just ios-build` — BUILD SUCCEEDED.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes

>[!IMPORTANT]
> **Merge #2265 first.** The `search` provenance only exists server-side on that branch (`WishlistSource::Search` in `shared/` plus the migration widening the `wishlist_entries.source` CHECK). Against `main` as it stands today, a title-search wishlist add from this build would be rejected by the server; the scan and typed-ISBN paths work either way. Nothing from #2265 was cherry-picked here, so the two branches touch the same few lines of `Models.swift` and `WishlistSection.swift` with identical content.