### PR TITLE
[OMNI-2279] Shelf Authoring MCP Tools

### DIFF
--- a/mcp/src/client.rs
+++ b/mcp/src/client.rs
@@ -51,6 +51,16 @@ pub const WRITE_ALLOWLIST: &[&str] = &[
     // from external meta; the remove is the per-book detail route.
     "POST /api/scan/wishlist",
     "DELETE /api/physical/{uuid}/wishlist",
+    // Content state (rule 08 tier 3): which shelves exist for a user and
+    // which books they hold is per-user content, not configuration.
+    "POST /api/shelves",
+    "PATCH /api/shelves/{id}",
+    "DELETE /api/shelves/{id}",
+    "POST /api/shelves/{id}/books",
+    "DELETE /api/shelves/{id}/books/{uuid}",
+    // Not a mutation at all — rule 08 calls this one out as "a read wearing
+    // POST": it evaluates a candidate smart rule and creates nothing.
+    "POST /api/shelves/preview",
 ];
 
 /// True when `method path` is covered by [`WRITE_ALLOWLIST`]. A `{param}`
@@ -385,12 +395,16 @@ impl OmnibusClient {
         })
     }
 
-    /// Send an allowlisted body-less write whose success answer carries no
-    /// content (the `204` DELETE endpoints).
-    pub async fn write_no_content(&self, method: Method, path: &str) -> Result<(), ClientError> {
-        let resp = self
-            .write_with_relogin::<()>(method.clone(), path, None)
-            .await?;
+    /// Send an allowlisted write (with an optional JSON body) whose success
+    /// answer carries no content — the `204` DELETE endpoints, and the shelf
+    /// membership `POST` that acknowledges with `204`.
+    pub async fn write_no_content<B: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<(), ClientError> {
+        let resp = self.write_with_relogin(method.clone(), path, body).await?;
         if !resp.status().is_success() {
             return Err(Self::write_status_error(&method, path, resp).await);
         }

--- a/mcp/src/client/tests.rs
+++ b/mcp/src/client/tests.rs
@@ -107,6 +107,18 @@ async fn delete_thing(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Allowlisted body-carrying 204 route (`POST /api/shelves/{id}/books`):
+/// records the body and answers no content.
+async fn add_books_thing(
+    State(stub): State<Arc<Stub>>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Result<StatusCode, StatusCode> {
+    check_bearer(&stub, &headers)?;
+    *stub.last_write_body.lock().unwrap() = Some(body);
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// Boot a stub instance and return `(client, stub)`.
 async fn stub_client() -> (OmnibusClient, Arc<Stub>) {
     let stub = Arc::new(Stub::default());
@@ -114,6 +126,7 @@ async fn stub_client() -> (OmnibusClient, Arc<Stub>) {
         .route("/api/auth/login", post(login))
         .route("/api/thing", get(protected))
         .route("/api/scan/resolve", post(write_thing))
+        .route("/api/shelves/{id}/books", post(add_books_thing))
         .route(
             "/api/scan/search",
             post(|| async { (StatusCode::BAD_REQUEST, "query is required") }),
@@ -376,10 +389,21 @@ async fn write_json_returns_write_status_carrying_the_server_message() {
 async fn write_no_content_succeeds_on_a_204_delete() {
     let (client, stub) = stub_client().await;
     client
-        .write_no_content(Method::DELETE, "/api/physical/uuid-1/wishlist")
+        .write_no_content::<()>(Method::DELETE, "/api/physical/uuid-1/wishlist", None)
         .await
         .unwrap();
     assert_eq!(stub.deletes.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn write_no_content_sends_the_json_body_on_a_204_post() {
+    let (client, stub) = stub_client().await;
+    let body = serde_json::json!({ "book_uuids": ["uuid-1", "uuid-2"] });
+    client
+        .write_no_content(Method::POST, "/api/shelves/5/books", Some(&body))
+        .await
+        .unwrap();
+    assert_eq!(stub.last_write_body.lock().unwrap().take(), Some(body));
 }
 
 #[tokio::test]

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,6 +1,6 @@
 //! MCP stdio server for Omnibus: authenticates over `POST /api/auth/login`
 //! and exposes the library, search, discovery, shelf, stats, progress, and
-//! annotation reads — plus the physical check-in and wishlist tools — with
+//! annotation reads — plus the check-in, wishlist, and shelf tools — with
 //! result schemas derived from the `omnibus_shared` wire types. Write policy
 //! is [`client::WRITE_ALLOWLIST`]; configuration is documented on [`config`].
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -23,11 +23,11 @@ impl OmnibusMcp {
     ///
     /// Later issues add write-tool families as further
     /// `#[tool_router(router = <name>)]` impl blocks under `crate::tools`
-    /// and combine them here: `Self::read_tools() + Self::write_tools()`.
+    /// and combine them here.
     pub fn new(client: Arc<OmnibusClient>) -> Self {
         Self {
             client,
-            tool_router: Self::read_tools() + Self::checkin_tools(),
+            tool_router: Self::read_tools() + Self::checkin_tools() + Self::shelf_tools(),
         }
     }
 }
@@ -56,14 +56,18 @@ impl ServerHandler for OmnibusMcp {
                  and search books, explore authors/series/tags/genres and shelves, and \
                  read the signed-in user's stats, progress, highlights, bookmarks, and \
                  journal entries; books are identified by the uuid field returned by \
-                 the listing and search tools. The physical-collection tools are the \
-                 only mutations: resolve ISBNs and title searches against the library \
-                 and the external metadata providers (always relay which provider \
-                 answered), check in physical copies, and manage the wishlist and copy \
-                 notes. check_in_physical_book and remove_physical_copy have lasting \
-                 effects, so they require confirm=true — resolve first, show the user \
-                 the target, and confirm only with their approval. Digital library \
-                 content, settings, and reading state are never modified."
+                 the listing and search tools. The physical-collection tools resolve \
+                 ISBNs and title searches against the library and the external \
+                 metadata providers (always relay which provider answered), check in \
+                 physical copies, and manage the wishlist and copy notes; \
+                 check_in_physical_book and remove_physical_copy have lasting effects, \
+                 so they require confirm=true — resolve first, show the user the \
+                 target, and confirm only with their approval. The shelf tools author \
+                 shelves for the signed-in user: iterate a smart rule with \
+                 preview_shelf_rule (which creates nothing) before create_shelf, and \
+                 delete_shelf requires confirm=true after explicit user confirmation. \
+                 Digital library content, settings, and reading state are never \
+                 modified."
                     .to_string(),
             )
     }

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -1011,3 +1011,65 @@ async fn update_shelf_surfaces_a_403_naming_the_ownership_rule() {
         err.message
     );
 }
+
+#[tokio::test]
+async fn remove_book_from_shelf_rejects_a_uuid_that_is_not_one_path_segment() {
+    // A slash-bearing "uuid" would otherwise split the request path into
+    // extra segments and trip the WRITE_ALLOWLIST assert — a panic, not an
+    // error. The guard must answer invalid params before any request forms.
+    let service = offline_server();
+    let err = match service
+        .remove_book_from_shelf(Parameters(RemoveBookParams {
+            id: 5,
+            uuid: "uuid-a/../../settings".into(),
+        }))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected an invalid-params error"),
+    };
+    assert!(err.message.contains("uuid"), "message: {}", err.message);
+}
+
+#[tokio::test]
+async fn remove_from_wishlist_rejects_a_uuid_that_is_not_one_path_segment() {
+    let service = offline_server();
+    let err = match service
+        .remove_from_wishlist(Parameters(crate::tools::checkin::BookUuid {
+            uuid: "a/b".into(),
+        }))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected an invalid-params error"),
+    };
+    assert!(err.message.contains("uuid"), "message: {}", err.message);
+}
+
+#[tokio::test]
+async fn create_shelf_rejects_invalid_kind_combinations_locally() {
+    // A smart shelf without rules fails CreateShelfRequest::validate before
+    // any request leaves the client (offline_server has no instance behind
+    // it, so reaching the network would surface a transport error instead).
+    let service = offline_server();
+    let err = match service
+        .create_shelf(Parameters(CreateShelfParams {
+            kind: ShelfKind::Smart,
+            name: "Broken".into(),
+            description: None,
+            visibility: None,
+            match_mode: None,
+            rules: None,
+            book_uuids: None,
+        }))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected a validation error"),
+    };
+    assert!(
+        err.message.contains("match mode"),
+        "message: {}",
+        err.message
+    );
+}

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -5,11 +5,18 @@ use axum::routing::{get, post};
 use axum::{Json as AxumJson, Router};
 use rmcp::handler::server::wrapper::Parameters;
 
-use omnibus_shared::{EbookLibrary, EbookMetadata};
+use omnibus_shared::{
+    EbookLibrary, EbookMetadata, MatchMode, RuleField, RuleOp, RulePreview, Shelf, ShelfKind,
+    ShelfRule, Visibility,
+};
 
 use super::*;
 use crate::config::Config;
 use crate::tools::read::{BookRef, ListBooksParams};
+use crate::tools::shelves::{
+    AddBooksParams, CreateShelfParams, DeleteShelfParams, PreviewRuleParams, RemoveBookParams,
+    UpdateShelfParams,
+};
 
 /// Every read tool this issue ships, by MCP tool name.
 const EXPECTED_TOOLS: &[&str] = &[
@@ -76,6 +83,7 @@ fn get_info_declares_tools_and_the_confirm_gated_write_surface() {
     let instructions = info.instructions.unwrap_or_default();
     assert!(instructions.contains("Read-only"));
     assert!(instructions.contains("confirm=true"));
+    assert!(instructions.contains("preview_shelf_rule"));
 }
 
 /// Boot a stub instance serving shared-typed JSON and return a service
@@ -687,4 +695,319 @@ async fn remove_physical_copy_names_the_missing_edit_permission_on_403() {
         .await
         .expect_err_data();
     assert!(err.message.contains("can_edit"), "got: {}", err.message);
+}
+
+// --- shelf authoring tools -------------------------------------------------
+
+/// Every shelf-authoring tool, by MCP tool name.
+const EXPECTED_SHELF_TOOLS: &[&str] = &[
+    "preview_shelf_rule",
+    "create_shelf",
+    "update_shelf",
+    "add_books_to_shelf",
+    "remove_book_from_shelf",
+    "delete_shelf",
+];
+
+#[test]
+fn shelf_tools_router_lists_every_expected_tool_with_a_description() {
+    let router = OmnibusMcp::shelf_tools();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in EXPECTED_SHELF_TOOLS {
+        assert!(names.contains(expected), "missing tool {expected}");
+    }
+    assert_eq!(
+        tools.len(),
+        EXPECTED_SHELF_TOOLS.len(),
+        "unexpected extra tools: {names:?}"
+    );
+    for tool in &tools {
+        let desc = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            desc.len() > 20,
+            "tool {} needs a real description",
+            tool.name
+        );
+    }
+}
+
+/// State recorded by the shelf stub: the last body per capturing route, plus
+/// every bodyless-delete path that was hit.
+#[derive(Default)]
+struct ShelfStub {
+    last_preview_body: std::sync::Mutex<Option<serde_json::Value>>,
+    last_create_body: std::sync::Mutex<Option<serde_json::Value>>,
+    last_add_body: std::sync::Mutex<Option<serde_json::Value>>,
+    deletes: std::sync::Mutex<Vec<String>>,
+}
+
+fn sample_shelf() -> Shelf {
+    Shelf {
+        id: 5,
+        owner_user_id: 1,
+        owner_username: "reader".into(),
+        kind: ShelfKind::Smart,
+        name: "Le Guin EPUBs".into(),
+        description: None,
+        visibility: Visibility::Private,
+        accent: None,
+        match_mode: Some(MatchMode::All),
+        rules: vec![ShelfRule {
+            field: RuleField::Author,
+            op: RuleOp::Contains,
+            value: "le guin".into(),
+        }],
+        book_count: 2,
+        sync_to_kobo: false,
+    }
+}
+
+/// Boot a stub instance serving the shelf endpoints and return a service
+/// pointed at it plus the recorded state.
+async fn shelf_stub_service() -> (OmnibusMcp, Arc<ShelfStub>) {
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::routing::{delete, patch};
+
+    async fn login() -> AxumJson<serde_json::Value> {
+        AxumJson(serde_json::json!({
+            "user": {
+                "id": 1, "username": "reader", "is_admin": false,
+                "can_upload": false, "can_edit": false, "can_download": true
+            },
+            "token": "token-1",
+        }))
+    }
+    async fn preview(
+        State(stub): State<Arc<ShelfStub>>,
+        AxumJson(body): AxumJson<serde_json::Value>,
+    ) -> AxumJson<RulePreview> {
+        *stub.last_preview_body.lock().unwrap() = Some(body);
+        AxumJson(RulePreview {
+            matched: 2,
+            total: 10,
+            sample: vec![EbookMetadata {
+                id: 7,
+                filename: "dispossessed.epub".into(),
+                title: Some("The Dispossessed".into()),
+                unique_identifier: Some("uuid-dispossessed".into()),
+                ..EbookMetadata::default()
+            }],
+        })
+    }
+    async fn create(
+        State(stub): State<Arc<ShelfStub>>,
+        AxumJson(body): AxumJson<serde_json::Value>,
+    ) -> (StatusCode, AxumJson<Shelf>) {
+        *stub.last_create_body.lock().unwrap() = Some(body);
+        (StatusCode::CREATED, AxumJson(sample_shelf()))
+    }
+    async fn update_forbidden() -> (StatusCode, &'static str) {
+        (StatusCode::FORBIDDEN, "not your shelf")
+    }
+    async fn add_books(
+        State(stub): State<Arc<ShelfStub>>,
+        AxumJson(body): AxumJson<serde_json::Value>,
+    ) -> StatusCode {
+        *stub.last_add_body.lock().unwrap() = Some(body);
+        StatusCode::NO_CONTENT
+    }
+    async fn record_delete(
+        State(stub): State<Arc<ShelfStub>>,
+        req: axum::http::Request<axum::body::Body>,
+    ) -> StatusCode {
+        stub.deletes.lock().unwrap().push(req.uri().path().into());
+        StatusCode::NO_CONTENT
+    }
+
+    let stub = Arc::new(ShelfStub::default());
+    let app = Router::new()
+        .route("/api/auth/login", post(login))
+        .route("/api/shelves/preview", post(preview))
+        .route("/api/shelves", post(create))
+        .route("/api/shelves/{id}", patch(update_forbidden))
+        .route("/api/shelves/{id}", delete(record_delete))
+        .route("/api/shelves/{id}/books", post(add_books))
+        .route("/api/shelves/{id}/books/{uuid}", delete(record_delete))
+        .with_state(stub.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OmnibusClient::new(Config {
+        base_url: format!("http://{addr}"),
+        username: "reader".into(),
+        password: "correct horse battery".into(),
+    })
+    .unwrap();
+    (OmnibusMcp::new(Arc::new(client)), stub)
+}
+
+fn candidate_rules() -> Vec<ShelfRule> {
+    vec![
+        ShelfRule {
+            field: RuleField::Author,
+            op: RuleOp::Contains,
+            value: "le guin".into(),
+        },
+        ShelfRule {
+            field: RuleField::Format,
+            op: RuleOp::Includes,
+            value: "epub".into(),
+        },
+    ]
+}
+
+#[tokio::test]
+async fn preview_shelf_rule_round_trips_the_rule_and_returns_matches_without_creating() {
+    let (service, stub) = shelf_stub_service().await;
+    let preview = service
+        .preview_shelf_rule(Parameters(PreviewRuleParams {
+            match_mode: MatchMode::All,
+            rules: candidate_rules(),
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(preview.0.matched, 2);
+    assert_eq!(preview.0.total, 10);
+    assert_eq!(preview.0.sample.len(), 1);
+    assert_eq!(
+        preview.0.sample[0].title.as_deref(),
+        Some("The Dispossessed")
+    );
+
+    // The wire body carried the exact candidate rule, and nothing was created
+    // or deleted by previewing.
+    let body = stub.last_preview_body.lock().unwrap().clone().unwrap();
+    assert_eq!(body["match_mode"], "all");
+    assert_eq!(body["rules"][0]["field"], "author");
+    assert_eq!(body["rules"][0]["op"], "contains");
+    assert_eq!(body["rules"][0]["value"], "le guin");
+    assert_eq!(body["rules"][1]["field"], "format");
+    assert!(stub.last_create_body.lock().unwrap().is_none());
+    assert!(stub.deletes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn create_shelf_sends_the_previewed_rule_as_the_create_payload() {
+    let (service, stub) = shelf_stub_service().await;
+    let shelf = service
+        .create_shelf(Parameters(CreateShelfParams {
+            kind: ShelfKind::Smart,
+            name: "Le Guin EPUBs".into(),
+            description: None,
+            visibility: None,
+            match_mode: Some(MatchMode::All),
+            rules: Some(candidate_rules()),
+            book_uuids: None,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(shelf.0.id, 5);
+    assert_eq!(shelf.0.name, "Le Guin EPUBs");
+
+    let body = stub.last_create_body.lock().unwrap().clone().unwrap();
+    assert_eq!(body["kind"], "smart");
+    assert_eq!(body["name"], "Le Guin EPUBs");
+    assert_eq!(body["visibility"], "private");
+    assert_eq!(body["match_mode"], "all");
+    assert_eq!(body["rules"][0]["value"], "le guin");
+    assert_eq!(body["rules"][1]["value"], "epub");
+    assert_eq!(body["book_uuids"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn add_books_to_shelf_posts_the_explicit_uuid_list() {
+    let (service, stub) = shelf_stub_service().await;
+    let ack = service
+        .add_books_to_shelf(Parameters(AddBooksParams {
+            id: 5,
+            book_uuids: vec!["uuid-a".into(), "uuid-b".into()],
+        }))
+        .await
+        .unwrap();
+    assert!(ack.0.done);
+    let body = stub.last_add_body.lock().unwrap().clone().unwrap();
+    assert_eq!(body["book_uuids"], serde_json::json!(["uuid-a", "uuid-b"]));
+}
+
+#[tokio::test]
+async fn remove_book_from_shelf_deletes_the_membership_row() {
+    let (service, stub) = shelf_stub_service().await;
+    let ack = service
+        .remove_book_from_shelf(Parameters(RemoveBookParams {
+            id: 5,
+            uuid: "uuid-a".into(),
+        }))
+        .await
+        .unwrap();
+    assert!(ack.0.done);
+    assert_eq!(
+        stub.deletes.lock().unwrap().clone(),
+        vec!["/api/shelves/5/books/uuid-a".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn delete_shelf_refuses_without_explicit_confirmation() {
+    let (service, stub) = shelf_stub_service().await;
+    let err = match service
+        .delete_shelf(Parameters(DeleteShelfParams {
+            id: 5,
+            confirm: false,
+        }))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected a confirmation refusal"),
+    };
+    assert!(err.message.contains("confirm: true"));
+    // The refusal happened before any request left the client.
+    assert!(stub.deletes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn delete_shelf_deletes_when_confirmed() {
+    let (service, stub) = shelf_stub_service().await;
+    let ack = service
+        .delete_shelf(Parameters(DeleteShelfParams {
+            id: 5,
+            confirm: true,
+        }))
+        .await
+        .unwrap();
+    assert!(ack.0.done);
+    assert_eq!(
+        stub.deletes.lock().unwrap().clone(),
+        vec!["/api/shelves/5".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn update_shelf_surfaces_a_403_naming_the_ownership_rule() {
+    let (service, _stub) = shelf_stub_service().await;
+    let err = match service
+        .update_shelf(Parameters(UpdateShelfParams {
+            id: 9,
+            name: Some("Renamed".into()),
+            description: None,
+            visibility: None,
+            match_mode: None,
+            rules: None,
+            sync_to_kobo: None,
+        }))
+        .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected a forbidden error"),
+    };
+    assert!(err.message.contains("owner"), "message: {}", err.message);
+    assert!(
+        err.message.contains("not your shelf"),
+        "message: {}",
+        err.message
+    );
 }

--- a/mcp/src/tools/checkin.rs
+++ b/mcp/src/tools/checkin.rs
@@ -338,7 +338,7 @@ impl OmnibusMcp {
     ) -> Result<Json<Ack>, ErrorData> {
         let path = format!("/api/physical/{}/wishlist", p.uuid);
         self.client
-            .write_no_content(Method::DELETE, &path)
+            .write_no_content::<()>(Method::DELETE, &path, None)
             .await
             .map_err(write_error)?;
         Ok(Json(Ack {
@@ -391,7 +391,7 @@ impl OmnibusMcp {
         }
         let path = format!("/api/physical/copies/{}", p.copy_id);
         self.client
-            .write_no_content(Method::DELETE, &path)
+            .write_no_content::<()>(Method::DELETE, &path, None)
             .await
             .map_err(write_error)?;
         Ok(Json(Ack {

--- a/mcp/src/tools/checkin.rs
+++ b/mcp/src/tools/checkin.rs
@@ -336,13 +336,14 @@ impl OmnibusMcp {
         &self,
         Parameters(p): Parameters<BookUuid>,
     ) -> Result<Json<Ack>, ErrorData> {
-        let path = format!("/api/physical/{}/wishlist", p.uuid);
+        let uuid = crate::tools::path_segment(&p.uuid, "uuid")?;
+        let path = format!("/api/physical/{uuid}/wishlist");
         self.client
             .write_no_content::<()>(Method::DELETE, &path, None)
             .await
             .map_err(write_error)?;
         Ok(Json(Ack {
-            message: format!("removed {} from the wishlist", p.uuid),
+            message: format!("removed {uuid} from the wishlist"),
         }))
     }
 

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -9,3 +9,28 @@
 pub mod checkin;
 pub mod read;
 pub mod shelves;
+
+use rmcp::ErrorData;
+
+/// Validate a model-supplied handle before it becomes one URL path segment.
+///
+/// The write plumbing asserts every request path against
+/// [`crate::client::WRITE_ALLOWLIST`], so a value that splits into extra
+/// segments (or an empty one) would trip that assert and panic the process.
+/// Every path-bound handle this crate sends (book uuids) is a plain
+/// `[A-Za-z0-9-]` string, so anything else is rejected as invalid params
+/// before a path is built.
+pub(crate) fn path_segment<'a>(value: &'a str, what: &str) -> Result<&'a str, ErrorData> {
+    let well_formed =
+        !value.is_empty() && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+    if well_formed {
+        Ok(value)
+    } else {
+        Err(ErrorData::invalid_params(
+            format!(
+                "{what} must be a non-empty identifier (letters, digits, dashes): got {value:?}"
+            ),
+            None,
+        ))
+    }
+}

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -2,8 +2,10 @@
 //! `#[tool_router(router = <name>)]` impl block on
 //! [`crate::server::OmnibusMcp`]; `OmnibusMcp::new` combines the routers.
 //! Read tools live in [`read`], the check-in / wishlist / physical-collection
-//! family in [`checkin`]; later issues add further families as sibling
-//! modules, subject to the allowlist policy in [`crate::client`].
+//! family in [`checkin`], shelf authoring in [`shelves`]; later issues add
+//! further families as sibling modules, subject to the allowlist policy in
+//! [`crate::client`].
 
 pub mod checkin;
 pub mod read;
+pub mod shelves;

--- a/mcp/src/tools/shelves.rs
+++ b/mcp/src/tools/shelves.rs
@@ -1,0 +1,255 @@
+//! The shelf authoring tool family: create, update, and delete shelves,
+//! edit hand-picked membership, and preview an unsaved smart rule. Every
+//! tool wraps one existing `/api/shelves*` endpoint on the
+//! [`crate::client::WRITE_ALLOWLIST`]; descriptions are the model-facing
+//! API docs — the rule syntax documented on `preview_shelf_rule` is the
+//! source of truth for what a model may send.
+
+use reqwest::Method;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router, ErrorData, Json};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use omnibus_shared::{
+    CreateShelfRequest, MatchMode, RulePreview, RulePreviewRequest, Shelf, ShelfKind, ShelfRule,
+    UpdateShelfRequest, Visibility,
+};
+
+use crate::client::ClientError;
+use crate::server::OmnibusMcp;
+
+/// Parameters for previewing a candidate smart-shelf rule set.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PreviewRuleParams {
+    /// How the rules combine: `all` = AND, `any` = OR.
+    pub match_mode: MatchMode,
+    /// The candidate conditions (at most 50).
+    pub rules: Vec<ShelfRule>,
+}
+
+/// Parameters for creating a shelf.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateShelfParams {
+    /// `manual` (hand-picked members) or `smart` (rule-driven membership).
+    pub kind: ShelfKind,
+    /// Shelf name, unique per library (≤ 120 chars).
+    pub name: String,
+    /// Optional description (≤ 2048 chars).
+    pub description: Option<String>,
+    /// `private` (owner + admins, the default) or `public` (every user).
+    pub visibility: Option<Visibility>,
+    /// Required for smart shelves: how the rules combine.
+    pub match_mode: Option<MatchMode>,
+    /// Required (non-empty) for smart shelves, forbidden for manual ones.
+    pub rules: Option<Vec<ShelfRule>>,
+    /// Optional initial members for a manual shelf (book uuids).
+    pub book_uuids: Option<Vec<String>>,
+}
+
+/// Parameters for partially updating a shelf.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateShelfParams {
+    /// Shelf id from list_shelves / get_shelf.
+    pub id: i64,
+    /// New name (≤ 120 chars, unique per library).
+    pub name: Option<String>,
+    /// New description (≤ 2048 chars).
+    pub description: Option<String>,
+    /// `private` (owner + admins) or `public` (every user).
+    pub visibility: Option<Visibility>,
+    /// New match mode (smart shelves only).
+    pub match_mode: Option<MatchMode>,
+    /// Replaces the ENTIRE rule set (smart shelves only) — send the full
+    /// final set, not a delta.
+    pub rules: Option<Vec<ShelfRule>>,
+    /// Opt the shelf's books in or out of the owner's Kobo wireless sync.
+    pub sync_to_kobo: Option<bool>,
+}
+
+/// Parameters for appending books to a hand-picked shelf.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddBooksParams {
+    /// Shelf id from list_shelves / get_shelf.
+    pub id: i64,
+    /// Book uuids to append (from the listing/search tools; at most 2000).
+    pub book_uuids: Vec<String>,
+}
+
+/// Parameters for removing one book from a shelf.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveBookParams {
+    /// Shelf id from list_shelves / get_shelf.
+    pub id: i64,
+    /// The member book's uuid.
+    pub uuid: String,
+}
+
+/// Parameters for deleting a shelf.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteShelfParams {
+    /// Shelf id from list_shelves / get_shelf.
+    pub id: i64,
+    /// Must be `true`. Deletion is permanent; set it only after the user has
+    /// explicitly confirmed deleting this specific shelf.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Acknowledgement for the shelf writes whose endpoint answers
+/// `204 No Content` on success.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WriteAck {
+    /// Always `true` — an unsuccessful write is a tool error instead.
+    pub done: bool,
+}
+
+/// Map a shelf-write failure onto a model-actionable error: 403 names the
+/// permission rule, and the other 4xx errors carry the server's own message
+/// (rule validation, name conflicts) verbatim so the model can self-correct.
+fn write_error(e: ClientError) -> ErrorData {
+    match &e {
+        ClientError::WriteStatus {
+            status: 403,
+            message,
+            ..
+        } => ErrorData::invalid_params(
+            format!(
+                "forbidden: only a shelf's owner (or an admin) may modify it, and \
+                 system shelves like the built-in Wishlist can never be modified — \
+                 server said: {message}"
+            ),
+            None,
+        ),
+        ClientError::WriteStatus {
+            status: status @ (404 | 409 | 422),
+            message,
+            ..
+        } => ErrorData::invalid_params(format!("HTTP {status}: {message}"), None),
+        _ => e.into(),
+    }
+}
+
+#[tool_router(router = shelf_tools, vis = "pub(crate)")]
+impl OmnibusMcp {
+    #[tool(
+        description = "Evaluate a candidate smart-shelf rule set WITHOUT creating anything: returns how many books match (matched of total) plus a sample of the matching books. This is the iteration tool — preview, inspect the sample, refine the rules, preview again, and only call create_shelf once the preview matches the intent, passing the exact rules you previewed. Rule syntax: Each rule is {field, op, value} (all strings); rules combine per match_mode: 'all' = every rule must hold (AND), 'any' = at least one (OR). Fields and their operators: tag / genre / author / series take is, is_not, contains, starts_with with value = the name, case-insensitive (genres are user-assigned; tags come from the files); format takes includes (exact, e.g. 'epub', 'cbz', 'm4b', 'mp3'), contains, starts_with; rating takes is or gte with value = stars '0.5' to '5' (halves allowed, e.g. '3.5'); status takes is with value 'unread', 'reading', or 'finished'; year takes is or gte with an integer publication year; date_added / date_updated take in_last (value '30d', '2w', '3m', '1y'), between (value 'START..END' ISO dates, e.g. '2025-01-01..2025-06-30'), before, after (ISO date). rating and status evaluate against the shelf owner's data. Example: {\"match_mode\": \"all\", \"rules\": [{\"field\": \"author\", \"op\": \"contains\", \"value\": \"le guin\"}, {\"field\": \"format\", \"op\": \"includes\", \"value\": \"epub\"}]} matches Le Guin books that have an EPUB file."
+    )]
+    pub async fn preview_shelf_rule(
+        &self,
+        Parameters(p): Parameters<PreviewRuleParams>,
+    ) -> Result<Json<RulePreview>, ErrorData> {
+        let req = RulePreviewRequest {
+            match_mode: p.match_mode,
+            rules: p.rules,
+        };
+        let preview: RulePreview = self
+            .client
+            .write_json(Method::POST, "/api/shelves/preview", &req)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(preview))
+    }
+
+    #[tool(
+        description = "Create a shelf owned by the signed-in user and return it. kind 'manual' takes an optional book_uuids member list and no rules; kind 'smart' requires match_mode + rules (same syntax as preview_shelf_rule — ALWAYS iterate the rule with preview_shelf_rule first, then create with the exact rules you previewed). Names must be unique. visibility defaults to private (owner + admins only)."
+    )]
+    pub async fn create_shelf(
+        &self,
+        Parameters(p): Parameters<CreateShelfParams>,
+    ) -> Result<Json<Shelf>, ErrorData> {
+        let req = CreateShelfRequest {
+            kind: p.kind,
+            name: p.name,
+            description: p.description,
+            visibility: p.visibility.unwrap_or_default(),
+            match_mode: p.match_mode,
+            rules: p.rules.unwrap_or_default(),
+            book_uuids: p.book_uuids.unwrap_or_default(),
+        };
+        let shelf: Shelf = self
+            .client
+            .write_json(Method::POST, "/api/shelves", &req)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(shelf))
+    }
+
+    #[tool(
+        description = "Partially update a shelf and return it: only the fields you pass change, and rules (smart shelves only) replaces the whole rule set — preview the new set with preview_shelf_rule first. Only the shelf's owner (or an admin) may update it: a shelf you can see but don't own answers 403, and the built-in Wishlist shelf can never be modified."
+    )]
+    pub async fn update_shelf(
+        &self,
+        Parameters(p): Parameters<UpdateShelfParams>,
+    ) -> Result<Json<Shelf>, ErrorData> {
+        let req = UpdateShelfRequest {
+            name: p.name,
+            description: p.description,
+            visibility: p.visibility,
+            match_mode: p.match_mode,
+            rules: p.rules,
+            sync_to_kobo: p.sync_to_kobo,
+        };
+        let path = format!("/api/shelves/{}", p.id);
+        let shelf: Shelf = self
+            .client
+            .write_json(Method::PATCH, &path, &req)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(shelf))
+    }
+
+    #[tool(
+        description = "Append books (by uuid, from the listing/search tools) to a hand-picked manual shelf. Owner-or-admin only (403 otherwise); smart shelves compute their membership from rules and cannot take hand-picked books."
+    )]
+    pub async fn add_books_to_shelf(
+        &self,
+        Parameters(p): Parameters<AddBooksParams>,
+    ) -> Result<Json<WriteAck>, ErrorData> {
+        let path = format!("/api/shelves/{}/books", p.id);
+        let body = serde_json::json!({ "book_uuids": p.book_uuids });
+        self.client
+            .write_no_content(Method::POST, &path, Some(&body))
+            .await
+            .map_err(write_error)?;
+        Ok(Json(WriteAck { done: true }))
+    }
+
+    #[tool(
+        description = "Remove one book (by uuid) from a hand-picked manual shelf. Owner-or-admin only (403 otherwise). The book itself is untouched — only the shelf membership is removed."
+    )]
+    pub async fn remove_book_from_shelf(
+        &self,
+        Parameters(p): Parameters<RemoveBookParams>,
+    ) -> Result<Json<WriteAck>, ErrorData> {
+        let path = format!("/api/shelves/{}/books/{}", p.id, p.uuid);
+        self.client
+            .write_no_content::<()>(Method::DELETE, &path, None)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(WriteAck { done: true }))
+    }
+
+    #[tool(
+        description = "Delete a shelf permanently — the one destructive tool in this family. Requires confirm: true, which you must only set after the user has explicitly confirmed deleting this specific shelf (name it to them first). Owner-or-admin only (403 otherwise); the built-in Wishlist shelf cannot be deleted. Member books are untouched."
+    )]
+    pub async fn delete_shelf(
+        &self,
+        Parameters(p): Parameters<DeleteShelfParams>,
+    ) -> Result<Json<WriteAck>, ErrorData> {
+        if !p.confirm {
+            return Err(ErrorData::invalid_params(
+                "refusing to delete: shelf deletion is permanent. Confirm the deletion \
+                 of this specific shelf with the user (by name), then call delete_shelf \
+                 again with confirm: true.",
+                None,
+            ));
+        }
+        let path = format!("/api/shelves/{}", p.id);
+        self.client
+            .write_no_content::<()>(Method::DELETE, &path, None)
+            .await
+            .map_err(write_error)?;
+        Ok(Json(WriteAck { done: true }))
+    }
+}

--- a/mcp/src/tools/shelves.rs
+++ b/mcp/src/tools/shelves.rs
@@ -167,6 +167,12 @@ impl OmnibusMcp {
             rules: p.rules.unwrap_or_default(),
             book_uuids: p.book_uuids.unwrap_or_default(),
         };
+        // Enforce the kind-specific invariants (smart needs match_mode +
+        // rules, manual takes neither, the system Wishlist kind is never
+        // creatable) locally, so the model gets the message without a
+        // round-trip the server would 422.
+        req.validate()
+            .map_err(|msg| ErrorData::invalid_params(msg, None))?;
         let shelf: Shelf = self
             .client
             .write_json(Method::POST, "/api/shelves", &req)
@@ -222,7 +228,8 @@ impl OmnibusMcp {
         &self,
         Parameters(p): Parameters<RemoveBookParams>,
     ) -> Result<Json<WriteAck>, ErrorData> {
-        let path = format!("/api/shelves/{}/books/{}", p.id, p.uuid);
+        let uuid = crate::tools::path_segment(&p.uuid, "uuid")?;
+        let path = format!("/api/shelves/{}/books/{uuid}", p.id);
         self.client
             .write_no_content::<()>(Method::DELETE, &path, None)
             .await

--- a/shared/src/shelves.rs
+++ b/shared/src/shelves.rs
@@ -364,6 +364,7 @@ impl UpdateShelfRequest {
 
 /// Live-preview result for the create modal: "N of M match" + sample covers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct RulePreview {
     pub matched: i64,
     pub total: i64,


### PR DESCRIPTION
## Summary
- Adds the shelf authoring tool family in `mcp/src/tools/shelves.rs`: preview a smart rule without creating anything, create/update/delete shelves, and add/remove hand-picked members (delete is confirm-gated).
- Reuses the canonical write plumbing that landed with #2300 — every call routes through `write_json`/`write_no_content` and `WRITE_ALLOWLIST`, which gains the five shelf writes plus `/api/shelves/preview` (a read wearing POST).
- Extends `write_no_content` with an optional JSON body so the membership `POST` (body in, `204` out) shares the allowlisted no-content path instead of growing a parallel helper.
- Tool descriptions carry the full rule syntax so a model can iterate preview → refine → create with the exact rules it previewed.

Closes #2279

## Test plan
- [x] `cargo test -p omnibus-mcp` (53 tests: shelf router/tool coverage incl. 403/422 error surfacing and the confirm gate, plus the new body-carrying 204 write test)
- [x] `cargo test -p omnibus-shared` (405 tests)
- [x] `cargo clippy -p omnibus-mcp --all-targets -- -D warnings`, `cargo fmt --check`

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- The branch's original duplicate plumbing (`send_json`/`send_no_content`, its own allowlist matcher and `WriteStatus` variant) was dropped during the restack in favor of main's; its plumbing tests were dropped as duplicates except the body-carrying no-content case, which main lacked.