### PR TITLE
fix: keep landing overlays floating, not anchored in the book column

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -10940,8 +10940,10 @@ html {
 /* Lifts each section above the wash. Overlays flatten in as children here too
    (Dioxus has no portal), and this rule ties them on specificity while winning
    on source order — so without the exclusion it re-anchors a `position: fixed`
-   modal into the page column. Add any new fixed overlay mounted here to the list. */
-.lmq > *:not(.shelf-modal-overlay, .author-photo-modal-backdrop, .bulk-edit-bar) {
+   modal into the page column. Add any new fixed overlay mounted here to the list.
+   `:where()` keeps this at (0,1,0): a bare `:not()` takes its most specific
+   argument, which would outrank `.lmq-edge`'s own later `position: fixed`. */
+.lmq > *:where(:not(.shelf-modal-overlay, .author-photo-modal-backdrop, .bulk-edit-bar)) {
   position: relative;
   z-index: 1;
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -10937,7 +10937,14 @@ html {
     radial-gradient(64% 78% at 18% 0%, color-mix(in oklch, var(--accent) 17%, transparent), transparent 62%),
     radial-gradient(52% 70% at 92% 12%, color-mix(in oklch, var(--accent) 9%, transparent), transparent 58%);
 }
-.lmq > * { position: relative; z-index: 1; }
+/* Lifts each section above the wash. Overlays flatten in as children here too
+   (Dioxus has no portal), and this rule ties them on specificity while winning
+   on source order — so without the exclusion it re-anchors a `position: fixed`
+   modal into the page column. Add any new fixed overlay mounted here to the list. */
+.lmq > *:not(.shelf-modal-overlay, .author-photo-modal-backdrop, .bulk-edit-bar) {
+  position: relative;
+  z-index: 1;
+}
 
 /* ── The stack: the open books, fanned ───────────────────────────── */
 .lmq-stack {

--- a/ui_tests/playwright/tests/flows/landing_bulk_edit.spec.ts
+++ b/ui_tests/playwright/tests/flows/landing_bulk_edit.spec.ts
@@ -60,6 +60,12 @@ test("selecting rows reveals the bulk edit bar and checkbox clicks do not naviga
 
   const bar = page.getByTestId("bulk-edit-bar");
   await expect(bar).toContainText("2 books selected");
+  // The bar flattens into the landing column, where `.lmq > *` lifts each
+  // section — a rule that ties the bar on specificity. Losing that tie drops
+  // it into the flow, far below the rows it reports on.
+  await expect
+    .poll(() => bar.evaluate((el) => getComputedStyle(el).position))
+    .toBe("fixed");
 
   await page.getByTestId("bulk-edit-clear").click();
   await expect(bar).toHaveCount(0);

--- a/ui_tests/playwright/tests/flows/shelf_gallery.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelf_gallery.spec.ts
@@ -453,6 +453,11 @@ test("resume stays reachable as an edge ribbon once the stack scrolls away", asy
   await expect(ribbon).toBeAttached();
   await expect(root).not.toHaveClass(/lmq--past/);
   await expect(ribbon).toHaveCSS("opacity", "0");
+  // Pinned to the viewport, not to the column. `.lmq > *` also matches the
+  // ribbon and is only outranked because it stays at (0,1,0) — a `:not()`
+  // there that forgets its `:where()` wrapper silently drops it into the flow,
+  // where the assertions below still pass or fail on scroll position alone.
+  await expect(ribbon).toHaveCSS("position", "fixed");
 
   await page.evaluate(() => window.scrollTo(0, 600));
   await expect(root).toHaveClass(/lmq--past/);

--- a/ui_tests/playwright/tests/flows/shelves.spec.ts
+++ b/ui_tests/playwright/tests/flows/shelves.spec.ts
@@ -55,6 +55,28 @@ test("renders the shelf gallery on the library page", async ({ page }) => {
   await expectNavVisible(page);
 });
 
+test("floats the create-shelf modal above the page, not in the book column", async ({
+  page,
+}) => {
+  await gotoReady(page, "/");
+
+  await page.getByTestId("new-shelf").click();
+  const modal = page.getByTestId("create-shelf-modal");
+  await expect(modal).toBeVisible();
+
+  // The modal flattens into the landing column, where `.lmq > *` lifts each
+  // section — a rule that ties `.shelf-modal-overlay` on specificity. Losing
+  // that tie re-anchors the overlay into the flow, where it renders as a
+  // block between the shelves row and the book grid instead of over them.
+  await expect
+    .poll(() => modal.evaluate((el) => getComputedStyle(el).position))
+    .toBe("fixed");
+
+  // An in-flow overlay scrolls away with the column; a floating one does not.
+  await page.mouse.wheel(0, 600);
+  await expect.poll(async () => (await modal.boundingBox())?.y).toBe(0);
+});
+
 test("creates a hand-picked shelf and shows it in the gallery", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- `.lmq > *` lifted every landing section with `position: relative; z-index: 1`. It ties `.shelf-modal-overlay` on specificity (both `0,1,0`) and sits ~3,650 lines later in the sheet, so it won on source order and overwrote the overlay's `position: fixed` — the create-shelf modal rendered as a block in the page column between the shelves row and the book grid instead of floating over them.
- The same rule silently de-fixed three more overlays that flatten into `.lmq`: the edit-shelf modal (same class), the bulk-edit modal's backdrop, and the floating bulk-edit selection bar. All four float again.
- `.lmq-edge` is unaffected either way — it declares `position: fixed` *after* the lift rule, so it already won on source order.
- The exclusion is by class name, so any new fixed-position overlay mounted under `.lmq` has to be added to the list; the rule carries a comment saying so.

## Test plan
- [x] Full Playwright suite against a real dev server: 445 passed, 5 failed — all 5 triaged as unrelated. Two are `settings.spec.ts` API-key tests reading ambient `HARDCOVER_API_KEY`/`GOOGLE_BOOKS_API_KEY` from a local `.env` (the exact case rule 03 warns about); the other three (`merge.spec.ts:134`, `reader.spec.ts:858`, `shelf_gallery.spec.ts:441`) pass on isolated re-run.
- [x] New E2E coverage: `shelves.spec.ts` asserts the create-shelf overlay computes to `fixed` and holds `y: 0` across a scroll; `landing_bulk_edit.spec.ts` asserts the same on the selection bar.
- [x] Verified in a browser against the real SSR + hydration path — overlay computes `position: fixed`, `z-index: 120`, box `{top: 0, left: 0, 1280x720}`.
- [x] `just lint-css` and `just lint-ts` clean.

## Version
- [x] **Patch** — the default.