### PR TITLE
[OMNI-2278] Metadata Repair MCP Tools With Dry-Run Diffs

### DIFF
--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,4 +1,4 @@
-# Standalone read-only MCP (Model Context Protocol) stdio server. Talks plain
+# Standalone MCP (Model Context Protocol) stdio server. Talks plain
 # HTTP to any Omnibus instance's `/api/*` REST surface — deliberately NOT a
 # route inside `server/`, so it works against a remote instance unchanged and
 # owns no transport beyond stdio. Out of the workspace default-members (like

--- a/mcp/src/client.rs
+++ b/mcp/src/client.rs
@@ -61,6 +61,19 @@ pub const WRITE_ALLOWLIST: &[&str] = &[
     // Not a mutation at all — rule 08 calls this one out as "a read wearing
     // POST": it evaluates a candidate smart rule and creates nothing.
     "POST /api/shelves/preview",
+    // Metadata overrides sit in rule 08's "library-wide, every user sees it"
+    // tier — excluded from any offline queue for exactly that reason. They
+    // are permitted here only as live, per-uuid, confirm-gated tool calls
+    // (`apply_metadata_changes` / `revert_metadata_overrides` refuse without
+    // an explicit `confirm: true`), and the server re-gates them on
+    // `can_edit`.
+    "POST /api/ebooks/{uuid}/overrides",
+    "DELETE /api/ebooks/{uuid}/overrides",
+    // Reads wearing POST (the `/api/shelves/preview` shape): they mutate
+    // nothing, but spend outbound metadata-provider calls, so the server
+    // gates them on `can_edit` like the overrides write.
+    "POST /api/metadata/editions/search",
+    "POST /api/metadata/editions/hydrate",
 ];
 
 /// True when `method path` is covered by [`WRITE_ALLOWLIST`]. A `{param}`
@@ -373,18 +386,16 @@ impl OmnibusClient {
         }
     }
 
