### PR TITLE
chore: realistic exploration data and wider journal formatting

### DIFF
--- a/docs/qa/agentic_exploration/flows/adding_book.md
+++ b/docs/qa/agentic_exploration/flows/adding_book.md
@@ -56,8 +56,10 @@ goes in through the front door* in [start.md](../start.md).
    Three things to expect rather than report as bugs. The form may come back
    **entirely empty** — audiobooks often carry no container tags at all, and
    there is then nothing to review; fill in Title and Author yourself, since the
-   required-field guard will otherwise block the save. The **audiobook form has
-   no Series fields**, unlike the ebook one. And the form offers a single Author
+   required-field guard will otherwise block the save — with the book's *real*
+   title and author, read off the filename or folder, never a placeholder like
+   `Untitled` or `Test Audiobook`. The book stays in the shared library after
+   you leave. The **audiobook form has no Series fields**, unlike the ebook one. And the form offers a single Author
    field even when the file names several creators — check the detail page
    afterwards to see whether the others survived, and journal the answer.
 5. Click **Add to library**.

--- a/docs/qa/agentic_exploration/flows/adding_highlight.md
+++ b/docs/qa/agentic_exploration/flows/adding_highlight.md
@@ -16,9 +16,10 @@ must never affect what you see.
 1. While reading, select a passage — a sentence or two, not a single word and
    not a whole chapter.
 2. Save it as a highlight. Pick a colour if offered one.
-3. **Half the time, attach a note.** Write something a person would write, and
-   include a distinctive word so you can find it again later. Journal the exact
-   text.
+3. **Half the time, attach a note.** Write something a person would write — a
+   reaction, a question, a cross-reference — and work in a word you will
+   recognise again when you scan the list later. A memorable word, not a
+   generated token: no ids, no timestamps. Journal the exact text.
 4. Carry on reading for a page or two.
 5. Open the list of saved passages and confirm yours is there, with its colour
    and note intact.

--- a/docs/qa/agentic_exploration/flows/adding_journal.md
+++ b/docs/qa/agentic_exploration/flows/adding_journal.md
@@ -58,20 +58,25 @@ button too, and finding the button is itself worth doing sometimes.
 | `- item`, `1. item` | Bullet and numbered lists. |
 | `- [ ] task` | A checkbox. It is meant to be **read-only** — clicking it in a saved entry must do nothing. |
 | `[text](https://example.com)` | A link. |
-| `\|\|spoiler\|\|` | Hidden until revealed. The hint sits under the composer. |
 | a single newline | A visible line break, **not** a collapsed space. A blank line starts a new paragraph. Both must survive saving exactly as you typed them. |
 
-**On iOS, only the first four rows apply.** The iOS card renders the entry
-inline-only, so bold, italic, code, strikethrough and links come out formatted
-while headings, quotes, lists, checkboxes and spoilers stay on screen as the
-literal characters you typed. That is current behaviour on that surface, not a
-defect — do not report it. Everything below is a **web** criterion.
+Spoilers are the one syntax kept out of the table. Their markers are a pair of
+pipe characters, and a pipe inside a table cell has to be written escaped — so
+the raw text you are reading here would not be the text you should type. Wrap
+the hidden words in two pipes either side, as the hint under the composer
+shows.
+
+**iOS renders inline syntax only.** Bold, italic, inline code, strikethrough,
+links and line breaks come out formatted there; headings, quotes, lists,
+checkboxes and spoilers stay on screen as the literal characters you typed.
+That is current behaviour on that surface, not a defect — do not report it.
+Everything below is a **web** criterion.
 
 Two worth deliberately trying on web, because each has been wrong before:
 
 - **Spoilers are a button, not a blur.** Tab to it and press Enter — it should
-  reveal that way, not only on a mouse click. An unpaired trailing `||` is meant
-  to stay on screen as two literal pipes.
+  reveal that way, not only on a mouse click. A trailing pair with no closing
+  pair is meant to stay on screen as two literal pipes.
 - **Line breaks are load-bearing.** Type a three-line stanza with single
   newlines and confirm it saves as three lines. Collapsing them into one
   paragraph is a real defect, not a markdown nicety.

--- a/docs/qa/agentic_exploration/flows/adding_journal.md
+++ b/docs/qa/agentic_exploration/flows/adding_journal.md
@@ -20,41 +20,94 @@ your own entry appearing without the "you" marker.
 ## Steps
 
 1. From a book's detail page, find where entries about the book are written.
