### PR TITLE
[OMNI-2283] MCP Merge, Chapter Text, and Content Search Tools

### DIFF
--- a/mcp/src/client.rs
+++ b/mcp/src/client.rs
@@ -74,6 +74,13 @@ pub const WRITE_ALLOWLIST: &[&str] = &[
     // gates them on `can_edit` like the overrides write.
     "POST /api/metadata/editions/search",
     "POST /api/metadata/editions/hydrate",
+    // Book merge/undo — the strongest tier in this list: admin-gated on the
+    // server, library-wide (merge deletes the source `books` row and
+    // retargets every reader's state onto the target; undo restores it),
+    // and confirm-gated in the tools (`merge_books` / `undo_merge` refuse
+    // without an explicit `confirm: true`).
+    "POST /api/books/merge",
+    "POST /api/books/merge/undo",
 ];
 
 /// True when `method path` is covered by [`WRITE_ALLOWLIST`]. A `{param}`

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -30,7 +30,9 @@ impl OmnibusMcp {
             tool_router: Self::read_tools()
                 + Self::checkin_tools()
                 + Self::shelf_tools()
-                + Self::metadata_tools(),
+                + Self::metadata_tools()
+                + Self::merge_tools()
+                + Self::content_tools(),
         }
     }
 }
@@ -59,7 +61,12 @@ impl ServerHandler for OmnibusMcp {
                  and search books, explore authors/series/tags/genres and shelves, and \
                  read the signed-in user's stats, progress, highlights, bookmarks, and \
                  journal entries; books are identified by the uuid field returned by \
-                 the listing and search tools. The physical-collection tools resolve \
+                 the listing and search tools. Book text is readable too: list_chapters \
+                 maps a book's chapters to spine indexes, read_chapter_text reads one \
+                 chapter as bounded plain-text slices (page via next_offset), and \
+                 search_book_content full-text-searches the library's book text — \
+                 distinct from search_books, which matches metadata only — citing each \
+                 hit back to a book and chapter. The physical-collection tools resolve \
                  ISBNs and title searches against the library and the external \
                  metadata providers (always relay which provider answered), check in \
                  physical copies, and manage the wishlist and copy notes; \
@@ -74,7 +81,12 @@ impl ServerHandler for OmnibusMcp {
                  apply_metadata_changes and revert_metadata_overrides write metadata \
                  overrides — library-wide state every user sees — and refuse to run \
                  until called with confirm: true after the user has approved the diff. \
-                 Settings and reading state are never modified."
+                 Duplicate resolution is admin-only and the strongest write here: \
+                 merge_books deletes the source book's row and retargets every reader's \
+                 state onto the target, undo_merge reverses a merge via its returned \
+                 merge_log_id, and both refuse to run without confirm: true — fetch both \
+                 books with get_book and present them to the user first. Settings and \
+                 reading state are never modified."
                     .to_string(),
             )
     }

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -86,6 +86,8 @@ fn get_info_declares_tools_and_the_confirm_gated_write_surface() {
     assert!(instructions.contains("preview_shelf_rule"));
     assert!(instructions.contains("confirm: true"));
     assert!(instructions.contains("propose_metadata_changes"));
+    assert!(instructions.contains("merge_books"));
+    assert!(instructions.contains("search_book_content"));
 }
 
 /// Boot a stub instance serving shared-typed JSON and return a service
@@ -431,12 +433,10 @@ fn checkin_tools_router_lists_every_expected_tool_with_a_description() {
 }
 
 #[test]
