### PR TITLE
fix: name the section in the URL while scrolling on mobile

### DIFF
--- a/site/src/app.js
+++ b/site/src/app.js
@@ -1,6 +1,6 @@
 /* Omnibus site — panel deck.
  *
- * Twelve full-viewport panels on one translated track. Wheel, keys and touch
+ * Thirteen full-viewport panels on one translated track. Wheel, keys and touch
  * all funnel through one gate so a trackpad's inertia can't skip three panels
  * at once. Nothing here is required to read the page: the document ships with
  * `body.flow` set, so with JS off every panel stays in the DOM as an ordinary
@@ -117,12 +117,22 @@
     render();
   }
 
+  /* The address bar names the panel you are on, so any panel can be linked
+     to. replaceState, not a hash assignment: assigning location.hash pushes a
+     history entry per panel, which turns Back into a walk through the deck. */
+  var stamped = '';
+  function stamp(id) {
+    if (id === stamped) return;
+    stamped = id;
+    if (history.replaceState) history.replaceState(null, '', '#' + id);
+  }
+
   function render() {
     track.style.transform = 'translate3d(0,' + (-i * 100) + 'vh,0)';
     panes.forEach(function (p, k) { p.classList.toggle('on', k === i); });
     railBtns.forEach(function (b, k) { b.classList.toggle('on', k === i); });
     cue.classList.toggle('hide', i !== 0);
-    if (history.replaceState) history.replaceState(null, '', '#' + panes[i].id);
+    stamp(panes[i].id);
   }
 
   function gate(d) {
@@ -170,6 +180,19 @@
   if (hash) {
     var found = panes.findIndex(function (p) { return p.id === hash; });
     if (found > 0) i = found;
+  }
+
+  /* ── flow mode: keep the hash on the section being read ─────────
+     The deck stamps the hash from render(); flow mode never calls it, so on a
+     phone the URL froze at whatever was loaded and no section could be linked
+     to. One observer, watching a band across the middle of the viewport, so
+     the section that owns the screen is the one that gets named. */
+  if (window.IntersectionObserver) {
+    var seen = new IntersectionObserver(function (entries) {
+      if (deck) return;
+      entries.forEach(function (e) { if (e.isIntersecting) stamp(e.target.id); });
+    }, { rootMargin: '-45% 0px -45% 0px' });
+    panes.forEach(function (p) { seen.observe(p); });
   }
 
   if (deckOK.addEventListener) deckOK.addEventListener('change', setMode);

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -241,7 +241,7 @@
         <div class="center-copy" style="max-width:900px">
           <p class="kick" data-anim>Scanning</p>
           <h2 class="h2" data-anim style="--d:70ms">Your files; untouched</h2>
-          <p class="lede" data-anim style="--d:130ms;max-width:74ch;margin:0 auto">Omnibus's scanner recursively searches through the library folder you give it to find all applicable filetypes. <b>Omnibus does not, however, write to your files EVER.</b> Any updates to your book's metadata is saved to the database and is applied to the book when it is exported or sent out of Omnibus.</p>
+          <p class="lede" data-anim style="--d:130ms;max-width:74ch;margin:0 auto">Omnibus's scanner recursively searches through the library folder you give it to find all applicable filetypes. <b>Omnibus <u>never</u> writes to your files directly.</b> Any updates to your book's metadata is saved to the database and is applied to the book when it is exported or sent out of Omnibus.</p>
         </div>
         <div class="duo">
           <div>


### PR DESCRIPTION
## Summary
- On a phone the address bar froze at whatever was loaded, so no section could be linked *out of*. The deck stamps the hash from `render()`, which flow mode never calls; an IntersectionObserver watching a band across the middle of the viewport now stamps the section that owns the screen.
- `replaceState`, not a hash assignment — assigning `location.hash` pushes a history entry per section and turns Back into a walk through the page.
- Swaps the shouted `EVER` in the scanner copy for an underlined `never`, and corrects the panel count in the `app.js` header comment (twelve → thirteen).

Deep links *in* already worked and are unchanged: the pane's flow-mode top padding (~113px) already clears the 63px sticky header, so no `scroll-margin` was needed.

## Test plan
- [x] Mobile (375×812): scrolling through read / kobo / mcp / faq stamps each hash in turn, `history.length` unchanged
- [x] Desktop deck: rail clicks still stamp `#listen` / `#kindle` / `#mcp`, `history.length` unchanged, observer no-ops via its `deck` guard
- [x] Round-trip: loading `#mcp` on mobile lands on the section with its kicker clear of the sticky header
- [x] No console errors; served with `Cache-Control: no-store` so the checks ran against the new `app.js`, not a cached one

## Version
- [x] **Patch** — the default.