### PR TITLE
[OMNI-2310] Fix TestFlight Distribute betaGroups 403

### DIFF
--- a/scripts/testflight_distribute.py
+++ b/scripts/testflight_distribute.py
@@ -14,9 +14,10 @@ it (the first build of a marketing version does; later ones are usually waved
 through), optionally sets "What to Test", and adds the build to each named
 group.
 
-Idempotent by construction: a group already attached to the build is skipped and
-a build already submitted for review is left alone, so a re-run — or a retry
-after a half-finished run — is a no-op rather than a duplicate.
+Idempotent by construction: attaching a group is a set-semantics relationship
+add (re-adding an attached build is a 204 no-op) and a build already submitted
+for review is left alone, so a re-run — or a retry after a half-finished run —
+is a no-op rather than a duplicate.
 
 Reuses the App Store Connect API key the build-upload workflow already
 configures (`ASC_API_KEY_BASE64` / `ASC_KEY_ID` / `ASC_ISSUER_ID`); that key is
@@ -266,21 +267,21 @@ def set_whats_new(build_id):
 
 
 def add_to_groups(build_id, groups):
-    """Attach the build to each group it isn't already in."""
-    attached = {g["id"] for g in asc("GET", f"/v1/builds/{build_id}/betaGroups",
-                                     params={"limit": 200})["data"]}
-    todo = [g for g in groups if g["id"] not in attached]
-    for g in groups:
-        if g["id"] in attached:
-            print(f"group {g['attributes']['name']!r}: already attached")
-    if not todo:
-        return
-    names = ", ".join(repr(g["attributes"]["name"]) for g in todo)
+    """Attach the build to each group, from the group side.
+
+    Deliberately no membership pre-check: App Store Connect forbids reading a
+    build's `betaGroups` relationship (403 `GET_RELATED`; only CREATE/DELETE
+    are allowed), and the group-side relationship add is set-semantics —
+    re-adding an already-attached build answers 204 and changes nothing — so
+    posting unconditionally is what keeps the script idempotent.
+    """
+    names = ", ".join(repr(g["attributes"]["name"]) for g in groups)
     if DRY_RUN:
         print(f"groups: [dry] would attach to {names}")
         return
-    asc("POST", f"/v1/builds/{build_id}/relationships/betaGroups",
-        json={"data": [{"type": "betaGroups", "id": g["id"]} for g in todo]})
+    for g in groups:
+        asc("POST", f"/v1/betaGroups/{g['id']}/relationships/builds",
+            json={"data": [{"type": "builds", "id": build_id}]})
     print(f"groups: attached to {names}")
 
 

--- a/scripts/tests/testflight-distribute.test.py
+++ b/scripts/tests/testflight-distribute.test.py
@@ -7,8 +7,10 @@ tracks the shipped implementation rather than a hand-copied duplicate) and only
 its two I/O primitives — `asc_raw` and `asc_jwt` — are stubbed. Each scenario
 declares what the API would answer, then asserts which writes the script makes.
 Which writes it *doesn't* make is the point of half of them: the run is meant to
-be re-runnable, so an already-attached group or an already-submitted review must
-produce no POST at all.
+be re-runnable, so an already-submitted review must produce no POST at all.
+Group attachment is the exception by design: it always posts, because the
+group-side relationship add is a set-semantics no-op on re-run and App Store
+Connect forbids reading a build's groups to check first.
 
 Usage: scripts/tests/testflight-distribute.test.py
 """
@@ -62,11 +64,10 @@ class FakeASC:
     """
 
     def __init__(self, build_states, external_state="READY_FOR_BETA_SUBMISSION",
-                 attached_groups=(), localizations=(), groups=((GROUP_ID, GROUP_NAME),),
+                 localizations=(), groups=((GROUP_ID, GROUP_NAME),),
                  review_status=201, listed_version=None):
         self.build_states = list(build_states)
         self.external_state = external_state
-        self.attached_groups = list(attached_groups)
         self.localizations = list(localizations)
         self.groups = list(groups)
         self.review_status = review_status
@@ -103,9 +104,6 @@ class FakeASC:
                               "attributes": {"externalBuildState": self.external_state}}],
             })
 