-fn combined_router_carries_both_families_without_collisions() {
-    let combined = OmnibusMcp::read_tools() + OmnibusMcp::checkin_tools();
-    assert_eq!(
-        combined.list_all().len(),
-        EXPECTED_TOOLS.len() + EXPECTED_CHECKIN_TOOLS.len()
-    );
+fn combined_router_carries_every_family_without_collisions() {
+    // 21 read + 9 checkin + 6 shelf + 6 metadata + 2 merge + 3 content.
+    let combined = offline_server().tool_router;
+    assert_eq!(combined.list_all().len(), 47);
 }
 
 #[tokio::test]

--- a/mcp/src/server/tests.rs
+++ b/mcp/src/server/tests.rs
@@ -434,9 +434,22 @@ fn checkin_tools_router_lists_every_expected_tool_with_a_description() {
 
 #[test]
 fn combined_router_carries_every_family_without_collisions() {
-    // 21 read + 9 checkin + 6 shelf + 6 metadata + 2 merge + 3 content.
+    // Derived from the per-family routers, not hardcoded: a name collision
+    // between families would make the combined router smaller than the sum.
+    let per_family: usize = [
+        OmnibusMcp::read_tools().list_all().len(),
+        OmnibusMcp::checkin_tools().list_all().len(),
+        OmnibusMcp::shelf_tools().list_all().len(),
+        OmnibusMcp::metadata_tools().list_all().len(),
+        OmnibusMcp::merge_tools().list_all().len(),
+        OmnibusMcp::content_tools().list_all().len(),
+    ]
+    .iter()
+    .sum();
     let combined = offline_server().tool_router;
-    assert_eq!(combined.list_all().len(), 47);
+    assert_eq!(combined.list_all().len(), per_family);
+    // 21 read + 9 checkin + 6 shelf + 6 metadata + 2 merge + 3 content.
+    assert_eq!(per_family, 47);
 }
 
 #[tokio::test]

--- a/mcp/src/tools/content.rs
+++ b/mcp/src/tools/content.rs
@@ -1,0 +1,106 @@
+//! The book-content read tool family: list an EPUB's chapters, read one
+//! chapter's plain text in bounded slices, and full-text search the
+//! library's indexed chapter text. Pure reads over existing `GET` endpoints
+//! — nothing here touches the [`crate::client::WRITE_ALLOWLIST`].
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router, ErrorData, Json};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use omnibus_shared::{ChapterListResponse, ChapterTextResponse, ContentSearchResults};
+
+use crate::server::OmnibusMcp;
+
+/// Parameters for the chapter listing.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListChaptersParams {
+    /// The book's uuid (the `unique_identifier` field on book records).
+    pub book_uuid: String,
+}
+
+/// Parameters for the bounded chapter-text read.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ChapterTextParams {
+    /// The book's uuid.
+    pub book_uuid: String,
+    /// The chapter's spine index, from list_chapters (valid indexes are
+    /// `0..spine_count`).
+    pub spine_index: u64,
+    /// Char offset to start from — pass a previous slice's `next_offset`
+    /// to continue. Defaults to 0.
+    pub offset: Option<u64>,
+    /// Slice size in chars; server-clamped to at most 100000.
+    pub limit: Option<u64>,
+}
+
+/// Parameters for the content search.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ContentSearchParams {
+    /// Full-text query over book content (FTS5 syntax; a plain phrase works).
+    pub query: String,
+}
+
+#[tool_router(router = content_tools, vis = "pub(crate)")]
+impl OmnibusMcp {
+    #[tool(
+        description = "List a book's chapters: TOC titles plus the spine_index each chapter's text is read by (via read_chapter_text), and spine_count, the number of addressable spine documents. has_text: false means the book's served format has no extractable text (audiobook-only, comic-only). A TOC-less but readable EPUB reports has_text: true with an empty chapters list — its text is still readable by spine index up to spine_count. Errors if the uuid is unknown."
+    )]
+    pub async fn list_chapters(
+        &self,
+        Parameters(p): Parameters<ListChaptersParams>,
+    ) -> Result<Json<ChapterListResponse>, ErrorData> {
+        let uuid = crate::tools::path_segment(&p.book_uuid, "book_uuid")?;
+        let path = format!("/api/ebooks/{uuid}/chapters");
+        let chapters: Option<ChapterListResponse> = self.client.get_json_opt(&path, &[]).await?;
+        chapters
+            .map(Json)
+            .ok_or_else(|| ErrorData::invalid_params(format!("book {uuid} not found"), None))
+    }
+
+    #[tool(
+        description = "Read one chapter of a book as plain text, in bounded slices (at most 100000 chars per call). Address the chapter by the spine_index from list_chapters. When truncated is true the slice ended before the chapter did — page through by re-calling with offset set to the returned next_offset until truncated is false. has_text: false means the book has no extractable text. Errors if the uuid is unknown or spine_index is out of range."
+    )]
+    pub async fn read_chapter_text(
+        &self,
+        Parameters(p): Parameters<ChapterTextParams>,
+    ) -> Result<Json<ChapterTextResponse>, ErrorData> {
+        let uuid = crate::tools::path_segment(&p.book_uuid, "book_uuid")?;
+        let spine_index = p.spine_index;
+        let path = format!("/api/ebooks/{uuid}/chapters/{spine_index}/text");
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(offset) = p.offset {
+            query.push(("offset", offset.to_string()));
+        }
+        if let Some(limit) = p.limit {
+            query.push(("limit", limit.to_string()));
+        }
+        let text: Option<ChapterTextResponse> = self.client.get_json_opt(&path, &query).await?;
+        text.map(Json).ok_or_else(|| {
+            ErrorData::invalid_params(
+                format!(
+                    "book {uuid} not found, or spine_index {spine_index} is out of range \
+                     (list_chapters reports the valid range as 0..spine_count)"
+                ),
+                None,
+            )
+        })
+    }
+
+    #[tool(
+        description = "Full-text search over the TEXT of the library's books — distinct from search_books, which matches metadata (title, author, series, tags) only. Use this for \"find the passage where …\" questions. Each hit cites the book (book_uuid, title) and the chapter it came from (spine_index) plus a snippet with the matched terms bracketed; follow up with read_chapter_text on the hit's book_uuid + spine_index to read the surrounding text. Only books with extractable text are indexed, so an empty result does not prove the phrase is absent from unindexed formats."
+    )]
+    pub async fn search_book_content(
+        &self,
+        Parameters(p): Parameters<ContentSearchParams>,
+    ) -> Result<Json<ContentSearchResults>, ErrorData> {
+        let hits: ContentSearchResults = self
+            .client
+            .get_json("/api/search/content", &[("q", p.query)])
+            .await?;
+        Ok(Json(hits))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/mcp/src/tools/content.rs
+++ b/mcp/src/tools/content.rs
@@ -19,19 +19,34 @@ pub struct ListChaptersParams {
     pub book_uuid: String,
 }
 
-/// Parameters for the bounded chapter-text read.
+/// Parameters for the bounded chapter-text read. The numeric fields are
+/// `i64` to match the shared wire types (`ChapterListEntry::spine_index`,
+/// `ChapterTextResponse::next_offset`) so a schema-driven client round-trips
+/// them without signed/unsigned coercion; negatives are rejected up front.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ChapterTextParams {
     /// The book's uuid.
     pub book_uuid: String,
     /// The chapter's spine index, from list_chapters (valid indexes are
     /// `0..spine_count`).
-    pub spine_index: u64,
+    pub spine_index: i64,
     /// Char offset to start from — pass a previous slice's `next_offset`
     /// to continue. Defaults to 0.
-    pub offset: Option<u64>,
+    pub offset: Option<i64>,
     /// Slice size in chars; server-clamped to at most 100000.
-    pub limit: Option<u64>,
+    pub limit: Option<i64>,
+}
+
+/// Reject a negative value before it is formatted into a URL the server's
+/// unsigned parses would answer with an opaque 400.
+fn non_negative(value: i64, what: &str) -> Result<i64, ErrorData> {
+    if value < 0 {
+        return Err(ErrorData::invalid_params(
+            format!("{what} must be non-negative: got {value}"),
+            None,
+        ));
+    }
+    Ok(value)
 }
 
 /// Parameters for the content search.
