### PR TITLE
fix: read TestFlight group membership from the builds side

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -540,9 +540,9 @@ release dispatch against Apple's live API, its suite
 (`scripts/tests/testflight-distribute.test.py`, HTTP stubbed, no credentials) is
 gated in CI by `script-tests.yml`. Those stubs encode Apple's contract as it
 was last observed, and cannot notice it changing: `GET /v1/builds/{id}/betaGroups`
-answered for months, then began returning `FORBIDDEN_ERROR` because that
-relationship is write-only, and the suite went on passing while every real
-dispatch failed short of attaching anything. Membership is therefore read from
+answered for months before App Store Connect began enforcing that relationship
+as write-only and returning `FORBIDDEN_ERROR`, and the suite went on passing
+against the stub while every real dispatch failed short of attaching anything. Membership is therefore read from
 the builds side (`filter[id]` + `filter[betaGroups]`), and a live dispatch stays
 the only place the contract is genuinely exercised. A daily companion workflow
 (`testflight-feedback.yml`) turns new TestFlight screenshot feedback into

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -538,7 +538,13 @@ Store Connect API — reuses the same team-scoped API key, and is idempotent, so
 re-run attaches nothing twice. Because that script only ever executes during a
 release dispatch against Apple's live API, its suite
 (`scripts/tests/testflight-distribute.test.py`, HTTP stubbed, no credentials) is
-gated in CI by `script-tests.yml`. A daily companion workflow
+gated in CI by `script-tests.yml`. Those stubs encode Apple's contract as it
+was last observed, and cannot notice it changing: `GET /v1/builds/{id}/betaGroups`
+answered for months, then began returning `FORBIDDEN_ERROR` because that
+relationship is write-only, and the suite went on passing while every real
+dispatch failed short of attaching anything. Membership is therefore read from
+the builds side (`filter[id]` + `filter[betaGroups]`), and a live dispatch stays
+the only place the contract is genuinely exercised. A daily companion workflow
 (`testflight-feedback.yml`) turns new TestFlight screenshot feedback into
 GitHub issues via `scripts/testflight_feedback_to_issues.py`.
 

--- a/scripts/testflight_distribute.py
+++ b/scripts/testflight_distribute.py
@@ -265,10 +265,28 @@ def set_whats_new(build_id):
     print(f"what to test: set for {len(existing) or 1} localization(s)")
 
 
+def already_in_group(build_id, group_id):
+    """Whether this build is already one of that group's builds.
+
+    Asked from the *builds* side, filtered down to the one pair in question.
+    The obvious read — `GET /v1/builds/{id}/betaGroups` — is refused: App Store
+    Connect answers `FORBIDDEN_ERROR: the relationship 'betaGroups' does not
+    allow 'GET_RELATED'`, because that relationship is write-only (CREATE and
+    DELETE). It served this script for months and then stopped, and because the
+    check runs ahead of the attach it took distribution down with it: a build
+    was uploaded, given its What to Test and submitted for review, and then
+    handed to no group at all — the exact silence this script exists to break.
+    """
+    return bool(asc("GET", "/v1/builds", params={
+        "filter[id]": build_id,
+        "filter[betaGroups]": group_id,
+        "limit": 1,
+    })["data"])
+
+
 def add_to_groups(build_id, groups):
     """Attach the build to each group it isn't already in."""
-    attached = {g["id"] for g in asc("GET", f"/v1/builds/{build_id}/betaGroups",
-                                     params={"limit": 200})["data"]}
+    attached = {g["id"] for g in groups if already_in_group(build_id, g["id"])}
     todo = [g for g in groups if g["id"] not in attached]
     for g in groups:
         if g["id"] in attached:

--- a/scripts/tests/testflight-distribute.test.py
+++ b/scripts/tests/testflight-distribute.test.py
@@ -74,6 +74,7 @@ class FakeASC:
         # under; None matches whatever is asked for.
         self.listed_version = listed_version
         self.build_queries = []  # every preReleaseVersion.version filter tried
+        self.membership_probes = []  # every (build, group) membership question asked
         self.writes = []  # (method, path, body) for every mutating call
 
     def __call__(self, method, path, **kw):
@@ -90,6 +91,15 @@ class FakeASC:
                 for gid, name in self.groups]})
 
         if path == "/v1/builds":
+            # Two different questions share this path. A membership probe
+            # carries filter[betaGroups]; the processing poll carries the
+            # version filter. Routing on the params rather than the path is
+            # what keeps `build_queries` a record of the poll alone.
+            if "filter[betaGroups]" in kw["params"]:
+                self.membership_probes.append(
+                    (kw["params"]["filter[id]"], kw["params"]["filter[betaGroups]"]))
+                in_group = kw["params"]["filter[betaGroups]"] in self.attached_groups
+                return Resp(payload={"data": [{"id": BUILD_ID}] if in_group else []})
             asked = kw["params"]["filter[preReleaseVersion.version]"]
             self.build_queries.append(asked)
             if self.listed_version is not None and asked != self.listed_version:
@@ -102,9 +112,6 @@ class FakeASC:
                 "included": [{"type": "buildBetaDetails",
                               "attributes": {"externalBuildState": self.external_state}}],
             })
-
-        if path == f"/v1/builds/{BUILD_ID}/betaGroups":
-            return Resp(payload={"data": [{"id": g} for g in self.attached_groups]})
 
         if path == "/v1/betaAppReviewSubmissions":
             return Resp(status_code=self.review_status, payload={})
