### PR TITLE
[OMNI-2200] Give Each Exploration Agent Its Own Browser

### DIFF
--- a/docs/qa/agentic_exploration/flows/adding_journal.md
+++ b/docs/qa/agentic_exploration/flows/adding_journal.md
@@ -27,7 +27,9 @@ your own entry appearing without the "you" marker.
    indexed, so a search returning nothing is not a finding.
 3. Use at least one piece of formatting: bold, italic, a quote, or a list. Vary
    which one across runs.
-4. Occasionally embed an image from the corpus.
+4. Occasionally embed an image. The corpus carries one beside most books —
+   `cover.jpg`, in the same folder as the book file — and that is the one to
+   use; there is no separate image library.
 5. Save it, and confirm it renders — the formatting applied, the text intact.
 6. Come back later in the run, find it again, and confirm it is unchanged.
 7. Occasionally edit it and confirm the edit sticks; occasionally delete it and

--- a/docs/qa/agentic_exploration/flows/browsing_book_details.md
+++ b/docs/qa/agentic_exploration/flows/browsing_book_details.md
@@ -18,7 +18,7 @@ turn up something cosmetic that no assertion would catch.
    dates, identifiers, tags, genres, ratings, saved passages, suggestions.
    There is **no page or chapter count** on this page — do not go looking for
    one, and do not report its absence.
-3. Ask of each thing: is this plausible? A negative page count, a date in 1900,
+3. Ask of each thing: is this plausible? A publication year of 0101, a date in 1900,
    an author of "Unknown, Unknown", a description that is raw HTML, a cover
    that belongs to another book — all findings.
 4. Then do **each** of the following, in whatever order you like. You do not

--- a/docs/qa/agentic_exploration/flows/creating_a_shelf.md
+++ b/docs/qa/agentic_exploration/flows/creating_a_shelf.md
@@ -66,7 +66,9 @@ the book uuids — those are what the audit reconciles.
 - Another user's shelf is visible **and you are not an admin**. Admins see every
   shelf by design, and the exploration accounts are currently all admins — so on
   this instance the criterion is undecidable and you should journal `uncertain`
-  rather than guess. (Worth reporting separately: another user's private shelf
+  rather than guess. Non-admin exploration accounts are planned; once one exists
+  this becomes a real, decidable fail criterion and the `uncertain` escape stops
+  applying. (Worth reporting separately: another user's private shelf
   renders in the rail with no owner attribution, while the wishlists beside it
   do show owner names.)
 - **On iOS:** removing a book from a shelf deletes the book. High severity.

--- a/docs/qa/agentic_exploration/flows/listening_to_audiobook.md
+++ b/docs/qa/agentic_exploration/flows/listening_to_audiobook.md
@@ -24,19 +24,22 @@ chapter seams are testable even when file seams are not.
 ## Steps
 
 1. Reach the book and start listening.
-2. Let it play. Do not sit in silence watching a counter; use the controls the
-   way a listener does — skip back thirty seconds after losing the thread, skip
-   forward past something dull.
+2. **Skip ahead to roughly 10% of the book** rather than listening through to
+   it — a tenth of a ten-hour audiobook is an hour of wall clock, and nothing
+   here tests your patience. Play a stretch at each place you land so you can
+   hear that audio actually runs, and use the controls the way a listener does:
+   skip back thirty seconds after losing the thread, skip forward past
+   something dull.
 3. Change the playback speed at least once, and let it play on at the new rate.
 4. If the book has several files or chapters, cross at least one boundary and
    watch what happens at the seam.
 5. Occasionally set a sleep timer and watch it count down; you need not wait
    for it to fire.
-6. Leave the player and check the book's detail page reflects where you got to.
-   There is no single "exit" control: the book title links back to the detail
-   page, and once you are elsewhere the persistent mini-player offers "Stop and
-   close player". Leaving via the title does **not** stop playback — the
-   mini-player keeps going, which is intended.
+6. **Go back to the library, then close the mini-player.** Follow the book title
+   out of the player, then use the persistent mini-player's "Stop and close
+   player". There is no single exit control, and leaving via the title does
+   **not** stop playback — the mini-player keeps going, which is intended.
+   Then check the book's detail page reflects where you got to.
 
 ## Journal
 

--- a/docs/qa/agentic_exploration/flows/reading_a_book.md
+++ b/docs/qa/agentic_exploration/flows/reading_a_book.md
@@ -32,7 +32,9 @@ starting.
 4. Somewhere in the middle, do one incidental thing a reader does — open the
    table of contents, change the font size, search for a word, switch the
    theme. Pick a different one each time.
-5. Leave the reader deliberately, through the app's own way out.
+5. Leave the reader with its **Back to book** control, which returns you to the
+   book's detail page. Unlike the audiobook player there is no mini-player, so
+   this genuinely ends the session.
 6. Come back to the book's detail page and check that your position is
    reflected there.
 

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,14 @@
         # an extra bootstrap step — they're ~10 MB each and harmless.
         slimPackages = [
           pkgs-unstable.git
+          # The agentic-exploration scripts (scripts/explore/) shell out to all
+          # three: curl for the instance's HTTP API, python3 for JSON handling,
+          # and lsof for driver.sh's port ownership. macOS supplies them
+          # system-wide, which is why their absence here went unnoticed — a
+          # clean Linux host or CI runner has no such luck.
+          pkgs.curl
+          pkgs.python3
+          pkgs.lsof
           pkgs.sqlite
           pkgs.pkg-config
           pkgs.openssl

--- a/scripts/explore/driver/package-lock.json
+++ b/scripts/explore/driver/package-lock.json
@@ -19,21 +19,6 @@
         "ws": "^8.19.0"
       }
     },
