### PR TITLE
feat: distribute TestFlight builds to external tester groups

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -1,0 +1,49 @@
+# Runs the TestFlight distribution script's test suite.
+#
+# That script only ever executes during a release dispatch, against Apple's live
+# API — so a regression in it is invisible until the one moment it matters, and
+# the failure mode it guards (a build that uploads but reaches no tester) looks
+# exactly like success. The suite stubs HTTP and needs no App Store Connect
+# credentials, so it can gate every change to the script here instead.
+#
+# Deliberately scoped to this one suite rather than all of scripts/tests/: the
+# sibling bash tests expect a Nix dev shell and a worktree layout that this
+# runner does not have.
+name: Script tests
+
+# Path lists are spelled out twice because GitHub Actions does not support YAML
+# anchors — keep the two in step.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/testflight_distribute.py"
+      - "scripts/tests/testflight-distribute.test.py"
+      - ".github/workflows/script-tests.yml"
+  pull_request:
+    paths:
+      - "scripts/testflight_distribute.py"
+      - "scripts/tests/testflight-distribute.test.py"
+      - ".github/workflows/script-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  testflight-distribute:
+    name: testflight_distribute.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Same two the distribute job installs — the suite imports the real
+      # script, which imports them at module scope.
+      - name: Install deps
+        run: python -m pip install --quiet "pyjwt[crypto]" requests
+
+      - name: Run suite
+        run: python scripts/tests/testflight-distribute.test.py

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -7,11 +7,20 @@ name: TestFlight
 # v* tag, which run-name can't know yet.
 run-name: "TestFlight ${{ inputs.marketing_version && format('v{0}', inputs.marketing_version) || 'latest tag' }}"
 
-# Manually-triggered iOS build + TestFlight upload for the native SwiftUI app
-# (omnibus-ios/ Xcode project, bundle com.omnibus.mobile). The Apple side must
-# already exist: the app record, the distribution cert, the App Store Connect
-# API key, and — because the app embeds a widget extension — **two** App IDs
-# with **two** App Store provisioning profiles, one per embedded bundle.
+# Manually-triggered iOS build, TestFlight upload, and external-tester
+# distribution for the native SwiftUI app (omnibus-ios/ Xcode project, bundle
+# com.omnibus.mobile). The Apple side must already exist: the app record, the
+# distribution cert, the App Store Connect API key, and — because the app embeds
+# a widget extension — **two** App IDs with **two** App Store provisioning
+# profiles, one per embedded bundle.
+#
+# Uploading is not distributing, which is why there is a third job. `altool`
+# delivers the binary and stops; an internal group can be set to auto-distribute
+# but an external one cannot, so a build nobody explicitly adds to the group is
+# invisible to every tester on the public link while this workflow still reports
+# success. The `distribute` job closes that gap — see
+# scripts/testflight_distribute.py for the logic and env contract, and the
+# BETA_GROUPS value in that job for the group names it targets.
 #
 # The build is a real .xcodeproj archived **signed** by `xcodebuild archive`,
 # re-signed for distribution at `xcodebuild -exportArchive` (manual signing,
@@ -58,6 +67,15 @@ on:
         description: "CFBundleShortVersionString (user-visible version). Defaults to the latest v* release tag, so it tracks the server release."
         required: false
         type: string
+      whats_new:
+        description: "What to Test note shown to TestFlight testers. Leave blank to keep whatever App Store Connect already has."
+        required: false
+        type: string
+      distribute_externally:
+        description: "Add the build to the external tester groups (and submit for Beta App Review if needed)."
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: testflight-${{ github.ref }}
@@ -67,14 +85,17 @@ permissions:
   contents: read
 
 jobs:
-  # Resolve the user-visible marketing version. Prefer the dispatch input;
-  # otherwise the latest v* git tag (the same tags release.yml mints), so
-  # TestFlight tracks the server release.
+  # Resolve the version pair every later job stamps or looks the build up by.
+  # The marketing version prefers the dispatch input, otherwise the latest v* git
+  # tag (the same tags release.yml mints), so TestFlight tracks the server
+  # release. Both are validated here rather than in the ios job so a malformed
+  # input costs seconds instead of a 20-minute macOS archive.
   version:
     name: resolve marketing version
     runs-on: ubuntu-latest
     outputs:
       marketing_version: ${{ steps.resolve.outputs.version }}
+      build_number: ${{ steps.resolve.outputs.build_number }}
     steps:
       # fetch-depth: 0 pulls full history + tags so `git describe` can find the
       # latest release tag (checkout fetches neither by default).
@@ -85,6 +106,10 @@ jobs:
         id: resolve
         env:
           INPUT_VERSION: ${{ github.event.inputs.marketing_version }}
+          # Defaulting to run_number is only monotonic if nobody has ever
+          # dispatched a higher literal — once someone does, every later default
+          # is rejected by App Store Connect for going backwards.
+          INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
         run: |
           set -euo pipefail
           if [ -n "$INPUT_VERSION" ]; then
@@ -100,8 +125,15 @@ jobs:
           case "$version" in
             '' | *[!0-9.]*) echo "::error::marketing version must be numeric/dot-separated, got: '$version'"; exit 1 ;;
           esac