-    /// Send an allowlisted write with a JSON body and decode the success
-    /// response as `T`. Non-success statuses become
+    /// Send an allowlisted write (with an optional JSON body) and decode the
+    /// success response as `T`. Non-success statuses become
     /// [`ClientError::WriteStatus`] with the server's error body.
     pub async fn write_json<B: Serialize + ?Sized, T: DeserializeOwned>(
         &self,
         method: Method,
         path: &str,
-        body: &B,
+        body: Option<&B>,
     ) -> Result<T, ClientError> {
-        let resp = self
-            .write_with_relogin(method.clone(), path, Some(body))
-            .await?;
+        let resp = self.write_with_relogin(method.clone(), path, body).await?;
         if !resp.status().is_success() {
             return Err(Self::write_status_error(&method, path, resp).await);
         }

--- a/mcp/src/client/tests.rs
+++ b/mcp/src/client/tests.rs
@@ -334,7 +334,7 @@ async fn write_json_sends_the_body_with_bearer_and_decodes_the_response() {
     let (client, stub) = stub_client().await;
     let body = serde_json::json!({ "isbn": "9780306406157" });
     let answer: Payload = client
-        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .write_json(Method::POST, "/api/scan/resolve", Some(&body))
         .await
         .unwrap();
     assert_eq!(answer, Payload { value: 42 });
@@ -348,13 +348,13 @@ async fn write_json_relogs_in_transparently_when_the_session_expired() {
     let (client, stub) = stub_client().await;
     let body = serde_json::json!({ "isbn": "9780306406157" });
     let _: Payload = client
-        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .write_json(Method::POST, "/api/scan/resolve", Some(&body))
         .await
         .unwrap();
     // Simulate the 7-day idle expiry: the server no longer knows the token.
     stub.revoke_all();
     let answer: Payload = client
-        .write_json(Method::POST, "/api/scan/resolve", &body)
+        .write_json(Method::POST, "/api/scan/resolve", Some(&body))
         .await
         .unwrap();
     assert_eq!(answer, Payload { value: 42 });
@@ -366,7 +366,7 @@ async fn write_json_returns_write_status_carrying_the_server_message() {
     let (client, _stub) = stub_client().await;
     let body = serde_json::json!({ "query": "" });
     let err = client
-        .write_json::<_, Payload>(Method::POST, "/api/scan/search", &body)
+        .write_json::<_, Payload>(Method::POST, "/api/scan/search", Some(&body))
         .await
         .unwrap_err();
     match err {
@@ -412,7 +412,7 @@ async fn write_json_panics_on_a_path_outside_the_allowlist() {
     let (client, _stub) = stub_client().await;
     let body = serde_json::json!({});
     let _: Result<Payload, _> = client
-        .write_json(Method::POST, "/api/settings", &body)
+        .write_json(Method::POST, "/api/settings", Some(&body))
         .await;
 }
 

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,6 +1,7 @@
 //! MCP stdio server for Omnibus: authenticates over `POST /api/auth/login`
 //! and exposes the library, search, discovery, shelf, stats, progress, and
-//! annotation reads — plus the check-in, wishlist, and shelf tools — with
+//! annotation reads — plus the check-in, wishlist, shelf, and metadata
+//! repair tools — with
 //! result schemas derived from the `omnibus_shared` wire types. Write policy
 //! is [`client::WRITE_ALLOWLIST`]; configuration is documented on [`config`].
 

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -21,13 +21,16 @@ pub struct OmnibusMcp {
 impl OmnibusMcp {
     /// Build the service around an authenticated client.
     ///
-    /// Later issues add write-tool families as further
+    /// Later issues add further tool families as
     /// `#[tool_router(router = <name>)]` impl blocks under `crate::tools`
     /// and combine them here.
     pub fn new(client: Arc<OmnibusClient>) -> Self {
         Self {
             client,
-            tool_router: Self::read_tools() + Self::checkin_tools() + Self::shelf_tools(),
+            tool_router: Self::read_tools()
+                + Self::checkin_tools()
+                + Self::shelf_tools()
+                + Self::metadata_tools(),
         }
     }
 }
@@ -66,8 +69,12 @@ impl ServerHandler for OmnibusMcp {
                  shelves for the signed-in user: iterate a smart rule with \
                  preview_shelf_rule (which creates nothing) before create_shelf, and \
                  delete_shelf requires confirm=true after explicit user confirmation. \
-                 Digital library content, settings, and reading state are never \
-                 modified."
+                 Metadata repair follows a dry-run workflow: propose_metadata_changes \
+                 computes a per-book before/after diff without writing; \
+                 apply_metadata_changes and revert_metadata_overrides write metadata \
+                 overrides — library-wide state every user sees — and refuse to run \
+                 until called with confirm: true after the user has approved the diff. \
+                 Settings and reading state are never modified."
                     .to_string(),
             )
     }

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -84,6 +84,8 @@ fn get_info_declares_tools_and_the_confirm_gated_write_surface() {
     assert!(instructions.contains("Read-only"));
     assert!(instructions.contains("confirm=true"));
     assert!(instructions.contains("preview_shelf_rule"));
+    assert!(instructions.contains("confirm: true"));
+    assert!(instructions.contains("propose_metadata_changes"));
 }
 
 /// Boot a stub instance serving shared-typed JSON and return a service

--- a/mcp/src/tools/checkin.rs
+++ b/mcp/src/tools/checkin.rs
@@ -212,7 +212,7 @@ impl OmnibusMcp {
             let req = ResolveRequest { isbn: isbn.clone() };
             match self
                 .client
-                .write_json::<_, ScanOutcome>(Method::POST, "/api/scan/resolve", &req)
+                .write_json::<_, ScanOutcome>(Method::POST, "/api/scan/resolve", Some(&req))
                 .await
             {
                 Ok(outcome) => results.push(resolution(isbn, outcome)),
@@ -242,7 +242,7 @@ impl OmnibusMcp {
         let req = ScanSearchRequest { query: p.query };
         Ok(Json(
             self.client
-                .write_json(Method::POST, "/api/scan/search", &req)
+                .write_json(Method::POST, "/api/scan/search", Some(&req))
                 .await
                 .map_err(write_error)?,
         ))
@@ -259,7 +259,7 @@ impl OmnibusMcp {
         let req = ResolveMetaRequest { meta: p.meta };
         let outcome: ScanOutcome = self
             .client
-            .write_json(Method::POST, "/api/scan/resolve-meta", &req)
+            .write_json(Method::POST, "/api/scan/resolve-meta", Some(&req))
             .await
             .map_err(write_error)?;
         Ok(Json(resolution(isbn, outcome)))
@@ -288,7 +288,7 @@ impl OmnibusMcp {
         };
         Ok(Json(
             self.client
-                .write_json(Method::POST, "/api/scan/check-in", &req)
+                .write_json(Method::POST, "/api/scan/check-in", Some(&req))
                 .await
                 .map_err(write_error)?,
         ))
@@ -323,7 +323,7 @@ impl OmnibusMcp {
         };
         Ok(Json(
             self.client
-                .write_json(Method::POST, "/api/scan/wishlist", &req)
+                .write_json(Method::POST, "/api/scan/wishlist", Some(&req))
                 .await
                 .map_err(write_error)?,
         ))
@@ -369,7 +369,7 @@ impl OmnibusMcp {
         let req = UpdateCopyNoteRequest { note: p.note };
         Ok(Json(
             self.client
-                .write_json(Method::PATCH, &path, &req)
+                .write_json(Method::PATCH, &path, Some(&req))
                 .await
                 .map_err(write_error)?,
         ))

--- a/mcp/src/tools/metadata.rs
+++ b/mcp/src/tools/metadata.rs
@@ -226,7 +226,9 @@ fn validate_change(change: &BookChange) -> Result<(), ErrorData> {
 }
 
 /// The mid-batch failure report: which books were written, which failed,
-/// which were never attempted. Partial application must be visible.
+/// which were never attempted. Partial application must be visible. The
+/// structured payload keys are operation-neutral (`written`), since both the
+/// apply and the revert batches report through here.
 fn partial_failure(
     op: &str,
     written_verb: &str,
@@ -248,7 +250,7 @@ fn partial_failure(
     ErrorData::internal_error(
         message,
         Some(serde_json::json!({
-            "applied": written_uuids,
+            "written": written_uuids,
             "failed": { "book_uuid": failed_uuid, "error": cause },
             "not_attempted": not_attempted,
         })),
@@ -310,6 +312,7 @@ impl OmnibusMcp {
         }
         let mut books = Vec::with_capacity(p.changes.len());
         for change in &p.changes {
+            crate::tools::path_segment(&change.book_uuid, "book_uuid")?;
             validate_change(change)?;
             let book = self.fetch_book(&change.book_uuid).await?;
             books.push(BookDiff {

--- a/mcp/src/tools/metadata.rs
+++ b/mcp/src/tools/metadata.rs
@@ -1,0 +1,485 @@
+//! The metadata repair tool family: dry-run diffs over the per-book override
+//! endpoints, plus the provider-lookup reads that source repair values.
+//! The workflow is propose (writes nothing) → show the user the diff →
+//! apply/revert with an explicit `confirm: true`. Overrides are library-wide,
+//! so every write is confirm-gated and takes an explicit uuid list only.
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router, ErrorData, Json};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use omnibus_shared::metadata_lookup::{
+    EditionHydrateRequest, EditionSearchRequest, EditionSearchResponse, ProviderEdition,
+};
+use omnibus_shared::{EbookMetadata, MetadataOverrides};
+
+use crate::client::ClientError;
+use crate::server::OmnibusMcp;
+
+/// An explicit list of book uuids — the only addressing mode the write tools
+/// accept, so the confirmed set is always the applied set.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BookSetParams {
+    /// The books' uuids (the `unique_identifier` field on book records).
+    pub uuids: Vec<String>,
+}
+
+/// One book's proposed field changes, in the override wire shape.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BookChange {
+    /// The book's uuid.
+    pub book_uuid: String,
+    /// The fields to change. Only fields present are touched; list fields
+    /// (`creators`, `subjects`, `genres`) replace the whole list, and an
+    /// empty string clears a scalar field's override.
+    pub changes: MetadataOverrides,
+}
+
+/// Parameters for the dry-run diff.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProposeParams {
+    /// The per-book changes to preview.
+    pub changes: Vec<BookChange>,
+}
+
+/// Parameters for the apply step — the propose change-set plus the gate.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ApplyParams {
+    /// The per-book changes to apply — the same list a prior
+    /// propose_metadata_changes call diffed.
+    pub changes: Vec<BookChange>,
+    /// Must be `true`. Omitting it (or passing `false`) refuses with an
+    /// explanation of the propose → confirm → apply workflow.
+    pub confirm: Option<bool>,
+}
+
+/// Parameters for the revert step — an explicit uuid list plus the gate.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RevertParams {
+    /// The books whose overrides to delete.
+    pub uuids: Vec<String>,
+    /// Must be `true`. Omitting it (or passing `false`) refuses with an
+    /// explanation of the confirm workflow.
+    pub confirm: Option<bool>,
+}
+
+/// One field's before/after in a dry-run diff.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct FieldDiff {
+    /// The override field name (e.g. `title`, `genres`).
+    pub field: String,
+    /// The book's current effective value (overrides already merged).
+    pub before: serde_json::Value,
+    /// The proposed value.
+    pub after: serde_json::Value,
+    /// Present when the change has semantics beyond a plain field edit —
+    /// notably genres, which are override-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// One book's dry-run diff.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BookDiff {
+    pub book_uuid: String,
+    /// The book's current title, for showing the diff to a person.
+    pub title: Option<String>,
+    /// Whether the book already carries metadata overrides. Applying any
+    /// change establishes (or extends) an override row on the book.
+    pub already_has_override: bool,
+    pub fields: Vec<FieldDiff>,
+}
+
+/// The dry-run result: per-book diffs plus the workflow reminder.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ProposedChanges {
+    pub books: Vec<BookDiff>,
+    /// What to do with this diff.
+    pub next_step: String,
+}
+
+/// One book a write landed on.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WrittenBook {
+    pub book_uuid: String,
+    pub title: Option<String>,
+    /// Whether the book carries overrides after the write (`true` after an
+    /// apply, `false` after a revert).
+    pub has_override: bool,
+}
+
+/// A fully-successful apply: every requested book was written.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ApplyReport {
+    pub applied: Vec<WrittenBook>,
+}
+
+/// A fully-successful revert: every requested book's overrides were deleted.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RevertReport {
+    pub reverted: Vec<WrittenBook>,
+}
+
+/// The genre annotation AC5 requires: a genre change is not an override *of*
+/// anything — it establishes the override row that is the genres' only home.
+const GENRE_NOTE: &str =
+    "genres are override-only (nothing Omnibus scans carries a genre), so this \
+     change establishes a metadata override on the book and flips has_override; reverting the \
+     book's overrides later clears its genres entirely rather than restoring a scanned value";
+
+/// Serialize a value for a diff cell. Infallible for these wire types; a
+/// hypothetical failure degrades to `null` rather than panicking.
+fn jv<T: Serialize>(value: &T) -> serde_json::Value {
+    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+}
+
+/// The per-field delta between a book's current effective metadata and one
+/// proposed change-set. Only fields the change-set names appear.
+fn diff_book(book: &EbookMetadata, changes: &MetadataOverrides) -> Vec<FieldDiff> {
+    let mut fields = Vec::new();
+    let mut push = |field: &str, before: serde_json::Value, after: serde_json::Value| {
+        fields.push(FieldDiff {
+            field: field.to_string(),
+            before,
+            after,
+            note: None,
+        });
+    };
+    let scalars: [(&str, &Option<String>, &Option<String>); 9] = [
+        ("title", &changes.title, &book.title),
+        ("description", &changes.description, &book.description),
+        ("publisher", &changes.publisher, &book.publisher),
+        ("published", &changes.published, &book.published),
+        ("language", &changes.language, &book.language),
+        ("series", &changes.series, &book.series),
+        ("series_index", &changes.series_index, &book.series_index),
+        ("isbn13", &changes.isbn13, &book.isbn13),
+        ("isbn10", &changes.isbn10, &book.isbn10),
+    ];
+    for (name, proposed, current) in scalars {
+        if let Some(after) = proposed {
+            push(name, jv(current), jv(after));
+        }
+    }
+    if let Some(after) = &changes.creators {
+        push("creators", jv(&book.creators), jv(after));
+    }
+    if let Some(after) = &changes.subjects {
+        push("subjects", jv(&book.subjects), jv(after));
+    }
+    if let Some(after) = &changes.print_pages {
+        push("print_pages", jv(&book.print_pages), jv(after));
+    }
+    if let Some(after) = &changes.genres {
+        fields.push(FieldDiff {
+            field: "genres".to_string(),
+            before: jv(&book.genres),
+            after: jv(after),
+            note: Some(GENRE_NOTE.to_string()),
+        });
+    }
+    fields
+}
+
+/// The refusal both write tools answer when `confirm` is not `true`.
+fn unconfirmed(tool: &str, effect: &str) -> ErrorData {
+    ErrorData::invalid_params(
+        format!(
+            "refused: confirm is not true. {tool} {effect} — metadata overrides are \
+             library-wide and visible to every user. First call propose_metadata_changes \
+             (and get_effective_metadata) to preview the change, show the user the \
+             per-book before/after diff, and only after the user approves re-call {tool} \
+             with the same explicit book list plus confirm: true."
+        ),
+        None,
+    )
+}
+
+/// Render a client failure on a `can_edit`-gated route: a 403 names the
+/// missing permission instead of surfacing a bare status code.
+fn describe_edit_failure(e: &ClientError) -> String {
+    if matches!(
+        e,
+        ClientError::WriteStatus { status: 403, .. } | ClientError::Status { status: 403, .. }
+    ) {
+        return "the signed-in account lacks the edit permission (can_edit) this metadata \
+                operation requires — ask an Omnibus admin to grant it"
+            .to_string();
+    }
+    e.to_string()
+}
+
+/// Validate one change entry locally, so a dry run surfaces the same 400 the
+/// server would and an apply cannot fail validation mid-batch.
+fn validate_change(change: &BookChange) -> Result<(), ErrorData> {
+    if change.changes == MetadataOverrides::default() {
+        return Err(ErrorData::invalid_params(
+            format!("book {}: changes names no fields", change.book_uuid),
+            None,
+        ));
+    }
+    change
+        .changes
+        .validate()
+        .map_err(|msg| ErrorData::invalid_params(format!("book {}: {msg}", change.book_uuid), None))
+}
+
+/// The mid-batch failure report: which books were written, which failed,
+/// which were never attempted. Partial application must be visible.
+fn partial_failure(
+    op: &str,
+    written_verb: &str,
+    written: &[WrittenBook],
+    failed_uuid: &str,
+    error: &ClientError,
+    not_attempted: &[String],
+) -> ErrorData {
+    let written_uuids: Vec<&str> = written.iter().map(|b| b.book_uuid.as_str()).collect();
+    let cause = describe_edit_failure(error);
+    let message = format!(
+        "{op} stopped partway: {} of {} books were {written_verb} before {failed_uuid} \
+         failed ({cause}). {written_verb} (these writes DID land): {written_uuids:?}. Not \
+         {written_verb}: {failed_uuid} plus {not_attempted:?}. Resolve the failure, then \
+         re-run with only the books that were not {written_verb}.",
+        written.len(),
+        written.len() + 1 + not_attempted.len(),
+    );
+    ErrorData::internal_error(
+        message,
+        Some(serde_json::json!({
+            "applied": written_uuids,
+            "failed": { "book_uuid": failed_uuid, "error": cause },
+            "not_attempted": not_attempted,
+        })),
+    )
+}
+
+impl OmnibusMcp {
+    /// One book's current effective metadata, or an error naming the uuid.
+    async fn fetch_book(&self, uuid: &str) -> Result<EbookMetadata, ErrorData> {
+        let uuid = crate::tools::path_segment(uuid, "uuid")?;
+        let path = format!("/api/ebooks/{uuid}");
+        let book: Option<EbookMetadata> = self.client.get_json_opt(&path, &[]).await?;
+        book.ok_or_else(|| ErrorData::invalid_params(format!("book {uuid} not found"), None))
+    }
+
+    /// One book's write, mapped to the batch-failure vocabulary: `Ok` is the
+    /// updated book, `Err` is the failure `partial_failure` will report.
+    async fn write_book(
+        &self,
+        method: reqwest::Method,
+        uuid: &str,
+        body: Option<&MetadataOverrides>,
+    ) -> Result<WrittenBook, ClientError> {
+        let path = format!("/api/ebooks/{uuid}/overrides");
+        let book: EbookMetadata = self.client.write_json(method, &path, body).await?;
+        Ok(WrittenBook {
+            book_uuid: uuid.to_string(),
+            title: book.title,
+            has_override: book.has_override,
+        })
+    }
+}
+
+#[tool_router(router = metadata_tools, vis = "pub(crate)")]
+impl OmnibusMcp {
+    #[tool(
+        description = "Current effective metadata (scanned values with any overrides already merged) for an explicit list of book uuids — the before-state that metadata repair works from. Step 1 of the repair workflow: fetch this, then call propose_metadata_changes for a dry-run diff, show the user, and only then apply_metadata_changes with confirm: true. Errors if any uuid is unknown."
+    )]
+    pub async fn get_effective_metadata(
+        &self,
+        Parameters(p): Parameters<BookSetParams>,
+    ) -> Result<Json<Vec<EbookMetadata>>, ErrorData> {
+        let mut books = Vec::with_capacity(p.uuids.len());
+        for uuid in &p.uuids {
+            books.push(self.fetch_book(uuid).await?);
+        }
+        Ok(Json(books))
+    }
+
+    #[tool(
+        description = "DRY RUN — writes nothing. Takes per-book field changes ({book_uuid, changes}) and returns a per-book before/after diff computed against current effective metadata. changes uses the override shape: only fields present are touched, list fields (creators, subjects/tags, genres) replace the whole list, and an empty string clears a scalar. A genres entry is annotated specially: genres are override-only, so a genre change establishes a metadata override on the book. Always call this first, show the user the diff, then call apply_metadata_changes with the same change list and confirm: true."
+    )]
+    pub async fn propose_metadata_changes(
+        &self,
+        Parameters(p): Parameters<ProposeParams>,
+    ) -> Result<Json<ProposedChanges>, ErrorData> {
+        if p.changes.is_empty() {
+            return Err(ErrorData::invalid_params("changes names no books", None));
+        }
+        let mut books = Vec::with_capacity(p.changes.len());
+        for change in &p.changes {
+            validate_change(change)?;
+            let book = self.fetch_book(&change.book_uuid).await?;
+            books.push(BookDiff {
+                book_uuid: change.book_uuid.clone(),
+                title: book.title.clone(),
+                already_has_override: book.has_override,
+                fields: diff_book(&book, &change.changes),
+            });
+        }
+        Ok(Json(ProposedChanges {
+            books,
+            next_step: "Nothing has been written. Show the user this per-book diff; once they \
+                        approve, call apply_metadata_changes with the same changes plus \
+                        confirm: true."
+                .to_string(),
+        }))
+    }
+
+    #[tool(
+        description = "Apply per-book metadata changes as overrides (one write per book). Overrides are library-wide — every user sees the result — so this tool REFUSES unless confirm: true: first call propose_metadata_changes, show the user the diff, and pass confirm: true only after the user approves. Applies exactly the explicit book list given (there is deliberately no filter/query form) sequentially; on a mid-batch failure it stops, and the error reports which books were written and which were not. Requires the account's edit permission (can_edit)."
+    )]
+    pub async fn apply_metadata_changes(
+        &self,
+        Parameters(p): Parameters<ApplyParams>,
+    ) -> Result<Json<ApplyReport>, ErrorData> {
+        if p.confirm != Some(true) {
+            return Err(unconfirmed(
+                "apply_metadata_changes",
+                "writes metadata overrides onto every listed book",
+            ));
+        }
+        if p.changes.is_empty() {
+            return Err(ErrorData::invalid_params("changes names no books", None));
+        }
+        // Everything checkable locally is checked before the first write, so
+        // a validation problem can never leave the batch half-applied.
+        for change in &p.changes {
+            crate::tools::path_segment(&change.book_uuid, "book_uuid")?;
+            validate_change(change)?;
+        }
+        let mut applied: Vec<WrittenBook> = Vec::with_capacity(p.changes.len());
+        for (i, change) in p.changes.iter().enumerate() {
+            match self
+                .write_book(
+                    reqwest::Method::POST,
+                    &change.book_uuid,
+                    Some(&change.changes),
+                )
+                .await
+            {
+                Ok(book) => applied.push(book),
+                Err(e) if applied.is_empty() => {
+                    return Err(ErrorData::internal_error(
+                        format!(
+                            "apply_metadata_changes wrote nothing: {} failed ({})",
+                            change.book_uuid,
+                            describe_edit_failure(&e)
+                        ),
+                        None,
+                    ));
+                }
+                Err(e) => {
+                    let not_attempted: Vec<String> = p.changes[i + 1..]
+                        .iter()
+                        .map(|c| c.book_uuid.clone())
+                        .collect();
+                    return Err(partial_failure(
+                        "apply_metadata_changes",
+                        "applied",
+                        &applied,
+                        &change.book_uuid,
+                        &e,
+                        &not_attempted,
+                    ));
+                }
+            }
+        }
+        Ok(Json(ApplyReport { applied }))
+    }
+
+    #[tool(
+        description = "Delete every metadata override on each listed book, restoring the file-embedded scanned metadata (one delete per book). Override-only fields — genres, print_pages, isbn10 — are cleared outright, since they have no scanned value underneath. Library-wide, so this tool REFUSES unless confirm: true: show the user the affected books (get_effective_metadata reports current values and has_override) and pass confirm: true only after they approve the explicit uuid list. Sequential with the same stop-and-report batch semantics as apply_metadata_changes. Requires can_edit."
+    )]
+    pub async fn revert_metadata_overrides(
+        &self,
+        Parameters(p): Parameters<RevertParams>,
+    ) -> Result<Json<RevertReport>, ErrorData> {
+        if p.confirm != Some(true) {
+            return Err(unconfirmed(
+                "revert_metadata_overrides",
+                "deletes every metadata override on the listed books, including \
+                 override-only genres",
+            ));
+        }
+        if p.uuids.is_empty() {
+            return Err(ErrorData::invalid_params("uuids names no books", None));
+        }
+        for uuid in &p.uuids {
+            crate::tools::path_segment(uuid, "uuid")?;
+        }
+        let mut reverted: Vec<WrittenBook> = Vec::with_capacity(p.uuids.len());
+        for (i, uuid) in p.uuids.iter().enumerate() {
+            match self
+                .write_book(reqwest::Method::DELETE, uuid, None::<&MetadataOverrides>)
+                .await
+            {
+                Ok(book) => reverted.push(book),
+                Err(e) if reverted.is_empty() => {
+                    return Err(ErrorData::internal_error(
+                        format!(
+                            "revert_metadata_overrides reverted nothing: {uuid} failed ({})",
+                            describe_edit_failure(&e)
+                        ),
+                        None,
+                    ));
+                }
+                Err(e) => {
+                    let not_attempted: Vec<String> = p.uuids[i + 1..].to_vec();
+                    return Err(partial_failure(
+                        "revert_metadata_overrides",
+                        "reverted",
+                        &reverted,
+                        uuid,
+                        &e,
+                        &not_attempted,
+                    ));
+                }
+            }
+        }
+        Ok(Json(RevertReport { reverted }))
+    }
+
+    #[tool(
+        description = "Search the external metadata providers (Open Library, Google Books, and Hardcover when configured) for candidate editions of a book — the source of correct values for metadata repair. This is a read: it writes nothing (the POST is read-shaped), but the server requires the edit permission (can_edit) because it spends outbound provider calls. Provide free-text query and/or structured title/author/isbn (the ISBN is the strongest signal). Candidates stay attributed per provider, alongside a per-source status row; feed a candidate's source + provider_ref to hydrate_provider_edition for its full record."
+    )]
+    pub async fn search_metadata_providers(
+        &self,
+        Parameters(p): Parameters<EditionSearchRequest>,
+    ) -> Result<Json<EditionSearchResponse>, ErrorData> {
+        let found: EditionSearchResponse = self
+            .client
+            .write_json(
+                reqwest::Method::POST,
+                "/api/metadata/editions/search",
+                Some(&p),
+            )
+            .await
+            .map_err(|e| ErrorData::internal_error(describe_edit_failure(&e), None))?;
+        Ok(Json(found))
+    }
+
+    #[tool(
+        description = "Re-fetch one selected search candidate in full from the provider that offered it — a search hit is thinner than the provider's own record (e.g. Open Library search hits carry no description). Pass the candidate's source and provider_ref (and isbn13 when it has one) from search_metadata_providers. A read; requires can_edit like the search. Returns null when the provider no longer knows the candidate."
+    )]
+    pub async fn hydrate_provider_edition(
+        &self,
+        Parameters(p): Parameters<EditionHydrateRequest>,
+    ) -> Result<Json<Option<ProviderEdition>>, ErrorData> {
+        let found: Option<ProviderEdition> = self
+            .client
+            .write_json(
+                reqwest::Method::POST,
+                "/api/metadata/editions/hydrate",
+                Some(&p),
+            )
+            .await
+            .map_err(|e| ErrorData::internal_error(describe_edit_failure(&e), None))?;
+        Ok(Json(found))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/mcp/src/tools/metadata/tests.rs
+++ b/mcp/src/tools/metadata/tests.rs
@@ -1,0 +1,470 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json as AxumJson, Router};
+use rmcp::handler::server::wrapper::Parameters;
+
+use omnibus_shared::metadata_lookup::{
+    EditionSearchRequest, EditionSearchResponse, MetadataProvider, ProviderEdition,
+    ProviderSearchSource, ProviderSearchStatus,
+};
+use omnibus_shared::{EbookMetadata, MetadataOverrides};
+
+use super::*;
+use crate::client::OmnibusClient;
+use crate::config::Config;
+
+/// Every metadata tool this issue ships, by MCP tool name.
+const EXPECTED_TOOLS: &[&str] = &[
+    "get_effective_metadata",
+    "propose_metadata_changes",
+    "apply_metadata_changes",
+    "revert_metadata_overrides",
+    "search_metadata_providers",
+    "hydrate_provider_edition",
+];
+
+const KNOWN: &[&str] = &["uuid-1", "uuid-2", "uuid-3"];
+
+/// Stub instance state: records override writes and lets a test force a
+/// failure status for one uuid's mutating requests.
+#[derive(Default)]
+struct Stub {
+    posts: Mutex<Vec<(String, serde_json::Value)>>,
+    deletes: Mutex<Vec<String>>,
+    fail: Mutex<HashMap<String, u16>>,
+}
+
+fn stub_book(uuid: &str) -> EbookMetadata {
+    EbookMetadata {
+        id: 7,
+        filename: format!("{uuid}.epub"),
+        title: Some("Old Title".into()),
+        series: Some("Old Series".into()),
+        subjects: vec!["scanned-tag".into()],
+        unique_identifier: Some(uuid.into()),
+        ..EbookMetadata::default()
+    }
+}
+
+async fn login() -> AxumJson<serde_json::Value> {
+    AxumJson(serde_json::json!({
+        "user": {
+            "id": 1, "username": "editor", "is_admin": false,
+            "can_upload": false, "can_edit": true, "can_download": true
+        },
+        "token": "token-1",
+    }))
+}
+
+async fn get_book(Path(uuid): Path<String>) -> Result<AxumJson<EbookMetadata>, StatusCode> {
+    if KNOWN.contains(&uuid.as_str()) {
+        Ok(AxumJson(stub_book(&uuid)))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn post_overrides(
+    State(stub): State<Arc<Stub>>,
+    Path(uuid): Path<String>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> Result<AxumJson<EbookMetadata>, StatusCode> {
+    if let Some(status) = stub.fail.lock().unwrap().get(&uuid) {
+        return Err(StatusCode::from_u16(*status).unwrap());
+    }
+    stub.posts.lock().unwrap().push((uuid.clone(), body));
+    let mut book = stub_book(&uuid);
+    book.has_override = true;
+    Ok(AxumJson(book))
+}
+
+async fn delete_overrides(
+    State(stub): State<Arc<Stub>>,
+    Path(uuid): Path<String>,
+) -> Result<AxumJson<EbookMetadata>, StatusCode> {
+    if let Some(status) = stub.fail.lock().unwrap().get(&uuid) {
+        return Err(StatusCode::from_u16(*status).unwrap());
+    }
+    stub.deletes.lock().unwrap().push(uuid.clone());
+    Ok(AxumJson(stub_book(&uuid)))
+}
+
+async fn edition_search(
+    AxumJson(req): AxumJson<EditionSearchRequest>,
+) -> AxumJson<EditionSearchResponse> {
+    AxumJson(EditionSearchResponse {
+        editions: vec![ProviderEdition {
+            source: MetadataProvider::OpenLibrary,
+            provider_ref: "OL123W".into(),
+            isbn13: None,
+            isbn10: None,
+            title: req.query,
+            authors: vec!["Mary Shelley".into()],
+            year: Some("1818".into()),
+            pages: None,
+            publisher: None,
+            description: None,
+            cover_url: None,
+            series: None,
+            series_index: None,
+            first_publish_year: Some(1818),
+            genres: vec![],
+            relevance: Some(1000),
+        }],
+        sources: vec![ProviderSearchSource {
+            provider: MetadataProvider::OpenLibrary,
+            display_name: "Open Library".into(),
+            status: ProviderSearchStatus::Answered { count: 1 },
+        }],
+    })
+}
+
+/// Boot a stub instance and return a service pointed at it plus the stub.
+async fn stub_service() -> (OmnibusMcp, Arc<Stub>) {
+    let stub = Arc::new(Stub::default());
+    let app = Router::new()
+        .route("/api/auth/login", post(login))
+        .route("/api/ebooks/{uuid}", get(get_book))
+        .route(
+            "/api/ebooks/{uuid}/overrides",
+            post(post_overrides).delete(delete_overrides),
+        )
+        .route("/api/metadata/editions/search", post(edition_search))
+        .with_state(stub.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OmnibusClient::new(Config {
+        base_url: format!("http://{addr}"),
+        username: "editor".into(),
+        password: "correct horse battery".into(),
+    })
+    .unwrap();
+    (OmnibusMcp::new(Arc::new(client)), stub)
+}
+
+/// `unwrap_err` needs `T: Debug`, which `rmcp::Json` does not implement.
+fn expect_err<T>(result: Result<T, ErrorData>) -> ErrorData {
+    match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected an error"),
+    }
+}
+
+fn title_change(uuid: &str, title: &str) -> BookChange {
+    BookChange {
+        book_uuid: uuid.into(),
+        changes: MetadataOverrides {
+            title: Some(title.into()),
+            ..MetadataOverrides::default()
+        },
+    }
+}
+
+#[test]
+fn metadata_tools_router_lists_every_expected_tool_with_a_description() {
+    let router = OmnibusMcp::metadata_tools();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in EXPECTED_TOOLS {
+        assert!(names.contains(expected), "missing tool {expected}");
+    }
+    assert_eq!(
+        tools.len(),
+        EXPECTED_TOOLS.len(),
+        "unexpected extra tools: {names:?}"
+    );
+    for tool in &tools {
+        let desc = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            desc.len() > 20,
+            "tool {} needs a real description",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn get_effective_metadata_returns_each_requested_book_in_order() {
+    let (service, _stub) = stub_service().await;
+    let books = service
+        .get_effective_metadata(Parameters(BookSetParams {
+            uuids: vec!["uuid-1".into(), "uuid-2".into()],
+        }))
+        .await
+        .unwrap();
+    assert_eq!(books.0.len(), 2);
+    assert_eq!(books.0[0].unique_identifier.as_deref(), Some("uuid-1"));
+    assert_eq!(books.0[1].unique_identifier.as_deref(), Some("uuid-2"));
+}
+
+#[tokio::test]
+async fn get_effective_metadata_reports_not_found_for_an_unknown_uuid() {
+    let (service, _stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .get_effective_metadata(Parameters(BookSetParams {
+                uuids: vec!["uuid-missing".into()],
+            }))
+            .await,
+    );
+    assert!(err.message.contains("uuid-missing"));
+    assert!(err.message.contains("not found"));
+}
+
+#[tokio::test]
+async fn propose_metadata_changes_diffs_current_values_and_writes_nothing() {
+    let (service, stub) = stub_service().await;
+    let proposed = service
+        .propose_metadata_changes(Parameters(ProposeParams {
+            changes: vec![BookChange {
+                book_uuid: "uuid-1".into(),
+                changes: MetadataOverrides {
+                    title: Some("New Title".into()),
+                    series: Some("New Series".into()),
+                    ..MetadataOverrides::default()
+                },
+            }],
+        }))
+        .await
+        .unwrap();
+
+    let book = &proposed.0.books[0];
+    assert_eq!(book.book_uuid, "uuid-1");
+    assert!(!book.already_has_override);
+    assert_eq!(book.fields.len(), 2);
+    let title = book.fields.iter().find(|f| f.field == "title").unwrap();
+    assert_eq!(title.before, serde_json::json!("Old Title"));
+    assert_eq!(title.after, serde_json::json!("New Title"));
+    assert!(title.note.is_none());
+    let series = book.fields.iter().find(|f| f.field == "series").unwrap();
+    assert_eq!(series.before, serde_json::json!("Old Series"));
+    assert_eq!(series.after, serde_json::json!("New Series"));
+    assert!(proposed.0.next_step.contains("confirm: true"));
+
+    // A dry run: nothing reached the override endpoints.
+    assert!(stub.posts.lock().unwrap().is_empty());
+    assert!(stub.deletes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn propose_metadata_changes_annotates_a_genre_change_as_establishing_an_override() {
+    let (service, _stub) = stub_service().await;
+    let proposed = service
+        .propose_metadata_changes(Parameters(ProposeParams {
+            changes: vec![BookChange {
+                book_uuid: "uuid-1".into(),
+                changes: MetadataOverrides {
+                    genres: Some(vec!["Gothic".into(), "Horror".into()]),
+                    ..MetadataOverrides::default()
+                },
+            }],
+        }))
+        .await
+        .unwrap();
+    let genres = &proposed.0.books[0].fields[0];
+    assert_eq!(genres.field, "genres");
+    assert_eq!(genres.before, serde_json::json!([]));
+    assert_eq!(genres.after, serde_json::json!(["Gothic", "Horror"]));
+    let note = genres.note.as_deref().unwrap();
+    assert!(note.contains("override-only"));
+    assert!(note.contains("establishes a metadata override"));
+}
+
+#[tokio::test]
+async fn propose_metadata_changes_rejects_an_entry_that_names_no_fields() {
+    let (service, _stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .propose_metadata_changes(Parameters(ProposeParams {
+                changes: vec![BookChange {
+                    book_uuid: "uuid-1".into(),
+                    changes: MetadataOverrides::default(),
+                }],
+            }))
+            .await,
+    );
+    assert!(err.message.contains("names no fields"));
+}
+
+#[tokio::test]
+async fn apply_metadata_changes_refuses_without_confirm() {
+    let (service, stub) = stub_service().await;
+    for confirm in [None, Some(false)] {
+        let err = expect_err(
+            service
+                .apply_metadata_changes(Parameters(ApplyParams {
+                    changes: vec![title_change("uuid-1", "New Title")],
+                    confirm,
+                }))
+                .await,
+        );
+        assert!(err.message.contains("refused"));
+        assert!(err.message.contains("confirm: true"));
+        assert!(err.message.contains("propose_metadata_changes"));
+    }
+    assert!(stub.posts.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn apply_metadata_changes_posts_each_books_overrides_with_the_expected_body() {
+    let (service, stub) = stub_service().await;
+    let report = service
+        .apply_metadata_changes(Parameters(ApplyParams {
+            changes: vec![
+                title_change("uuid-1", "New Title"),
+                title_change("uuid-2", "Other Title"),
+            ],
+            confirm: Some(true),
+        }))
+        .await
+        .unwrap();
+
+    let posts = stub.posts.lock().unwrap().clone();
+    assert_eq!(
+        posts,
+        vec![
+            (
+                "uuid-1".to_string(),
+                serde_json::json!({"title": "New Title"})
+            ),
+            (
+                "uuid-2".to_string(),
+                serde_json::json!({"title": "Other Title"})
+            ),
+        ]
+    );
+    assert_eq!(report.0.applied.len(), 2);
+    assert_eq!(report.0.applied[0].book_uuid, "uuid-1");
+    assert!(report.0.applied[0].has_override);
+}
+
+#[tokio::test]
+async fn apply_metadata_changes_names_the_missing_edit_permission_on_a_403() {
+    let (service, stub) = stub_service().await;
+    stub.fail.lock().unwrap().insert("uuid-1".into(), 403);
+    let err = expect_err(
+        service
+            .apply_metadata_changes(Parameters(ApplyParams {
+                changes: vec![title_change("uuid-1", "New Title")],
+                confirm: Some(true),
+            }))
+            .await,
+    );
+    assert!(err.message.contains("can_edit"), "got: {}", err.message);
+    assert!(err.message.contains("edit permission"));
+    assert!(stub.posts.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn apply_metadata_changes_reports_partial_application_on_a_mid_batch_failure() {
+    let (service, stub) = stub_service().await;
+    stub.fail.lock().unwrap().insert("uuid-2".into(), 500);
+    let err = expect_err(
+        service
+            .apply_metadata_changes(Parameters(ApplyParams {
+                changes: vec![
+                    title_change("uuid-1", "A"),
+                    title_change("uuid-2", "B"),
+                    title_change("uuid-3", "C"),
+                ],
+                confirm: Some(true),
+            }))
+            .await,
+    );
+
+    // Only the first write landed; the failure stopped the batch.
+    let posts = stub.posts.lock().unwrap().clone();
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].0, "uuid-1");
+
+    // The report names all three dispositions.
+    assert!(err.message.contains("uuid-1"));
+    assert!(err.message.contains("uuid-2"));
+    assert!(err.message.contains("uuid-3"));
+    let data = err.data.unwrap();
+    assert_eq!(data["applied"], serde_json::json!(["uuid-1"]));
+    assert_eq!(data["failed"]["book_uuid"], serde_json::json!("uuid-2"));
+    assert_eq!(data["not_attempted"], serde_json::json!(["uuid-3"]));
+}
+
+#[tokio::test]
+async fn revert_metadata_overrides_refuses_without_confirm() {
+    let (service, stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .revert_metadata_overrides(Parameters(RevertParams {
+                uuids: vec!["uuid-1".into()],
+                confirm: None,
+            }))
+            .await,
+    );
+    assert!(err.message.contains("refused"));
+    assert!(err.message.contains("confirm: true"));
+    assert!(stub.deletes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn revert_metadata_overrides_deletes_each_books_overrides() {
+    let (service, stub) = stub_service().await;
+    let report = service
+        .revert_metadata_overrides(Parameters(RevertParams {
+            uuids: vec!["uuid-1".into(), "uuid-2".into()],
+            confirm: Some(true),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(
+        stub.deletes.lock().unwrap().clone(),
+        vec!["uuid-1".to_string(), "uuid-2".to_string()]
+    );
+    assert_eq!(report.0.reverted.len(), 2);
+    assert!(!report.0.reverted[0].has_override);
+}
+
+#[tokio::test]
+async fn search_metadata_providers_returns_the_attributed_fan_out() {
+    let (service, _stub) = stub_service().await;
+    let found = service
+        .search_metadata_providers(Parameters(EditionSearchRequest {
+            query: "Frankenstein".into(),
+            ..EditionSearchRequest::default()
+        }))
+        .await
+        .unwrap();
+    assert_eq!(found.0.editions.len(), 1);
+    assert_eq!(found.0.editions[0].title, "Frankenstein");
+    assert_eq!(found.0.editions[0].provider_ref, "OL123W");
+    assert_eq!(
+        found.0.sources[0].status,
+        ProviderSearchStatus::Answered { count: 1 }
+    );
+}
+
+#[tokio::test]
+async fn apply_metadata_changes_rejects_a_uuid_that_is_not_one_path_segment() {
+    // A slash-bearing "uuid" would split the overrides path into extra
+    // segments and trip the WRITE_ALLOWLIST assert — the up-front guard must
+    // answer invalid params before the first write.
+    let (service, stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .apply_metadata_changes(Parameters(ApplyParams {
+                changes: vec![title_change("uuid-1/../uuid-2", "Frankenstein")],
+                confirm: Some(true),
+            }))
+            .await,
+    );
+    assert!(
+        err.message.contains("book_uuid"),
+        "message: {}",
+        err.message
+    );
+    assert!(stub.posts.lock().unwrap().is_empty());
+}

--- a/mcp/src/tools/metadata/tests.rs
+++ b/mcp/src/tools/metadata/tests.rs
@@ -389,7 +389,7 @@ async fn apply_metadata_changes_reports_partial_application_on_a_mid_batch_failu
     assert!(err.message.contains("uuid-2"));
     assert!(err.message.contains("uuid-3"));
     let data = err.data.unwrap();
-    assert_eq!(data["applied"], serde_json::json!(["uuid-1"]));
+    assert_eq!(data["written"], serde_json::json!(["uuid-1"]));
     assert_eq!(data["failed"]["book_uuid"], serde_json::json!("uuid-2"));
     assert_eq!(data["not_attempted"], serde_json::json!(["uuid-3"]));
 }

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -2,11 +2,12 @@
 //! `#[tool_router(router = <name>)]` impl block on
 //! [`crate::server::OmnibusMcp`]; `OmnibusMcp::new` combines the routers.
 //! Read tools live in [`read`], the check-in / wishlist / physical-collection
-//! family in [`checkin`], shelf authoring in [`shelves`]; later issues add
-//! further families as sibling modules, subject to the allowlist policy in
-//! [`crate::client`].
+//! family in [`checkin`], shelf authoring in [`shelves`], the confirm-gated
+//! metadata repair family in [`metadata`]; later issues add further families
+//! as sibling modules, subject to the allowlist policy in [`crate::client`].
 
 pub mod checkin;
+pub mod metadata;
 pub mod read;
 pub mod shelves;
 

--- a/mcp/src/tools/shelves.rs
+++ b/mcp/src/tools/shelves.rs
@@ -145,7 +145,7 @@ impl OmnibusMcp {
         };
         let preview: RulePreview = self
             .client
-            .write_json(Method::POST, "/api/shelves/preview", &req)
+            .write_json(Method::POST, "/api/shelves/preview", Some(&req))
             .await
             .map_err(write_error)?;
         Ok(Json(preview))
@@ -175,7 +175,7 @@ impl OmnibusMcp {
             .map_err(|msg| ErrorData::invalid_params(msg, None))?;
         let shelf: Shelf = self
             .client
-            .write_json(Method::POST, "/api/shelves", &req)
+            .write_json(Method::POST, "/api/shelves", Some(&req))
             .await
             .map_err(write_error)?;
         Ok(Json(shelf))
@@ -199,7 +199,7 @@ impl OmnibusMcp {
         let path = format!("/api/shelves/{}", p.id);
         let shelf: Shelf = self
             .client
-            .write_json(Method::PATCH, &path, &req)
+            .write_json(Method::PATCH, &path, Some(&req))
             .await
             .map_err(write_error)?;
         Ok(Json(shelf))

--- a/shared/src/ebook/overrides.rs
+++ b/shared/src/ebook/overrides.rs
@@ -14,6 +14,7 @@ use super::metadata::Contributor;
 /// M2M fields (`creators`, `subjects`, `genres`) replace entirely when
 /// present — a tag list override replaces, not appends.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MetadataOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,

--- a/shared/src/metadata_lookup.rs
+++ b/shared/src/metadata_lookup.rs
@@ -200,6 +200,7 @@ impl ExternalBookMeta {
 /// from the client, and keeping its contract frozen is worth more than the
 /// reuse. Convert with `From` where a check-in-shaped value is wanted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ProviderEdition {
     pub source: MetadataProvider,
     /// Opaque, provider-scoped handle for re-fetching this candidate in full
@@ -416,6 +417,7 @@ impl TryFrom<ProviderEdition> for ExternalBookMeta {
 /// collapsing them makes an outage read as a miss.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProviderSearchStatus {
     /// The provider answered. `count` is how many of its candidates reached
     /// the returned list — post-cap, so it never overstates what is there.
@@ -441,6 +443,7 @@ pub enum ProviderSearchStatus {
 
 /// One row of the per-source status table returned alongside the candidates.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ProviderSearchSource {
     pub provider: MetadataProvider,
     pub display_name: String,
@@ -449,6 +452,7 @@ pub struct ProviderSearchSource {
 
 /// Body for `POST /api/metadata/editions/search`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EditionSearchRequest {
     /// The query as free text — what the reader sees in the search box, and
     /// the whole request from a client that sends nothing else.
@@ -541,6 +545,7 @@ impl EditionSearchRequest {
 /// `provider_ref` is echoed back exactly as the search handed it over;
 /// Omnibus never parses it, so it is capped rather than validated for shape.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EditionHydrateRequest {
     pub source: MetadataProvider,
     pub provider_ref: String,
@@ -596,6 +601,7 @@ impl EditionHydrateRequest {
 /// skipped or failed, which is why a caller can render "Hardcover: couldn't
 /// reach it" instead of quietly showing a shorter list.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EditionSearchResponse {
     pub editions: Vec<ProviderEdition>,
     pub sources: Vec<ProviderSearchSource>,


### PR DESCRIPTION
## Summary
- Adds the metadata repair tool family in `mcp/src/tools/metadata.rs`: fetch effective metadata, propose changes as a per-book before/after dry-run diff, apply them as overrides, revert overrides, and search/hydrate provider editions — the two writing tools refuse without `confirm: true` and report partial batch failures explicitly.
- Reuses the canonical write plumbing: all calls route through `write_json`/`WRITE_ALLOWLIST`, which gains the overrides POST/DELETE (rule-08 library-wide state, confirm-gated) and the editions search/hydrate reads-wearing-POST.
- Generalizes `write_json` to an optional body (matching `write_no_content`) so the body-less overrides DELETE that answers with the updated book shares the allowlisted path.
- Applies the `path_segment` guard from #2304 to every model-supplied uuid before a path is built, and derives feature-gated `schemars::JsonSchema` on the metadata-lookup and overrides wire types.

Closes #2278

## Test plan
- [x] `cargo test -p omnibus-mcp` (70 tests: dry-run diffing, confirm gates, partial-failure reporting, 403 permission naming, path-segment guard)
- [x] `cargo test -p omnibus-shared` (405 tests)
- [x] `cargo clippy -p omnibus-mcp --all-targets -- -D warnings`, `cargo fmt --check`
- [x] stdio smoke: initialize + tools/list against the built binary answers all 42 tools (21 read + 9 checkin + 6 shelf + 6 metadata), every one carrying an output schema

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
- The branch's original duplicate plumbing (its own `send_json` and the `method` fields it added to `ClientError::Status`/`Decode`) was dropped during the restack in favor of main's write surface.