-    "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.62.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -132,6 +117,21 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/playwright-repl/node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ws": {

--- a/scripts/explore/driver/package.json
+++ b/scripts/explore/driver/package.json
@@ -7,6 +7,7 @@
   },
   "overrides": {
     "playwright": "1.61.1",
-    "playwright-core": "1.61.1"
+    "playwright-core": "1.61.1",
+    "@playwright/test": "1.61.1"
   }
 }


### PR DESCRIPTION
## Summary
- Corrects the flow-catalog instructions that agents could not follow in run `r-20260828-02`: an audiobook "tenth" that meant an hour of wall clock (now: skip ahead to ~10%), exit steps that described rather than instructed, a page count the detail page does not show, and "an image from the corpus" when the corpus is book files.
- Adds `curl`, `python3` and `lsof` to the dev shells. Every script under `scripts/explore/` shells out to them, and macOS supplies all three system-wide — which is exactly why their absence went unnoticed until a review caught it.
- Pins `@playwright/test` in the exploration driver. `playwright` and `playwright-core` were already pinned to 1.61.1 to share the flake's Chromium, but the lock resolved the test runner to 1.62.1 — a tree expecting a `playwright` it is not getting.

Part of #2200

## Test plan
- [x] `curl`, `python3` and `lsof` all resolve inside `nix develop .#e2e` after the change.
- [x] Driver lock regenerated; all four playwright packages now agree at 1.61.1.
- [x] Doc changes verified against the live UI: the reader's exit is **Back to book**, the player has no single exit (title link, then the mini-player's "Stop and close player"), and 225 of the corpus's 236 images are the `cover.jpg` beside a book.

## Version
- [x] **No release** — docs and dev-shell only; no shipped code changes.

## Notes
- Originally opened carrying a duplicate driver implementation; #2267 landed that first, so this was rebuilt on `main` and now contains only what that PR does not. Both review findings below were re-verified as still live on `main` before being re-applied.
- Two agent-reported items were investigated and deliberately **not** acted on: `locator.fill()` dropping newlines in the journal editor is Chromium's documented `insertText` behaviour on a path no real user takes (the editor already intercepts `Enter` and paste), and the sparkline axis label beside LONGEST SIT only misleads an agent flattening the page to `innerText`.