### PR TITLE
[OMNI-2296] Flow Catalog Corrections From Run r-20260828-03

### DIFF
--- a/docs/qa/agentic_exploration/flows/browsing_book_details.md
+++ b/docs/qa/agentic_exploration/flows/browsing_book_details.md
@@ -14,6 +14,16 @@ turn up something cosmetic that no assertion would catch.
 ## Steps
 
 1. Reach a book's detail page from wherever you happen to be.
+
+   **In the library's table view, click the book's cover.** The row carries
+   `role="button"` and an `aria-label` of "Open details for …", so it reads
+   like the whole row is the target — but most of its cells (title, author,
+   series, tags, genres, published, language) are inline editors that swallow
+   the click and open themselves instead. Only the cells with no editor behind
+   them — **cover**, formats, and the two date columns — let the click through
+   to the navigation. Clicking a title and landing in an edit box is the table
+   working as designed; it is **not** a broken row, and must not be journalled
+   as one. In grid view, click the tile.
 2. Actually read the page. Cover, title, author, series, description, formats,
    dates, identifiers, tags, genres, ratings, saved passages, suggestions.
    There is **no page or chapter count** on this page — do not go looking for

--- a/docs/qa/agentic_exploration/flows/creating_a_shelf.md
+++ b/docs/qa/agentic_exploration/flows/creating_a_shelf.md
@@ -23,11 +23,32 @@ current design, not a bug, and **you must not spend the flow hunting for a
 control that does not exist.** If you are on web, create the shelf, confirm it
 selects, and end the flow — do not go looking.
 
+**On iOS, membership is where the web's missing control went.** You are the
+agent expected to fill a shelf, so here is exactly where it lives:
+
+- Shelves are at **You → Shelves**, a grid of shelf cards — not a rail above
+  the library, and not on the Library tab at all.
+- **Create** with the `+` in the navigation bar of that Shelves screen.
+- **Open** a shelf by tapping its card; it *pushes its own screen*. It does not
+  filter the library, and there is no "All Books" to go back to — you leave a
+  shelf with the back button.
+- **Add** books with the `+` in that shelf screen's navigation bar, or with the
+  **Add the first book** button an empty hand-picked shelf offers in its place.
+- **Remove** a book by **long-pressing its tile** on the shelf screen and
+  choosing **Remove from shelf**. There is no visible remove button; the
+  context menu is the whole control, and it appears only on hand-picked
+  shelves — a Smart shelf's tiles do not offer it, correctly.
+
 ## Steps
 
-1. Go to the library. The shelves rail sits above the book list, starting with
-   **All Books**.
-2. Click **＋ New shelf**.
+Steps 1–2 and 6–8 below describe **the web surface**. The iOS equivalent of
+each is in the box above; take that path instead, and do not report the web
+control as missing when you are on iOS.
+
+1. **(web)** Go to the library. The shelves rail sits above the book list,
+   starting with **All Books**. **(iOS)** Go to **You → Shelves**.
+2. **(web)** Click **＋ New shelf**. **(iOS)** Tap the `+` in the Shelves
+   navigation bar.
 3. Name it the way a reader would name a shelf — *Weeknight Reading*, *Books
    Dad Lent Me*, *Finish Before Winter*. Not your actor id, not a date, not
    `test`. Journal the name you chose; that is what the audit matches on, so
@@ -35,15 +56,30 @@ selects, and end the flow — do not go looking.
 4. Choose its visibility — **Private** or **Public** — and note whether you are
    making a hand-picked shelf or a **Smart** one (a smart shelf fills itself
    from a rule; a hand-picked one does not).
+
+   **iOS only shows you back a *public* choice.** The shelf screen's meta line
+   reads "N books · Manual · Public", and a private shelf simply omits that
+   last part — there is no "Private" label anywhere. So on iOS you can confirm
+   Public directly and Private only by the absence of the marker. If you want
+   the visibility you chose to be checkable at all on that surface, choose
+   **Public**; if you choose Private, journal the choice and record the
+   confirmation as `uncertain` rather than claiming the app agreed with you.
 5. Click **Create**.