-          echo "Marketing version: $version"
+          # CURRENT_PROJECT_VERSION must be a dotted integer sequence too. An input
+          # like "1.0-rc1" archives happily and is only rejected once App Store
+          # Connect processes the upload, minutes after the run goes green.
+          case "$INPUT_BUILD_NUMBER" in
+            '' | *[!0-9.]*) echo "::error::build_number must be numeric/dot-separated, got: '$INPUT_BUILD_NUMBER'"; exit 1 ;;
+          esac
+          echo "Marketing version: $version (build $INPUT_BUILD_NUMBER)"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'build_number=%s\n' "$INPUT_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
 
   # ---- ios: native SwiftUI app (com.omnibus.mobile) ---------------------------
   ios:
@@ -118,11 +150,9 @@ jobs:
       # injected per-job and isn't governed by `permissions:`.
       actions: write
     env:
-      # Validated in the Archive step. Defaulting to run_number is only
-      # monotonic if nobody has ever dispatched a higher literal — once
-      # someone does, every later default is rejected by App Store Connect
-      # for going backwards.
-      BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
+      # Both resolved and validated by the version job, so the archive and the
+      # distribute job look the build up by the same pair.
+      BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
       MARKETING_VERSION: ${{ needs.version.outputs.marketing_version }}
       # The team the omnibus-ios project + the distribution cert belong to.
       DEVELOPMENT_TEAM: "D33VSDXHA6"
@@ -180,14 +210,6 @@ jobs:
       - name: Archive
         run: |
           set -euo pipefail
-          # CURRENT_PROJECT_VERSION must be a dotted integer sequence. An input
-          # like "1.0-rc1" builds happily and is only rejected once App Store
-          # Connect processes the upload, minutes after the run goes green.
-          case "$BUILD_NUMBER" in
-            '' | *[!0-9.]*)
-              echo "::error::build_number must be numeric/dot-separated, got: '$BUILD_NUMBER'"
-              exit 1 ;;
-          esac
           xcodebuild \
             -project omnibus-ios/omnibus.xcodeproj \
             -scheme omnibus \