-2. Write something a person would write about a book — a paragraph, not a test
-   string. Include a **distinctive phrase** and journal it, so the audit can
-   match the entry later. Do **not** expect to find it via search: the command
-   palette's full-text section is marked "Coming soon" and journal text is not
-   indexed, so a search returning nothing is not a finding.
-3. Use at least one piece of formatting: bold, italic, a quote, or a list. Vary
-   which one across runs.
+2. Write something a person would write about a book — a paragraph of actual
+   opinion, not a test string, and **more than one paragraph at least half the
+   time**. Work in a **phrase you will recognise again** and journal it, so the
+   audit can match the entry later; a memorable phrase, never a generated token
+   (see *What you type into the app* in [start.md](../start.md)). Do **not**
+   expect to find it via search: the command palette's full-text section is
+   marked "Coming soon" and journal text is not indexed, so a search returning
+   nothing is not a finding.
+3. Use formatting, and **rotate which kind across runs** — the editor offers far
+   more than bold. Pick two or three from the table below rather than reaching
+   for bold every time.
 4. Occasionally embed an image. The corpus carries one beside most books —
    `cover.jpg`, in the same folder as the book file — and that is the one to
-   use; there is no separate image library.
+   use; there is no separate image library. Inserting one drops an
+   `Add a caption` placeholder in: **replace it with a real caption**, because
+   that text becomes the image's visible caption. Try it both ways across runs
+   — an image alone on its own line, and an image in the middle of a sentence —
+   they are meant to render differently.
 5. Save it, and confirm it renders — the formatting applied, the text intact.
 6. Come back later in the run, find it again, and confirm it is unchanged.
 7. Occasionally edit it and confirm the edit sticks; occasionally delete it and
    confirm it goes.
 
+## What to format with
+
+Rotate through these. The first column is what you type; several have a toolbar
+button too, and finding the button is itself worth doing sometimes.
+
+| | What it should do |
+|---|---|
+| `**bold**`, `*italic*` | The obvious two. There is **no underline** — if you find a control offering one, that is the finding. |
+| `~~struck through~~` | Renders struck through. |
+| `` `inline code` `` | Renders in a monospace font. |
+| `# Title`, `## Subtitle` | A heading, larger than body text. Only these two are decorated as you type; a deeper `### ` is still a heading once saved, and that difference is expected. |
+| `> a quoted line` | An indented quote. Saved passages inserted from the highlights picker arrive as one of these. |
+| `- item`, `1. item` | Bullet and numbered lists. |
+| `- [ ] task` | A checkbox. It is meant to be **read-only** — clicking it in a saved entry must do nothing. |
+| `[text](https://example.com)` | A link. |
+| `\|\|spoiler\|\|` | Hidden until revealed. The hint sits under the composer. |
+| a single newline | A visible line break, **not** a collapsed space. A blank line starts a new paragraph. Both must survive saving exactly as you typed them. |
+
+**On iOS, only the first four rows apply.** The iOS card renders the entry
+inline-only, so bold, italic, code, strikethrough and links come out formatted
+while headings, quotes, lists, checkboxes and spoilers stay on screen as the
+literal characters you typed. That is current behaviour on that surface, not a
+defect — do not report it. Everything below is a **web** criterion.
+
+Two worth deliberately trying on web, because each has been wrong before:
+
+- **Spoilers are a button, not a blur.** Tab to it and press Enter — it should
+  reveal that way, not only on a mouse click. An unpaired trailing `||` is meant
+  to stay on screen as two literal pipes.
+- **Line breaks are load-bearing.** Type a three-line stanza with single
+  newlines and confirm it saves as three lines. Collapsing them into one
+  paragraph is a real defect, not a markdown nicety.
+
 ## Journal
 
 `journal.create` with the uuid and the **verbatim text you typed**, including
-the markup. `journal.update` with before and after. `journal.delete` with the
-distinctive phrase, so the audit can tell a deliberate delete from a loss.
+the markup. `journal.update` with before and after. `journal.delete` with the phrase you
+chose, so the audit can tell a deliberate delete from a loss.
 
 ## Pass
 
 - The entry saves and appears without a reload.
-- Formatting renders as formatting, not as visible markup characters.
-- An embedded image displays.
+- In the **saved** entry, formatting renders as formatting rather than as
+  visible markup characters (subject to the iOS caveat above).
+- Line breaks and paragraph breaks survive exactly as you typed them.
+- On web, a spoiler is hidden until revealed, and reveals from the keyboard as
+  well as the mouse.
+- On web, a checkbox from a `- [ ]` line is inert.
+- An embedded image displays, and a caption you wrote appears with it.
 - The text is exactly what you typed — no truncation, no escaped characters
   where there should be none.
 - It is still there, unchanged, when you come back.
 
 ## Fail
 
-- The entry saves but shows raw markup, or renders the wrong formatting.
+- The **saved** entry shows raw markup, or renders the wrong formatting. (The
+  composer is a different matter — see *Sharp edges*.)
+- Multiple lines collapse into one paragraph, or a blank line is swallowed.
+- **On web**, a spoiler renders as literal `||` pipes, or reveals its text
+  before it is activated.
+- **On web**, a checkbox is clickable, or a heading renders at body size.
+  (On iOS both are expected to be literal text — see above.)
 - Text is truncated, reordered, or has characters mangled.
