### PR TITLE
fix: correct edge-case rendering of dates, counts, and identifiers

### DIFF
--- a/frontend/src/components/search_palette/results.rs
+++ b/frontend/src/components/search_palette/results.rs
@@ -191,7 +191,7 @@ fn SpBookRow(book: PaletteBookHit, selected: bool, on_click: EventHandler<MouseE
         }
     };
 
-    let year = book.year.as_deref().unwrap_or("");
+    let year = palette_row_year(book.year.as_deref());
     let formats: String = book.formats.join(" · ");
 
     rsx! {
@@ -332,6 +332,15 @@ fn SpGenreRow(
 
 // ── Helpers ───────────────────────────────────────────────────────
 
+/// The year shown in a palette book row, gated through the shared sentinel
+/// rule so Calibre's `0101-01-01` placeholder (which `PaletteBookHit.year`
+/// carries verbatim as `"0101"`) renders nothing — matching the library table
+/// and the detail page, which already suppress it (#2348).
+fn palette_row_year(year: Option<&str>) -> String {
+    year.and_then(crate::format::format_year)
+        .unwrap_or_default()
+}
+
 /// Build the small-thumbnail URL for a palette book row.
 ///
 /// Extracted so the URL shape — `/api/thumbs/{uuid}/sm` — has a test that
@@ -368,5 +377,19 @@ mod tests {
     fn build_flat_items_is_empty_when_results_are_none() {
         let items = build_flat_items(&None);
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn palette_row_year_suppresses_the_calibre_sentinel() {
+        // `year` arrives pre-extracted as the four-digit string, so the
+        // sentinel reaches the palette as "0101" rather than a full date.
+        assert_eq!(palette_row_year(Some("0101")), "");
+        assert_eq!(palette_row_year(Some("0101-01-01T00:00:00+00:00")), "");
+        assert_eq!(palette_row_year(None), "");
+    }
+
+    #[test]
+    fn palette_row_year_keeps_a_real_year() {
+        assert_eq!(palette_row_year(Some("2016")), "2016");
     }
 }

--- a/frontend/src/format.rs
+++ b/frontend/src/format.rs
@@ -206,11 +206,20 @@ pub fn format_year(raw: &str) -> Option<String> {
 /// than [`format_date_short`] since a card only has room for month + year,
 /// on the same abbreviated month names. Same absent/sentinel handling.
 pub fn format_date_month_year(raw: &str) -> String {
+    format_date_month_year_opt(raw).unwrap_or_else(|| EM_DASH.to_string())
+}
+
+/// [`format_date_month_year`]'s answer, or `None` where that would render an
+/// em dash — for the series card eyebrow, which drops the whole date slot
+/// (its `·` separator included) rather than trailing a bare dash. Mirrors
+/// [`format_date_short_opt`]; without it a sentinel/absent date renders `· —`
+/// beside a `None` date's nothing, so two equally-dateless books disagree
+/// (#2294, #2360).
+pub fn format_date_month_year_opt(raw: &str) -> Option<String> {
     render_date(raw, |d| match d.month.and_then(month_name) {
         Some(month) => format!("{month} {}", d.year),
         None => d.year.to_string(),
     })
-    .unwrap_or_else(|| EM_DASH.to_string())
 }
 
 #[cfg(test)]

--- a/frontend/src/format/tests.rs
+++ b/frontend/src/format/tests.rs
@@ -216,6 +216,28 @@ fn format_date_month_year_renders_an_em_dash_for_an_empty_string() {
 }
 
 #[test]
+fn format_date_month_year_opt_is_some_for_a_real_date() {
+    assert_eq!(
+        format_date_month_year_opt("2016-05-02"),
+        Some("May 2016".to_string())
+    );
+    assert_eq!(format_date_month_year_opt("2016"), Some("2016".to_string()));
+}
+
+#[test]
+fn format_date_month_year_opt_is_none_for_absent_and_sentinel_dates() {
+    // The series card drops the whole slot on `None`, so a sentinel and a
+    // truly-absent date must both answer `None` — otherwise one renders `· —`
+    // and the other nothing (#2294, #2360).
+    assert_eq!(format_date_month_year_opt(""), None);
+    assert_eq!(format_date_month_year_opt("circa 1850"), None);
+    assert_eq!(
+        format_date_month_year_opt("0101-01-01T00:00:00+00:00"),
+        None
+    );
+}
+
+#[test]
 fn facet_query_scopes_every_word_of_a_multi_word_name() {
     // The bug this replaced: `format!("tag:{name}")` scoped only "Dark" and
     // let "academia" fall through to `build_fts_match`'s free-text arm, so a

--- a/frontend/src/pages/book_detail/identifiers.rs
+++ b/frontend/src/pages/book_detail/identifiers.rs
@@ -138,23 +138,54 @@ pub(super) fn bd_identifier_rows(identifiers: &[Identifier]) -> Vec<BdIdentifier
     rows.into_iter().map(|(row, _)| row).collect()
 }
 
-/// True when `value`, with hyphens and whitespace stripped, is the right length for an ISBN-10 or ISBN-13, digits-only except a trailing ISBN-10 `X` check digit.
+/// True when `value`, with hyphens and whitespace stripped, is a valid ISBN —
+/// the right length for an ISBN-10 or ISBN-13 **and** passing its check digit.
+///
+/// The check digit is the point: a shape-only test (right length, digits with
+/// an optional trailing `X`) labelled a checksum-failing `unknown`-scheme
+/// value like `2100906924` as an ISBN, presenting bad file metadata as
+/// verified data (#2359). Only used to *infer* a label when the scheme said
+/// nothing, so a false positive here is a mislabel.
 fn bd_looks_like_isbn(value: &str) -> bool {
     let cleaned: Vec<char> = value
         .chars()
         .filter(|c| !c.is_whitespace() && *c != '-')
         .collect();
     match cleaned.len() {
-        10 => {
-            let last = cleaned.len() - 1;
-            cleaned
-                .iter()
-                .enumerate()
-                .all(|(i, c)| c.is_ascii_digit() || (i == last && c.eq_ignore_ascii_case(&'x')))
-        }
-        13 => cleaned.iter().all(|c| c.is_ascii_digit()),
+        10 => isbn10_checksum_ok(&cleaned),
+        13 => isbn13_checksum_ok(&cleaned),
         _ => false,
     }
+}
+
+/// ISBN-10 check: `Σ digitᵢ·(10−i) ≡ 0 (mod 11)`, where only the final digit
+/// may be `X` (value 10). Any other non-digit fails.
+fn isbn10_checksum_ok(cleaned: &[char]) -> bool {
+    let mut sum = 0u32;
+    for (i, c) in cleaned.iter().enumerate() {
+        let digit = if i == 9 && c.eq_ignore_ascii_case(&'x') {
+            10
+        } else {
+            match c.to_digit(10) {
+                Some(d) => d,
+                None => return false,
+            }
+        };
+        sum += digit * (10 - i as u32);
+    }
+    sum.is_multiple_of(11)
+}
+
+/// ISBN-13 check: alternating 1/3 weights sum to a multiple of 10.
+fn isbn13_checksum_ok(cleaned: &[char]) -> bool {
+    let mut sum = 0u32;
+    for (i, c) in cleaned.iter().enumerate() {
+        let Some(digit) = c.to_digit(10) else {
+            return false;
+        };
+        sum += if i % 2 == 0 { digit } else { digit * 3 };
+    }
+    sum.is_multiple_of(10)
 }
 
 #[cfg(test)]

--- a/frontend/src/pages/book_detail/identifiers/tests.rs
+++ b/frontend/src/pages/book_detail/identifiers/tests.rs
@@ -63,10 +63,35 @@ fn bd_identifier_label_prefers_a_real_scheme() {
 }
 
 #[test]
-fn bd_identifier_label_infers_isbn_from_shape_when_scheme_unknown() {
+fn bd_identifier_label_infers_isbn_from_a_valid_value_when_scheme_unknown() {
+    // A valid ISBN-13, and a valid ISBN-10 whose check digit is `X`, are
+    // inferred as ISBN; a non-ISBN string is not.
     assert_eq!(label(&ident(Some("unknown"), "978-0-7564-0407-9")), "ISBN");
-    assert_eq!(label(&ident(None, "012345678X")), "ISBN");
+    assert_eq!(label(&ident(None, "080442957X")), "ISBN");
     assert_eq!(label(&ident(None, "not-an-isbn")), "Identifier");
+}
+
+#[test]
+fn bd_identifier_label_does_not_infer_isbn_for_a_checksum_failure() {
+    // #2359: ten digits but a failing ISBN-10 check digit, under an `unknown`
+    // scheme — presenting it as an ISBN made bad file metadata look verified.
+    assert_eq!(label(&ident(Some("unknown"), "2100906924")), "Identifier");
+    // A single wrong digit in an otherwise-valid ISBN-13 is caught too.
+    assert_eq!(label(&ident(None, "9780756404078")), "Identifier");
+}
+
+#[test]
+fn bd_looks_like_isbn_validates_the_check_digit() {
+    // Valid ISBN-13, valid ISBN-10, valid ISBN-10 ending in X.
+    assert!(bd_looks_like_isbn("978-0-7564-0407-9"));
+    assert!(bd_looks_like_isbn("0-316-76948-7"));
+    assert!(bd_looks_like_isbn("080442957X"));
+    // Right length, wrong checksum.
+    assert!(!bd_looks_like_isbn("2100906924"));
+    assert!(!bd_looks_like_isbn("9780756404078"));
+    // `X` is only a check digit in the final position, and length must match.
+    assert!(!bd_looks_like_isbn("X123456789"));
+    assert!(!bd_looks_like_isbn("12345"));
 }
 
 #[test]

--- a/frontend/src/pages/book_detail/marquee/stats.rs
+++ b/frontend/src/pages/book_detail/marquee/stats.rs
@@ -60,7 +60,7 @@ pub(super) fn MarqueeStatsStop(
 /// The populated record: stat grid, note line, spark.
 fn render_stats(i: &BookInsights, progress: &MarqueeProgress, audio_only: bool) -> Element {
     let started_short = short_date(i.started_at);
-    let days_in = ((now_unix() - i.started_at) / 86_400).max(0) + 1;
+    let started_sub = days_in_label(now_unix(), i.started_at);
     let avg = duration_label(avg_sit_secs(i));
     let time_label = if audio_only {
         "Time listened"
@@ -72,7 +72,7 @@ fn render_stats(i: &BookInsights, progress: &MarqueeProgress, audio_only: bool) 
     let max = spark.iter().copied().max().unwrap_or(0).max(1);
     rsx! {
         div { class: "bdmq-stats", "data-testid": "bdmq-stats",
-            {stat_cell("Started", &started_short, &format!("{} in", count_label(days_in, "day")))}
+            {stat_cell("Started", &started_short, &started_sub)}
             {stat_cell(time_label, &duration_label(i.seconds_total), &count_label(i.sessions, "session"))}
             {stat_cell("Pickups", &i.sessions.to_string(), &format!("avg sit {avg}"))}
             {stat_cell("Longest sit", &duration_label(i.longest_seconds), &short_date(i.longest_started_at))}
@@ -94,6 +94,21 @@ fn render_stats(i: &BookInsights, progress: &MarqueeProgress, audio_only: bool) 
             span { "minutes \u{b7} by day" }
             span { "today" }
         }
+    }
+}
+
+/// The "Started" tile's sub-label: how long the book has been in progress,
+/// counting *elapsed* days. A book started within the last day reads "today"
+/// rather than "1 day in" — the old inclusive `+ 1` count printed "1 day in"
+/// the moment a book was opened, which reads as an off-by-one (#2357). A full
+/// day or more elapsed reads "N day(s) in". `now` is injected so the label is
+/// testable on a fixed clock.
+fn days_in_label(now: i64, started_at: i64) -> String {
+    let days = ((now - started_at) / 86_400).max(0);
+    if days == 0 {
+        "today".to_string()
+    } else {
+        format!("{} in", count_label(days, "day"))
     }
 }
 
@@ -345,6 +360,18 @@ mod tests {
     fn short_date_formats_utc_month_day() {
         assert_eq!(short_date(1_700_000_000), "Nov 14");
     }
+
+    #[test]
+    fn days_in_label_reads_today_on_the_first_day_then_counts_elapsed_days() {
+        let now = 10 * 86_400;
+        // Same day (started an hour ago) and a future timestamp from clock
+        // skew both read "today" (#2357) — never a countdown, never "1 day in".
+        assert_eq!(days_in_label(now, now - 3_600), "today");
+        assert_eq!(days_in_label(now, now + 100), "today");
+        // A full elapsed day is "1 day in" (singular), more are pluralized.
+        assert_eq!(days_in_label(now, now - 86_400), "1 day in");
+        assert_eq!(days_in_label(now, now - 3 * 86_400), "3 days in");
+    }
 }
 
 // Render-smoke coverage of the stat grid's counted nouns — a separate module
@@ -356,12 +383,11 @@ mod render_tests {
     use crate::test_support::render;
 
     // Regression for issue #2250: a count of one renders a singular noun.
-    // `days_in` counts inclusively from `started_at`, so a book started this
-    // second is on day one.
+    // One full elapsed day reads "1 day in" (singular), never "1 days in".
     #[test]
     fn stat_grid_renders_singular_nouns_for_a_count_of_one() {
         let mut i = insights(3_600, 1, 3_600, 3_600);
-        i.started_at = now_unix();
+        i.started_at = now_unix() - 86_400;
         let html = render(render_stats(&i, &progress_at(50), false));
         assert!(html.contains("1 day in"), "{html}");
         assert!(html.contains("1 session"), "{html}");
@@ -374,7 +400,20 @@ mod render_tests {
         let mut i = insights(3_600, 4, 3_600, 3_600);
         i.started_at = now_unix() - 3 * 86_400;
         let html = render(render_stats(&i, &progress_at(50), false));
-        assert!(html.contains("4 days in"), "{html}");
+        assert!(html.contains("3 days in"), "{html}");
         assert!(html.contains("4 sessions"), "{html}");
+    }
+
+    // #2357: the Started sub-label reads "today", not the old "1 day in". The
+    // spark axis also carries a "today" tick, so a book started today makes it
+    // the second occurrence — one alone would mean the Started cell said
+    // something else.
+    #[test]
+    fn stat_grid_reads_today_on_the_start_day() {
+        let mut i = insights(3_600, 1, 3_600, 3_600);
+        i.started_at = now_unix();
+        let html = render(render_stats(&i, &progress_at(50), false));
+        assert_eq!(html.matches("today").count(), 2, "{html}");
+        assert!(!html.contains("day in"), "{html}");
     }
 }

--- a/frontend/src/pages/series.rs
+++ b/frontend/src/pages/series.rs
@@ -105,6 +105,26 @@ fn series_header(s: &SeriesDetail) -> Element {
     }
 }
 
+/// The series card's eyebrow — `"Book #1 · May 2016"`, dropping either half
+/// when it's absent. Only a real date carries the `·` separator: a sentinel or
+/// truly-absent date drops the whole date slot rather than trailing a bare
+/// `· —`, so two equally-dateless books read the same (#2294, #2360).
+fn series_card_eyebrow(book: &EbookMetadata) -> String {
+    let idx = book
+        .series_index
+        .as_deref()
+        .map(|idx| format!("Book #{idx}"));
+    let date = book
+        .published
+        .as_deref()
+        .and_then(crate::format::format_date_month_year_opt);
+    match (idx, date) {
+        (Some(idx), Some(date)) => format!("{idx} \u{b7} {date}"),
+        (Some(part), None) | (None, Some(part)) => part,
+        (None, None) => String::new(),
+    }
+}
+
 /// One book card in the series grid: cover, index/year label, title link, and
 /// an optional description.
 fn series_book_row(book: &EbookMetadata) -> Element {
@@ -119,14 +139,7 @@ fn series_book_row(book: &EbookMetadata) -> Element {
                 }
             }
             div { class: "series-card-info",
-                span { class: "label",
-                    if let Some(ref idx) = book.series_index {
-                        "Book #{idx}"
-                    }
-                    if let Some(ref published) = book.published {
-                        " · {crate::format::format_date_month_year(published)}"
-                    }
-                }
+                span { class: "label", "{series_card_eyebrow(book)}" }
                 h3 { class: "series-card-title",
                     Link {
                         to: Route::BookDetail { uuid: book.unique_identifier.clone().unwrap_or_default() },
@@ -141,5 +154,46 @@ fn series_book_row(book: &EbookMetadata) -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn book(series_index: Option<&str>, published: Option<&str>) -> EbookMetadata {
+        EbookMetadata {
+            series_index: series_index.map(str::to_string),
+            published: published.map(str::to_string),
+            ..EbookMetadata::default()
+        }
+    }
+
+    #[test]
+    fn eyebrow_pairs_the_index_with_a_real_date() {
+        assert_eq!(
+            series_card_eyebrow(&book(Some("1"), Some("2016-05-02"))),
+            "Book #1 \u{b7} May 2016"
+        );
+    }
+
+    #[test]
+    fn eyebrow_reads_the_same_for_an_absent_and_a_sentinel_date() {
+        // Both dateless books must render "Book #1" with no trailing `· —`
+        // (#2294, #2360) — the whole point is that they agree.
+        let absent = series_card_eyebrow(&book(Some("1"), None));
+        let sentinel = series_card_eyebrow(&book(Some("1"), Some("0101-01-01T00:00:00+00:00")));
+        assert_eq!(absent, "Book #1");
+        assert_eq!(sentinel, "Book #1");
+        assert!(!sentinel.contains('\u{2014}'));
+    }
+
+    #[test]
+    fn eyebrow_drops_the_leading_separator_when_only_a_date_is_present() {
+        assert_eq!(
+            series_card_eyebrow(&book(None, Some("2016-05"))),
+            "May 2016"
+        );
+        assert_eq!(series_card_eyebrow(&book(None, None)), "");
     }
 }

--- a/omnibus-ios/OmnibusShared/WidgetLabels.swift
+++ b/omnibus-ios/OmnibusShared/WidgetLabels.swift
@@ -37,6 +37,11 @@ enum WidgetLabels {
     /// ago reads "2 hr, 0 min", which on a card full of audiobooks looks like
     /// time *remaining*.
     static func relative(_ date: Date, relativeTo now: Date = .now) -> String {
+        // A position written moments ago can carry a timestamp at or just past
+        // `now` — clock skew between the write and this render — which the
+        // relative formatter phrases as a countdown ("in 0s"). Anything not
+        // in the past reads as "just now" (#2358).
+        guard date < now else { return "just now" }
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: now)

--- a/omnibus-ios/omnibus/Design/Components/Primitives.swift
+++ b/omnibus-ios/omnibus/Design/Components/Primitives.swift
@@ -583,6 +583,11 @@ enum Format {
     /// views — and an untestable duplicate is how the two would drift.
     static func relative(unix: Int64, relativeTo now: Date = Date()) -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(unix))
+        // Non-past deltas — a moments-ago write whose timestamp sits at or just
+        // past `now` from clock skew — read as "just now" rather than the
+        // formatter's countdown ("in 0s"). Mirrors `WidgetLabels.relative`
+        // (#2358); the two are held equal by `WidgetSnapshotTests`.
+        guard date < now else { return "just now" }
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: now)

--- a/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
+++ b/omnibus-ios/omnibusTests/WidgetSnapshotTests.swift
@@ -408,6 +408,19 @@ struct WidgetLabelsTests {
                 == Format.relative(unix: Int64(then.timeIntervalSince1970), relativeTo: now)
         )
     }
+
+    @Test
+    func relative_reads_just_now_at_or_past_the_present_not_a_countdown() {
+        // #2358: a position written moments ago carries a timestamp at or just
+        // past `now`; the raw relative formatter phrases that as "in 0s".
+        let now = Date(timeIntervalSince1970: 1_724_500_000)
+        let unix = Int64(now.timeIntervalSince1970)
+
+        #expect(WidgetLabels.relative(now, relativeTo: now) == "just now")
+        #expect(WidgetLabels.relative(now.addingTimeInterval(0.5), relativeTo: now) == "just now")
+        #expect(Format.relative(unix: unix, relativeTo: now) == "just now")
+        #expect(Format.relative(unix: unix + 5, relativeTo: now) == "just now")
+    }
 }
 
 @Suite("Resume format resolution")


### PR DESCRIPTION
## Summary
- Six edge-case rendering bugs where a formatter or renderer mishandled an empty, sentinel, or zero-edge value — each small, independent, and covered by a test.
- Series card eyebrow: a sentinel or absent publication date no longer trails a bare `· —` while a null date shows nothing — both dateless books now render identically (via a new `format_date_month_year_opt`). Closes #2294, closes #2360.
- Search palette: the book row's year routes through the shared sentinel gate, so Calibre's `0101` placeholder renders no year — matching the library table and detail page that already suppress it. Closes #2348.
- Stats "Started" tile: counts *elapsed* days, so a book started today reads "today" instead of the off-by-one "1 day in". Closes #2357.
- Book-detail identifiers: an "ISBN" label now requires a valid ISBN-10/13 check digit, so a checksum-failing `unknown`-scheme value (e.g. `2100906924`) is labelled "Identifier" rather than presented as verified. Closes #2359.
- iOS Continue widget: a non-past relative timestamp clamps to "just now" instead of the formatter's "in 0s" countdown, in both mirrored copies. Closes #2358.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 1087 passed, 0 failed
- [x] `cargo fmt --check` clean; `clippy -D warnings` clean on the server feature and the wasm32 `web` target
- [x] `just ios-test` (omnibusTests) — TEST SUCCEEDED, including the new `WidgetLabels` relative-clamp case and the existing app/widget agreement test
- [x] New unit tests per fix: `format_date_month_year_opt` gate, series eyebrow, `palette_row_year`, `days_in_label`, ISBN check-digit, iOS relative clamp

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- #2294 and #2360 are the same defect (the series card eyebrow) reported from two angles — one fix closes both.
- #2358 was filed under `frontend` but is the native iOS Continue widget; fixed in Swift. The two mirrored relative formatters stay in lock-step via the existing agreement test.
- Deliberately excluded: #2293 ("Added" header casing) is a test artefact, not a user-facing bug — the column is `display: none` at ≤1300px, so Playwright's `innerText` returns its untransformed source case while visible siblings read uppercase.