### PR TITLE
chore: stop citing the latest migration filename in rule 06

### DIFF
--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -12,8 +12,9 @@ works in production.
 ## Authoring a migration
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
-   number after the highest existing file — run `ls db/migrations | tail`
-   for the current highest. The number is the version
+   number after the highest existing file — run
+   `ls -1 db/migrations | tail -n 1` for the current highest. The number
+   is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere

--- a/.claude/rules/06-migrations.md
+++ b/.claude/rules/06-migrations.md
@@ -12,8 +12,8 @@ works in production.
 ## Authoring a migration
 
 1. **Name it `NNNN_short_description.sql`.** Take the next zero-padded
-   number after the highest existing file (latest is
-   `0090_daily_reading_goals.sql`). The number is the version
+   number after the highest existing file — run `ls db/migrations | tail`
+   for the current highest. The number is the version
    `_sqlx_migrations` records; renumbering or renaming an applied file
    breaks the applied-version bookkeeping.
 2. **Never edit an applied migration.** Once a file has run anywhere


### PR DESCRIPTION
## Summary
- Rule 06's "latest is `NNNN_….sql`" citation rots every time a migration lands (it has been bumped 0086 → 0089 → 0090 and was stale again at 0091), so replace the hardcoded filename with a `ls db/migrations | tail` pointer per rule 98's don't-rot guidance.

## Test plan
- N/A — docs only.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [ ] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [x] **No release** — unlabeled docs-only diffs skip the release automatically.