-- An image uploads but does not display, or displays on another entry.
+- An image uploads but does not display, displays on another entry, or keeps the
+  `Add a caption` placeholder as its caption after you replaced it.
 - The entry attaches to the wrong book.
 - An entry is attributed to the wrong reader, or your own entry renders without
   the "you" marker. (Merely *seeing* another reader's entry is expected — the
@@ -63,6 +116,11 @@ distinctive phrase, so the audit can tell a deliberate delete from a loss.
 
 ## Sharp edges
 
+- **The composer shows markdown characters on purpose.** It is a live editor,
+  not a preview: the `**` and `> ` stay in the text and fade out except on the
+  line your caret is on. Seeing them while writing is correct, and only the
+  **saved** entry is judged on rendering. Use the **Preview** tab if you want to
+  see it rendered before publishing.
 - On iOS an entry may briefly show its markdown source before the server
   returns the rendered version. That is deliberate — the client will not guess
   at rendering it locally. Only a source view that **persists** is a finding.

--- a/docs/qa/agentic_exploration/flows/creating_a_shelf.md
+++ b/docs/qa/agentic_exploration/flows/creating_a_shelf.md
@@ -28,7 +28,10 @@ selects, and end the flow — do not go looking.
 1. Go to the library. The shelves rail sits above the book list, starting with
    **All Books**.
 2. Click **＋ New shelf**.
-3. Name it something clearly yours, including your actor id.
+3. Name it the way a reader would name a shelf — *Weeknight Reading*, *Books
+   Dad Lent Me*, *Finish Before Winter*. Not your actor id, not a date, not
+   `test`. Journal the name you chose; that is what the audit matches on, so
+   the two must agree exactly. Do not reuse a name you have already used.
 4. Choose its visibility — **Private** or **Public** — and note whether you are
    making a hand-picked shelf or a **Smart** one (a smart shelf fills itself
    from a rule; a hand-picked one does not).

--- a/docs/qa/agentic_exploration/flows/editing_metadata.md
+++ b/docs/qa/agentic_exploration/flows/editing_metadata.md
@@ -22,10 +22,9 @@ content.
 2. Read the current values before changing anything, and journal them.
 3. Change one or two fields. Good candidates: subtitle, series name or number,
    publisher, tags, genres, description. Make it a **plausible** value — a real
-   publisher, a genre the book could actually be — and append rather than
-   replace where a field already has content: adding `Modern Library` to an
-   empty publisher, or a `maritime` tag beside the existing ones, beats
-   overwriting what is there.
+   publisher, a genre the book could actually be. Fill a field that is empty;
+   where one already has content, add to it rather than replacing it — a
+   `maritime` tag beside the existing tags, not instead of them.
 
    Do **not** sign your edit. A title reading `Foo (ed. agent-3)` is
    library-wide and permanent — every reader sees it, on a book nobody owns —

--- a/docs/qa/agentic_exploration/flows/editing_metadata.md
+++ b/docs/qa/agentic_exploration/flows/editing_metadata.md
@@ -20,9 +20,17 @@ content.
 
 1. From a book's detail page, open its metadata editor.
 2. Read the current values before changing anything, and journal them.
-3. Change one or two fields. Good candidates: title suffix, subtitle, series
-   name or number, publisher, tags, genres, description. Append rather than
-   replace where you can — `Foo (ed. agent-3)` beats overwriting `Foo`.
+3. Change one or two fields. Good candidates: subtitle, series name or number,
+   publisher, tags, genres, description. Make it a **plausible** value — a real
+   publisher, a genre the book could actually be — and append rather than
+   replace where a field already has content: adding `Modern Library` to an
+   empty publisher, or a `maritime` tag beside the existing ones, beats
+   overwriting what is there.
+
+   Do **not** sign your edit. A title reading `Foo (ed. agent-3)` is
+   library-wide and permanent — every reader sees it, on a book nobody owns —
+   and your journal entry already records that you made the change. See *What
+   you type into the app* in [start.md](../start.md).
 4. Occasionally replace the cover image instead. Use **that book's own**
    `cover.jpg` sidecar from the corpus — another book's cover would make the
    shared library worse, which this flow tells you not to do. Note that the

--- a/docs/qa/agentic_exploration/flows/updating_profile.md
+++ b/docs/qa/agentic_exploration/flows/updating_profile.md
@@ -17,8 +17,11 @@ never change anyone's permissions, and never delete a user.
 ## Steps
 
 1. Go to your account page.
-2. Change your display name to something clearly yours and clearly new —
-   include your actor id and a counter, so a stale copy elsewhere is obvious.
+2. Change your display name to a **different plausible person's name** — not
+   your actor id, not a counter, not a date. A stale copy elsewhere is just as
+   obvious when the chrome still says `Mara Ellison` after you saved
+   `Ada Whitfield`, and the name is displayed all over the app and copied into
+   your wishlist shelf's name, so it needs to read like a person's.
 3. Save, and confirm the new name appears in the app's own chrome — wherever
    your name is shown while you are signed in.
 4. Occasionally replace your picture instead, and confirm it appears everywhere

--- a/docs/qa/agentic_exploration/start.md
+++ b/docs/qa/agentic_exploration/start.md
@@ -30,7 +30,7 @@ exercise is entirely in the paths a spec author would never have thought to
 write down, so if a flow says "browse for a while", browse for a while rather
 than firing the minimum number of clicks that satisfies the wording.
 
-Two things follow from that:
+Three things follow from that:
 
 - **You navigate by clicking, never by typing.** See *Getting around* below.
   This is a rule, not a preference.
@@ -38,6 +38,39 @@ Two things follow from that:
   or test id, deliberately. If you cannot find the control a flow describes,
   that is a candidate finding — journal it as `uncertain` and say what you
   looked for.
+- **What you type is what a person would type.** See *What you type into the
+  app* below. Also a rule.
+
+## What you type into the app
+
+Everything you type into a field is data somebody reads later, in a shared
+library that outlives the run. Shelf names, display names, metadata edits,
+bookmark labels, highlight notes, journal entries — all of it persists, and
+all of it is visible to every other reader.
+
+So write what a person would write. **Never type an identifier into a field
+the app displays**: no uuids, no ISO timestamps or long date strings, no run
+ids, no actor ids, no counters, no `test` / `foo` / `asdf`. A shelf called
+`agent-3-shelf-2026-08-26T14:02:09Z` tests nothing a reader will ever do, and
+everyone else is left looking at it.
+
+**Traceability is the journal's job, not the data's.** Every line you write
+already carries `run`, `actor`, `ts`, and the values in `params` — stamping the
+data as well buys nothing. Uuids still belong in the journal's `target` field,
+in full; that rule is unchanged. They do not belong in anything the app renders.
+
+Where a flow needs one value to be tellable from another — a stale copy, a
+before and an after — vary it *realistically*. A display name going from
+`Mara Ellison` to `Mara Ellison-Reyes` proves a stale copy exactly as well as a
+counter does, and reads like a person changing their name.
+
+Two practical limits:
+
+- **Memorable, not unique.** Where a flow asks for something distinctive so you
+  can find it again, it means a phrase you will recognise on sight — the bit
+  about the lighthouse — not a generated token.
+- **Do not reuse a name you have already used** for the same kind of thing. The
+  audit reports two shelves sharing one name as a duplicate finding.
 
 ## Getting around
 


### PR DESCRIPTION
## Summary
- Three exploration flows told agents to stamp identifiers into data every reader sees: shelf names carried the actor id, metadata edits were signed `Foo (ed. agent-3)`, and display names carried an actor id plus a counter. Each is now realistic guidance, backed by a new *What you type into the app* rule in `start.md` that bans uuids, ISO timestamps, run/actor ids, counters and `test`/`foo` placeholders from any field the app displays.
- None of that marking was load-bearing: the audit matches shelves on the journalled name (`_check_shelf` in `scripts/explore/audit_lib/compare.py`) and never reads display names at all, so attribution stays where it already lived — the journal's `run`/`actor`/`ts`/`params`, not the library.
- `adding_journal` asked for one of bold/italic/quote/list, roughly a third of what the live editor and `db/src/journals/markdown.rs` actually support. It now carries a rotation table covering strikethrough, inline code, headings, links, task lists, spoilers and hard line breaks, with Pass/Fail criteria for each.
- Those new criteria are scoped to **web** on purpose: the iOS card renders `bodyMd` with `interpretedSyntax: .inlineOnlyPreservingWhitespace`, so block syntax and spoilers stay literal there and would otherwise be reported as defects.

## Test plan
- [x] N/A — docs only.

## Version
- [x] **No release** — `no release` label applied; the diff is confined to `docs/`.

## Notes
- The composer legitimately shows `**` and `> ` while you type (markers fade off the caret's line), which collides with the flow's "shows raw markup" fail criterion. Added as a *Sharp edges* bullet so the wider formatting guidance doesn't manufacture false findings.
- The `pitfalls.md` journal entries are deliberately untouched: [#2269](https://github.com/seamus-sloan/omnibus/issues/2269) (Cmd/Ctrl+End) is still open, and the `locator.fill()` newline-stripping is Chromium's `execCommand("insertText")` behaviour rather than an app bug, so both remain accurate.