### PR TITLE
[OMNI-2320] Fix The Attach Slot Guard And The Stale has_cover Flag

### DIFF
--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -129,6 +129,12 @@ pub(super) async fn find_attach_target(
 
 /// Return whether another file holds the `(book_id, format)` attachment slot.
 /// The incoming `scan_key` is excluded so re-attaching the same file proceeds.
+///
+/// Both tables are consulted because neither alone describes the slot:
+/// `merged_uuids` records attached files but never a book's own native file,
+/// so asking it alone let a second on-disk copy of one book evict the native
+/// file's `book_files` row and then trade the slot back on the following scan,
+/// restamping `books.last_modified` forever (#2320).
 pub(super) async fn slot_held_by_other(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     book_id: i64,
@@ -137,8 +143,15 @@ pub(super) async fn slot_held_by_other(
 ) -> Result<bool, sqlx::Error> {
     let held: Option<i64> = sqlx::query_scalar(
         "SELECT 1 FROM merged_uuids
-          WHERE book_id = ? AND format = ? AND scan_key <> ? LIMIT 1",
+          WHERE book_id = ? AND format = ? AND scan_key <> ?
+         UNION ALL
+         SELECT 1 FROM book_files
+          WHERE book_id = ? AND format = ? AND scan_key <> ?
+         LIMIT 1",
     )
+    .bind(book_id)
+    .bind(format)
+    .bind(scan_key)
     .bind(book_id)
     .bind(format)
     .bind(scan_key)

--- a/db/src/sync/attach/mod.rs
+++ b/db/src/sync/attach/mod.rs
@@ -141,13 +141,15 @@ pub(super) async fn slot_held_by_other(
     format: &str,
     scan_key: &str,
 ) -> Result<bool, sqlx::Error> {
-    let held: Option<i64> = sqlx::query_scalar(
-        "SELECT 1 FROM merged_uuids
-          WHERE book_id = ? AND format = ? AND scan_key <> ?
-         UNION ALL
-         SELECT 1 FROM book_files
-          WHERE book_id = ? AND format = ? AND scan_key <> ?
-         LIMIT 1",
+    // Two `EXISTS` subqueries rather than a `UNION ALL … LIMIT 1`: each one
+    // short-circuits on its first hit without planning a compound query, and
+    // the ledger side — the common case — settles it before `book_files` is
+    // touched at all.
+    let held: i64 = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM merged_uuids
+                        WHERE book_id = ? AND format = ? AND scan_key <> ?)
+             OR EXISTS(SELECT 1 FROM book_files
+                        WHERE book_id = ? AND format = ? AND scan_key <> ?)",
     )
     .bind(book_id)
     .bind(format)
@@ -155,9 +157,9 @@ pub(super) async fn slot_held_by_other(
     .bind(book_id)
     .bind(format)
     .bind(scan_key)
-    .fetch_optional(&mut **tx)
+    .fetch_one(&mut **tx)
     .await?;
-    Ok(held.is_some())
+    Ok(held != 0)
 }
 
 /// Drop the `merged_uuids` row for `(library_path, scan_key)`. Called when a

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -1004,13 +1004,33 @@ async fn attach_refuses_when_the_books_own_native_file_holds_the_slot() {
     .await
     .unwrap();
 
-    let incumbent: String =
-        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'EPUB'")
-            .bind(book_id)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-    assert_eq!(incumbent, "yumi-a", "the native file keeps its own slot");
+    // Assert the slot's occupancy by count rather than reading one row back:
+    // a regression here produces a *second* `book_files` row, and an unordered
+    // `fetch_one` would pick between them arbitrarily — flaking, or masking the
+    // very failure this test exists to catch.
+    assert_eq!(
+        count(
+            &pool,
+            &format!(
+                "SELECT COUNT(*) FROM book_files WHERE book_id = {book_id} AND format = 'EPUB'"
+            )
+        )
+        .await,
+        1,
+        "the slot holds exactly one file"
+    );
+    assert_eq!(
+        count(
+            &pool,
+            &format!(
+                "SELECT COUNT(*) FROM book_files
+                  WHERE book_id = {book_id} AND format = 'EPUB' AND filename = 'yumi-a'"
+            )
+        )
+        .await,
+        1,
+        "the native file keeps its own slot"
+    );
     assert_eq!(
         count(
             &pool,

--- a/db/src/sync/attach/tests.rs
+++ b/db/src/sync/attach/tests.rs
@@ -957,3 +957,76 @@ async fn attachment_survives_a_scan_root_repoint() {
         "no duplicate ledger row"
     );
 }
+
+#[tokio::test]
+async fn attach_refuses_when_the_books_own_native_file_holds_the_slot() {
+    // A book's native file carries no `merged_uuids` row, so a guard that
+    // consults only the ledger cannot see it holding the slot. Two on-disk
+    // copies of one ebook then trade the single (book, EPUB) slot on every
+    // scan, restamping `books.last_modified` forever (#2320).
+    let _covers = CoversTempDir::new("attach_native_slot_guard");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    seed_ebook(&pool, "Sanderson/yumi-a.epub", "Yumi", "Brandon Sanderson").await;
+    let book_id: i64 = sqlx::query_scalar("SELECT id FROM books")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // A stale ledger row of the kind a library reorganization leaves behind,
+    // naming a second on-disk copy of the same book.
+    let scan_key_b = crate::helpers::scan_key_for("Sanderson/yumi-b.epub");
+    sqlx::query(
+        "INSERT INTO merged_uuids (uuid, book_id, format, library_path, scan_key)
+         VALUES ('stale-ledger', ?, 'EPUB', '/ebooks', ?)",
+    )
+    .bind(book_id)
+    .bind(&scan_key_b)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // The second copy arrives as New and replays that ledger row.
+    sync_books(
+        &pool,
+        "/ebooks",
+        SyncPlan {
+            new_books: vec![indexed(
+                "Sanderson/yumi-b.epub",
+                Some("Yumi"),
+                &["Brandon Sanderson"],
+                &[],
+                None,
+                None,
+            )],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let incumbent: String =
+        sqlx::query_scalar("SELECT filename FROM book_files WHERE book_id = ? AND format = 'EPUB'")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(incumbent, "yumi-a", "the native file keeps its own slot");
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM book_files WHERE format = 'EPUB'"
+        )
+        .await,
+        2,
+        "the second copy became its own book's file"
+    );
+    assert_eq!(
+        count(
+            &pool,
+            "SELECT COUNT(*) FROM merged_uuids WHERE uuid = 'stale-ledger'"
+        )
+        .await,
+        0,
+        "the stale ledger row is forgotten so it stops replaying"
+    );
+}

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -1,8 +1,10 @@
 //! Removed bucket: every uuid whose file disappeared keeps its `books` row. One
 //! chunked DELETE drops only the book's own native `book_files` rows — a row
 //! still backed by a `merged_uuids` entry is a cross-format attachment and
-//! survives — and one chunked UPDATE flags each book missing. Idempotent: a
-//! re-run on an already-fileless row deletes nothing and the flag UPDATE no-ops.
+//! survives — then two chunked UPDATEs flag each book missing and clear its
+//! `has_cover`, keeping the flag consistent with the cover file the
+//! post-commit reconcile unlinks. Idempotent: a re-run on an already-fileless
+//! row deletes nothing and both UPDATEs no-op via their guards.
 
 use sqlx::Transaction;
 
@@ -40,6 +42,7 @@ pub(super) async fn sync_removed(
         }
         delete_removed_book_files(tx, &ids).await?;
         flag_books_missing(tx, &ids).await?;
+        clear_has_cover(tx, &ids).await?;
     }
     if missing > 0 {
         // These rows are flagged missing (F10); `missing_files::gc_books_missing_files`
@@ -95,6 +98,35 @@ async fn delete_removed_book_files(
         delete_q = delete_q.bind(id);
     }
     delete_q.execute(&mut **tx).await?;
+    Ok(())
+}
+
+/// One UPDATE per chunk: clear `has_cover` for the books whose cover files the
+/// post-commit reconcile is about to unlink (`delete_cover_files_for`, called
+/// with every removed uuid). Leaving the flag set strands the book with
+/// `has_cover = 1` and no file on disk, which nothing repairs: `get_cover`
+/// trusts the flag and probes a path that is gone, `maybe_adopt_cover` returns
+/// early on `has_cover != 0` so a returning file never re-adopts, and
+/// `backfill_covers` selects on `has_cover = 0` so the re-extraction pass never
+/// sees it (#2321). Clearing it hands the book back to that pass, which
+/// re-extracts under the correct `books.uuid` once a file is present again.
+///
+/// The uploaded cover override is `metadata_overrides.has_cover_override`, a
+/// different column read through `find_override_cover_file`, and is untouched.
+async fn clear_has_cover(
+    tx: &mut Transaction<'_, sqlx::Sqlite>,
+    ids: &[i64],
+) -> Result<(), sqlx::Error> {
+    let id_placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let update_sql =
+        format!("UPDATE books SET has_cover = 0 WHERE id IN ({id_placeholders}) AND has_cover = 1");
+    let mut update_q = sqlx::query(&update_sql);
+    for id in ids {
+        update_q = update_q.bind(id);
+    }
+    update_q.execute(&mut **tx).await?;
     Ok(())
 }
 

--- a/db/src/sync/books/removed.rs
+++ b/db/src/sync/books/removed.rs
@@ -8,6 +8,12 @@
 
 use sqlx::Transaction;
 
+/// `"?, ?, …"` for an `IN (…)` list of `n` binds. Every statement in this
+/// module is chunked over a slice of ids, so they all need one.
+fn placeholders(n: usize) -> String {
+    std::iter::repeat_n("?", n).collect::<Vec<_>>().join(", ")
+}
+
 /// Mark a batch of removed books' files missing. The file is gone, but the
 /// `books` row — its metadata, taxonomy links, FTS row, and every soft-ref
 /// user-data row — is **retained**; only the book's own native `book_files`
@@ -58,10 +64,9 @@ async fn resolve_removed_book_ids(
     library_id: i64,
     chunk: &[String],
 ) -> Result<Vec<i64>, sqlx::Error> {
-    let placeholders = std::iter::repeat_n("?", chunk.len())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let id_sql = format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({placeholders})");
+    let uuid_placeholders = placeholders(chunk.len());
+    let id_sql =
+        format!("SELECT id FROM books WHERE library_id = ? AND uuid IN ({uuid_placeholders})");
     let mut q = sqlx::query_scalar::<_, i64>(&id_sql).bind(library_id);
     for uuid in chunk {
         q = q.bind(uuid);
@@ -80,9 +85,7 @@ async fn delete_removed_book_files(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     ids: &[i64],
 ) -> Result<(), sqlx::Error> {
-    let id_placeholders = std::iter::repeat_n("?", ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
+    let id_placeholders = placeholders(ids.len());
     let delete_sql = format!(
         "DELETE FROM book_files
           WHERE book_id IN ({id_placeholders})
@@ -117,9 +120,7 @@ async fn clear_has_cover(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     ids: &[i64],
 ) -> Result<(), sqlx::Error> {
-    let id_placeholders = std::iter::repeat_n("?", ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
+    let id_placeholders = placeholders(ids.len());
     let update_sql =
         format!("UPDATE books SET has_cover = 0 WHERE id IN ({id_placeholders}) AND has_cover = 1");
     let mut update_q = sqlx::query(&update_sql);
@@ -142,9 +143,7 @@ async fn flag_books_missing(
     tx: &mut Transaction<'_, sqlx::Sqlite>,
     ids: &[i64],
 ) -> Result<(), sqlx::Error> {
-    let id_placeholders = std::iter::repeat_n("?", ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
+    let id_placeholders = placeholders(ids.len());
     let update_sql = format!(
         "UPDATE books
             SET is_missing_files = 1, missing_files_since = unixepoch()

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -2150,3 +2150,49 @@ fn sync_error_from_settings_error_returns_other_for_non_db_variants() {
         "expected Other, got {json:?}"
     );
 }
+
+/// The post-commit reconcile unlinks the cover file for every removed uuid, so
+/// leaving `has_cover = 1` strands the book with a flag the filesystem no
+/// longer backs. Both repair paths key on that flag — `maybe_adopt_cover`
+/// returns early on `has_cover != 0` and `backfill_covers` selects on
+/// `has_cover = 0` — so the book would never regain a cover (#2321).
+#[tokio::test]
+async fn removed_book_clears_has_cover_so_the_cover_backfill_can_re_extract() {
+    let _covers = CoversTempDir::new("sync_books_removed_has_cover");
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+    let book_id = seed_book_with_file(&pool, library_id, "Old/book.epub").await;
+    sqlx::query("UPDATE books SET has_cover = 1 WHERE id = ?")
+        .bind(book_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM books WHERE id = ?")
+        .bind(book_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    sync_books(
+        &pool,
+        "/lib",
+        SyncPlan {
+            removed_uuids: vec![uuid],
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let (has_cover, is_missing): (i64, i64) =
+        sqlx::query_as("SELECT has_cover, is_missing_files FROM books WHERE id = ?")
+            .bind(book_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        has_cover, 0,
+        "the flag matches the cover file the reconcile unlinked"
+    );
+    assert_eq!(is_missing, 1, "the book is still flagged missing");
+}


### PR DESCRIPTION
## Summary
- `slot_held_by_other` consulted only `merged_uuids`, which never records a book's own native file — so a second on-disk copy of one ebook evicted the native `book_files` row, and the two copies traded the single `(book, format)` slot on every scan, restamping `books.last_modified` indefinitely. It now also refuses when a `book_files` row of that format sits under a different `scan_key`.
- Its one caller is the ebook attach path, so multi-part audiobooks — which legitimately carry several same-format rows — are unaffected; the existing `forget_attachment` fallback becomes reachable for the first time and the stray copy is inserted as its own book instead of replaying forever.
- The Removed bucket left `books.has_cover = 1` while the post-commit reconcile unlinked the cover file, stranding a flag the filesystem no longer backed. Neither repair path could heal it — `maybe_adopt_cover` returns early on `has_cover != 0` and `backfill_covers` selects on `has_cover = 0` — so `sync_removed` now clears the flag alongside the unlink, handing the book back to the re-extraction pass.
- Both were found tracing a production book that was rewritten on every reindex; the uploaded cover override lives in a different column and is deliberately untouched.

Closes #2320
Closes #2321

## Test plan
- [x] Two regression tests, both verified red against the unfixed code first: the slot guard test showed the incoming copy evicting the incumbent (`left: "yumi-b", right: "yumi-a"`), and the cover test showed `has_cover` stuck at `1`.
- [x] `just test` — full matrix green (db, server, frontend server + mobile, shared).
- [x] `just lint` — `cargo fmt --check` + clippy across the crate/feature matrix.
- [x] Existing attach suite passes unchanged, including `multipart_audiobook_attachments_survive_rescan_as_unchanged` and `replayed_second_file_accumulates_as_another_part_under_the_book`, which cover the same-format multi-row case the widened guard could have broken.

## Version
- [x] **Patch** — the default.

## Notes
- No migration: both fixes are write-path only. Instances already carrying the stale state heal on the next scan — the slot stops flipping, and a book left with `has_cover = 1` and no file is picked up by `backfill_covers` once the flag is cleared by a subsequent removal. A book already in that state without a further removal keeps its broken flag until then; there is no backfill here to repair historical rows.