### PR TITLE
[OMNI-2160] Fix the Recently Interacted Sort Option on Web and iOS

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5696,6 +5696,12 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
   font-size: 12px;
   padding: 4px 8px;
   height: 28px;
+  /* A floor, not a preference: the intrinsic width a `<select>` derives from
+     its options leaves the longest label ("Recently Interacted", uppercased
+     and letter-spaced by the `.lmq` skin below) with zero slack, and engines
+     that measure the dropdown indicator or the tracking differently clip it.
+     Sized for that label so the widest option always fits. */
+  min-width: 192px;
 }
 .lib-sort-select:focus { outline: none; border-color: var(--accent); }
 .lib-sort-dir {

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -97,9 +97,12 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     var formats: [String] = []
     var hasPhysical: Bool = false
     var addedAt: String?
-    /// Most recent reading signal on this book for the signed-in reader —
-    /// the axis behind the "Recently interacted" sort. Server-derived and
-    /// per-user, so it moves without the book's own metadata changing.
+    /// Most recent moment *anyone* touched this book — the axis behind the
+    /// "Recently interacted" sort. Library-wide, not per-reader: the server
+    /// folds it at read time from ratings, published journal entries, read
+    /// status, check-ins, and the book's own `last_modified`, none of them
+    /// scoped to the caller. So it can move for a book this reader has never
+    /// opened, and it moves without the book's own metadata changing.
     var lastInteractedAt: String?
     var error: String?
     var hasOverride: Bool = false

--- a/omnibus-ios/omnibus/Models/Models.swift
+++ b/omnibus-ios/omnibus/Models/Models.swift
@@ -97,6 +97,10 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
     var formats: [String] = []
     var hasPhysical: Bool = false
     var addedAt: String?
+    /// Most recent reading signal on this book for the signed-in reader —
+    /// the axis behind the "Recently interacted" sort. Server-derived and
+    /// per-user, so it moves without the book's own metadata changing.
+    var lastInteractedAt: String?
     var error: String?
     var hasOverride: Bool = false
     var hasCoverOverride: Bool = false
@@ -121,6 +125,7 @@ struct Book: Codable, Hashable, Sendable, Identifiable {
         case coverURL = "cover_url"
         case hasPhysical = "has_physical"
         case addedAt = "added_at"
+        case lastInteractedAt = "last_interacted_at"
         case hasOverride = "has_override"
         case hasCoverOverride = "has_cover_override"
         case bookFiles = "book_files"

--- a/omnibus-ios/omnibus/Offline/LibraryIndex.swift
+++ b/omnibus-ios/omnibus/Offline/LibraryIndex.swift
@@ -257,6 +257,9 @@ actor LibraryIndex {
             seriesIndex: Double(book.seriesIndex ?? "") ?? 0,
             addedAt: book.addedAt ?? "",
             modified: book.modified ?? book.addedAt ?? "",
+            // Empty when the reader has never touched the book — which sorts
+            // last under this axis's descending default, matching the server.
+            lastInteracted: book.lastInteractedAt ?? "",
             // Deduped: the hidden-formats predicate strips each hidden token
             // from the CSV once, so a duplicate would survive the strip and
             // read as "still visible". A physical copy rides as a pseudo-token
@@ -415,12 +418,16 @@ actor LibraryIndex {
         return (clauses.joined(separator: " AND "), bindings)
     }
 
-    private static func order(sort: SortKey, direction: SortDirection) -> String {
+    /// `ORDER BY` fragment for one sort axis. `internal` (not private) on the
+    /// same grounds as `predicate`: the ordering each axis produces is
+    /// testable as a pure function against a scratch table.
+    static func order(sort: SortKey, direction: SortDirection) -> String {
         let dir = direction == .asc ? "ASC" : "DESC"
         switch sort {
         case .title: return "title \(dir)"
         case .author: return "author \(dir), title ASC"
         case .series: return "series \(dir), series_index ASC, title ASC"
+        case .recentlyInteracted: return "last_interacted \(dir), title ASC"
         case .lastUpdated: return "modified \(dir), title ASC"
         case .newestAdded: return "added_at \(dir), title ASC"
         }

--- a/omnibus-ios/omnibus/Offline/LibraryIndex.swift
+++ b/omnibus-ios/omnibus/Offline/LibraryIndex.swift
@@ -257,8 +257,9 @@ actor LibraryIndex {
             seriesIndex: Double(book.seriesIndex ?? "") ?? 0,
             addedAt: book.addedAt ?? "",
             modified: book.modified ?? book.addedAt ?? "",
-            // Empty when the reader has never touched the book — which sorts
-            // last under this axis's descending default, matching the server.
+            // Empty when no one has ever touched the book — which sorts last
+            // under this axis's descending default, where the server's own
+            // NULL lands.
             lastInteracted: book.lastInteractedAt ?? "",
             // Deduped: the hidden-formats predicate strips each hidden token
             // from the CSV once, so a duplicate would survive the strip and

--- a/omnibus-ios/omnibus/Offline/OfflineStore.swift
+++ b/omnibus-ios/omnibus/Offline/OfflineStore.swift
@@ -378,7 +378,7 @@ actor OfflineStore {
         // books_staging`, so the two schemas must stay column-for-column
         // aligned. A mirror written before this column existed carries the
         // empty default, which sorts last under the axis's descending default
-        // — the same place the server puts a never-touched book.
+        // — the same place the server's NULL puts a book nobody has touched.
         for table in ["books", "books_staging"] where !hasColumn(table, "last_interacted") {
             exec("ALTER TABLE \(table) ADD COLUMN last_interacted TEXT NOT NULL DEFAULT ''")
         }

--- a/omnibus-ios/omnibus/Offline/OfflineStore.swift
+++ b/omnibus-ios/omnibus/Offline/OfflineStore.swift
@@ -343,6 +343,7 @@ actor OfflineStore {
                 series_index REAL NOT NULL DEFAULT 0,
                 added_at     TEXT NOT NULL DEFAULT '',
                 modified     TEXT NOT NULL DEFAULT '',
+                last_interacted TEXT NOT NULL DEFAULT '',
                 formats      TEXT NOT NULL DEFAULT '',
                 search_text  TEXT NOT NULL DEFAULT '',
                 payload      BLOB NOT NULL
@@ -366,11 +367,21 @@ actor OfflineStore {
                 series_index REAL NOT NULL DEFAULT 0,
                 added_at     TEXT NOT NULL DEFAULT '',
                 modified     TEXT NOT NULL DEFAULT '',
+                last_interacted TEXT NOT NULL DEFAULT '',
                 formats      TEXT NOT NULL DEFAULT '',
                 search_text  TEXT NOT NULL DEFAULT '',
                 payload      BLOB NOT NULL
             )
             """)
+        // Additive, and deliberately applied to both tables in lockstep: the
+        // staging swap is a positional `INSERT INTO books SELECT * FROM
+        // books_staging`, so the two schemas must stay column-for-column
+        // aligned. A mirror written before this column existed carries the
+        // empty default, which sorts last under the axis's descending default
+        // — the same place the server puts a never-touched book.
+        for table in ["books", "books_staging"] where !hasColumn(table, "last_interacted") {
+            exec("ALTER TABLE \(table) ADD COLUMN last_interacted TEXT NOT NULL DEFAULT ''")
+        }
     }
 
     /// Rebuild a pre-`kind` download registry in place.
@@ -752,6 +763,7 @@ actor OfflineStore {
         var seriesIndex: Double
         var addedAt: String
         var modified: String
+        var lastInteracted: String
         var formats: String
         var searchText: String
         var payload: Data
@@ -787,12 +799,13 @@ actor OfflineStore {
         let sql = """
             INSERT INTO books_staging
               (uuid, title, author, series, series_index, added_at, modified,
-               formats, search_text, payload)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               last_interacted, formats, search_text, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(uuid) DO UPDATE SET
               title = excluded.title, author = excluded.author,
               series = excluded.series, series_index = excluded.series_index,
               added_at = excluded.added_at, modified = excluded.modified,
+              last_interacted = excluded.last_interacted,
               formats = excluded.formats, search_text = excluded.search_text,
               payload = excluded.payload
             """
@@ -808,9 +821,10 @@ actor OfflineStore {
             sqlite3_bind_double(stmt, 5, row.seriesIndex)
             bind(stmt, 6, row.addedAt)
             bind(stmt, 7, row.modified)
-            bind(stmt, 8, row.formats)
-            bind(stmt, 9, row.searchText)
-            bind(stmt, 10, row.payload)
+            bind(stmt, 8, row.lastInteracted)
+            bind(stmt, 9, row.formats)
+            bind(stmt, 10, row.searchText)
+            bind(stmt, 11, row.payload)
             sqlite3_step(stmt)
             sqlite3_reset(stmt)
         }

--- a/omnibus-ios/omnibus/Services/LibraryService.swift
+++ b/omnibus-ios/omnibus/Services/LibraryService.swift
@@ -8,10 +8,14 @@
 
 import Foundation
 
+/// Declaration order is the picker's order, and mirrors the web toolbar's
+/// `SORT_KEYS`. Raw values are the shared wire vocabulary
+/// (`shared/src/view_prefs.rs`), so a new case must be added there first.
 enum SortKey: String, CaseIterable, Codable, Sendable {
     case title
     case author
     case series
+    case recentlyInteracted = "recently_interacted"
     case lastUpdated = "last_updated"
     case newestAdded = "newest_added"
 
@@ -20,6 +24,7 @@ enum SortKey: String, CaseIterable, Codable, Sendable {
         case .title: "Title"
         case .author: "Author"
         case .series: "Series"
+        case .recentlyInteracted: "Recently interacted"
         case .lastUpdated: "Last updated"
         case .newestAdded: "Newest added"
         }

--- a/omnibus-ios/omnibusTests/RecentlyInteractedSortTests.swift
+++ b/omnibus-ios/omnibusTests/RecentlyInteractedSortTests.swift
@@ -1,0 +1,152 @@
+//  RecentlyInteractedSortTests.swift
+//  The "Recently interacted" sort axis on the native client: its place in the
+//  shared wire vocabulary and the picker, the `Book` field it reads, and the
+//  ordering the offline mirror produces for it — including where a book the
+//  reader has never touched lands.
+
+import Foundation
+import SQLite3
+import Testing
+
+@testable import omnibus
+
+// MARK: - Wire vocabulary + picker
+
+struct RecentlyInteractedSortKeyTests {
+    @Test func sortKeyUsesTheSharedWireToken() {
+        #expect(SortKey.recentlyInteracted.rawValue == "recently_interacted")
+        #expect(SortKey(rawValue: "recently_interacted") == .recentlyInteracted)
+    }
+
+    @Test func sortPickerOffersRecentlyInteracted() {
+        // `allCases` *is* the picker's content, so its membership and order
+        // are the control's contract.
+        #expect(SortKey.allCases.contains(.recentlyInteracted))
+        #expect(SortKey.recentlyInteracted.label == "Recently interacted")
+        #expect(
+            SortKey.allCases.map(\.rawValue) == [
+                "title", "author", "series", "recently_interacted",
+                "last_updated", "newest_added",
+            ]
+        )
+    }
+}
+
+// MARK: - Decode
+
+struct LastInteractedDecodeTests {
+    private func decode(_ json: String) throws -> Book {
+        try JSONDecoder().decode(Book.self, from: Data(json.utf8))
+    }
+
+    @Test func bookDecodesLastInteractedAt() throws {
+        let book = try decode(
+            #"{"id":1,"filename":"a.epub","last_interacted_at":"2026-08-29T10:00:00Z"}"#
+        )
+        #expect(book.lastInteractedAt == "2026-08-29T10:00:00Z")
+    }
+
+    @Test func bookDecodesWithoutLastInteractedAt() throws {
+        // Listing projections for a never-touched book omit the field, and a
+        // payload cached before this field existed has no key at all.
+        let book = try decode(#"{"id":1,"filename":"a.epub"}"#)
+        #expect(book.lastInteractedAt == nil)
+    }
+}
+
+// MARK: - Mirror row
+
+struct LastInteractedRowTests {
+    private func row(lastInteractedAt: String?) -> OfflineStore.BookRow {
+        var book = Book(id: 1, filename: "a.epub", title: "A", uniqueIdentifier: "u1")
+        book.lastInteractedAt = lastInteractedAt
+        return LibraryIndex.row(for: book, payload: Data())
+    }
+
+    @Test func rowCarriesTheInteractionSignal() {
+        #expect(row(lastInteractedAt: "2026-08-29T10:00:00Z").lastInteracted
+            == "2026-08-29T10:00:00Z")
+    }
+
+    @Test func rowLeavesTheSignalEmptyWhenTheBookWasNeverTouched() {
+        // Empty rather than absent: the column is NOT NULL, and an empty
+        // string is what sorts the book last under the axis's default.
+        #expect(row(lastInteractedAt: nil).lastInteracted == "")
+    }
+}
+
+// MARK: - Ordering, run against a scratch SQLite table
+
+/// Order `(uuid, last_interacted, title)` triples through the exact fragment
+/// `LibraryIndex.order` generates, returning the uuids in result order.
+private func ordered(
+    _ rows: [(uuid: String, lastInteracted: String, title: String)],
+    direction: SortDirection
+) -> [String] {
+    var db: OpaquePointer?
+    #expect(sqlite3_open(":memory:", &db) == SQLITE_OK)
+    defer { sqlite3_close(db) }
+    sqlite3_exec(
+        db,
+        """
+        CREATE TABLE books (
+            uuid TEXT NOT NULL,
+            last_interacted TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT ''
+        )
+        """,
+        nil, nil, nil
+    )
+    let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    for row in rows {
+        var insert: OpaquePointer?
+        sqlite3_prepare_v2(
+            db, "INSERT INTO books (uuid, last_interacted, title) VALUES (?, ?, ?)",
+            -1, &insert, nil
+        )
+        sqlite3_bind_text(insert, 1, row.uuid, -1, transient)
+        sqlite3_bind_text(insert, 2, row.lastInteracted, -1, transient)
+        sqlite3_bind_text(insert, 3, row.title, -1, transient)
+        sqlite3_step(insert)
+        sqlite3_finalize(insert)
+    }
+
+    let clause = LibraryIndex.order(sort: .recentlyInteracted, direction: direction)
+    var stmt: OpaquePointer?
+    #expect(
+        sqlite3_prepare_v2(db, "SELECT uuid FROM books ORDER BY \(clause)", -1, &stmt, nil)
+            == SQLITE_OK
+    )
+    defer { sqlite3_finalize(stmt) }
+    var out: [String] = []
+    while sqlite3_step(stmt) == SQLITE_ROW {
+        out.append(String(cString: sqlite3_column_text(stmt, 0)))
+    }
+    return out
+}
+
+struct RecentlyInteractedOrderTests {
+    private let rows: [(uuid: String, lastInteracted: String, title: String)] = [
+        ("untouched", "", "b"),
+        ("old", "2026-01-01T00:00:00Z", "c"),
+        ("newest", "2026-08-29T10:00:00Z", "a"),
+    ]
+
+    @Test func descendingPutsTheLatestSignalFirstAndTheUntouchedBookLast() {
+        // Descending is the axis's natural direction, and it is what makes an
+        // empty signal read as "never touched" rather than "touched first".
+        #expect(ordered(rows, direction: .desc) == ["newest", "old", "untouched"])
+    }
+
+    @Test func ascendingReversesTheAxisWithoutFallingBackToTheDateColumns() {
+        #expect(ordered(rows, direction: .asc) == ["untouched", "old", "newest"])
+    }
+
+    @Test func titleBreaksTiesWithinOneInstant() {
+        let tied: [(uuid: String, lastInteracted: String, title: String)] = [
+            ("zeta", "2026-08-29T10:00:00Z", "z"),
+            ("alpha", "2026-08-29T10:00:00Z", "a"),
+        ]
+        #expect(ordered(tied, direction: .desc) == ["alpha", "zeta"])
+    }
+}

--- a/omnibus-ios/omnibusTests/RecentlyInteractedSortTests.swift
+++ b/omnibus-ios/omnibusTests/RecentlyInteractedSortTests.swift
@@ -1,8 +1,8 @@
 //  RecentlyInteractedSortTests.swift
 //  The "Recently interacted" sort axis on the native client: its place in the
 //  shared wire vocabulary and the picker, the `Book` field it reads, and the
-//  ordering the offline mirror produces for it — including where a book the
-//  reader has never touched lands.
+//  ordering the offline mirror produces for it — including where a book nobody
+//  has ever touched lands.
 
 import Foundation
 import SQLite3
@@ -70,7 +70,9 @@ struct LastInteractedRowTests {
 
     @Test func rowLeavesTheSignalEmptyWhenTheBookWasNeverTouched() {
         // Empty rather than absent: the column is NOT NULL, and an empty
-        // string is what sorts the book last under the axis's default.
+        // string is what sorts the book last under the axis's default — where
+        // the server's own NULL lands. The signal is library-wide, so this is
+        // "nobody has touched it", not "this reader hasn't".
         #expect(row(lastInteractedAt: nil).lastInteracted == "")
     }
 }
@@ -83,40 +85,64 @@ private func ordered(
     _ rows: [(uuid: String, lastInteracted: String, title: String)],
     direction: SortDirection
 ) -> [String] {
+    // Every SQLite step is guarded rather than `#expect`ed: a failed `#expect`
+    // reports and keeps going, and the next call would then run against a nil
+    // handle and take the whole test process down with it. Recording an issue
+    // and returning empty fails the caller's assertion with a readable signal.
     var db: OpaquePointer?
-    #expect(sqlite3_open(":memory:", &db) == SQLITE_OK)
+    guard sqlite3_open(":memory:", &db) == SQLITE_OK, db != nil else {
+        Issue.record("could not open an in-memory database")
+        return []
+    }
     defer { sqlite3_close(db) }
-    sqlite3_exec(
-        db,
-        """
-        CREATE TABLE books (
-            uuid TEXT NOT NULL,
-            last_interacted TEXT NOT NULL DEFAULT '',
-            title TEXT NOT NULL DEFAULT ''
-        )
-        """,
-        nil, nil, nil
-    )
+    guard
+        sqlite3_exec(
+            db,
+            """
+            CREATE TABLE books (
+                uuid TEXT NOT NULL,
+                last_interacted TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL DEFAULT ''
+            )
+            """,
+            nil, nil, nil
+        ) == SQLITE_OK
+    else {
+        Issue.record("could not create the scratch books table")
+        return []
+    }
+
     let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     for row in rows {
         var insert: OpaquePointer?
-        sqlite3_prepare_v2(
-            db, "INSERT INTO books (uuid, last_interacted, title) VALUES (?, ?, ?)",
-            -1, &insert, nil
-        )
+        guard
+            sqlite3_prepare_v2(
+                db, "INSERT INTO books (uuid, last_interacted, title) VALUES (?, ?, ?)",
+                -1, &insert, nil
+            ) == SQLITE_OK
+        else {
+            Issue.record("could not prepare the insert for \(row.uuid)")
+            return []
+        }
+        defer { sqlite3_finalize(insert) }
         sqlite3_bind_text(insert, 1, row.uuid, -1, transient)
         sqlite3_bind_text(insert, 2, row.lastInteracted, -1, transient)
         sqlite3_bind_text(insert, 3, row.title, -1, transient)
-        sqlite3_step(insert)
-        sqlite3_finalize(insert)
+        guard sqlite3_step(insert) == SQLITE_DONE else {
+            Issue.record("could not insert \(row.uuid)")
+            return []
+        }
     }
 
     let clause = LibraryIndex.order(sort: .recentlyInteracted, direction: direction)
     var stmt: OpaquePointer?
-    #expect(
+    guard
         sqlite3_prepare_v2(db, "SELECT uuid FROM books ORDER BY \(clause)", -1, &stmt, nil)
             == SQLITE_OK
-    )
+    else {
+        Issue.record("could not prepare a select ordered by: \(clause)")
+        return []
+    }
     defer { sqlite3_finalize(stmt) }
     var out: [String] = []
     while sqlite3_step(stmt) == SQLITE_ROW {
@@ -134,7 +160,7 @@ struct RecentlyInteractedOrderTests {
 
     @Test func descendingPutsTheLatestSignalFirstAndTheUntouchedBookLast() {
         // Descending is the axis's natural direction, and it is what makes an
-        // empty signal read as "never touched" rather than "touched first".
+        // empty signal read as "untouched" rather than "touched first".
         #expect(ordered(rows, direction: .desc) == ["newest", "old", "untouched"])
     }
 


### PR DESCRIPTION
## Summary
- The landing toolbar's sort `<select>` sized itself to fit "Recently Interacted" with zero slack, so any engine that measures the dropdown indicator or the `.lmq` skin's letter-spacing slightly differently clipped the label; it now carries a `min-width` floor sized for that option.
- iOS never offered the axis at all — `SortKey` on the native client stopped at `newestAdded`, so the library sort menu had five options where web had six. Added the case, its wire token, and its label.
- The offline mirror learned the axis alongside it: `Book` now decodes `last_interacted_at`, `books`/`books_staging` carry a `last_interacted` column (additive, both tables in lockstep so the positional staging swap stays aligned), and `LibraryIndex.order` orders on it.
- Part of #2160.

## Test plan
- [x] `just ios-test` — full unit suite green, including 9 new `RecentlyInteractedSortTests` cases (wire token, picker membership + order, `Book` decode with and without the field, mirror row population, and the `ORDER BY` fragment run against a scratch SQLite table).
- [x] `just lint-css` clean.
- [x] Web: dev server + browser — the option renders fully inside the control with visible slack before the chevron.
- [x] iOS: simulator against a live server — "Recently interacted" appears between Series and Last updated, and selecting it re-fetches the grid into interaction order.

## Version
- [x] **Patch** — the default.

## Notes
- Sort direction stays an independent toggle on iOS rather than adopting the web's per-axis default: the native control has always worked that way, and the app's default is already descending, which is this axis's natural direction.
- The mirror's copy of the signal is as fresh as the last sync pass, matching how the web replica approximates the same axis offline.