@@ -181,6 +188,29 @@ check("re-run does not re-attach an attached group", 0,
       len(writes_to(fake, "/relationships/betaGroups")))
 check("re-run does not resubmit for review", 0,
       len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
+
+# Membership is asked from the builds side, filtered to the one (build, group)
+# pair. `GET /v1/builds/{id}/betaGroups` reads naturally and is refused by App
+# Store Connect — that relationship is write-only — so a regression to it now
+# trips FakeASC's unstubbed-request assertion rather than passing here and 403ing
+# in production, which is how it shipped the first time.
+code, fake = run(FakeASC(["VALID"]))
+check("membership is probed once per group", [(BUILD_ID, GROUP_ID)], fake.membership_probes)
+check("the membership probe is not a version query", ["0.14.3"], fake.build_queries)
+
+# Two groups, one of which already holds the build: the attach must carry only
+# the other one, so a re-run after a partial attach finishes the job instead of
+# repeating it.
+SECOND_ID = "group-2"
+code, fake = run(FakeASC(["VALID"], external_state="IN_BETA_TESTING",
+                         groups=[(GROUP_ID, GROUP_NAME), (SECOND_ID, "Beta Crew")],
+                         attached_groups=[GROUP_ID]),
+                 BETA_GROUPS=f"{GROUP_NAME},Beta Crew")
+check("a partly-attached build exits 0", 0, code)
+attach = writes_to(fake, "/relationships/betaGroups")
+check("only the missing group is attached", 1, len(attach))
+check("the attach names just that group", [{"type": "betaGroups", "id": SECOND_ID}],
+      attach[0][2]["data"])
 
 # A build already awaiting review still needs attaching — the two are separate
 # facts, and treating "submitted" as "distributed" is the original bug.

--- a/scripts/tests/testflight-distribute.test.py
+++ b/scripts/tests/testflight-distribute.test.py
@@ -56,9 +56,11 @@ class Resp:
 class FakeASC:
     """A scripted App Store Connect.
 
-    `build_states` is consumed one entry per `GET /v1/builds`, so a scenario can
-    say "PROCESSING, then VALID" and exercise the poll rather than only its
-    happy last iteration.
+    `build_states` is consumed one entry per *processing poll* — the
+    version-filtered `GET /v1/builds` — so a scenario can say "PROCESSING, then
+    VALID" and exercise the poll rather than only its happy last iteration. The
+    membership probe shares that path but is answered from `attached_groups` and
+    consumes nothing, so adding groups to a scenario cannot shift its states.
     """
 
     def __init__(self, build_states, external_state="READY_FOR_BETA_SUBMISSION",


### PR DESCRIPTION
## Summary
- App Store Connect refuses `GET /v1/builds/{id}/betaGroups` with `FORBIDDEN_ERROR: the relationship 'betaGroups' does not allow 'GET_RELATED'` — it is write-only (CREATE, DELETE). It answered for months and then stopped, so this is an Apple-side contract change, not a regression from any commit here.
- That read is the *first* thing `add_to_groups` does, so it took distribution down with it. On [run 33229624863](https://github.com/seamus-sloan/omnibus/actions/runs/33229624863) build **v0.28.41 (82)** was uploaded, processed, given its What to Test and submitted for Beta App Review — and then handed to no group at all. Precisely the silence the script exists to break, except it failed loudly instead of going green.
- Ask the same question from the builds side, filtered to the one (build, group) pair: `GET /v1/builds?filter[id]=…&filter[betaGroups]=…`. Both filters are documented on the Builds list endpoint. Idempotency is unchanged — an already-attached group is still skipped.
- The test fake stubbed the forbidden path, which is how this shipped: the suite passed while every real dispatch 403'd. That stub is gone, so a regression to it now trips `unstubbed request` instead.

## Test plan
- [x] `python scripts/tests/testflight-distribute.test.py` — 33 passed, 0 failed (was 27).
- [x] Verified the guard bites: restoring `GET /v1/builds/{id}/betaGroups` fails the suite with `AssertionError: unstubbed request: GET /v1/builds/build-1/betaGroups`.
- [x] New cases cover the probe shape (one per group, not confused with the version poll) and a two-group build already in one of them, asserting the attach carries only the missing group.
- [ ] The live contract can only be exercised by a real dispatch — see Notes.

## Version
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).

## Notes
> [!IMPORTANT]
> Build **82 is already consumed** and is sitting in App Store Connect attached to nothing. Merging this does not retroactively distribute it — it needs either a fresh TestFlight dispatch (new build number) or a manual add of 0.28.41 (82) to *First 20 Testers*.

- The stubs encode Apple's contract as last observed and cannot notice it changing; that is the whole failure mode here, and it is now written down in [docs/architecture.md](docs/architecture.md) rather than left to be rediscovered.
- Deliberately **not** widened: the probe is still fatal on an unexpected error, matching every other call in the script. That means a future ASC change to this read would again abort before the attach. Making it non-fatal would need the attach to tolerate a duplicate-relationship POST, whose behaviour I have not verified against the live API — worth doing, but as its own change rather than on an unverified assumption.
- Branch is `u/sloan/…` because this came out of a failed release run rather than a tracked issue. Happy to file one retroactively if you want it in the backlog.