### PR TITLE
[OMNI-2280] Check-In, Wishlist, and Physical Collection MCP Tools

### DIFF
--- a/mcp/src/client.rs
+++ b/mcp/src/client.rs
@@ -1,10 +1,13 @@
 //! Authenticated HTTP client for one Omnibus instance. Logs in over
-//! `POST /api/auth/login` for a bearer token, sends every read as a `GET`
-//! with that token, and re-logs-in transparently when a session idle-expires
-//! mid-run (7 days of inactivity — `SESSION_IDLE_TIMEOUT_SECS`). The password
-//! and token are held in memory and never logged.
+//! `POST /api/auth/login` for a bearer token, sends reads as `GET`s and the
+//! allowlisted writes with that token, and re-logs-in transparently when a
+//! session idle-expires mid-run (7 days of inactivity —
+//! `SESSION_IDLE_TIMEOUT_SECS`). The password and token are held in memory
+//! and never logged.
 
+use reqwest::Method;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use tokio::sync::{Mutex, RwLock};
 
 use omnibus_shared::{LoginRequest, LoginResponse};
@@ -20,10 +23,64 @@ use crate::config::Config;
 /// lands here as it ships. **Instance configuration** (`/api/settings`, API
 /// keys, SMTP, registration) and **commands** (`/api/reindex`,
 /// `/api/scan-library`, `/api/fts/rebuild`, `/api/kindle/send`) are never
-/// added. Enforcement matches the statement: [`OmnibusClient`]'s public
-/// surface builds only `GET` requests, and the one `POST` lives in the
-/// private `login` path below.
-pub const WRITE_ALLOWLIST: &[&str] = &["POST /api/auth/login"];
+/// added. Enforcement matches the statement: [`OmnibusClient`]'s public read
+/// surface builds only `GET` requests, and every non-`GET` routes through
+/// [`OmnibusClient::write_json`] / [`OmnibusClient::write_no_content`], which
+/// assert membership here (a `{param}` segment matches any single path
+/// segment) — a request outside the list is a bug in this crate and fails
+/// loudly before it reaches the instance.
+pub const WRITE_ALLOWLIST: &[&str] = &[
+    // The session itself (the one write the read-only crate shipped with).
+    "POST /api/auth/login",
+    // Reads wearing POST: the scan lookup ladder takes its argument in a
+    // JSON body, but none of these three mutates anything — resolve answers
+    // for one ISBN, search for a title query, resolve-meta for a picked
+    // search candidate.
+    "POST /api/scan/resolve",
+    "POST /api/scan/search",
+    "POST /api/scan/resolve-meta",
+    // Content state (rule 08 tier 3): which physical copies the household
+    // owns. Library-wide like a digital file, and an assertion ("we own this
+    // copy"), not a command. Check-in also binds the ISBN to the book on the
+    // exact-identifier rung, which is why the tool is confirm-gated.
+    "POST /api/scan/check-in",
+    "PATCH /api/physical/copies/{copy_id}",
+    "DELETE /api/physical/copies/{copy_id}",
+    // Content state (rule 08 tier 3): the caller's own wishlist rows. The
+    // scan-flow add covers both a library book (by uuid) and a fileless book
+    // from external meta; the remove is the per-book detail route.
+    "POST /api/scan/wishlist",
+    "DELETE /api/physical/{uuid}/wishlist",
+];
+
+/// True when `method path` is covered by [`WRITE_ALLOWLIST`]. A `{param}`
+/// segment in an entry matches exactly one non-empty path segment.
+fn write_allowlisted(method: &Method, path: &str) -> bool {
+    WRITE_ALLOWLIST.iter().any(|entry| {
+        entry
+            .split_once(' ')
+            .is_some_and(|(m, pattern)| m == method.as_str() && path_matches(pattern, path))
+    })
+}
+
+/// Segment-wise match of a concrete request path against an allowlist
+/// pattern, treating `{param}` segments as single-segment wildcards.
+fn path_matches(pattern: &str, path: &str) -> bool {
+    let mut pattern = pattern.split('/');
+    let mut path = path.split('/');
+    loop {
+        match (pattern.next(), path.next()) {
+            (None, None) => return true,
+            (Some(p), Some(s)) if p.starts_with('{') && p.ends_with('}') => {
+                if s.is_empty() {
+                    return false;
+                }
+            }
+            (Some(p), Some(s)) if p == s => {}
+            _ => return false,
+        }
+    }
+}
 
 /// `User-Agent` on every request, so MCP traffic is separable from web and
 /// iOS traffic in the instance's request log.
@@ -56,6 +113,17 @@ pub enum ClientError {
     /// already retried through.
     #[error("GET {path} failed: server answered HTTP {status}")]
     Status { path: String, status: u16 },
+    /// An allowlisted write (or a lookup the API models as `POST`) returned a
+    /// non-success status. Carries the server's plain-text error body — the
+    /// actionable detail (a 400's validation message, a 403's missing
+    /// permission) that tools surface instead of an opaque status code.
+    #[error("{method} {path} failed: server answered HTTP {status}: {message}")]
+    WriteStatus {
+        method: String,
+        path: String,
+        status: u16,
+        message: String,
+    },
     /// The response body did not match the `omnibus_shared` wire type — the
     /// drift signal this crate exists to surface loudly.
     #[error("GET {path} did not match the expected wire shape: {message}")]
@@ -230,6 +298,103 @@ impl OmnibusClient {
             Err(ClientError::Status { status: 404, .. }) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    async fn send_write<B: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+        token: &str,
+    ) -> Result<reqwest::Response, ClientError> {
+        let mut req = self
+            .http
+            .request(method, format!("{}{path}", self.base_url))
+            .bearer_auth(token);
+        if let Some(body) = body {
+            req = req.json(body);
+        }
+        Ok(req.send().await?)
+    }
+
+    /// `method path`, re-logging-in transparently on a 401 (same contract as
+    /// [`Self::get_with_relogin`]). Panics when the request is not covered by
+    /// [`WRITE_ALLOWLIST`] — that is a bug in this crate, and failing loudly
+    /// beats letting an unvetted write reach the instance.
+    async fn write_with_relogin<B: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<reqwest::Response, ClientError> {
+        assert!(
+            write_allowlisted(&method, path),
+            "{method} {path} is not in WRITE_ALLOWLIST"
+        );
+        let token = self.bearer().await?;
+        let resp = self.send_write(method.clone(), path, body, &token).await?;
+        if resp.status() != reqwest::StatusCode::UNAUTHORIZED {
+            return Ok(resp);
+        }
+        let token = self.login_once(Some(&token)).await?;
+        self.send_write(method, path, body, &token).await
+    }
+
+    /// Build the [`ClientError::WriteStatus`] for a failed write, carrying
+    /// (a bounded prefix of) the server's plain-text error body.
+    async fn write_status_error(
+        method: &Method,
+        path: &str,
+        resp: reqwest::Response,
+    ) -> ClientError {
+        let status = resp.status().as_u16();
+        let message: String = resp
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(500)
+            .collect();
+        ClientError::WriteStatus {
+            method: method.to_string(),
+            path: path.to_string(),
+            status,
+            message,
+        }
+    }
+
+    /// Send an allowlisted write with a JSON body and decode the success
+    /// response as `T`. Non-success statuses become
+    /// [`ClientError::WriteStatus`] with the server's error body.
+    pub async fn write_json<B: Serialize + ?Sized, T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        body: &B,
+    ) -> Result<T, ClientError> {
+        let resp = self
+            .write_with_relogin(method.clone(), path, Some(body))
+            .await?;
+        if !resp.status().is_success() {
+            return Err(Self::write_status_error(&method, path, resp).await);
+        }
+        let bytes = resp.bytes().await?;
+        serde_json::from_slice(&bytes).map_err(|e| ClientError::Decode {
+            path: path.to_string(),
+            message: e.to_string(),
+        })
+    }
+
+    /// Send an allowlisted body-less write whose success answer carries no
+    /// content (the `204` DELETE endpoints).
+    pub async fn write_no_content(&self, method: Method, path: &str) -> Result<(), ClientError> {
+        let resp = self
+            .write_with_relogin::<()>(method.clone(), path, None)
+            .await?;
+        if !resp.status().is_success() {
+            return Err(Self::write_status_error(&method, path, resp).await);
+        }
+        Ok(())
     }
 }
 