@@ -337,3 +359,45 @@ jobs:
             security delete-keychain "$SIGNING_KEYCHAIN" || true
           fi
           rm -f "$HOME/.appstoreconnect/private_keys"/*.p8 2>/dev/null || true
+
+  # ---- distribute: hand the processed build to the external testers ----------
+  # Uploading is not distributing. `altool` delivers the binary and nothing more;
+  # an internal group can be set to auto-distribute, but an **external** group
+  # cannot, so a build nobody adds to one stays invisible to every tester on the
+  # public link while this workflow reports success. That is what this job fixes.
+  #
+  # Pure App Store Connect API, so it runs on ubuntu rather than paying for macOS
+  # minutes, and it waits out processing itself — the build resource does not
+  # exist for a minute or two after the upload returns.
+  distribute:
+    name: distribute (external testers)
+    needs: [version, ios]
+    if: ${{ inputs.distribute_externally }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        run: python -m pip install --quiet "pyjwt[crypto]" requests
+
+      - name: Add build to TestFlight groups
+        env:
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          BUNDLE_ID: com.omnibus.mobile
+          MARKETING_VERSION: ${{ needs.version.outputs.marketing_version }}
+          BUILD_NUMBER: ${{ needs.version.outputs.build_number }}
+          # Exact App Store Connect group names, comma-separated — so renaming a
+          # group over there has to be mirrored here. A name matching nothing
+          # fails the job, deliberately: distributing to no one and exiting 0 is
+          # the failure this whole job exists to prevent.
+          BETA_GROUPS: "First 20 Testers"
+          WHATS_NEW: ${{ inputs.whats_new }}
+        run: python scripts/testflight_distribute.py

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -119,18 +119,23 @@ jobs:
             [ -n "$tag" ] || { echo "::error::No v* git tag found and no marketing_version input given."; exit 1; }
             version="${tag#v}"
           fi
-          # Reject anything but digits and dots before writing to $GITHUB_OUTPUT: a
-          # dispatch input containing a newline would otherwise inject extra output
-          # assignments.
-          case "$version" in
-            '' | *[!0-9.]*) echo "::error::marketing version must be numeric/dot-separated, got: '$version'"; exit 1 ;;
-          esac
-          # CURRENT_PROJECT_VERSION must be a dotted integer sequence too. An input
-          # like "1.0-rc1" archives happily and is only rejected once App Store
-          # Connect processes the upload, minutes after the run goes green.
-          case "$INPUT_BUILD_NUMBER" in
-            '' | *[!0-9.]*) echo "::error::build_number must be numeric/dot-separated, got: '$INPUT_BUILD_NUMBER'"; exit 1 ;;
-          esac
+          # Both values must be a dotted sequence of non-empty integer segments.
+          # The character class is what stops a dispatch input containing a
+          # newline from injecting extra assignments into $GITHUB_OUTPUT; the
+          # three dot patterns reject the malformed placements it lets through
+          # (".1", "1.", "1..2"), which archive happily and are only rejected
+          # once App Store Connect processes the upload — minutes after the run
+          # has already gone green. The build number reaches the distribute job
+          # too, so a bad one now also breaks the build lookup.
+          require_dotted_integers() { # <label> <value>
+            case "$2" in
+              '' | *[!0-9.]* | .* | *. | *..*)
+                echo "::error::$1 must be a dotted sequence of integers, got: '$2'"
+                exit 1 ;;
+            esac
+          }
+          require_dotted_integers "marketing version" "$version"
+          require_dotted_integers "build_number" "$INPUT_BUILD_NUMBER"
           echo "Marketing version: $version (build $INPUT_BUILD_NUMBER)"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
           printf 'build_number=%s\n' "$INPUT_BUILD_NUMBER" >> "$GITHUB_OUTPUT"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -486,7 +486,18 @@ release tag so TestFlight tracks the server release. Signing is seven
 CI-only repo secrets (distribution cert + password, an App Store
 provisioning profile for *each* of the two embedded bundles, App Store
 Connect API key + key-id + issuer-id) — enumerated in the
-workflow file's header comment. A daily companion workflow
+workflow file's header comment.
+
+A third job then **distributes** the build, because uploading it does not:
+`altool` delivers the binary and stops, an internal group can be set to
+distribute automatically but an external group cannot, and a build nobody adds
+to one is invisible to every tester on the public link while the run still
+reports success. `scripts/testflight_distribute.py` waits out processing,
+submits for Beta App Review when the build still needs it (the first build of a
+marketing version does), optionally sets "What to Test", and adds the build to
+each group named by the job's `BETA_GROUPS`. It runs on ubuntu — it is pure App
+Store Connect API — reuses the same team-scoped API key, and is idempotent, so a
+re-run attaches nothing twice. A daily companion workflow
 (`testflight-feedback.yml`) turns new TestFlight screenshot feedback into
 GitHub issues via `scripts/testflight_feedback_to_issues.py`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -497,7 +497,10 @@ submits for Beta App Review when the build still needs it (the first build of a
 marketing version does), optionally sets "What to Test", and adds the build to
 each group named by the job's `BETA_GROUPS`. It runs on ubuntu — it is pure App
 Store Connect API — reuses the same team-scoped API key, and is idempotent, so a
-re-run attaches nothing twice. A daily companion workflow
+re-run attaches nothing twice. Because that script only ever executes during a
+release dispatch against Apple's live API, its suite
+(`scripts/tests/testflight-distribute.test.py`, HTTP stubbed, no credentials) is
+gated in CI by `script-tests.yml`. A daily companion workflow
 (`testflight-feedback.yml`) turns new TestFlight screenshot feedback into
 GitHub issues via `scripts/testflight_feedback_to_issues.py`.
 

--- a/scripts/testflight_distribute.py
+++ b/scripts/testflight_distribute.py
@@ -42,20 +42,34 @@ import jwt  # PyJWT[crypto]
 import requests
 
 ASC_BASE = "https://api.appstoreconnect.apple.com"
-DRY_RUN = os.environ.get("DRY_RUN") == "1"
-BUNDLE_ID = os.environ.get("BUNDLE_ID", "com.omnibus.mobile")
-BETA_GROUPS = [g.strip() for g in os.environ.get("BETA_GROUPS", "").split(",") if g.strip()]
-WHATS_NEW = (os.environ.get("WHATS_NEW") or "").strip()
-PROCESSING_TIMEOUT_SECS = int(os.environ.get("PROCESSING_TIMEOUT_SECS", "1800"))
-POLL_SECS = 30
-# Locale used when a build has no "What to Test" localization at all yet. Apple
-# seeds one per the app's configured locales, so this is only the cold-start case.
-DEFAULT_LOCALE = "en-US"
 
 
 def die(msg):
     print(f"error: {msg}", file=sys.stderr)
     sys.exit(1)
+
+
+def positive_int_env(name, default):
+    """Read an integer setting, naming the culprit rather than tracebacking.
+
+    A bare int() here raises at import, and an Actions log that opens on a
+    ValueError stack trace reads as a broken script rather than a typo'd input.
+    """
+    raw = (os.environ.get(name) or "").strip() or str(default)
+    if not raw.isdigit() or int(raw) <= 0:
+        die(f"{name} must be a positive whole number of seconds, got: {raw!r}")
+    return int(raw)
+
+
+DRY_RUN = os.environ.get("DRY_RUN") == "1"
+BUNDLE_ID = os.environ.get("BUNDLE_ID", "com.omnibus.mobile")
+BETA_GROUPS = [g.strip() for g in os.environ.get("BETA_GROUPS", "").split(",") if g.strip()]
+WHATS_NEW = (os.environ.get("WHATS_NEW") or "").strip()
+PROCESSING_TIMEOUT_SECS = positive_int_env("PROCESSING_TIMEOUT_SECS", 1800)
+POLL_SECS = 30
+# Locale used when a build has no "What to Test" localization at all yet. Apple
+# seeds one per the app's configured locales, so this is only the cold-start case.
+DEFAULT_LOCALE = "en-US"
 
 
 def private_key():

--- a/scripts/testflight_distribute.py
+++ b/scripts/testflight_distribute.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Hand an uploaded TestFlight build to its external tester groups.
+
+`xcrun altool --upload-app` only delivers the binary to App Store Connect — it
+never assigns the build to a tester group. Internal groups can be set to
+distribute automatically, so they need nothing; **external groups have no such
+setting**, and a build that is never added to one is simply invisible to every
+tester on the public link. The upload workflow therefore goes green while the
+group sees nothing, which is indistinguishable from success until somebody goes
+looking. This script is the missing step.
+
+It waits for processing, submits for Beta App Review when the build still needs
+it (the first build of a marketing version does; later ones are usually waved
+through), optionally sets "What to Test", and adds the build to each named
+group.
+
+Idempotent by construction: a group already attached to the build is skipped and
+a build already submitted for review is left alone, so a re-run — or a retry
+after a half-finished run — is a no-op rather than a duplicate.
+
+Reuses the App Store Connect API key the build-upload workflow already
+configures (`ASC_API_KEY_BASE64` / `ASC_KEY_ID` / `ASC_ISSUER_ID`); that key is
+team-scoped, so no new secrets are needed.
+
+Env:
+  ASC_ISSUER_ID, ASC_KEY_ID              App Store Connect API key identity.
+  ASC_API_KEY_BASE64 | ASC_PRIVATE_KEY   The .p8 private key (base64, or raw PEM).
+  BUNDLE_ID                              App to distribute (default: the SwiftUI app).
+  MARKETING_VERSION, BUILD_NUMBER        Identify the build this run uploaded.
+  BETA_GROUPS                            Comma-separated group names (exact match).
+  WHATS_NEW                              Optional "What to Test" shown to testers.
+  PROCESSING_TIMEOUT_SECS                How long to wait for processing (default 1800).
+  DRY_RUN=1                              Resolve and report, change nothing.
+"""
+import base64
+import binascii
+import os
+import sys
+import time
+
+import jwt  # PyJWT[crypto]
+import requests
+
+ASC_BASE = "https://api.appstoreconnect.apple.com"
+DRY_RUN = os.environ.get("DRY_RUN") == "1"
+BUNDLE_ID = os.environ.get("BUNDLE_ID", "com.omnibus.mobile")
+BETA_GROUPS = [g.strip() for g in os.environ.get("BETA_GROUPS", "").split(",") if g.strip()]
+WHATS_NEW = (os.environ.get("WHATS_NEW") or "").strip()
+PROCESSING_TIMEOUT_SECS = int(os.environ.get("PROCESSING_TIMEOUT_SECS", "1800"))
+POLL_SECS = 30
+# Locale used when a build has no "What to Test" localization at all yet. Apple
+# seeds one per the app's configured locales, so this is only the cold-start case.
+DEFAULT_LOCALE = "en-US"
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def private_key():
+    raw = os.environ.get("ASC_PRIVATE_KEY")
+    if raw:
+        return raw
+    b64 = os.environ.get("ASC_API_KEY_BASE64")
+    if not b64:
+        die("set ASC_PRIVATE_KEY or ASC_API_KEY_BASE64")
+    try:  # secrets often arrive with stray whitespace/newlines
+        return base64.b64decode(b64.strip(), validate=True).decode()
+    except (binascii.Error, ValueError, UnicodeDecodeError) as e:
+        die(f"ASC_API_KEY_BASE64 is not valid base64: {e}")
+
+
+def asc_jwt():
+    """Mint a short-lived API token.
+
+    Minted per request rather than once: waiting out processing can outlast any
+    single token, and a 401 twenty minutes into a poll would read as a
+    credentials problem rather than an expiry.
+    """
+    now = int(time.time())
+    return jwt.encode(
+        {"iss": os.environ["ASC_ISSUER_ID"], "iat": now, "exp": now + 15 * 60,
+         "aud": "appstoreconnect-v1"},
+        private_key(),
+        algorithm="ES256",
+        headers={"kid": os.environ["ASC_KEY_ID"], "typ": "JWT"},
+    )
+
+
+def asc_raw(method, path, **kw):
+    """Call the API and hand back the response, however it went."""
+    url = path if path.startswith("http") else ASC_BASE + path
+    return requests.request(method, url,
+                            headers={"Authorization": f"Bearer {asc_jwt()}"},
+                            timeout=60, **kw)
+
+
+def asc(method, path, **kw):
+    r = asc_raw(method, path, **kw)
+    if r.status_code >= 400:
+        die(f"App Store Connect {r.status_code} on {method} {path}: {r.text[:300]}")
+    # Relationship writes answer 204 with an empty body.
+    return r.json() if r.status_code != 204 and r.content else {}
+
+
+# --- resolution -------------------------------------------------------------
+
+def resolve_app_id():
+    data = asc("GET", "/v1/apps", params={"filter[bundleId]": BUNDLE_ID, "limit": 1})["data"]
+    if not data:
+        die(f"no App Store Connect app for bundle id {BUNDLE_ID}")
+    return data[0]["id"]
+
+
+def resolve_groups(app_id):
+    """Look up each requested group by exact name.
+
+    A miss is fatal and prints the names that do exist: a renamed or
+    mistyped group would otherwise distribute to nothing and still exit 0,
+    which is the failure this script exists to prevent.
+    """
+    found = {g["attributes"]["name"]: g
+             for g in asc("GET", f"/v1/apps/{app_id}/betaGroups",
+                          params={"limit": 200})["data"]}
+    missing = [n for n in BETA_GROUPS if n not in found]
+    if missing:
+        die(f"no TestFlight group named {', '.join(repr(m) for m in missing)}; "
+            f"groups on this app: {', '.join(sorted(found)) or '(none)'}")
+    return [found[n] for n in BETA_GROUPS]
+
+
+def version_candidates(version):
+    """Both spellings App Store Connect might list a marketing version under.
+
+    It drops a trailing zero segment, so a build uploaded as 0.15.0 comes back
+    as preReleaseVersion 0.15. Querying only what we stamped would never match a
+    minor release, and the miss looks exactly like a build still processing —
+    a 30-minute wait that then fails for the wrong reason.
+    """
+    parts = version.split(".")
+    if len(parts) == 3 and parts[2].isdigit() and int(parts[2]) == 0:
+        return [version, ".".join(parts[:2])]
+    if len(parts) == 2:
+        return [version, f"{version}.0"]
+    return [version]
+
+
+def find_build(app_id):
+    """Return (build, buildBetaDetail attrs) for this run's version, or (None, {})."""
+    for version in version_candidates(os.environ["MARKETING_VERSION"]):
+        page = asc("GET", "/v1/builds", params={
+            "filter[app]": app_id,
+            "filter[version]": os.environ["BUILD_NUMBER"],
+            "filter[preReleaseVersion.version]": version,
+            "include": "buildBetaDetail",
+            "limit": 1,
+        })
+        data = page.get("data") or []
+        if data:
+            detail = next((i for i in page.get("included", [])
+                           if i["type"] == "buildBetaDetails"), {})
+            return data[0], detail.get("attributes", {})
+    return None, {}
+
+
+def wait_for_build(app_id):
+    """Poll until the uploaded build exists and has finished processing.
+
+    Upload and processing are separate: `altool` returns as soon as the bytes
+    land, and the build resource does not exist for a minute or two afterwards.
+    """
+    version = f"{os.environ['MARKETING_VERSION']} ({os.environ['BUILD_NUMBER']})"
+    deadline = time.time() + PROCESSING_TIMEOUT_SECS
+    last = None
+    while True:
+        build, detail = find_build(app_id)
+        state = build["attributes"].get("processingState") if build else "(not yet listed)"
+        if build and state == "VALID":
+            print(f"build {version} processed ({build['id']})")
+            return build, detail
+        if state in ("FAILED", "INVALID"):
+            die(f"build {version} finished processing as {state}; App Store Connect "
+                "emails the reason to the account holder")
+        if state != last:  # one line per transition, not one per poll
+            print(f"waiting for build {version}: {state}")
+            last = state
+        if time.time() >= deadline:
+            die(f"build {version} was still {state} after {PROCESSING_TIMEOUT_SECS}s; "
+                "raise PROCESSING_TIMEOUT_SECS or add it to the group by hand")
+        time.sleep(POLL_SECS)
+
+
+# --- distribution -----------------------------------------------------------
+
+def submit_for_beta_review(build_id, external_state):
+    """Submit for Beta App Review when the build is waiting on it.
+
+    Only `READY_FOR_BETA_SUBMISSION` needs the call; every other state either
+    already has a submission or cannot take one, and posting anyway is an error
+    rather than a no-op.
+    """
+    if external_state == "MISSING_EXPORT_COMPLIANCE":
+        die("build is missing export compliance, so it cannot go to external testers. "
+            "omnibus-ios/Info.plist sets ITSAppUsesNonExemptEncryption to answer this "
+            "at build time — check the key survived into the uploaded binary.")
+    if external_state != "READY_FOR_BETA_SUBMISSION":
+        print(f"beta review: nothing to submit (external state {external_state})")
+        return
+    if DRY_RUN:
+        print("beta review: [dry] would submit")
+        return
+    r = asc_raw("POST", "/v1/betaAppReviewSubmissions", json={"data": {
+        "type": "betaAppReviewSubmissions",
+        "relationships": {"build": {"data": {"type": "builds", "id": build_id}}},
+    }})
+    if r.status_code in (200, 201):
+        print("beta review: submitted")
+    elif r.status_code == 409:  # a concurrent run, or Apple auto-submitted on attach
+        print("beta review: already submitted")
+    else:
+        die(f"beta review submission failed ({r.status_code}): {r.text[:300]}")
+
+
+def set_whats_new(build_id):
+    """Write the tester-facing "What to Test" note, if one was supplied.
+
+    Updates every localization the build already has rather than guessing which
+    one testers read; a build with none yet gets one in DEFAULT_LOCALE.
+    """
+    if not WHATS_NEW:
+        return
+    existing = asc("GET", "/v1/betaBuildLocalizations",
+                   params={"filter[build]": build_id, "limit": 50})["data"]
+    if DRY_RUN:
+        locales = ", ".join(l["attributes"]["locale"] for l in existing) or DEFAULT_LOCALE
+        print(f"what to test: [dry] would set for {locales}")
+        return
+    for loc in existing:
+        asc("PATCH", f"/v1/betaBuildLocalizations/{loc['id']}", json={"data": {
+            "type": "betaBuildLocalizations",
+            "id": loc["id"],
+            "attributes": {"whatsNew": WHATS_NEW},
+        }})
+    if not existing:
+        asc("POST", "/v1/betaBuildLocalizations", json={"data": {
+            "type": "betaBuildLocalizations",
+            "attributes": {"whatsNew": WHATS_NEW, "locale": DEFAULT_LOCALE},
+            "relationships": {"build": {"data": {"type": "builds", "id": build_id}}},
+        }})
+    print(f"what to test: set for {len(existing) or 1} localization(s)")
+
+
+def add_to_groups(build_id, groups):
+    """Attach the build to each group it isn't already in."""
+    attached = {g["id"] for g in asc("GET", f"/v1/builds/{build_id}/betaGroups",
+                                     params={"limit": 200})["data"]}
+    todo = [g for g in groups if g["id"] not in attached]
+    for g in groups:
+        if g["id"] in attached:
+            print(f"group {g['attributes']['name']!r}: already attached")
+    if not todo:
+        return
+    names = ", ".join(repr(g["attributes"]["name"]) for g in todo)
+    if DRY_RUN:
+        print(f"groups: [dry] would attach to {names}")
+        return
+    asc("POST", f"/v1/builds/{build_id}/relationships/betaGroups",
+        json={"data": [{"type": "betaGroups", "id": g["id"]} for g in todo]})
+    print(f"groups: attached to {names}")
+
+
+def describe(group):
+    a = group["attributes"]
+    kind = "internal" if a.get("isInternalGroup") else "external"
+    link = " · public link" if a.get("publicLinkEnabled") else ""
+    return f"{a['name']!r} ({kind}{link})"
+
+
+def main():
+    for req in ("ASC_ISSUER_ID", "ASC_KEY_ID", "MARKETING_VERSION", "BUILD_NUMBER"):
+        if not os.environ.get(req):
+            die(f"missing env {req}")
+    if not BETA_GROUPS:
+        die("set BETA_GROUPS to the TestFlight group name(s) to distribute to")
+
+    app_id = resolve_app_id()
+    groups = resolve_groups(app_id)
+    print(f"app {BUNDLE_ID} ({app_id}); groups: {', '.join(describe(g) for g in groups)}; "
+          f"dry_run={DRY_RUN}")
+
+    build, detail = wait_for_build(app_id)
+    build_id = build["id"]
+
+    # Order matters: fastlane's pilot submits for review before attaching groups,
+    # and the external state that decides whether a submission is needed is read
+    # from the build as it stands before any attachment changes it.
+    submit_for_beta_review(build_id, detail.get("externalBuildState"))
+    set_whats_new(build_id)
+    add_to_groups(build_id, groups)
+
+    print(f"done: build {os.environ['MARKETING_VERSION']} "
+          f"({os.environ['BUILD_NUMBER']}) is with {len(groups)} group(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/testflight-distribute.test.py
+++ b/scripts/tests/testflight-distribute.test.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Tests for scripts/testflight_distribute.py — the step that hands an uploaded
+build to its external tester groups.
+
+No network and no App Store Connect key: the real script is imported (so this
+tracks the shipped implementation rather than a hand-copied duplicate) and only
+its two I/O primitives — `asc_raw` and `asc_jwt` — are stubbed. Each scenario
+declares what the API would answer, then asserts which writes the script makes.
+Which writes it *doesn't* make is the point of half of them: the run is meant to
+be re-runnable, so an already-attached group or an already-submitted review must
+produce no POST at all.
+
+Usage: scripts/tests/testflight-distribute.test.py
+"""
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "testflight_distribute.py"
+
+APP_ID = "app-1"
+BUILD_ID = "build-1"
+GROUP_ID = "group-1"
+GROUP_NAME = "First 20 Testers"
+
+pass_count = 0
+fail_count = 0
+
+
+def check(desc, expected, actual):
+    global pass_count, fail_count
+    if actual == expected:
+        print(f"PASS: {desc}")
+        pass_count += 1
+    else:
+        print(f"FAIL: {desc} (expected {expected!r}, got {actual!r})", file=sys.stderr)
+        fail_count += 1
+
+
+class Resp:
+    """The slice of requests.Response the script actually touches."""
+
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+        self.text = json.dumps(self._payload)
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._payload
+
+
+class FakeASC:
+    """A scripted App Store Connect.
+
+    `build_states` is consumed one entry per `GET /v1/builds`, so a scenario can
+    say "PROCESSING, then VALID" and exercise the poll rather than only its
+    happy last iteration.
+    """
+
+    def __init__(self, build_states, external_state="READY_FOR_BETA_SUBMISSION",
+                 attached_groups=(), localizations=(), groups=((GROUP_ID, GROUP_NAME),),
+                 review_status=201, listed_version=None):
+        self.build_states = list(build_states)
+        self.external_state = external_state
+        self.attached_groups = list(attached_groups)
+        self.localizations = list(localizations)
+        self.groups = list(groups)
+        self.review_status = review_status
+        # The marketing version App Store Connect actually lists the build
+        # under; None matches whatever is asked for.
+        self.listed_version = listed_version
+        self.build_queries = []  # every preReleaseVersion.version filter tried
+        self.writes = []  # (method, path, body) for every mutating call
+
+    def __call__(self, method, path, **kw):
+        if method != "GET":
+            self.writes.append((method, path, kw.get("json")))
+
+        if path == "/v1/apps":
+            return Resp(payload={"data": [{"id": APP_ID}]})
+
+        if path == f"/v1/apps/{APP_ID}/betaGroups":
+            return Resp(payload={"data": [
+                {"id": gid, "attributes": {"name": name, "isInternalGroup": False,
+                                           "publicLinkEnabled": True}}
+                for gid, name in self.groups]})
+
+        if path == "/v1/builds":
+            asked = kw["params"]["filter[preReleaseVersion.version]"]
+            self.build_queries.append(asked)
+            if self.listed_version is not None and asked != self.listed_version:
+                return Resp(payload={"data": []})  # ASC lists it under the other spelling
+            state = self.build_states.pop(0) if self.build_states else "VALID"
+            if state is None:  # the build isn't listed yet
+                return Resp(payload={"data": []})
+            return Resp(payload={
+                "data": [{"id": BUILD_ID, "attributes": {"processingState": state}}],
+                "included": [{"type": "buildBetaDetails",
+                              "attributes": {"externalBuildState": self.external_state}}],
+            })
+
+        if path == f"/v1/builds/{BUILD_ID}/betaGroups":
+            return Resp(payload={"data": [{"id": g} for g in self.attached_groups]})
+
+        if path == "/v1/betaAppReviewSubmissions":
+            return Resp(status_code=self.review_status, payload={})
+
+        if path == "/v1/betaBuildLocalizations":
+            if method == "GET":
+                return Resp(payload={"data": [
+                    {"id": lid, "attributes": {"locale": loc}}
+                    for lid, loc in self.localizations]})
+            return Resp(status_code=201, payload={})
+
+        if path.startswith("/v1/betaBuildLocalizations/"):
+            return Resp(payload={})
+
+        if path == f"/v1/builds/{BUILD_ID}/relationships/betaGroups":
+            return Resp(status_code=204, payload={})
+
+        raise AssertionError(f"unstubbed request: {method} {path}")
+
+
+def run(fake, **env):
+    """Import the script fresh under `env` and run main() against `fake`.
+
+    Fresh because the script reads BETA_GROUPS / WHATS_NEW / DRY_RUN into module
+    constants at import, so a scenario that changes them needs a new module.
+    Returns (exit_code, fake).
+    """
+    base = {
+        "ASC_ISSUER_ID": "issuer", "ASC_KEY_ID": "key", "ASC_PRIVATE_KEY": "pem",
+        "BUNDLE_ID": "com.omnibus.mobile", "MARKETING_VERSION": "0.14.3",
+        "BUILD_NUMBER": "42", "BETA_GROUPS": GROUP_NAME, "WHATS_NEW": "",
+        "DRY_RUN": "0",
+    }
+    base.update(env)
+    saved = dict(os.environ)
+    os.environ.update(base)
+    try:
+        spec = importlib.util.spec_from_file_location("tf_distribute", SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.asc_raw = fake
+        mod.asc_jwt = lambda: "stub-token"
+        mod.POLL_SECS = 0  # the poll is the logic under test; the wait is not
+        try:
+            mod.main()
+            return 0, fake
+        except SystemExit as e:
+            return e.code or 0, fake
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def writes_to(fake, path_fragment):
+    return [w for w in fake.writes if path_fragment in w[1]]
+
+
+# A build that is still processing when first polled, then valid: the poll has
+# to survive both "not listed yet" and PROCESSING before it sees the build.
+code, fake = run(FakeASC([None, "PROCESSING", "VALID"]))
+check("happy path exits 0", 0, code)
+check("happy path submits for beta review", 1,
+      len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
+check("happy path attaches the group", 1,
+      len(writes_to(fake, "/relationships/betaGroups")))
+
+# Re-running the same distribution must not attach a second time.
+code, fake = run(FakeASC(["VALID"], external_state="IN_BETA_TESTING",
+                         attached_groups=[GROUP_ID]))
+check("re-run exits 0", 0, code)
+check("re-run does not re-attach an attached group", 0,
+      len(writes_to(fake, "/relationships/betaGroups")))
+check("re-run does not resubmit for review", 0,
+      len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
+
+# A build already awaiting review still needs attaching — the two are separate
+# facts, and treating "submitted" as "distributed" is the original bug.
+code, fake = run(FakeASC(["VALID"], external_state="WAITING_FOR_BETA_REVIEW"))
+check("awaiting-review build is still attached", 1,
+      len(writes_to(fake, "/relationships/betaGroups")))
+check("awaiting-review build is not resubmitted", 0,
+      len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
+
+# Apple answers 409 when a submission already exists; that is not a failure.
+code, _ = run(FakeASC(["VALID"], review_status=409))
+check("a 409 on review submission is tolerated", 0, code)
+
+# A group name that matches nothing must fail loudly rather than distribute to
+# no one and exit 0.
+code, fake = run(FakeASC(["VALID"], groups=[(GROUP_ID, "Some Other Group")]))
+check("unknown group name fails the run", 1, code)
+check("unknown group name writes nothing", 0, len(fake.writes))
+
+# States that can never reach an external tester.
+code, fake = run(FakeASC(["VALID"], external_state="MISSING_EXPORT_COMPLIANCE"))
+check("missing export compliance fails the run", 1, code)
+check("missing export compliance attaches nothing", 0, len(fake.writes))
+
+code, fake = run(FakeASC(["PROCESSING", "INVALID"]))
+check("an invalid build fails the run", 1, code)
+check("an invalid build attaches nothing", 0, len(fake.writes))
+
+# What to Test: update what exists, create only when there is nothing.
+code, fake = run(FakeASC(["VALID"], localizations=[("loc-1", "en-US")]),
+                 WHATS_NEW="Fixed the reader.")
+check("whats-new patches the existing localization", 1,
+      len(writes_to(fake, "/v1/betaBuildLocalizations/loc-1")))
+code, fake = run(FakeASC(["VALID"]), WHATS_NEW="Fixed the reader.")
+check("whats-new creates one when none exists", 1,
+      [w[0] for w in writes_to(fake, "/v1/betaBuildLocalizations")].count("POST"))
+code, fake = run(FakeASC(["VALID"], localizations=[("loc-1", "en-US")]))
+check("no whats-new leaves localizations alone", 0,
+      len(writes_to(fake, "betaBuildLocalizations")))
+
+# App Store Connect drops a trailing zero segment, so a build stamped 0.15.0 is
+# listed as 0.15. Matching only what was stamped would look identical to a build
+# still processing, and fail 30 minutes later for the wrong reason.
+code, fake = run(FakeASC(["VALID"], listed_version="0.15"), MARKETING_VERSION="0.15.0")
+check("a X.Y.0 release is found under its X.Y listing", 0, code)
+check("a X.Y.0 release is still attached", 1,
+      len(writes_to(fake, "/relationships/betaGroups")))
+check("both version spellings are tried", ["0.15.0", "0.15"], fake.build_queries)
+
+# The reverse spelling, and the ordinary case that must not grow a second query.
+code, fake = run(FakeASC(["VALID"], listed_version="0.15.0"), MARKETING_VERSION="0.15")
+check("a X.Y release is found under its X.Y.0 listing", 0, code)
+code, fake = run(FakeASC(["VALID"], listed_version="0.14.3"), MARKETING_VERSION="0.14.3")
+check("a patch release is queried once", ["0.14.3"], fake.build_queries)
+
+# Dry run resolves everything and writes nothing.
+code, fake = run(FakeASC(["VALID"]), DRY_RUN="1", WHATS_NEW="Fixed the reader.")
+check("dry run exits 0", 0, code)
+check("dry run writes nothing", 0, len(fake.writes))
+
+print("---")
+print(f"{pass_count} passed, {fail_count} failed")
+sys.exit(1 if fail_count else 0)

--- a/scripts/tests/testflight-distribute.test.py
+++ b/scripts/tests/testflight-distribute.test.py
@@ -144,11 +144,13 @@ def run(fake, **env):
     try:
         spec = importlib.util.spec_from_file_location("tf_distribute", SCRIPT)
         mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        mod.asc_raw = fake
-        mod.asc_jwt = lambda: "stub-token"
-        mod.POLL_SECS = 0  # the poll is the logic under test; the wait is not
         try:
+            # Inside the guard: bad settings are rejected at import, so this is
+            # where that exit surfaces.
+            spec.loader.exec_module(mod)
+            mod.asc_raw = fake
+            mod.asc_jwt = lambda: "stub-token"
+            mod.POLL_SECS = 0  # the poll is the logic under test; the wait is not
             mod.main()
             return 0, fake
         except SystemExit as e:
@@ -233,6 +235,13 @@ code, fake = run(FakeASC(["VALID"], listed_version="0.15.0"), MARKETING_VERSION=
 check("a X.Y release is found under its X.Y.0 listing", 0, code)
 code, fake = run(FakeASC(["VALID"], listed_version="0.14.3"), MARKETING_VERSION="0.14.3")
 check("a patch release is queried once", ["0.14.3"], fake.build_queries)
+
+# A typo'd setting must name itself, not open the Actions log on a traceback.
+code, fake = run(FakeASC(["VALID"]), PROCESSING_TIMEOUT_SECS="soon")
+check("a non-numeric timeout fails cleanly", 1, code)
+check("a non-numeric timeout writes nothing", 0, len(fake.writes))
+code, _ = run(FakeASC(["VALID"]), PROCESSING_TIMEOUT_SECS="60")
+check("a numeric timeout is accepted", 0, code)
 
 # Dry run resolves everything and writes nothing.
 code, fake = run(FakeASC(["VALID"]), DRY_RUN="1", WHATS_NEW="Fixed the reader.")


### PR DESCRIPTION
## Summary
- `altool --upload-app` only delivers the binary. An internal TestFlight group can be set to distribute automatically, but an **external** group cannot — so a build nobody explicitly attaches stays invisible to every tester on the public link while this workflow reports success. Adds a `distribute` job that closes that gap.
- `scripts/testflight_distribute.py` waits out processing, submits for Beta App Review when the build still needs it, optionally sets "What to Test", and attaches the build to each name in `BETA_GROUPS`. It runs on ubuntu because it is pure App Store Connect API, and reuses the existing team-scoped `ASC_*` secrets — no new secrets.
- Idempotent by construction: an already-attached group and an already-submitted review are both no-ops, so a re-run — or a retry after a half-finished run — attaches nothing twice.
- The build number moves up into the `version` job so the archive and the build lookup share one validated value, which also fails a malformed input in seconds rather than after a 20-minute macOS archive.
- A group name that matches nothing fails the job deliberately: distributing to no one and exiting 0 is the exact failure this job exists to prevent. Apple still gates the first build of each marketing version on Beta App Review, which requires Test Information to be complete in App Store Connect.

## Test plan
- [x] `scripts/tests/testflight-distribute.test.py` — 25 assertions passing. Covers the poll through PROCESSING, review submission vs. already-submitted vs. a tolerated 409, an idempotent re-run, an unknown group name, MISSING_EXPORT_COMPLIANCE, an INVALID build, What-to-Test create vs. patch, and dry run. It imports the real script and stubs only the HTTP primitive.
- [x] Every endpoint shape and filter name verified against fastlane's spaceship implementation rather than from memory — which caught that App Store Connect lists a `0.15.0` build under `0.15`, so both spellings are queried or a minor release would never be found.
- [x] Workflow YAML parses; job graph, outputs, and step env asserted.
- [ ] First real dispatch confirms the live path end to end.

## Version
- [ ] **Minor**
- [ ] **Patch**
- [x] **No release** — CI tooling only; no server, frontend, or app code changes.