-6. Confirm it appears in the rail, with the name, visibility, and kind you
-   chose.
-7. Select it and confirm the library narrows to it. A brand-new hand-picked
-   shelf will be empty, and its count should say so.
-8. Select **All Books** again and confirm the full library comes back.
-9. Reload and confirm the shelf is still there.
-10. **On iOS only:** open the shelf's own screen, add two or three books, and
-    confirm they appear. Then remove one and confirm it leaves the shelf but
+6. **(web)** Confirm it appears in the rail, with the name, visibility, and kind
+   you chose. **(iOS)** Confirm the card appears on the Shelves grid; open it
+   and read the name and meta line on its own screen.
+7. **(web only)** Select it and confirm the library narrows to it. A brand-new
+   hand-picked shelf will be empty, and its count should say so. **This step
+   does not exist on iOS** — tapping a shelf there pushes its own screen rather
+   than filtering anything, so open it and confirm it is empty instead.
+8. **(web only)** Select **All Books** again and confirm the full library comes
+   back. **There is no All Books on iOS**; back out of the shelf screen instead
+   and confirm the library is untouched.
+9. Reload and confirm the shelf is still there. **(iOS)** Pull to refresh —
+   both the Shelves grid and a shelf's own screen support it.
+10. **On iOS only:** on the shelf's own screen, add two or three books with the
+    `+` (or **Add the first book**), and confirm they appear. Then long-press
+    one, choose **Remove from shelf**, and confirm it leaves the shelf but
     **not** the library.
 
 ## Journal
@@ -54,10 +90,17 @@ the book uuids — those are what the audit reconciles.
 
 ## Pass
 
-- The shelf is created with the name, visibility, and kind you chose.
-- It appears in the rail and survives a reload.
-- Selecting it narrows the library; the count matches what is shown.
-- Selecting All Books restores the full library.
+- The shelf is created with the name and kind you chose — and with the
+  visibility you chose, **on web, and on iOS only when you chose Public**
+  (see step 4; a private shelf is unlabelled there and the criterion is
+  `uncertain`, not a fail).
+- It appears — in the web rail, or on the iOS Shelves grid — and survives a
+  reload.
+- **(web only)** Selecting it narrows the library; the count matches what is
+  shown.
+- **(web only)** Selecting All Books restores the full library.
+- **(iOS)** In place of those two: tapping the shelf pushes its own screen,
+  and that screen lists exactly the shelf's books.
 - On iOS, added books appear and a removed book leaves the shelf but stays in
   the library.
 
@@ -79,7 +122,8 @@ the book uuids — those are what the audit reconciles.
 ## Sharp edges
 
 - **Choosing a shelf on the web filters in place** — the address does not
-  change. Correct.
+  change. Correct. **On iOS it navigates instead**, to the shelf's own screen.
+  The two surfaces genuinely differ here; neither is the other one broken.
 - A **Smart** shelf fills by rule, so being unable to add a book to it by hand
   is correct on every surface.
 - Your display name is denormalised into the wishlist shelf's name. It has been

--- a/docs/qa/agentic_exploration/flows/sorting_the_library.md
+++ b/docs/qa/agentic_exploration/flows/sorting_the_library.md
@@ -22,11 +22,34 @@ there are fewer, journal that and end the flow `uncertain`.
 1. Go to the library from the nav.
 2. Note the current sort and write down the first several titles **and** their
    authors, exactly as displayed.
-3. Change the sort with the **Sort by** control. The axes are **Title**,
-   **Author**, **Added**, **Published**, and **Recently Interacted**.
+3. Change the sort. The axes are **Title**, **Author**, **Series**, **Recently
+   Interacted**, **Last Updated**, and **Newest Added** — those six, and no
+   others. There is no sort on publication date: **Published** is a table
+   column with no control behind it, so do not go looking for one and do not
+   report its absence as a defect.
+
+   **The control is not the same in both views, and neither is the reach.** In
+   **grid** view there is a **Sort by** select carrying all six axes, with a
+   direction toggle beside it. In **table** view that select is not in the DOM
+   at all — you sort by clicking a **column header**, and click the same header
+   again to reverse. An agent in table view hunting for "Sort by" will correctly
+   fail to find it; that is the view, not a missing control.
+
+   Two consequences worth knowing before you report anything. Only five of the
+   axes have a sortable header — **Recently Interacted has no column**, so it is
+   reachable from the grid alone; do not call it missing from the table. And the
+   header for **Newest Added** is labelled just **Added**. Same axis, two names;
+   that is not two different sorts disagreeing.
 4. **Read the rows and check them yourself.** Do not trust the control's label —
-   walk down the visible list and confirm it really is ordered on the field you
-   chose, using the values the page is *showing you*.
+   walk the list and confirm it really is ordered on the field you chose, using
+   the values the page is *showing you*.
+
+   **Read the whole list, not the first screenful.** The Author-sort defect
+   this step exists to catch does not show up at the top: the first five rows
+   look correctly ordered and the break comes further down. So when the head
+   looks right and something later looks wrong, the *entire list* is your
+   evidence base — the break is only provable by reading every row and testing
+   what key would actually produce the order you got.
 5. Flip the sort direction and confirm the order reverses.
 6. Switch between the **table** and **grid** views and confirm the same books
    appear in the same order in both.