@@ -66,14 +81,14 @@ impl OmnibusMcp {
         Parameters(p): Parameters<ChapterTextParams>,
     ) -> Result<Json<ChapterTextResponse>, ErrorData> {
         let uuid = crate::tools::path_segment(&p.book_uuid, "book_uuid")?;
-        let spine_index = p.spine_index;
+        let spine_index = non_negative(p.spine_index, "spine_index")?;
         let path = format!("/api/ebooks/{uuid}/chapters/{spine_index}/text");
         let mut query: Vec<(&str, String)> = Vec::new();
         if let Some(offset) = p.offset {
-            query.push(("offset", offset.to_string()));
+            query.push(("offset", non_negative(offset, "offset")?.to_string()));
         }
         if let Some(limit) = p.limit {
-            query.push(("limit", limit.to_string()));
+            query.push(("limit", non_negative(limit, "limit")?.to_string()));
         }
         let text: Option<ChapterTextResponse> = self.client.get_json_opt(&path, &query).await?;
         text.map(Json).ok_or_else(|| {

--- a/mcp/src/tools/content/tests.rs
+++ b/mcp/src/tools/content/tests.rs
@@ -263,6 +263,28 @@ async fn search_book_content_answers_no_match_with_an_empty_hit_list() {
 }
 
 #[tokio::test]
+async fn read_chapter_text_rejects_a_negative_spine_index_locally() {
+    // The params are i64 to match the shared wire types; a negative never
+    // becomes a URL the server's unsigned parse would opaquely 400.
+    let service = stub_service().await;
+    let err = expect_err(
+        service
+            .read_chapter_text(Parameters(ChapterTextParams {
+                book_uuid: "uuid-frank".into(),
+                spine_index: -1,
+                offset: None,
+                limit: None,
+            }))
+            .await,
+    );
+    assert!(
+        err.message.contains("non-negative"),
+        "message: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
 async fn read_chapter_text_rejects_a_uuid_that_is_not_one_path_segment() {
     // A slash-bearing "uuid" would splice extra segments into the request
     // path; the shared guard answers invalid params before any request forms.

--- a/mcp/src/tools/content/tests.rs
+++ b/mcp/src/tools/content/tests.rs
@@ -1,0 +1,285 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json as AxumJson, Router};
+use rmcp::handler::server::wrapper::Parameters;
+
+use omnibus_shared::{
+    ChapterListEntry, ChapterListResponse, ChapterTextResponse, ContentSearchHit,
+    ContentSearchResults,
+};
+
+use super::*;
+use crate::client::OmnibusClient;
+use crate::config::Config;
+
+/// Every content tool this issue ships, by MCP tool name.
+const EXPECTED_TOOLS: &[&str] = &["list_chapters", "read_chapter_text", "search_book_content"];
+
+async fn login() -> AxumJson<serde_json::Value> {
+    AxumJson(serde_json::json!({
+        "user": {
+            "id": 1, "username": "reader", "is_admin": false,
+            "can_upload": false, "can_edit": false, "can_download": true
+        },
+        "token": "token-1",
+    }))
+}
+
+async fn chapters(Path(uuid): Path<String>) -> Result<AxumJson<ChapterListResponse>, StatusCode> {
+    match uuid.as_str() {
+        "uuid-frank" => Ok(AxumJson(ChapterListResponse {
+            book_uuid: uuid,
+            has_text: true,
+            spine_count: 3,
+            chapters: vec![ChapterListEntry {
+                ordinal: 0,
+                title: "Letter 1".into(),
+                spine_index: 1,
+            }],
+        })),
+        "uuid-audio" => Ok(AxumJson(ChapterListResponse {
+            book_uuid: uuid,
+            has_text: false,
+            spine_count: 0,
+            chapters: vec![],
+        })),
+        _ => Err(StatusCode::NOT_FOUND),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct TextQuery {
+    offset: Option<i64>,
+    limit: Option<i64>,
+}
+
+async fn chapter_text(
+    Path((uuid, spine_index)): Path<(String, i64)>,
+    Query(q): Query<TextQuery>,
+) -> Result<AxumJson<ChapterTextResponse>, StatusCode> {
+    if uuid != "uuid-frank" || spine_index >= 3 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    // Echo the requested window as a truncated slice so the test can assert
+    // the boundary fields pass through the tool untouched.
+    let offset = q.offset.unwrap_or(0);
+    let limit = q.limit.unwrap_or(100_000);
+    Ok(AxumJson(ChapterTextResponse {
+        book_uuid: uuid,
+        has_text: true,
+        spine_index,
+        text: "It was on a dreary night of November".into(),
+        offset,
+        total_chars: 5_000,
+        truncated: true,
+        next_offset: Some(offset + limit),
+    }))
+}
+
+async fn content_search(
+    Query(q): Query<std::collections::HashMap<String, String>>,
+) -> AxumJson<ContentSearchResults> {
+    if q.get("q").map(String::as_str) == Some("dreary night") {
+        AxumJson(ContentSearchResults {
+            hits: vec![ContentSearchHit {
+                book_uuid: "uuid-frank".into(),
+                spine_index: 1,
+                title: "Frankenstein".into(),
+                snippet: "It was on a [dreary] [night] of November…".into(),
+            }],
+        })
+    } else {
+        AxumJson(ContentSearchResults::default())
+    }
+}
+
+/// Boot a stub instance serving the content read routes.
+async fn stub_service() -> OmnibusMcp {
+    let app = Router::new()
+        .route("/api/auth/login", post(login))
+        .route("/api/ebooks/{uuid}/chapters", get(chapters))
+        .route(
+            "/api/ebooks/{uuid}/chapters/{spine_index}/text",
+            get(chapter_text),
+        )
+        .route("/api/search/content", get(content_search));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OmnibusClient::new(Config {
+        base_url: format!("http://{addr}"),
+        username: "reader".into(),
+        password: "correct horse battery".into(),
+    })
+    .unwrap();
+    OmnibusMcp::new(Arc::new(client))
+}
+
+/// `unwrap_err` needs `T: Debug`, which `rmcp::Json` does not implement.
+fn expect_err<T>(result: Result<T, ErrorData>) -> ErrorData {
+    match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected an error"),
+    }
+}
+
+#[test]
+fn content_tools_router_lists_every_expected_tool_with_a_description() {
+    let router = OmnibusMcp::content_tools();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in EXPECTED_TOOLS {
+        assert!(names.contains(expected), "missing tool {expected}");
+    }
+    assert_eq!(
+        tools.len(),
+        EXPECTED_TOOLS.len(),
+        "unexpected extra tools: {names:?}"
+    );
+    for tool in &tools {
+        let desc = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            desc.len() > 20,
+            "tool {} needs a real description",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn list_chapters_returns_the_toc_with_spine_addressing() {
+    let service = stub_service().await;
+    let listing = service
+        .list_chapters(Parameters(ListChaptersParams {
+            book_uuid: "uuid-frank".into(),
+        }))
+        .await
+        .unwrap();
+    assert!(listing.0.has_text);
+    assert_eq!(listing.0.spine_count, 3);
+    assert_eq!(listing.0.chapters.len(), 1);
+    assert_eq!(listing.0.chapters[0].title, "Letter 1");
+    assert_eq!(listing.0.chapters[0].spine_index, 1);
+}
+
+#[tokio::test]
+async fn list_chapters_passes_through_the_no_text_answer() {
+    let service = stub_service().await;
+    let listing = service
+        .list_chapters(Parameters(ListChaptersParams {
+            book_uuid: "uuid-audio".into(),
+        }))
+        .await
+        .unwrap();
+    assert!(!listing.0.has_text);
+    assert_eq!(listing.0.spine_count, 0);
+    assert!(listing.0.chapters.is_empty());
+}
+
+#[tokio::test]
+async fn list_chapters_reports_not_found_for_an_unknown_uuid() {
+    let service = stub_service().await;
+    let err = expect_err(
+        service
+            .list_chapters(Parameters(ListChaptersParams {
+                book_uuid: "uuid-missing".into(),
+            }))
+            .await,
+    );
+    assert!(err.message.contains("not found"));
+}
+
+#[tokio::test]
+async fn read_chapter_text_sends_the_window_and_surfaces_the_truncation_boundary() {
+    let service = stub_service().await;
+    let slice = service
+        .read_chapter_text(Parameters(ChapterTextParams {
+            book_uuid: "uuid-frank".into(),
+            spine_index: 1,
+            offset: Some(200),
+            limit: Some(50),
+        }))
+        .await
+        .unwrap();
+    assert!(slice.0.has_text);
+    assert_eq!(slice.0.spine_index, 1);
+    assert!(slice.0.text.contains("dreary night"));
+    // The boundary fields the description tells the model to page by.
+    assert_eq!(slice.0.offset, 200);
+    assert_eq!(slice.0.total_chars, 5_000);
+    assert!(slice.0.truncated);
+    assert_eq!(slice.0.next_offset, Some(250));
+}
+
+#[tokio::test]
+async fn read_chapter_text_reports_an_out_of_range_spine_index() {
+    let service = stub_service().await;
+    let err = expect_err(
+        service
+            .read_chapter_text(Parameters(ChapterTextParams {
+                book_uuid: "uuid-frank".into(),
+                spine_index: 9,
+                offset: None,
+                limit: None,
+            }))
+            .await,
+    );
+    assert!(err.message.contains("out of range"), "got: {}", err.message);
+    assert!(err.message.contains("spine_count"));
+}
+
+#[tokio::test]
+async fn search_book_content_returns_chapter_cited_hits() {
+    let service = stub_service().await;
+    let results = service
+        .search_book_content(Parameters(ContentSearchParams {
+            query: "dreary night".into(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(results.0.hits.len(), 1);
+    let hit = &results.0.hits[0];
+    assert_eq!(hit.book_uuid, "uuid-frank");
+    assert_eq!(hit.spine_index, 1);
+    assert_eq!(hit.title, "Frankenstein");
+    assert!(hit.snippet.contains("[dreary]"));
+}
+
+#[tokio::test]
+async fn search_book_content_answers_no_match_with_an_empty_hit_list() {
+    let service = stub_service().await;
+    let results = service
+        .search_book_content(Parameters(ContentSearchParams {
+            query: "phrase in no book".into(),
+        }))
+        .await
+        .unwrap();
+    assert!(results.0.hits.is_empty());
+}
+
+#[tokio::test]
+async fn read_chapter_text_rejects_a_uuid_that_is_not_one_path_segment() {
+    // A slash-bearing "uuid" would splice extra segments into the request
+    // path; the shared guard answers invalid params before any request forms.
+    let service = stub_service().await;
+    let err = expect_err(
+        service
+            .read_chapter_text(Parameters(ChapterTextParams {
+                book_uuid: "uuid-a/../uuid-b".into(),
+                spine_index: 1,
+                offset: None,
+                limit: None,
+            }))
+            .await,
+    );
+    assert!(
+        err.message.contains("book_uuid"),
+        "message: {}",
+        err.message
+    );
+}

--- a/mcp/src/tools/merge.rs
+++ b/mcp/src/tools/merge.rs
@@ -1,0 +1,133 @@
+//! The book-merge tool family: merge one book into another and undo a
+//! recorded merge. Both wrap the admin-gated REST endpoints
+//! (`POST /api/books/merge`, `POST /api/books/merge/undo`) and refuse to
+//! run without an explicit `confirm: true` — a merge deletes a `books` row
+//! library-wide, the strongest write this crate exposes.
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{tool, tool_router, ErrorData, Json};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use omnibus_shared::{MergeBooksRequest, MergeBooksResult, UndoMergeRequest, UndoMergeResult};
+
+use crate::client::ClientError;
+use crate::server::OmnibusMcp;
+
+/// Parameters for the merge: the two books plus the gate.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MergeParams {
+    /// The book to absorb — its `books` row is deleted by the merge.
+    pub source_uuid: String,
+    /// The surviving book — it receives the source's files, links,
+    /// identifiers, and per-reader state.
+    pub target_uuid: String,
+    /// Must be `true`. Omitting it (or passing `false`) refuses with an
+    /// explanation of the fetch → present → confirm workflow.
+    pub confirm: Option<bool>,
+}
+
+/// Parameters for the undo: the merge-log handle plus the gate.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UndoMergeParams {
+    /// The `merge_log_id` a prior merge_books call returned — the undo
+    /// handle for that specific merge.
+    pub merge_log_id: i64,
+    /// Must be `true`. Omitting it (or passing `false`) refuses with an
+    /// explanation of the confirm workflow.
+    pub confirm: Option<bool>,
+}
+
+/// The refusal both tools answer when `confirm` is not `true`.
+fn unconfirmed(tool: &str, effect: &str, workflow: &str) -> ErrorData {
+    ErrorData::invalid_params(
+        format!("refused: confirm is not true. {tool} {effect} — {workflow}"),
+        None,
+    )
+}
+
+/// Map a merge-route failure onto a model-actionable error: the routes are
+/// admin-gated (not `can_edit`), so a 403 names the admin requirement, and
+/// the semantic statuses (404 unknown uuid/log id, 409 already undone,
+/// 422 same book) carry the server's own message verbatim.
+fn merge_error(e: ClientError) -> ErrorData {
+    match &e {
+        ClientError::WriteStatus { status: 403, .. } => ErrorData::invalid_params(
+            "forbidden: merging (and unmerging) books requires an admin account — the \
+             signed-in user is not an admin, and no other permission flag (can_edit \
+             included) grants it"
+                .to_string(),
+            None,
+        ),
+        ClientError::WriteStatus {
+            status: status @ (404 | 409 | 422),
+            message,
+            ..
+        } => ErrorData::invalid_params(format!("HTTP {status}: {message}"), None),
+        _ => e.into(),
+    }
+}
+
+#[tool_router(router = merge_tools, vis = "pub(crate)")]
+impl OmnibusMcp {
+    #[tool(
+        description = "Merge one book into another (duplicate resolution): the target book absorbs the source's files, formats, identifiers, and every reader's per-book state (progress, ratings, highlights, bookmarks, journals), and the source book's row is DELETED — library-wide, every user sees the result. Admin-only. REFUSES unless confirm: true: first call get_book on both uuids, present both books' titles, authors, and formats to the user, and re-call with confirm: true only after the user approves merging that specific pair. Returns merge_log_id — the handle undo_merge needs to reverse this exact merge — plus the surviving target_uuid."
+    )]
+    pub async fn merge_books(
+        &self,
+        Parameters(p): Parameters<MergeParams>,
+    ) -> Result<Json<MergeBooksResult>, ErrorData> {
+        if p.confirm != Some(true) {
+            return Err(unconfirmed(
+                "merge_books",
+                "deletes the source book's row and retargets every reader's state onto \
+                 the target",
+                "first call get_book on both uuids, present both books' titles, authors, \
+                 and formats to the user, and only after the user approves re-call \
+                 merge_books with the same source_uuid and target_uuid plus confirm: true",
+            ));
+        }
+        let source = crate::tools::path_segment(&p.source_uuid, "source_uuid")?.to_string();
+        let target = crate::tools::path_segment(&p.target_uuid, "target_uuid")?.to_string();
+        let body = MergeBooksRequest {
+            source_uuid: source,
+            target_uuid: target,
+        };
+        let merged: MergeBooksResult = self
+            .client
+            .write_json(reqwest::Method::POST, "/api/books/merge", Some(&body))
+            .await
+            .map_err(merge_error)?;
+        Ok(Json(merged))
+    }
+
+    #[tool(
+        description = "Reverse a recorded merge: restores the source book merge_books deleted, using the merge_log_id that merge_books returned as the undo handle. Admin-only, library-wide like the merge itself. REFUSES unless confirm: true: tell the user which merge is being reversed (the merge_log_id and, via get_book on its target_uuid, the book it merged into) and re-call with confirm: true only after they approve. A merge can be undone once — a second undo of the same merge_log_id answers HTTP 409. Returns the restored (source) book's uuid."
+    )]
+    pub async fn undo_merge(
+        &self,
+        Parameters(p): Parameters<UndoMergeParams>,
+    ) -> Result<Json<UndoMergeResult>, ErrorData> {
+        if p.confirm != Some(true) {
+            return Err(unconfirmed(
+                "undo_merge",
+                "restores the book a prior merge deleted",
+                "tell the user which merge is being reversed (this merge_log_id, and the \
+                 target book it merged into), and only after the user approves re-call \
+                 undo_merge with the same merge_log_id plus confirm: true",
+            ));
+        }
+        let body = UndoMergeRequest {
+            merge_log_id: p.merge_log_id,
+        };
+        let restored: UndoMergeResult = self
+            .client
+            .write_json(reqwest::Method::POST, "/api/books/merge/undo", Some(&body))
+            .await
+            .map_err(merge_error)?;
+        Ok(Json(restored))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/mcp/src/tools/merge/tests.rs
+++ b/mcp/src/tools/merge/tests.rs
@@ -1,0 +1,244 @@
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::{Json as AxumJson, Router};
+use rmcp::handler::server::wrapper::Parameters;
+
+use omnibus_shared::{MergeBooksResult, UndoMergeResult};
+
+use super::*;
+use crate::client::OmnibusClient;
+use crate::config::Config;
+
+/// Every merge tool this issue ships, by MCP tool name.
+const EXPECTED_TOOLS: &[&str] = &["merge_books", "undo_merge"];
+
+/// Stub instance state: records merge/undo bodies and lets a test force a
+/// failure status on either route.
+#[derive(Default)]
+struct Stub {
+    merges: Mutex<Vec<serde_json::Value>>,
+    undos: Mutex<Vec<serde_json::Value>>,
+    fail: Mutex<Option<(u16, &'static str)>>,
+}
+
+async fn login() -> AxumJson<serde_json::Value> {
+    AxumJson(serde_json::json!({
+        "user": {
+            "id": 1, "username": "admin", "is_admin": true,
+            "can_upload": true, "can_edit": true, "can_download": true
+        },
+        "token": "token-1",
+    }))
+}
+
+async fn post_merge(
+    State(stub): State<Arc<Stub>>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> Result<AxumJson<MergeBooksResult>, (StatusCode, &'static str)> {
+    if let Some((status, message)) = *stub.fail.lock().unwrap() {
+        return Err((StatusCode::from_u16(status).unwrap(), message));
+    }
+    let target = body["target_uuid"].as_str().unwrap().to_string();
+    stub.merges.lock().unwrap().push(body);
+    Ok(AxumJson(MergeBooksResult {
+        merge_log_id: 42,
+        target_uuid: target,
+    }))
+}
+
+async fn post_undo(
+    State(stub): State<Arc<Stub>>,
+    AxumJson(body): AxumJson<serde_json::Value>,
+) -> Result<AxumJson<UndoMergeResult>, (StatusCode, &'static str)> {
+    if let Some((status, message)) = *stub.fail.lock().unwrap() {
+        return Err((StatusCode::from_u16(status).unwrap(), message));
+    }
+    stub.undos.lock().unwrap().push(body);
+    Ok(AxumJson(UndoMergeResult {
+        restored_uuid: "uuid-source".into(),
+    }))
+}
+
+/// Boot a stub instance and return a service pointed at it plus the stub.
+async fn stub_service() -> (OmnibusMcp, Arc<Stub>) {
+    let stub = Arc::new(Stub::default());
+    let app = Router::new()
+        .route("/api/auth/login", post(login))
+        .route("/api/books/merge", post(post_merge))
+        .route("/api/books/merge/undo", post(post_undo))
+        .with_state(stub.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OmnibusClient::new(Config {
+        base_url: format!("http://{addr}"),
+        username: "admin".into(),
+        password: "correct horse battery".into(),
+    })
+    .unwrap();
+    (OmnibusMcp::new(Arc::new(client)), stub)
+}
+
+/// `unwrap_err` needs `T: Debug`, which `rmcp::Json` does not implement.
+fn expect_err<T>(result: Result<T, ErrorData>) -> ErrorData {
+    match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected an error"),
+    }
+}
+
+fn merge_params(confirm: Option<bool>) -> MergeParams {
+    MergeParams {
+        source_uuid: "uuid-source".into(),
+        target_uuid: "uuid-target".into(),
+        confirm,
+    }
+}
+
+#[test]
+fn merge_tools_router_lists_every_expected_tool_with_a_description() {
+    let router = OmnibusMcp::merge_tools();
+    let tools = router.list_all();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    for expected in EXPECTED_TOOLS {
+        assert!(names.contains(expected), "missing tool {expected}");
+    }
+    assert_eq!(
+        tools.len(),
+        EXPECTED_TOOLS.len(),
+        "unexpected extra tools: {names:?}"
+    );
+    for tool in &tools {
+        let desc = tool.description.as_deref().unwrap_or_default();
+        assert!(
+            desc.len() > 20,
+            "tool {} needs a real description",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn merge_books_refuses_without_confirm_and_sends_nothing() {
+    let (service, stub) = stub_service().await;
+    for confirm in [None, Some(false)] {
+        let err = expect_err(service.merge_books(Parameters(merge_params(confirm))).await);
+        assert!(err.message.contains("refused"));
+        assert!(err.message.contains("confirm: true"));
+        // The workflow: fetch both books, present them, then confirm.
+        assert!(err.message.contains("get_book"), "got: {}", err.message);
+    }
+    assert!(stub.merges.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn merge_books_posts_the_pair_and_returns_the_undo_handle_when_confirmed() {
+    let (service, stub) = stub_service().await;
+    let merged = service
+        .merge_books(Parameters(merge_params(Some(true))))
+        .await
+        .unwrap();
+    assert_eq!(merged.0.merge_log_id, 42);
+    assert_eq!(merged.0.target_uuid, "uuid-target");
+    assert_eq!(
+        stub.merges.lock().unwrap().clone(),
+        vec![serde_json::json!({
+            "source_uuid": "uuid-source",
+            "target_uuid": "uuid-target",
+        })]
+    );
+}
+
+#[tokio::test]
+async fn merge_books_names_the_admin_requirement_on_a_403() {
+    let (service, stub) = stub_service().await;
+    *stub.fail.lock().unwrap() = Some((403, "admin required"));
+    let err = expect_err(
+        service
+            .merge_books(Parameters(merge_params(Some(true))))
+            .await,
+    );
+    assert!(err.message.contains("admin"), "got: {}", err.message);
+    assert!(
+        !err.message.contains("can_edit is required"),
+        "must name the admin gate, not can_edit: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn merge_books_rejects_a_uuid_that_is_not_one_path_segment() {
+    // A slash-bearing "uuid" in the JSON body cannot split a path here (the
+    // merge path is fixed), but the shared guard still rejects it up front so
+    // no malformed handle ever reaches the instance.
+    let (service, stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .merge_books(Parameters(MergeParams {
+                source_uuid: "uuid-a/../uuid-b".into(),
+                target_uuid: "uuid-target".into(),
+                confirm: Some(true),
+            }))
+            .await,
+    );
+    assert!(
+        err.message.contains("source_uuid"),
+        "message: {}",
+        err.message
+    );
+    assert!(stub.merges.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn undo_merge_refuses_without_confirm_and_sends_nothing() {
+    let (service, stub) = stub_service().await;
+    let err = expect_err(
+        service
+            .undo_merge(Parameters(UndoMergeParams {
+                merge_log_id: 42,
+                confirm: None,
+            }))
+            .await,
+    );
+    assert!(err.message.contains("refused"));
+    assert!(err.message.contains("confirm: true"));
+    assert!(stub.undos.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn undo_merge_posts_the_log_id_and_returns_the_restored_uuid_when_confirmed() {
+    let (service, stub) = stub_service().await;
+    let restored = service
+        .undo_merge(Parameters(UndoMergeParams {
+            merge_log_id: 42,
+            confirm: Some(true),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(restored.0.restored_uuid, "uuid-source");
+    assert_eq!(
+        stub.undos.lock().unwrap().clone(),
+        vec![serde_json::json!({ "merge_log_id": 42 })]
+    );
+}
+
+#[tokio::test]
+async fn undo_merge_surfaces_the_already_undone_409_message() {
+    let (service, stub) = stub_service().await;
+    *stub.fail.lock().unwrap() = Some((409, "merge already undone"));
+    let err = expect_err(
+        service
+            .undo_merge(Parameters(UndoMergeParams {
+                merge_log_id: 42,
+                confirm: Some(true),
+            }))
+            .await,
+    );
+    assert!(err.message.contains("HTTP 409"), "got: {}", err.message);
+    assert!(err.message.contains("merge already undone"));
+}

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -3,10 +3,13 @@
 //! [`crate::server::OmnibusMcp`]; `OmnibusMcp::new` combines the routers.
 //! Read tools live in [`read`], the check-in / wishlist / physical-collection
 //! family in [`checkin`], shelf authoring in [`shelves`], the confirm-gated
-//! metadata repair family in [`metadata`]; later issues add further families
-//! as sibling modules, subject to the allowlist policy in [`crate::client`].
+//! metadata repair family in [`metadata`], the admin-gated merge/undo pair in
+//! [`merge`], and the chapter-text + content-search reads in [`content`] —
+//! all subject to the allowlist policy in [`crate::client`].
 
 pub mod checkin;
+pub mod content;
+pub mod merge;
 pub mod metadata;
 pub mod read;
 pub mod shelves;

--- a/mcp/src/tools/mod.rs
+++ b/mcp/src/tools/mod.rs
@@ -1,11 +1,8 @@
-//! Tool implementations, one module per family. Each module contributes a
-//! `#[tool_router(router = <name>)]` impl block on
-//! [`crate::server::OmnibusMcp`]; `OmnibusMcp::new` combines the routers.
-//! Read tools live in [`read`], the check-in / wishlist / physical-collection
-//! family in [`checkin`], shelf authoring in [`shelves`], the confirm-gated
-//! metadata repair family in [`metadata`], the admin-gated merge/undo pair in
-//! [`merge`], and the chapter-text + content-search reads in [`content`] —
-//! all subject to the allowlist policy in [`crate::client`].
+//! Tool implementations, one module per family: reads in [`read`], check-in /
+//! wishlist / physical in [`checkin`], shelf authoring in [`shelves`],
+//! metadata repair in [`metadata`], admin merge/undo in [`merge`], and the
+//! chapter/content-search reads in [`content`]. Each is a `#[tool_router]`
+//! impl block combined in `OmnibusMcp::new`, per [`crate::client`]'s allowlist.
 
 pub mod checkin;
 pub mod content;

--- a/shared/src/content_search.rs
+++ b/shared/src/content_search.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// One content-search hit: a chapter-level citation plus a match excerpt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ContentSearchHit {
     /// Durable book identity (`books.uuid`).
     pub book_uuid: String,
@@ -21,6 +22,7 @@ pub struct ContentSearchHit {
 
 /// Response body for `GET /api/search/content`, best-ranked hit first.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ContentSearchResults {
     pub hits: Vec<ContentSearchHit>,
 }

--- a/shared/src/ebook/chapters.rs
+++ b/shared/src/ebook/chapters.rs
@@ -14,6 +14,7 @@ pub const CHAPTER_TEXT_MAX_CHARS: usize = 100_000;
 /// One chapter in the listing: the TOC title plus the spine index the text
 /// read is addressed by.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ChapterListEntry {
     /// TOC order, 0-based.
     pub ordinal: i64,
@@ -29,6 +30,7 @@ pub struct ChapterListEntry {
 /// `chapters`; its text is still addressable by spine index up to
 /// `spine_count`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ChapterListResponse {
     pub book_uuid: String,
     pub has_text: bool,
@@ -45,6 +47,7 @@ pub struct ChapterListResponse {
 /// [`CHAPTER_TEXT_MAX_CHARS`] promises. `has_text: false` mirrors the
 /// listing's no-text answer (with everything else zeroed).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ChapterTextResponse {
     pub book_uuid: String,
     pub has_text: bool,

--- a/shared/src/merge.rs
+++ b/shared/src/merge.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Result of a successful merge: the audit-log id (the undo handle) and
 /// the surviving book's uuid.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MergeBooksResult {
     pub merge_log_id: i64,
     pub target_uuid: String,
@@ -13,6 +14,7 @@ pub struct MergeBooksResult {
 
 /// Request body for `POST /api/books/merge`: merge the source book into the target.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MergeBooksRequest {
     pub source_uuid: String,
     pub target_uuid: String,
@@ -20,12 +22,14 @@ pub struct MergeBooksRequest {
 
 /// Request body for `POST /api/books/merge/undo`: the `merge_log` id to reverse.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct UndoMergeRequest {
     pub merge_log_id: i64,
 }
 
 /// Result of a successful unmerge: the restored (source) book's uuid.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct UndoMergeResult {
     pub restored_uuid: String,
 }


### PR DESCRIPTION
## Summary
- Adds the `merge` MCP tool family (`merge_books`, `undo_merge`) over the admin-gated REST merge endpoints: both refuse without `confirm: true`, telling the model to fetch both books with `get_book` and present titles/authors/formats to the user first, and a 403 names the admin requirement rather than `can_edit`.
- Adds the `content` read family: `list_chapters`, `read_chapter_text` (surfaces `truncated`/`next_offset` and documents paging), and `search_book_content` (full-text over book content, cited back to book + chapter, distinct from the metadata-only `search_books`).
- Extends `WRITE_ALLOWLIST` with `POST /api/books/merge` and `POST /api/books/merge/undo`, commented as the strongest tier in the list (admin-gated, library-wide, confirm-gated); the content tools are plain GETs and add no entries.
- Derives `schemars::JsonSchema` (behind the existing `schemars` feature opt-in) on the chapter, content-search, and merge wire types in `shared/` so the tools return `Json<SharedType>` with derived output schemas.
- Stdio smoke: `tools/list` now reports 47 tools, all with output schemas.

Closes #2283
Part of #2282 — this lands its MCP wrapper AC; only AC6 (measuring the index's storage cost on a representative library) remains open there.

## Test plan
- [x] `cargo test -p omnibus-mcp` — 87 passed (merge confirm-refusal/happy/403-admin/undo-409, chapter list + `has_text: false`, truncation pass-through, content search happy + empty, router listing totals)
- [x] `cargo test -p omnibus-shared` — 405 passed
- [x] `cargo clippy -p omnibus-mcp --all-targets -- -D warnings` and `cargo fmt --check` clean
- [x] stdio smoke: initialize + `tools/list` shows 47 tools with output schemas

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.