-        if path == f"/v1/builds/{BUILD_ID}/betaGroups":
-            return Resp(payload={"data": [{"id": g} for g in self.attached_groups]})
-
         if path == "/v1/betaAppReviewSubmissions":
             return Resp(status_code=self.review_status, payload={})
 
@@ -119,7 +117,7 @@ class FakeASC:
         if path.startswith("/v1/betaBuildLocalizations/"):
             return Resp(payload={})
 
-        if path == f"/v1/builds/{BUILD_ID}/relationships/betaGroups":
+        if path == f"/v1/betaGroups/{GROUP_ID}/relationships/builds":
             return Resp(status_code=204, payload={})
 
         raise AssertionError(f"unstubbed request: {method} {path}")
@@ -171,14 +169,15 @@ check("happy path exits 0", 0, code)
 check("happy path submits for beta review", 1,
       len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
 check("happy path attaches the group", 1,
-      len(writes_to(fake, "/relationships/betaGroups")))
+      len(writes_to(fake, "/relationships/builds")))
 
-# Re-running the same distribution must not attach a second time.
-code, fake = run(FakeASC(["VALID"], external_state="IN_BETA_TESTING",
-                         attached_groups=[GROUP_ID]))
+# Re-running the same distribution re-posts the attach — deliberately: the
+# group-side relationship add is a set-semantics 204 no-op, and the build-side
+# membership read this used to skip on is forbidden by App Store Connect.
+code, fake = run(FakeASC(["VALID"], external_state="IN_BETA_TESTING"))
 check("re-run exits 0", 0, code)
-check("re-run does not re-attach an attached group", 0,
-      len(writes_to(fake, "/relationships/betaGroups")))
+check("re-run re-posts the attach as a set-add no-op", 1,
+      len(writes_to(fake, "/relationships/builds")))
 check("re-run does not resubmit for review", 0,
       len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
 
@@ -186,7 +185,7 @@ check("re-run does not resubmit for review", 0,
 # facts, and treating "submitted" as "distributed" is the original bug.
 code, fake = run(FakeASC(["VALID"], external_state="WAITING_FOR_BETA_REVIEW"))
 check("awaiting-review build is still attached", 1,
-      len(writes_to(fake, "/relationships/betaGroups")))
+      len(writes_to(fake, "/relationships/builds")))
 check("awaiting-review build is not resubmitted", 0,
       len(writes_to(fake, "/v1/betaAppReviewSubmissions")))
 
@@ -227,7 +226,7 @@ check("no whats-new leaves localizations alone", 0,
 code, fake = run(FakeASC(["VALID"], listed_version="0.15"), MARKETING_VERSION="0.15.0")
 check("a X.Y.0 release is found under its X.Y listing", 0, code)
 check("a X.Y.0 release is still attached", 1,
-      len(writes_to(fake, "/relationships/betaGroups")))
+      len(writes_to(fake, "/relationships/builds")))
 check("both version spellings are tried", ["0.15.0", "0.15"], fake.build_queries)
 
 # The reverse spelling, and the ordinary case that must not grow a second query.


### PR DESCRIPTION
## Summary
- `add_to_groups` no longer pre-checks membership at all — App Store Connect forbids the build-side `GET /v1/builds/{id}/betaGroups` read (403 `GET_RELATED`), which killed the distribute job after a successful upload (run 33231517406, build 0.28.43 (83)).
- Attaches via `POST /v1/betaGroups/{id}/relationships/builds` instead: set-semantics (re-add is a 204 no-op), so idempotency is preserved with one write per group and no reads. This supersedes the `filter[betaGroups]` membership probe #2309 hotfixed in, and the test suite's scenarios are updated to the new semantics (32 passing).

Closes #2310

## Test plan
- [x] `python3 -m py_compile` on the script
- [x] `scripts/tests/testflight-distribute.test.py` — 32 passed, 0 failed
- [ ] Post-merge `workflow_dispatch` of `testflight.yml` completes the distribute job

## Version
- [ ] **Minor**
- [x] **Patch** — the default
- [ ] **No release**

## Notes
- 