--- a/mcp/src/client/tests.rs
+++ b/mcp/src/client/tests.rs
@@ -4,20 +4,22 @@ use std::sync::{Arc, Mutex};
 
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 
 use super::*;
 use crate::config::Config;
 
 /// Stub instance state: counts logins, remembers which tokens are live, and
-/// records the last login body + request headers for assertions.
+/// records the last login body + request headers / write body for assertions.
 #[derive(Default)]
 struct Stub {
     logins: AtomicUsize,
     valid: Mutex<HashSet<String>>,
     last_login_body: Mutex<Option<serde_json::Value>>,
     last_get_headers: Mutex<Option<(Option<String>, Option<String>)>>,
+    last_write_body: Mutex<Option<serde_json::Value>>,
+    deletes: AtomicUsize,
 }
 
 impl Stub {
@@ -70,12 +72,53 @@ struct Payload {
     value: i64,
 }
 
+/// Bearer check shared by the stub's write routes: `Ok(token)` when the
+/// header carries a live token, 401 otherwise.
+fn check_bearer(stub: &Stub, headers: &HeaderMap) -> Result<(), StatusCode> {
+    let token = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|a| a.strip_prefix("Bearer "))
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    if !stub.valid.lock().unwrap().contains(token) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(())
+}
+
+/// Allowlisted write route (`POST /api/scan/resolve`): records the body.
+async fn write_thing(
+    State(stub): State<Arc<Stub>>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    check_bearer(&stub, &headers)?;
+    *stub.last_write_body.lock().unwrap() = Some(body);
+    Ok(Json(serde_json::json!({ "value": 42 })))
+}
+
+/// Allowlisted 204 route (`DELETE /api/physical/{uuid}/wishlist`).
+async fn delete_thing(
+    State(stub): State<Arc<Stub>>,
+    headers: HeaderMap,
+) -> Result<StatusCode, StatusCode> {
+    check_bearer(&stub, &headers)?;
+    stub.deletes.fetch_add(1, Ordering::SeqCst);
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// Boot a stub instance and return `(client, stub)`.
 async fn stub_client() -> (OmnibusClient, Arc<Stub>) {
     let stub = Arc::new(Stub::default());
     let app = Router::new()
         .route("/api/auth/login", post(login))
         .route("/api/thing", get(protected))
+        .route("/api/scan/resolve", post(write_thing))
+        .route(
+            "/api/scan/search",
+            post(|| async { (StatusCode::BAD_REQUEST, "query is required") }),
+        )
+        .route("/api/physical/{uuid}/wishlist", delete(delete_thing))
         .with_state(stub.clone());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -271,4 +314,103 @@ async fn get_json_opt_maps_404_to_none_and_success_to_some() {
     assert_eq!(missing, None);
     let found: Option<Payload> = client.get_json_opt("/api/thing", &[]).await.unwrap();
     assert_eq!(found, Some(Payload { value: 42 }));
+}
+
+#[tokio::test]
+async fn write_json_sends_the_body_with_bearer_and_decodes_the_response() {
+    let (client, stub) = stub_client().await;
+    let body = serde_json::json!({ "isbn": "9780306406157" });
+    let answer: Payload = client
+        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .await
+        .unwrap();
+    assert_eq!(answer, Payload { value: 42 });
+    assert_eq!(stub.logins.load(Ordering::SeqCst), 1);
+    let recorded = stub.last_write_body.lock().unwrap().clone().unwrap();
+    assert_eq!(recorded, body);
+}
+
+#[tokio::test]
+async fn write_json_relogs_in_transparently_when_the_session_expired() {
+    let (client, stub) = stub_client().await;
+    let body = serde_json::json!({ "isbn": "9780306406157" });
+    let _: Payload = client
+        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .await
+        .unwrap();
+    // Simulate the 7-day idle expiry: the server no longer knows the token.
+    stub.revoke_all();
+    let answer: Payload = client
+        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .await
+        .unwrap();
+    assert_eq!(answer, Payload { value: 42 });
+    assert_eq!(stub.logins.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn write_json_returns_write_status_carrying_the_server_message() {
+    let (client, _stub) = stub_client().await;
+    let body = serde_json::json!({ "query": "" });
+    let err = client
+        .write_json::<_, Payload>(Method::POST, "/api/scan/search", &body)
+        .await
+        .unwrap_err();
+    match err {
+        ClientError::WriteStatus {
+            method,
+            path,
+            status,
+            message,
+        } => {
+            assert_eq!(method, "POST");
+            assert_eq!(path, "/api/scan/search");
+            assert_eq!(status, 400);
+            assert_eq!(message, "query is required");
+        }
+        other => panic!("expected WriteStatus, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_no_content_succeeds_on_a_204_delete() {
+    let (client, stub) = stub_client().await;
+    client
+        .write_no_content(Method::DELETE, "/api/physical/uuid-1/wishlist")
+        .await
+        .unwrap();
+    assert_eq!(stub.deletes.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+#[should_panic(expected = "not in WRITE_ALLOWLIST")]
+async fn write_json_panics_on_a_path_outside_the_allowlist() {
+    let (client, _stub) = stub_client().await;
+    let body = serde_json::json!({});
+    let _: Result<Payload, _> = client
+        .write_json(Method::POST, "/api/settings", &body)
+        .await;
+}
+
+#[test]
+fn write_allowlisted_expands_param_segments_and_rejects_everything_else() {
+    // `{param}` matches exactly one non-empty segment.
+    assert!(write_allowlisted(&Method::PATCH, "/api/physical/copies/12"));
+    assert!(write_allowlisted(
+        &Method::DELETE,
+        "/api/physical/uuid-abc/wishlist"
+    ));
+    // Empty and extra segments do not satisfy a wildcard.
+    assert!(!write_allowlisted(
+        &Method::DELETE,
+        "/api/physical//wishlist"
+    ));
+    assert!(!write_allowlisted(
+        &Method::DELETE,
+        "/api/physical/a/b/wishlist"
+    ));
+    // Method mismatch and unlisted paths are refused.
+    assert!(!write_allowlisted(&Method::GET, "/api/scan/resolve"));
+    assert!(!write_allowlisted(&Method::POST, "/api/settings"));
+    assert!(!write_allowlisted(&Method::POST, "/api/scan/resolve/extra"));
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,8 +1,8 @@
-//! Read-only MCP stdio server for Omnibus: authenticates over
-//! `POST /api/auth/login` and exposes the library, search, discovery,
-//! shelf, stats, progress, and annotation reads as MCP tools whose result
-//! schemas derive from the `omnibus_shared` wire types. Write policy is
-//! [`client::WRITE_ALLOWLIST`]; configuration is documented on [`config`].
+//! MCP stdio server for Omnibus: authenticates over `POST /api/auth/login`
+//! and exposes the library, search, discovery, shelf, stats, progress, and
+//! annotation reads — plus the physical check-in and wishlist tools — with
+//! result schemas derived from the `omnibus_shared` wire types. Write policy
+//! is [`client::WRITE_ALLOWLIST`]; configuration is documented on [`config`].
 
 pub mod client;
 pub mod config;

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -27,7 +27,7 @@ impl OmnibusMcp {
     pub fn new(client: Arc<OmnibusClient>) -> Self {
         Self {
             client,
-            tool_router: Self::read_tools(),
+            tool_router: Self::read_tools() + Self::checkin_tools(),
         }
     }
 }
@@ -52,11 +52,18 @@ impl ServerHandler for OmnibusMcp {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(implementation)
             .with_instructions(
-                "Read-only access to an Omnibus ebook/audiobook library: browse and \
-                 search books, explore authors/series/tags/genres and shelves, and read \
-                 the signed-in user's stats, progress, highlights, bookmarks, and \
-                 journal entries. Books are identified by the uuid field returned by \
-                 the listing and search tools. No tool mutates the library."
+                "Access to an Omnibus ebook/audiobook library. Read-only tools browse \
+                 and search books, explore authors/series/tags/genres and shelves, and \
+                 read the signed-in user's stats, progress, highlights, bookmarks, and \
+                 journal entries; books are identified by the uuid field returned by \
+                 the listing and search tools. The physical-collection tools are the \
+                 only mutations: resolve ISBNs and title searches against the library \
+                 and the external metadata providers (always relay which provider \
+                 answered), check in physical copies, and manage the wishlist and copy \
+                 notes. check_in_physical_book and remove_physical_copy have lasting \
+                 effects, so they require confirm=true — resolve first, show the user \
+                 the target, and confirm only with their approval. Digital library \
+                 content, settings, and reading state are never modified."
                     .to_string(),
             )
     }

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -70,11 +70,12 @@ fn read_tools_router_lists_every_expected_tool_with_a_description() {
 }
 
 #[test]
-fn get_info_declares_tools_and_readonly_instructions() {
+fn get_info_declares_tools_and_the_confirm_gated_write_surface() {
     let info = offline_server().get_info();
     assert!(info.capabilities.tools.is_some());
     let instructions = info.instructions.unwrap_or_default();
     assert!(instructions.contains("Read-only"));
+    assert!(instructions.contains("confirm=true"));
 }
 
 /// Boot a stub instance serving shared-typed JSON and return a service
@@ -170,4 +171,520 @@ async fn list_books_tool_carries_the_header_pagination_metadata() {
     assert_eq!(page.0.library.books.len(), 1);
     assert_eq!(page.0.next_cursor.as_deref(), Some("cursor-2"));
     assert_eq!(page.0.total, Some(1));
+}
+
+// --- Check-in / wishlist / physical-collection tool family ---
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, patch};
+
+use omnibus_shared::{
+    ExternalBookMeta, MetadataProvider, PhysicalCopy, ScanBook, ScanOutcome, ScanSearchResponse,
+};
+
+use crate::tools::checkin::{
+    AddToWishlistParams, BookUuid, CheckInParams, LookupIsbnParams, RemoveCopyParams,
+    ResolveMetadataParams, SearchMetadataParams, UpdateCopyNoteParams,
+};
+
+/// `unwrap_err` needs `T: Debug`, which `rmcp::Json<T>` does not implement —
+/// this is the same unwrap with the bound the tool results can satisfy.
+trait ExpectErrData<E> {
+    fn expect_err_data(self) -> E;
+}
+
+impl<T, E> ExpectErrData<E> for Result<T, E> {
+    fn expect_err_data(self) -> E {
+        match self {
+            Err(e) => e,
+            Ok(_) => panic!("expected an error"),
+        }
+    }
+}
+
+/// Every check-in-family tool this issue ships, by MCP tool name.
+const EXPECTED_CHECKIN_TOOLS: &[&str] = &[
+    "lookup_isbn",
+    "search_book_metadata",
+    "resolve_book_metadata",
+    "check_in_physical_book",
+    "add_to_wishlist",
+    "remove_from_wishlist",
+    "list_physical_copies",
+    "update_copy_note",
+    "remove_physical_copy",
+];
+
+/// Stub write-route state: records mutation bodies and counts destructive
+/// calls so tests can assert what did (or did not) reach the server.
+#[derive(Default)]
+struct WriteStub {
+    check_ins: AtomicUsize,
+    last_check_in: Mutex<Option<serde_json::Value>>,
+    last_wishlist_add: Mutex<Option<serde_json::Value>>,
+    wishlist_deletes: Mutex<Vec<String>>,
+    copy_deletes: AtomicUsize,
+}
+
+fn provider_meta(source: MetadataProvider) -> ExternalBookMeta {
+    ExternalBookMeta {
+        isbn13: "9780306406157".into(),
+        title: "Voyage of the Beagle".into(),
+        authors: vec!["Charles Darwin".into()],
+        year: None,
+        pages: None,
+        publisher: None,
+        description: None,
+        cover_url: None,
+        series: None,
+        first_publish_year: None,
+        source,
+    }
+}
+
+fn library_book() -> ScanBook {
+    ScanBook {
+        uuid: "uuid-frank".into(),
+        title: "Frankenstein".into(),
+        authors: vec!["Mary Shelley".into()],
+        cover_url: None,
+        has_physical: false,
+        isbn: None,
+    }
+}
+
+async fn resolve(AxumJson(body): AxumJson<serde_json::Value>) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    match body["isbn"].as_str() {
+        Some("9780306406157") => AxumJson(ScanOutcome::NotInLibrary {
+            online: provider_meta(MetadataProvider::GoogleBooks),
+        })
+        .into_response(),
+        Some("9781111111111") => AxumJson(ScanOutcome::InLibraryUnowned {
+            book: library_book(),
+        })
+        .into_response(),
+        Some("bad") => (StatusCode::BAD_REQUEST, "invalid ISBN checksum").into_response(),
+        _ => AxumJson(ScanOutcome::Unresolved).into_response(),
+    }
+}
+
+async fn resolve_meta() -> AxumJson<ScanOutcome> {
+    AxumJson(ScanOutcome::CloseMatch {
+        book: library_book(),
+        others: vec![],
+        scanned: provider_meta(MetadataProvider::OpenLibrary),
+    })
+}
+
+async fn search() -> AxumJson<ScanSearchResponse> {
+    AxumJson(ScanSearchResponse {
+        results: vec![provider_meta(MetadataProvider::OpenLibrary)],
+    })
+}
+
+async fn check_in(
+    State(stub): State<Arc<WriteStub>>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> AxumJson<serde_json::Value> {
+    stub.check_ins.fetch_add(1, Ordering::SeqCst);
+    *stub.last_check_in.lock().unwrap() = Some(body);
+    AxumJson(serde_json::json!({ "book_uuid": "uuid-frank" }))
+}
+
+async fn wishlist_add(
+    State(stub): State<Arc<WriteStub>>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> AxumJson<serde_json::Value> {
+    *stub.last_wishlist_add.lock().unwrap() = Some(body);
+    AxumJson(serde_json::json!({ "book_uuid": "uuid-frank" }))
+}
+
+async fn wishlist_delete(
+    State(stub): State<Arc<WriteStub>>,
+    Path(uuid): Path<String>,
+) -> StatusCode {
+    stub.wishlist_deletes.lock().unwrap().push(uuid);
+    StatusCode::NO_CONTENT
+}
+
+fn copy(note: Option<String>) -> PhysicalCopy {
+    PhysicalCopy {
+        id: 5,
+        book_uuid: "uuid-frank".into(),
+        isbn: Some("9781111111111".into()),
+        added_by_user_id: Some(1),
+        checked_in_at: 1_700_000_000,
+        note,
+    }
+}
+
+async fn copies() -> AxumJson<Vec<PhysicalCopy>> {
+    AxumJson(vec![copy(Some("hardcover".into()))])
+}
+
+/// Copy 5 accepts edits; copy 6 answers the `can_edit` 403 the real handler
+/// sends; anything else is a 404.
+async fn patch_copy(
+    Path(copy_id): Path<i64>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    match copy_id {
+        5 => AxumJson(copy(body["note"].as_str().map(str::to_string))).into_response(),
+        6 => (StatusCode::FORBIDDEN, "edit permission required").into_response(),
+        _ => (StatusCode::NOT_FOUND, "physical copy not found").into_response(),
+    }
+}
+
+async fn delete_copy(
+    State(stub): State<Arc<WriteStub>>,
+    Path(copy_id): Path<i64>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    match copy_id {
+        5 => {
+            stub.copy_deletes.fetch_add(1, Ordering::SeqCst);
+            StatusCode::NO_CONTENT.into_response()
+        }
+        6 => (StatusCode::FORBIDDEN, "edit permission required").into_response(),
+        _ => (StatusCode::NOT_FOUND, "physical copy not found").into_response(),
+    }
+}
+
+/// Boot a stub instance carrying the scan/physical routes and return the
+/// service plus the recorded-writes handle.
+async fn checkin_stub_service() -> (OmnibusMcp, Arc<WriteStub>) {
+    async fn login() -> AxumJson<serde_json::Value> {
+        AxumJson(serde_json::json!({
+            "user": {
+                "id": 1, "username": "reader", "is_admin": false,
+                "can_upload": false, "can_edit": true, "can_download": true
+            },
+            "token": "token-1",
+        }))
+    }
+    let stub = Arc::new(WriteStub::default());
+    let app = Router::new()
+        .route("/api/auth/login", post(login))
+        .route("/api/scan/resolve", post(resolve))
+        .route("/api/scan/search", post(search))
+        .route("/api/scan/resolve-meta", post(resolve_meta))
+        .route("/api/scan/check-in", post(check_in))
+        .route("/api/scan/wishlist", post(wishlist_add))
+        .route("/api/physical/{uuid}/wishlist", delete(wishlist_delete))
+        .route("/api/physical/{uuid}/copies", get(copies))
+        .route(
+            "/api/physical/copies/{copy_id}",
+            patch(patch_copy).delete(delete_copy),
+        )
+        .with_state(stub.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OmnibusClient::new(Config {
+        base_url: format!("http://{addr}"),
+        username: "reader".into(),
+        password: "correct horse battery".into(),
+    })
+    .unwrap();
+    (OmnibusMcp::new(Arc::new(client)), stub)
+}
+
+#[test]
+fn checkin_tools_router_lists_every_expected_tool_with_a_description() {
+    let router = OmnibusMcp::checkin_tools();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in EXPECTED_CHECKIN_TOOLS {
+        assert!(names.contains(expected), "missing tool {expected}");
+    }
+    assert_eq!(
+        tools.len(),
+        EXPECTED_CHECKIN_TOOLS.len(),
+        "unexpected extra tools: {names:?}"
+    );
+    for tool in &tools {
+        let desc = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            desc.len() > 20,
+            "tool {} needs a real description",
+            tool.name
+        );
+    }
+}
+
+#[test]
+fn combined_router_carries_both_families_without_collisions() {
+    let combined = OmnibusMcp::read_tools() + OmnibusMcp::checkin_tools();
+    assert_eq!(
+        combined.list_all().len(),
+        EXPECTED_TOOLS.len() + EXPECTED_CHECKIN_TOOLS.len()
+    );
+}
+
+#[tokio::test]
+async fn lookup_isbn_names_the_provider_and_explains_every_no_match() {
+    let (service, _stub) = checkin_stub_service().await;
+    let results = service
+        .lookup_isbn(Parameters(LookupIsbnParams {
+            isbns: vec![
+                "9780306406157".into(),
+                "9781111111111".into(),
+                "9999999999999".into(),
+            ],
+        }))
+        .await
+        .unwrap();
+    let [provider_hit, library_hit, unresolved] = results.0.as_slice() else {
+        panic!("expected three rows, got {}", results.0.len());
+    };
+
+    // Provider-resolved: the answering provider is named.
+    assert_eq!(provider_hit.provider.as_deref(), Some("Google Books"));
+    assert!(matches!(
+        provider_hit.outcome,
+        Some(ScanOutcome::NotInLibrary { .. })
+    ));
+
+    // Library-exact: no provider involved, and the detail says so.
+    assert_eq!(library_hit.provider, None);
+    assert!(matches!(
+        library_hit.outcome,
+        Some(ScanOutcome::InLibraryUnowned { .. })
+    ));
+    assert!(library_hit.detail.as_deref().unwrap().contains("library"));
+
+    // Unresolved: reported with an explanation, never dropped.
+    assert!(matches!(unresolved.outcome, Some(ScanOutcome::Unresolved)));
+    assert!(unresolved.detail.as_deref().unwrap().contains("provider"));
+}
+
+#[tokio::test]
+async fn lookup_isbn_reports_an_invalid_isbn_as_a_structured_row() {
+    let (service, _stub) = checkin_stub_service().await;
+    let results = service
+        .lookup_isbn(Parameters(LookupIsbnParams {
+            isbns: vec!["bad".into(), "9781111111111".into()],
+        }))
+        .await
+        .unwrap();
+    assert!(results.0[0].outcome.is_none());
+    let detail = results.0[0].detail.as_deref().unwrap();
+    assert!(detail.contains("HTTP 400") && detail.contains("invalid ISBN checksum"));
+    // The failure did not swallow the rest of the batch.
+    assert!(results.0[1].outcome.is_some());
+}
+
+#[tokio::test]
+async fn search_book_metadata_returns_provider_attributed_candidates() {
+    let (service, _stub) = checkin_stub_service().await;
+    let response = service
+        .search_book_metadata(Parameters(SearchMetadataParams {
+            query: "voyage of the beagle".into(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(response.0.results.len(), 1);
+    assert_eq!(response.0.results[0].source, MetadataProvider::OpenLibrary);
+}
+
+#[tokio::test]
+async fn resolve_book_metadata_reports_the_close_match_with_its_provider() {
+    let (service, _stub) = checkin_stub_service().await;
+    let resolution = service
+        .resolve_book_metadata(Parameters(ResolveMetadataParams {
+            meta: provider_meta(MetadataProvider::OpenLibrary),
+        }))
+        .await
+        .unwrap();
+    assert!(matches!(
+        resolution.0.outcome,
+        Some(ScanOutcome::CloseMatch { .. })
+    ));
+    assert_eq!(resolution.0.provider.as_deref(), Some("Open Library"));
+}
+
+#[tokio::test]
+async fn check_in_physical_book_refuses_without_confirm_and_sends_nothing() {
+    let (service, stub) = checkin_stub_service().await;
+    let err = service
+        .check_in_physical_book(Parameters(CheckInParams {
+            book_uuid: "uuid-frank".into(),
+            isbn: Some("9781111111111".into()),
+            note: None,
+            confirm: false,
+        }))
+        .await
+        .expect_err_data();
+    assert!(err.message.contains("confirm"));
+    assert_eq!(stub.check_ins.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn check_in_physical_book_sends_the_expected_body_when_confirmed() {
+    let (service, stub) = checkin_stub_service().await;
+    let receipt = service
+        .check_in_physical_book(Parameters(CheckInParams {
+            book_uuid: "uuid-frank".into(),
+            isbn: Some("9781111111111".into()),
+            note: Some("shop find".into()),
+            confirm: true,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(receipt.0.book_uuid, "uuid-frank");
+    let body = stub.last_check_in.lock().unwrap().clone().unwrap();
+    assert_eq!(body["book_uuid"], "uuid-frank");
+    assert_eq!(body["isbn"], "9781111111111");
+    assert_eq!(body["note"], "shop find");
+}
+
+#[tokio::test]
+async fn add_to_wishlist_posts_the_library_uuid_with_detail_source() {
+    let (service, stub) = checkin_stub_service().await;
+    let landed = service
+        .add_to_wishlist(Parameters(AddToWishlistParams {
+            uuid: Some("uuid-frank".into()),
+            meta: None,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(landed.0.book_uuid, "uuid-frank");
+    let body = stub.last_wishlist_add.lock().unwrap().clone().unwrap();
+    assert_eq!(body["book_uuid"], "uuid-frank");
+    assert_eq!(body["source"], "detail");
+}
+
+#[tokio::test]
+async fn add_to_wishlist_posts_external_meta_with_search_source() {
+    let (service, stub) = checkin_stub_service().await;
+    service
+        .add_to_wishlist(Parameters(AddToWishlistParams {
+            uuid: None,
+            meta: Some(provider_meta(MetadataProvider::GoogleBooks)),
+        }))
+        .await
+        .unwrap();
+    let body = stub.last_wishlist_add.lock().unwrap().clone().unwrap();
+    assert_eq!(body["meta"]["isbn13"], "9780306406157");
+    assert_eq!(body["source"], "search");
+}
+
+#[tokio::test]
+async fn add_to_wishlist_refuses_when_neither_uuid_nor_meta_is_given() {
+    let (service, stub) = checkin_stub_service().await;
+    let err = service
+        .add_to_wishlist(Parameters(AddToWishlistParams {
+            uuid: None,
+            meta: None,
+        }))
+        .await
+        .expect_err_data();
+    assert!(err.message.contains("uuid") && err.message.contains("meta"));
+    assert!(stub.last_wishlist_add.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn remove_from_wishlist_deletes_the_entry() {
+    let (service, stub) = checkin_stub_service().await;
+    let ack = service
+        .remove_from_wishlist(Parameters(BookUuid {
+            uuid: "uuid-frank".into(),
+        }))
+        .await
+        .unwrap();
+    assert!(ack.0.message.contains("uuid-frank"));
+    assert_eq!(
+        stub.wishlist_deletes.lock().unwrap().clone(),
+        vec!["uuid-frank".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn list_physical_copies_returns_the_shared_typed_copies() {
+    let (service, _stub) = checkin_stub_service().await;
+    let copies = service
+        .list_physical_copies(Parameters(BookUuid {
+            uuid: "uuid-frank".into(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(copies.0.len(), 1);
+    assert_eq!(copies.0[0].id, 5);
+    assert_eq!(copies.0[0].note.as_deref(), Some("hardcover"));
+}
+
+#[tokio::test]
+async fn update_copy_note_patches_and_returns_the_copy() {
+    let (service, _stub) = checkin_stub_service().await;
+    let updated = service
+        .update_copy_note(Parameters(UpdateCopyNoteParams {
+            copy_id: 5,
+            note: Some("signed first edition".into()),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(updated.0.note.as_deref(), Some("signed first edition"));
+}
+
+#[tokio::test]
+async fn update_copy_note_names_the_missing_edit_permission_on_403() {
+    let (service, _stub) = checkin_stub_service().await;
+    let err = service
+        .update_copy_note(Parameters(UpdateCopyNoteParams {
+            copy_id: 6,
+            note: Some("nope".into()),
+        }))
+        .await
+        .expect_err_data();
+    assert!(err.message.contains("can_edit"), "got: {}", err.message);
+    assert!(err.message.contains("edit permission required"));
+}
+
+#[tokio::test]
+async fn remove_physical_copy_refuses_without_confirm() {
+    let (service, stub) = checkin_stub_service().await;
+    let err = service
+        .remove_physical_copy(Parameters(RemoveCopyParams {
+            copy_id: 5,
+            confirm: false,
+        }))
+        .await
+        .expect_err_data();
+    assert!(err.message.contains("confirm"));
+    assert_eq!(stub.copy_deletes.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn remove_physical_copy_deletes_when_confirmed() {
+    let (service, stub) = checkin_stub_service().await;
+    let ack = service
+        .remove_physical_copy(Parameters(RemoveCopyParams {
+            copy_id: 5,
+            confirm: true,
+        }))
+        .await
+        .unwrap();
+    assert!(ack.0.message.contains('5'));
+    assert_eq!(stub.copy_deletes.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn remove_physical_copy_names_the_missing_edit_permission_on_403() {
+    let (service, _stub) = checkin_stub_service().await;
+    let err = service
+        .remove_physical_copy(Parameters(RemoveCopyParams {
+            copy_id: 6,
+            confirm: true,
+        }))
+        .await
+        .expect_err_data();
+    assert!(err.message.contains("can_edit"), "got: {}", err.message);
 }

--- a/mcp/src/tools/checkin.rs
+++ b/mcp/src/tools/checkin.rs
@@ -274,9 +274,10 @@ impl OmnibusMcp {
     ) -> Result<Json<BookRef>, ErrorData> {
         if !p.confirm {
             return Err(ErrorData::invalid_params(
-                "confirm must be true: check-in files a physical copy AND permanently binds the \
-                 ISBN to this book for future lookups. Resolve the ISBN, show the user the \
-                 matched book, and pass confirm=true once they approve.",
+                "confirm must be true: check-in files a library-wide physical copy, and when \
+                 an isbn is passed it is permanently bound to this book for future \
+                 exact-identifier lookups. Show the user the matched book, and pass \
+                 confirm=true once they approve.",
                 None,
             ));
         }

--- a/mcp/src/tools/checkin.rs
+++ b/mcp/src/tools/checkin.rs
@@ -1,0 +1,400 @@
+//! The check-in / wishlist / physical-collection tool family: resolve ISBNs
+//! and title searches down the server's matching ladder, file physical
+//! copies, and manage the caller's wishlist and the library's copy records.
+//! Every mutation maps to a [`crate::client::WRITE_ALLOWLIST`] entry; the two
+//! irreversible tools (check-in's ISBN binding, copy deletion) are gated on
+//! an explicit `confirm` argument.
+
+use reqwest::Method;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router, ErrorData, Json};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use omnibus_shared::{
+    BookRef, CheckInRequest, ExternalBookMeta, PhysicalCopy, ResolveMetaRequest, ResolveRequest,
+    ScanOutcome, ScanSearchRequest, ScanSearchResponse, UpdateCopyNoteRequest, WishlistAddRequest,
+    WishlistSource,
+};
+
+use crate::client::ClientError;
+use crate::server::OmnibusMcp;
+
+/// A single book handle for the physical-collection tools — the
+/// `unique_identifier` from the listing/search tools, or the `uuid` on a
+/// scan outcome's matched book.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BookUuid {
+    /// The book's uuid.
+    pub uuid: String,
+}
+
+/// Parameters for the batch ISBN lookup.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LookupIsbnParams {
+    /// ISBNs to resolve (ISBN-10 or ISBN-13; separators tolerated). Each is
+    /// one server-side lookup, run sequentially — the endpoint has no batch
+    /// form.
+    pub isbns: Vec<String>,
+}
+
+/// One ISBN's trip down the resolution ladder.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct IsbnResolution {
+    /// The ISBN as submitted.
+    pub isbn: String,
+    /// The ladder's outcome; absent when the lookup request itself failed
+    /// (invalid ISBN, providers unreachable) — see `detail`.
+    pub outcome: Option<ScanOutcome>,
+    /// The external provider that supplied the metadata, when the outcome
+    /// carries provider-resolved metadata (`close_match` / `not_in_library`,
+    /// via that metadata's `source` field). Absent otherwise: exact-identifier
+    /// library hits are answered by the library itself, and `unresolved`
+    /// means no provider answered at all.
+    pub provider: Option<String>,
+    /// Human-readable explanation — why an `unresolved` outcome had no
+    /// match, how a library hit was matched, or the server's error message
+    /// for a failed lookup.
+    pub detail: Option<String>,
+}
+
+/// Parameters for the provider title search.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchMetadataParams {
+    /// Title text (optionally with the author) to search the providers for.
+    pub query: String,
+}
+
+/// Parameters for resolving a picked search candidate against the library.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResolveMetadataParams {
+    /// A candidate exactly as returned by `search_book_metadata`.
+    pub meta: ExternalBookMeta,
+}
+
+/// Parameters for filing a physical copy.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckInParams {
+    /// The library book's uuid, from a `lookup_isbn` /
+    /// `resolve_book_metadata` outcome the user has confirmed.
+    pub book_uuid: String,
+    /// The ISBN to record on the copy — and permanently bind to this book
+    /// for future exact-identifier lookups.
+    pub isbn: Option<String>,
+    /// Free-text edition/condition note for the copy.
+    pub note: Option<String>,
+    /// Must be `true`. Set it only after showing the user the resolved book
+    /// and getting their go-ahead.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Parameters for the wishlist add.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddToWishlistParams {
+    /// Uuid of a book already in the library. Set this or `meta`, not both;
+    /// when both are present the uuid wins and `meta` is ignored.
+    pub uuid: Option<String>,
+    /// External metadata for a book the library does not hold (from
+    /// `search_book_metadata` or a `not_in_library` lookup outcome) —
+    /// creates a fileless wishlist book.
+    pub meta: Option<ExternalBookMeta>,
+}
+
+/// Parameters for the copy-note edit.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateCopyNoteParams {
+    /// The copy's `id` from `list_physical_copies`.
+    pub copy_id: i64,
+    /// Replacement note; omit (or send blank) to clear it.
+    pub note: Option<String>,
+}
+
+/// Parameters for deleting a physical copy.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveCopyParams {
+    /// The copy's `id` from `list_physical_copies`.
+    pub copy_id: i64,
+    /// Must be `true`. Set it only after the user has confirmed which copy
+    /// to delete — the deletion is permanent.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Acknowledgement for tools whose endpoint answers `204 No Content`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct Ack {
+    /// What happened, in words.
+    pub message: String,
+}
+
+/// The provider named by a provider-resolved outcome's metadata; library
+/// hits and `unresolved` carry none.
+fn provider_of(outcome: &ScanOutcome) -> Option<String> {
+    match outcome {
+        ScanOutcome::CloseMatch { scanned, .. } => Some(scanned.source.display_name().to_string()),
+        ScanOutcome::NotInLibrary { online } => Some(online.source.display_name().to_string()),
+        _ => None,
+    }
+}
+
+/// Attach the honest provenance story to an outcome: who answered, or why
+/// nobody did.
+fn resolution(isbn: String, outcome: ScanOutcome) -> IsbnResolution {
+    let provider = provider_of(&outcome);
+    let detail = match &outcome {
+        ScanOutcome::AlreadyOwned { .. }
+        | ScanOutcome::OnWishlist { .. }
+        | ScanOutcome::InLibraryUnowned { .. } => Some(
+            "Matched a library book by exact identifier — no external provider was consulted."
+                .to_string(),
+        ),
+        ScanOutcome::CloseMatch { .. } | ScanOutcome::NotInLibrary { .. } => None,
+        ScanOutcome::Unresolved => Some(
+            "Neither the library nor any reachable metadata provider recognized this ISBN. \
+             The provider ladder is API-key-dependent (a provider without a configured key is \
+             skipped), so this instance may have consulted fewer sources; try \
+             search_book_metadata with the title instead."
+                .to_string(),
+        ),
+    };
+    IsbnResolution {
+        isbn,
+        outcome: Some(outcome),
+        provider,
+        detail,
+    }
+}
+
+/// Map a write failure to a tool error, naming the missing permission on a
+/// 403 and passing the server's actionable message through on the other
+/// user-addressable statuses.
+fn write_error(e: ClientError) -> ErrorData {
+    match e {
+        ClientError::WriteStatus {
+            status: 403,
+            message,
+            ..
+        } => ErrorData::invalid_params(
+            format!(
+                "forbidden: {message} — the signed-in account lacks the `can_edit` permission \
+                 (physical copies are library-wide, so editing them takes the same gate as \
+                 metadata overrides; an admin can grant it)"
+            ),
+            None,
+        ),
+        ClientError::WriteStatus {
+            status: status @ (400 | 404 | 409),
+            message,
+            ..
+        } => ErrorData::invalid_params(format!("HTTP {status}: {message}"), None),
+        other => other.into(),
+    }
+}
+
+#[tool_router(router = checkin_tools, vis = "pub(crate)")]
+impl OmnibusMcp {
+    #[tool(
+        description = "Resolve one or more ISBNs down the check-in ladder: exact identifier match against the library first, then the external metadata providers. Each result reports which provider answered when metadata came from a provider (results are provider-order- and API-key-dependent, so name the provider when relaying them); exact library hits involve no provider, and an unresolved ISBN is reported with an explanation rather than dropped. Outcomes: already_owned / on_wishlist / in_library_unowned (library hits), close_match (provider-resolved, fuzzily matched to library books — needs human confirmation), not_in_library (provider-resolved only), unresolved. To file a physical copy afterwards, show the user the matched book, then call check_in_physical_book with confirm=true."
+    )]
+    pub async fn lookup_isbn(
+        &self,
+        Parameters(p): Parameters<LookupIsbnParams>,
+    ) -> Result<Json<Vec<IsbnResolution>>, ErrorData> {
+        if p.isbns.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "isbns must contain at least one ISBN",
+                None,
+            ));
+        }
+        let mut results = Vec::with_capacity(p.isbns.len());
+        for isbn in p.isbns {
+            let req = ResolveRequest { isbn: isbn.clone() };
+            match self
+                .client
+                .write_json::<_, ScanOutcome>(Method::POST, "/api/scan/resolve", &req)
+                .await
+            {
+                Ok(outcome) => results.push(resolution(isbn, outcome)),
+                // A per-ISBN failure (invalid ISBN, providers down) is part
+                // of the batch answer, not a reason to lose the other rows.
+                Err(ClientError::WriteStatus {
+                    status, message, ..
+                }) => results.push(IsbnResolution {
+                    isbn,
+                    outcome: None,
+                    provider: None,
+                    detail: Some(format!("lookup failed (HTTP {status}): {message}")),
+                }),
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(Json(results))
+    }
+
+    #[tool(
+        description = "Search the external metadata providers by title/author text — the fallback when lookup_isbn reports unresolved. Returns candidate editions, each carrying `source` (which provider reported it) and the isbn13 it carries; which providers answer depends on the instance's configured API keys. Feed a picked candidate to resolve_book_metadata to match it against the library before acting on it."
+    )]
+    pub async fn search_book_metadata(
+        &self,
+        Parameters(p): Parameters<SearchMetadataParams>,
+    ) -> Result<Json<ScanSearchResponse>, ErrorData> {
+        let req = ScanSearchRequest { query: p.query };
+        Ok(Json(
+            self.client
+                .write_json(Method::POST, "/api/scan/search", &req)
+                .await
+                .map_err(write_error)?,
+        ))
+    }
+
+    #[tool(
+        description = "Match a picked search_book_metadata candidate against the library — the ladder's library rungs applied to metadata already in hand, no provider round-trip. Returns the same per-ISBN resolution shape as lookup_isbn; the provider named is the one the candidate came from."
+    )]
+    pub async fn resolve_book_metadata(
+        &self,
+        Parameters(p): Parameters<ResolveMetadataParams>,
+    ) -> Result<Json<IsbnResolution>, ErrorData> {
+        let isbn = p.meta.isbn13.clone();
+        let req = ResolveMetaRequest { meta: p.meta };
+        let outcome: ScanOutcome = self
+            .client
+            .write_json(Method::POST, "/api/scan/resolve-meta", &req)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(resolution(isbn, outcome)))
+    }
+
+    #[tool(
+        description = "File a physical copy of a library book. Two effects, one of them permanent: a copy row is created (visible to every user on the book's detail page), AND the given ISBN is bound to this book on the exact-identifier rung, so that ISBN resolves to this book in every future lookup. Resolve first (lookup_isbn / resolve_book_metadata), show the user the matched book, and only call this with confirm=true after they approve. Refuses without confirm."
+    )]
+    pub async fn check_in_physical_book(
+        &self,
+        Parameters(p): Parameters<CheckInParams>,
+    ) -> Result<Json<BookRef>, ErrorData> {
+        if !p.confirm {
+            return Err(ErrorData::invalid_params(
+                "confirm must be true: check-in files a physical copy AND permanently binds the \
+                 ISBN to this book for future lookups. Resolve the ISBN, show the user the \
+                 matched book, and pass confirm=true once they approve.",
+                None,
+            ));
+        }
+        let req = CheckInRequest {
+            book_uuid: p.book_uuid,
+            isbn: p.isbn,
+            note: p.note,
+        };
+        Ok(Json(
+            self.client
+                .write_json(Method::POST, "/api/scan/check-in", &req)
+                .await
+                .map_err(write_error)?,
+        ))
+    }
+
+    #[tool(
+        description = "Add a book to the signed-in user's physical wishlist: pass `uuid` for a book already in the library, or `meta` (a search_book_metadata candidate / not_in_library lookup result) to create a fileless wishlist book the library doesn't hold. Idempotent for an already-wishlisted book. Returns the uuid of the book the entry landed on."
+    )]
+    pub async fn add_to_wishlist(
+        &self,
+        Parameters(p): Parameters<AddToWishlistParams>,
+    ) -> Result<Json<BookRef>, ErrorData> {
+        if p.uuid.is_none() && p.meta.is_none() {
+            return Err(ErrorData::invalid_params(
+                "pass uuid (library book) or meta (external candidate)",
+                None,
+            ));
+        }
+        // Provenance the flow can actually claim: a uuid means the book was
+        // already identified in the library (the detail-page path); meta
+        // means it came out of a provider lookup/search. Never `scan` — no
+        // camera is involved here.
+        let source = if p.uuid.is_some() {
+            WishlistSource::Detail
+        } else {
+            WishlistSource::Search
+        };
+        let req = WishlistAddRequest {
+            book_uuid: p.uuid,
+            meta: p.meta,
+            source,
+        };
+        Ok(Json(
+            self.client
+                .write_json(Method::POST, "/api/scan/wishlist", &req)
+                .await
+                .map_err(write_error)?,
+        ))
+    }
+
+    #[tool(
+        description = "Remove a book from the signed-in user's physical wishlist by uuid. Idempotent — removing a book that isn't wishlisted still succeeds, since the desired end state already holds."
+    )]
+    pub async fn remove_from_wishlist(
+        &self,
+        Parameters(p): Parameters<BookUuid>,
+    ) -> Result<Json<Ack>, ErrorData> {
+        let path = format!("/api/physical/{}/wishlist", p.uuid);
+        self.client
+            .write_no_content(Method::DELETE, &path)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(Ack {
+            message: format!("removed {} from the wishlist", p.uuid),
+        }))
+    }
+
+    #[tool(
+        description = "List a book's physical copies (library-wide, oldest check-in first), each with its id, recorded ISBN, check-in time, and note. An unknown uuid simply has no copies (empty list)."
+    )]
+    pub async fn list_physical_copies(
+        &self,
+        Parameters(p): Parameters<BookUuid>,
+    ) -> Result<Json<Vec<PhysicalCopy>>, ErrorData> {
+        let path = format!("/api/physical/{}/copies", p.uuid);
+        Ok(Json(self.client.get_json(&path, &[]).await?))
+    }
+
+    #[tool(
+        description = "Replace a physical copy's free-text edition/condition note (blank or omitted note clears it). Copies are library-wide, so this requires the `can_edit` permission. Returns the updated copy."
+    )]
+    pub async fn update_copy_note(
+        &self,
+        Parameters(p): Parameters<UpdateCopyNoteParams>,
+    ) -> Result<Json<PhysicalCopy>, ErrorData> {
+        let path = format!("/api/physical/copies/{}", p.copy_id);
+        let req = UpdateCopyNoteRequest { note: p.note };
+        Ok(Json(
+            self.client
+                .write_json(Method::PATCH, &path, &req)
+                .await
+                .map_err(write_error)?,
+        ))
+    }
+
+    #[tool(
+        description = "Permanently delete one physical copy record (\"I sold it\") — every user stops seeing it, and there is no undo. Requires the `can_edit` permission, and refuses without confirm=true: show the user the copy (list_physical_copies) and get their approval first."
+    )]
+    pub async fn remove_physical_copy(
+        &self,
+        Parameters(p): Parameters<RemoveCopyParams>,
+    ) -> Result<Json<Ack>, ErrorData> {
+        if !p.confirm {
+            return Err(ErrorData::invalid_params(
+                "confirm must be true: deleting a physical copy is permanent and library-wide. \
+                 Show the user the copy (list_physical_copies) and pass confirm=true once they \
+                 approve.",
+                None,
+            ));
+        }
+        let path = format!("/api/physical/copies/{}", p.copy_id);
+        self.client
+            .write_no_content(Method::DELETE, &path)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(Ack {
+            message: format!("deleted physical copy {}", p.copy_id),
+        }))
+    }
+}

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,7 +1,9 @@
 //! Tool implementations, one module per family. Each module contributes a
 //! `#[tool_router(router = <name>)]` impl block on
 //! [`crate::server::OmnibusMcp`]; `OmnibusMcp::new` combines the routers.
-//! Read tools live in [`read`]; later issues add write families as sibling
+//! Read tools live in [`read`], the check-in / wishlist / physical-collection
+//! family in [`checkin`]; later issues add further families as sibling
 //! modules, subject to the allowlist policy in [`crate::client`].
 
+pub mod checkin;
 pub mod read;

--- a/shared/src/metadata_lookup.rs
+++ b/shared/src/metadata_lookup.rs
@@ -10,6 +10,7 @@ use crate::scan::SEARCH_QUERY_MAX_LEN;
 /// Which external provider a lookup resolved against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MetadataProvider {
     OpenLibrary,
     GoogleBooks,
@@ -100,6 +101,7 @@ pub struct GoogleBooksKeyStatus {
 /// they carry. `cover_url` is a provider-hosted image the caller fetches only
 /// when a book/wishlist entry is actually created, not at lookup time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ExternalBookMeta {
     /// The normalized ISBN-13 that resolved (always 13 digits, no hyphens).
     pub isbn13: String,

--- a/shared/src/physical.rs
+++ b/shared/src/physical.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// A physical copy of a book, owned library-wide (shared by all users like a
 /// digital file). A book can have many; each is individually deletable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PhysicalCopy {
     pub id: i64,
     pub book_uuid: String,
@@ -27,6 +28,7 @@ pub struct PhysicalCopy {
 /// the reader at all (#2247).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WishlistSource {
     /// Added after reading a barcode with the camera.
     Scan,

--- a/shared/src/scan.rs
+++ b/shared/src/scan.rs
@@ -10,6 +10,7 @@ use crate::physical::WishlistSource;
 /// A library book matched during scan resolution — just enough to display and
 /// act on it (the confirm/decision screens).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ScanBook {
     pub uuid: String,
     pub title: String,
@@ -29,6 +30,7 @@ pub struct ScanBook {
 /// picker rather than a reason to decline the match.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ScanOutcome {
     /// Exact identifier hit; the book already has a physical copy.
     AlreadyOwned { book: ScanBook },
@@ -109,6 +111,7 @@ impl ScanSearchRequest {
 /// Title-search results: provider-resolved candidates for the reader to pick
 /// from, each complete enough to feed [`ResolveMetaRequest`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ScanSearchResponse {
     pub results: Vec<ExternalBookMeta>,
 }
@@ -236,6 +239,7 @@ impl WishlistAddRequest {
 
 /// The uuid of the book a check-in / add / wishlist write landed on.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BookRef {
     pub book_uuid: String,
 }


### PR DESCRIPTION
## Summary
- Adds the first write-tool family to the MCP crate: 8 check-in/wishlist/physical-collection tools in `mcp/src/tools/checkin.rs` (ISBN resolve, title search, candidate hydrate, confirm-gated check-in, wishlist add/remove, copy note edit, copy delete).
- Grows the client a vetted write surface: `write_json`/`write_no_content` route every non-GET through `WRITE_ALLOWLIST` (segment-wise `{param}` matching) with a hard `assert!`, reuse the `login_once` singleflight on 401, and surface server error bodies via `ClientError::WriteStatus`.
- Mutating tools are confirm-gated (`confirm: true` required) because check-in binds the ISBN to the book on the exact-identifier rung and copies/wishlist rows are library-wide state.
- Derives `schemars::JsonSchema` (feature-gated) on the scan/physical/metadata-lookup wire types so the tool schemas track `omnibus_shared`.

Closes #2280

## Test plan
- [x] `cargo test -p omnibus-mcp` (44 tests: allowlist matching incl. `#[should_panic]` on an unlisted write, write plumbing, per-tool success/refusal/error-message cases)
- [x] `cargo test -p omnibus-shared` (405 tests)
- [x] `cargo clippy -p omnibus-mcp --all-targets -- -D warnings`, `cargo fmt --check`

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- Write policy prose lives on `WRITE_ALLOWLIST`'s doc comment; the crate docs stay trimmed.