@@ -38,7 +61,9 @@ there are fewer, journal that and end the flow `uncertain`.
 
 `library.sort` with the old and new sort key and direction, plus **the first
 five titles with their authors** under each. That list is the whole evidence
-base — a sort finding is unprovable without the before and after.
+base — a sort finding is unprovable without the before and after. If you are
+reporting an order that breaks partway down, journal the rows on either side of
+the break as well; five rows from the top do not show it.
 `library.view` on a table/grid switch.
 
 ## Pass
@@ -63,5 +88,5 @@ base — a sort finding is unprovable without the before and after.
   seeing different orders under it is expected; do not report it.
 - Books added by others mid-flow will change counts underneath you. Re-read the
   count rather than trusting one from a minute ago.
-- Missing values (no publication date, no series) have to sort somewhere.
+- Missing values (no series, no interaction yet) have to sort somewhere.
   Consistently first or last is fine; scattered is not.

--- a/docs/qa/agentic_exploration/ios_lane.md
+++ b/docs/qa/agentic_exploration/ios_lane.md
@@ -67,10 +67,28 @@ not observable from the web surface.
    to and note what it currently shows: position, read status, rating,
    highlights, bookmarks, journal entries. Journal that as your baseline; the
    audit compares against it.
+
+   **Then download it, while you still can.** The reader serves the downloaded
+   file when there is one and otherwise fetches the book over `/api/*` — which
+   is exactly the client the offline switch fails. A book you did not download
+   cannot be opened offline at all, so an agent who skips this reaches step 3
+   with nothing on the device and no way to perform it. Use the book detail
+   screen's **Download** control and wait for it to finish before you flip the
+   switch; a download started *after* going offline is the case the switch
+   deliberately does not cover.
 2. **Go offline** (`ios.sh offline on`) and confirm the app says so — an
-   "Offline" pill appears in the masthead.
+   "Offline" pill appears in the **Library tab's** masthead.
+
+   **That pill lives on the Library tab and nowhere else.** The You tab, the
+   book detail screen and the reader show no connectivity indicator of any
+   kind, so an agent checking from one of those sees nothing and concludes the
+   switch failed. Go to Library to read the pill — and either way, believe
+   `ios.sh state` over the screen.
 3. **Write, as a reader would.** Read a few pages and let the position move.
-   Save a highlight. Save a bookmark in an audiobook. Write a journal entry.
+   Save a highlight. Save a bookmark — the EPUB reader has an **Add bookmark**
+   control and so does the audiobook player, and they write the same model
+   through the same endpoint, so use whichever reader you already have open.
+   Write a journal entry.
    Add a book to a shelf. Not all of them every time — pick two or three and
    do them properly.
 4. **Look at what you wrote.** Every one of them must be visible in the app
@@ -81,8 +99,15 @@ not observable from the web surface.
    "Offline · N queued" and N should match. Journal the queue.
 6. **Kill and relaunch** (`ios.sh relaunch`). The queue must survive, still
    offline, still N. A write that vanishes here was never durable.
-7. **Come back** (`ios.sh offline off`). The pill turns to "Syncing", then
+7. **Come back** (`ios.sh offline off`). The pill turns to "Syncing N", then
    goes.
+
+   **Not seeing "Syncing" is not a failure.** The pill shows that state only
+   while writes are still in flight, and a handful of queued mutations drains
+   in a couple of seconds — under ~25s in every run so far, and often far
+   less. Missing the window means the drain was fast, not that it did not
+   happen. Step 8 is what proves the drain; the pill is a courtesy. Only an
+   `outbox` that stays non-empty is a finding.
 8. **Verify on the server.** Reopen the book and check every write you made is
    there, once. Then check `ios.sh outbox` is empty.
 
@@ -144,9 +169,15 @@ value it is indistinguishable from a write another agent happened to make.
 - Positions coalesce **on purpose**: reading for five minutes offline queues
   one position, not fifty, and the server should end up at the last one. One
   queued position for one book is correct, not a lost write.
-- The reader and the player write read status on their own — opening a book
-  marks it `reading`, finishing marks it `finished`. Do not journal that as a
-  write you made, and do not call it unexpected when the audit sees it.
+- The reader and the player are *meant* to write read status on their own —
+  opening a book marks it `reading`, finishing marks it `finished`. Where it
+  happens, do not journal it as a write you made, and do not call it unexpected
+  when the audit sees it. **On this surface it currently does not happen**
+  (#2289): a book read in the native reader comes back with no read status at
+  all, while the Library's continue card still shows it as Reading. Treat an
+  unchanged status on iOS as that known bug rather than a fresh finding, and do
+  not lean on the transition to set up a status you need — set it by hand from
+  the detail screen's status control.
 - A drained position answer can come back *different* from what you sent. The
   server resolves position conflicts, so another device's newer position
   winning is correct behaviour.

--- a/docs/qa/agentic_exploration/pitfalls.md
+++ b/docs/qa/agentic_exploration/pitfalls.md
@@ -76,9 +76,14 @@ Each of these was nearly filed as a defect by an agent that checked first.
 
 Each of these is intended, and each has been mistaken for a defect before:
 
-- **Opening a reader or starting a player changes your read status by itself.**
-  Unread becomes reading on open; reaching the end marks finished. You did not
-  do that, and it is not a bug.
+- **Opening a reader or starting a player changes your read status by itself —
+  on the web.** Unread becomes reading on open; reaching the end marks
+  finished. You did not do that, and it is not a bug. **This does not currently
+  hold on the iOS native reader** (#2289): a book read there comes back with no
+  read status at all, while the Library's continue card still shows it as
+  Reading, so the two surfaces disagree. On iOS, treat an unchanged status as
+  that known bug rather than a new finding — and do not rely on the transition
+  to put a book into a status you need, because it will not.
 - **Read status filters the continue surface** on the home page. A book you
   just marked finished vanishing from it is correct.
 - **The continue surface is an overlapping fan**, not a carousel — cards sit on


### PR DESCRIPTION
## Summary
- Corrects five documents in the exploration flow catalog that each sent an agent to a control that does not exist, stated a pass criterion the named surface cannot evaluate, or omitted a precondition the flow depends on. Every claim was re-verified against the current code rather than taken from the issue body, and three of the issue's own statements needed adjusting as a result (below).
- `sorting_the_library.md` — names the six axes the app actually offers (Title, Author, Series, Recently Interacted, Last Updated, Newest Added), retires the non-existent Published sort, and splits the control by view: a **Sort by** select in grid, column headers in table. Adds that Recently Interacted has no table header and that Newest Added's header reads just "Added", so neither reads as a missing or a disagreeing sort.
- `browsing_book_details.md` — documents the cover as the library table's click target, and why: the row does navigate, but its title/author/series/tags/genres/published/language cells are inline editors that swallow the click, leaving cover, formats and the date columns as the only cells that reach it.
- `ios_lane.md` — adds the download precondition to step 1 (the reader falls back to `/api/*`, which is exactly what the offline switch fails, so an undownloaded book cannot be opened offline at all), scopes the Offline pill to the Library tab masthead, says a missed "Syncing" state is a fast drain rather than a failure, and points step 3's bookmark at whichever reader is already open since both write the same model through one endpoint.
- `creating_a_shelf.md` — gives the iOS surface for every step that sends an iOS agent somewhere (You → Shelves, `+` in the nav bar, a pushed shelf screen, long-press → "Remove from shelf", "Add the first book" / `+`), and marks the two filter-the-library pass criteria web-only.
- `pitfalls.md` — qualifies the read-status auto-transition as web-only in practice, pointing at #2289 for the iOS gap.

Closes #2296

## Test plan
- [ ] N/A — docs only.

## Version
- [x] **No release** — unlabeled docs-only diff skips the release automatically.

## Notes
- Three of the issue's claims were adjusted after checking the code. iOS **does** show visibility, but only for a public shelf (`ShelvesViews.metaLine` appends "Public"; private is unlabelled) — so the doc scopes the criterion to Public and calls Private `uncertain` rather than saying visibility is never shown. The table row is **not** unresponsive — it navigates from any non-editable cell — so the doc explains the swallowed click rather than describing a broken row. And the iOS read-status transition is **intended and implemented** (`Reader/ReadStatusAuto.swift`, landed in #1604/#1624), so both docs frame it as a live bug under #2289 rather than a web-only design.
- `ios_lane.md` carried the same unqualified read-status claim as `pitfalls.md`, aimed squarely at the one agent it misleads; it is corrected here too. `.claude/rules/04-playwright.md` states it universally as well, but that file is #2289's AC4 and outside this docs-only change, so it is deliberately left alone.