### PR TITLE
fix: correct reader and audiobook-player edge cases

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -16,6 +16,14 @@
  */
 
 @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400..700;1,400..700&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap');
+/* Reader Aa-panel typeface chips preview their prose faces (Editorial =
+   Instrument Serif, Classic = EB Garamond), which the app-wide import above no
+   longer carries after the #2162 type slimming — so both chips fell back to a
+   generic serif and looked identical (#2163). Loaded here for the parent
+   document only, subset to the chips' "Aa" specimen glyphs so the cost is two
+   glyphs, not two families. The reader body itself gets these faces from
+   epub-reader-glue.js's own iframe import, which this does not touch. */
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&family=Instrument+Serif&text=Aa&display=swap');
 
 /* ── Tokens · dark (default) ─────────────────────────────────────── */
 :root {

--- a/frontend/assets/vendor/epub-reader-glue.js
+++ b/frontend/assets/vendor/epub-reader-glue.js
@@ -128,6 +128,12 @@
   // flush adds that raced it.
   var pendingAnnotations = [];
   var annotationRepaintTimer = null;
+  // First-paint watchdog: if rendition.display() never settles, none of the
+  // ready/error emits fire and the host's loading overlay stays up forever
+  // (#2346). Armed by init(), cleared on paint or teardown; on expiry it
+  // emits "error" so the host shows its "couldn't be loaded" + Retry surface
+  // rather than an indefinite "Loading…".
+  var firstPaintWatchdog = null;
   // A displayPercentage call that arrived before the book/locations were
   // ready — the follow-mode auto-jump fires ~50ms after mount, racing both
   // init() (book still null) and the locations pass (seconds on a first
@@ -170,6 +176,10 @@
     if (annotationRepaintTimer) {
       clearTimeout(annotationRepaintTimer);
       annotationRepaintTimer = null;
+    }
+    if (firstPaintWatchdog) {
+      clearTimeout(firstPaintWatchdog);
+      firstPaintWatchdog = null;
     }
     if (stageResizeObserver) {
       try {
@@ -434,6 +444,10 @@
     var firstPaint = new Promise(function (res) {
       paintResolve = function () {
         painted = true;
+        if (firstPaintWatchdog) {
+          clearTimeout(firstPaintWatchdog);
+          firstPaintWatchdog = null;
+        }
         res();
       };
     });
@@ -457,6 +471,18 @@
     // carry the spine-approximate `pct` (see buildRelocateData).
     var locationsCacheKey = opts.locationsKey ? "omn.locs::" + opts.locationsKey : null;
     var locBook = book;
+    // If this open never paints (e.g. rendition.display() never settles), none
+    // of the ready/error emits fire and the overlay hangs forever (#2346).
+    // Bound it: on expiry, if we still haven't painted and a newer open hasn't
+    // superseded this book, emit "error" so the host shows its Retry surface.
+    // The guard mirrors the book.ready .catch below.
+    var FIRST_PAINT_WATCHDOG_MS = 15000;
+    firstPaintWatchdog = setTimeout(function () {
+      firstPaintWatchdog = null;
+      if (!painted && book === locBook) {
+        emitStatus("error");
+      }
+    }, FIRST_PAINT_WATCHDOG_MS);
     book.ready
       .then(function () {
         tocFlat = [];

--- a/frontend/src/pages/listen/chapter_map.rs
+++ b/frontend/src/pages/listen/chapter_map.rs
@@ -122,8 +122,8 @@ pub(super) struct ChapterMapProps {
     pub duration: f64,
     /// Seconds remaining in the whole book.
     pub remaining: f64,
-    /// Current playback rate — every time readout (elapsed, remaining, total)
-    /// divides by it so the row is wall-clock listening time, not book time.
+    /// Current playback rate — only the "remaining" estimate divides by it;
+    /// elapsed and total are real book-time (#2344).
     pub rate: f64,
     /// Index of the currently-playing chapter.
     pub current_chapter_index: usize,
@@ -301,14 +301,14 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
                 {segment_bar(&chapters, eff_current, effective, duration)}
 
                 // Visible playhead + drag-time bubble. The bubble previews
-                // the same rate-adjusted elapsed the row's left label shows,
-                // so the two can't disagree mid-drag.
+                // the same book-time elapsed the row's left label shows, so
+                // the two can't disagree mid-drag.
                 div { class: "lp-chapter-thumb", style: "left: {thumb:.3}%;" }
                 if is_scrubbing {
                     div {
                         class: "lp-chapter-bubble",
                         style: "left: {thumb:.3}%;",
-                        "{format_hms(helpers::remaining_at_rate(effective, rate))}"
+                        "{format_hms(effective)}"
                     }
                 }
 
@@ -327,18 +327,16 @@ pub(super) fn ChapterMap(props: ChapterMapProps) -> Element {
                 }
             }
 
-            // All three readouts share one rate-adjusted wall-clock basis
-            // (elapsed + remaining = total at the current speed), the same
-            // one the chapter list's durations use (#2246) — a 1x label
-            // beside a rate-adjusted one disagrees with it off 1x (#2108,
-            // matching the iOS player). Scaled after the scrub preview so a
-            // drag previews the rate-adjusted times too.
+            // Elapsed and total are real book-time, matching the bookmark
+            // stamps and the book detail page (#2344). Only the middle
+            // "remaining" is a rate-adjusted wall-clock estimate of the time
+            // left, the same basis landing's resume meta uses.
             div { class: "lp-scrub-times", "data-testid": "listen-scrub-times",
-                span { "{format_hms(helpers::remaining_at_rate(effective, rate))}" }
+                span { "{format_hms(effective)}" }
                 span { class: "lp-scrub-remaining",
                     "\u{00b7} {format_hms(helpers::remaining_at_rate(eff_remaining, rate))} remaining"
                 }
-                span { "{format_hms(helpers::remaining_at_rate(duration, rate))}" }
+                span { "{format_hms(duration)}" }
             }
             if buffering {
                 div {
@@ -363,8 +361,9 @@ mod render_tests {
 
     #[component]
     fn MapHarness(rate: f64) -> Element {
-        // Two 30-minute chapters, 20 book-minutes in: at 2x the row must
-        // read 10:00 elapsed / 20:00 remaining / 30:00 total.
+        // Two 30-minute chapters, 10 book-minutes in. Elapsed (10:00) and total
+        // (1:00:00) are real book-time and stay put across speeds; only the
+        // middle "remaining" estimate scales (50:00 at 1x, 25:00 at 2x).
         rsx! {
             ChapterMap {
                 chapters: vec![
@@ -381,9 +380,9 @@ mod render_tests {
                         duration_seconds: 1800.0,
                     },
                 ],
-                elapsed: 1200.0,
+                elapsed: 600.0,
                 duration: 3600.0,
-                remaining: 2400.0,
+                remaining: 3000.0,
                 rate,
                 current_chapter_index: 0,
                 on_seek: EventHandler::new(|_| {}),
@@ -392,23 +391,29 @@ mod render_tests {
         }
     }
 
+    // Issue #2344: at 2x the elapsed and total labels stay real book-time
+    // (matching bookmark stamps + the detail page); only the middle "remaining"
+    // estimate is rate-adjusted.
     #[test]
-    fn chapter_map_renders_every_time_label_on_the_rate_adjusted_basis() {
+    fn chapter_map_keeps_book_time_elapsed_and_total_and_scales_only_remaining() {
         let html = render(rsx! { MapHarness { rate: 2.0 } });
+        // Elapsed 10:00 and total 1:00:00 are book-time — identical to the 1x
+        // render below.
         assert!(html.contains("10:00"), "{html}");
-        assert!(html.contains("20:00 remaining"), "{html}");
-        assert!(html.contains("30:00"), "{html}");
+        assert!(html.contains("1:00:00"), "{html}");
+        // The time-left halves at 2x: 50:00 (1x) -> 25:00.
+        assert!(html.contains("25:00 remaining"), "{html}");
         // The seek range stays in 1x book-time — it's a coordinate, not a
         // readout.
-        assert!(html.contains("value=\"1200\""), "{html}");
+        assert!(html.contains("value=\"600\""), "{html}");
         assert!(html.contains("max=\"3600\""), "{html}");
     }
 
     #[test]
     fn chapter_map_renders_unchanged_labels_at_1x() {
         let html = render(rsx! { MapHarness { rate: 1.0 } });
-        assert!(html.contains("20:00"), "{html}");
-        assert!(html.contains("40:00 remaining"), "{html}");
+        assert!(html.contains("10:00"), "{html}");
+        assert!(html.contains("50:00 remaining"), "{html}");
         assert!(html.contains("1:00:00"), "{html}");
     }
 }

--- a/frontend/src/pages/listen/chapters_drawer.rs
+++ b/frontend/src/pages/listen/chapters_drawer.rs
@@ -14,9 +14,9 @@ use super::panel_shell::ListenDrawerShell;
 
 /// One chapter row: ordinal/checkmark/play glyph, title, and
 /// duration-or-remaining label. `i` is the chapter's index in the list.
-/// Both time labels are rate-adjusted listening time, the same basis the
-/// transport row reads: a 1x chapter length beside a rate-adjusted total
-/// disagrees with it the moment the speed leaves 1x (#2246).
+/// The duration shows real book-time — matching bookmark stamps and the
+/// book detail page (#2344) — while the current row's "remaining" is a
+/// rate-adjusted estimate of the listening time left.
 fn chapter_row(
     i: usize,
     ch: &ChapterInfo,
@@ -42,7 +42,7 @@ fn chapter_row(
         "chapter-row-upcoming"
     };
 
-    let dur_label = format_hms(remaining_at_rate(ch.duration_seconds, rate));
+    let dur_label = format_hms(ch.duration_seconds);
     let remaining_in_ch = if is_current {
         let r = (ch.start_seconds + ch.duration_seconds - elapsed).max(0.0);
         Some(format!(
@@ -94,8 +94,8 @@ pub(super) fn ChaptersDrawer(
     chapters: Vec<ChapterInfo>,
     current_chapter_index: usize,
     elapsed: f64,
-    /// Current playback rate — every duration in the list divides by it, so
-    /// the drawer and the transport read one clock (#2246).
+    /// Current playback rate — only the current chapter's "remaining" label
+    /// divides by it; chapter durations show real book-time (#2344).
     rate: f64,
     on_seek: EventHandler<f64>,
     on_close: EventHandler<()>,
@@ -178,14 +178,17 @@ mod render_tests {
         assert!(html.contains("30:00"), "{html}");
     }
 
-    // Regression for issue #2246: the drawer's durations rescale with the
-    // speed, so they agree with the transport's rate-adjusted total instead
-    // of summing to a different book length.
+    // Regression for issue #2344: chapter durations show real book-time at any
+    // speed (matching bookmark stamps + the detail page), while only the
+    // current chapter's "remaining" is rate-adjusted.
     #[test]
-    fn chapter_rows_rescale_with_the_playback_rate() {
+    fn chapter_rows_keep_book_time_durations_but_scale_the_remaining() {
         let html = render_in_vdom(at_2x);
+        // The upcoming chapter's 30:00 duration is unchanged from 1x book-time...
+        assert!(html.contains("30:00"), "{html}");
+        // ...while the current chapter's remaining halves at 2x.
         assert!(html.contains("5:00 remaining"), "{html}");
-        assert!(html.contains("15:00"), "{html}");
-        assert!(!html.contains("30:00"), "{html}");
+        // No rate-scaled duration (15:00) appears.
+        assert!(!html.contains("15:00"), "{html}");
     }
 }

--- a/frontend/src/pages/listen/helpers/tests.rs
+++ b/frontend/src/pages/listen/helpers/tests.rs
@@ -131,24 +131,22 @@ fn remaining_at_rate_keeps_chapter_durations_summing_to_the_total() {
 }
 
 #[test]
-fn remaining_at_rate_keeps_elapsed_and_remaining_labels_on_one_basis() {
-    // The scrubber-row contract (mirrors the iOS `scrubberRowLabelsAgree`
-    // test for #2108): a 60-minute span at 2x, 20 book-minutes in, reads
-    // 10:00 elapsed and 20:00 remaining, summing to the 30-minute
-    // rate-adjusted total. An elapsed label left in 1x book-time would show
-    // 20:00 beside 20:00 remaining at the one-third mark.
+fn only_the_time_left_is_rate_adjusted_now() {
+    // Issue #2344: the player's elapsed and total readouts show real book-time
+    // — matching the bookmark stamps and the book detail page — and do NOT
+    // scale with the rate. Only the "time left" estimate is rate-adjusted.
     let duration = 3600.0;
-    let elapsed = 1200.0;
-    let rate = 2.0;
-    assert_eq!(format_hms(remaining_at_rate(elapsed, rate)), "10:00");
+    let elapsed = 600.0;
+    // Elapsed and total are raw book-time, identical whatever the rate.
+    assert_eq!(format_hms(elapsed), "10:00");
+    assert_eq!(format_hms(duration), "1:00:00");
+    // The time-left halves as the speed doubles.
     assert_eq!(
-        format_hms(remaining_at_rate(duration - elapsed, rate)),
-        "20:00"
+        format_hms(remaining_at_rate(duration - elapsed, 1.0)),
+        "50:00"
     );
-    assert!(
-        (remaining_at_rate(elapsed, rate) + remaining_at_rate(duration - elapsed, rate)
-            - remaining_at_rate(duration, rate))
-        .abs()
-            < f64::EPSILON
+    assert_eq!(
+        format_hms(remaining_at_rate(duration - elapsed, 2.0)),
+        "25:00"
     );
 }

--- a/frontend/src/pages/listen/mini_dock/meta.rs
+++ b/frontend/src/pages/listen/mini_dock/meta.rs
@@ -2,7 +2,7 @@
 //! gate shared with the `/read` route, and the subtitle line (chapter ·
 //! clock · time-left).
 
-use super::super::helpers::{format_hms, remaining_at_rate};
+use super::super::helpers::format_hms;
 
 /// Progress fill percent (0–100) for the dock's mini progress bar. Returns 0
 /// when the duration is unknown or either input is non-finite so the bar never
@@ -76,21 +76,16 @@ pub(super) fn time_left_text(elapsed: f64, duration: f64, rate: f64) -> Option<S
 
 /// Build the dock subtitle: the chapter label (when present), the inline
 /// `elapsed / total` clock, and the speed-adjusted time left. The single-row
-/// bar has no separate time track, so the clock lives here. The clock shares
-/// the time-left's rate-adjusted wall-clock basis — a 1x clock beside a
-/// rate-adjusted "left" disagrees with itself off 1x (#2108, matching the
-/// player surfaces).
+/// bar has no separate time track, so the clock lives here. The clock shows
+/// real book-time — matching the bookmark stamps and the book detail page
+/// (#2344) — while only the trailing "left" is a rate-adjusted estimate.
 pub(super) fn dock_sub_text(
     chapter_sub: Option<String>,
     elapsed: f64,
     duration: f64,
     rate: f64,
 ) -> String {
-    let time = format!(
-        "{} / {}",
-        format_hms(remaining_at_rate(elapsed, rate)),
-        format_hms(remaining_at_rate(duration, rate))
-    );
+    let time = format!("{} / {}", format_hms(elapsed), format_hms(duration));
     let mut sub = match chapter_sub {
         Some(chapter) => format!("{chapter} \u{00b7} {time}"),
         None => time,

--- a/frontend/src/pages/listen/mini_dock/mod.rs
+++ b/frontend/src/pages/listen/mini_dock/mod.rs
@@ -164,6 +164,10 @@ fn MiniDockBar(
 #[component]
 fn MiniDockActions(uuid: String) -> Element {
     let playback = use_playback();
+    // The sleep timer is app-scoped and outlives the dock, so dismissing the
+    // player must cancel it — otherwise an armed countdown keeps running with
+    // no player open (#2353).
+    let sleep = super::sleep::use_sleep();
     let on_dismiss = {
         let mut uuid_sig = playback.uuid;
         let mut book_sig = playback.book;
@@ -175,6 +179,7 @@ fn MiniDockActions(uuid: String) -> Element {
             // and PlaybackState stays coherent for any other consumer.
             #[cfg(feature = "web")]
             super::helpers::audio_call("stop", "");
+            sleep.cancel();
             book_sig.set(None);
             playing_set.set(false);
             uuid_sig.set(None);

--- a/frontend/src/pages/listen/mini_dock/tests.rs
+++ b/frontend/src/pages/listen/mini_dock/tests.rs
@@ -113,13 +113,13 @@ fn dock_sub_text_is_clock_and_time_left_without_chapters() {
 }
 
 #[test]
-fn dock_sub_text_scales_the_clock_to_the_playback_rate() {
-    // 10 book-minutes into an hour at 2x: the clock and the time-left share
-    // one wall-clock basis (5:00 elapsed + 25m left = the 30:00 total),
-    // rather than a 1x clock beside a rate-adjusted "left" (#2108).
+fn dock_sub_text_shows_real_book_time_regardless_of_rate() {
+    // Issue #2344: 10 book-minutes into an hour at 2x. The clock shows real
+    // book-time (10:00 / 1:00:00) — matching the bookmark stamps and the book
+    // detail page — while only the trailing "left" estimate is halved.
     assert_eq!(
         dock_sub_text(None, 600.0, 3600.0, 2.0),
-        "5:00 / 30:00 \u{00b7} about 25m left"
+        "10:00 / 1:00:00 \u{00b7} about 25m left"
     );
 }
 

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -262,7 +262,7 @@ struct PlayerDerived {
     within: f64,
     chapter_dur: f64,
     chapter_left: f64,
-    remaining_book: f64,
+    remaining_left: f64,
     scrub_max: f64,
     accent_style: String,
     rate_label: String,
@@ -299,7 +299,7 @@ fn derive_player_state(
     let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
     // Elapsed, chapter-elapsed and chapter-duration are real book-time,
     // matching the bookmark stamps and the book detail page (#2344). Only the
-    // "left" values (chapter_left, remaining_book) are rate-adjusted wall-clock
+    // "left" values (chapter_left, remaining_left) are rate-adjusted wall-clock
     // estimates. `effective` and `scrub_max` stay book-time: they're the range
     // input's seek coordinate, not a readout.
     let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
@@ -318,7 +318,7 @@ fn derive_player_state(
         within,
         chapter_dur,
         chapter_left,
-        remaining_book: remaining_at_rate(eff_remaining, rate),
+        remaining_left: remaining_at_rate(eff_remaining, rate),
         scrub_max: if duration > 0.0 { duration } else { 1.0 },
         accent_style: view
             .accent
@@ -522,7 +522,7 @@ fn render_player_scrubber(
                         "{format_ms(derived.within)} / {format_ms(derived.chapter_dur)} \u{00b7} {format_ms(derived.chapter_left)} left"
                     }
                 }
-                span { "-{format_hms(derived.remaining_book)}" }
+                span { "-{format_hms(derived.remaining_left)}" }
             }
         }
     }

--- a/frontend/src/pages/listen/mobile.rs
+++ b/frontend/src/pages/listen/mobile.rs
@@ -297,13 +297,13 @@ fn derive_player_state(
     );
     let current = view.chapters.get(disp_index);
     let chapter_start = current.map(|c| c.start_seconds).unwrap_or(0.0);
-    // Every displayed time shares one rate-adjusted wall-clock basis — a 1x
-    // elapsed or chapter-total label beside a rate-adjusted "left" disagrees
-    // with its own row off 1x (#2108, matching the iOS player). `effective`
-    // and `scrub_max` stay 1x book-time: they're the range input's seek
-    // coordinate, not a readout.
-    let chapter_dur = remaining_at_rate(current.map(|c| c.duration_seconds).unwrap_or(0.0), rate);
-    let within = remaining_at_rate((effective - chapter_start).max(0.0), rate);
+    // Elapsed, chapter-elapsed and chapter-duration are real book-time,
+    // matching the bookmark stamps and the book detail page (#2344). Only the
+    // "left" values (chapter_left, remaining_book) are rate-adjusted wall-clock
+    // estimates. `effective` and `scrub_max` stay book-time: they're the range
+    // input's seek coordinate, not a readout.
+    let chapter_dur = current.map(|c| c.duration_seconds).unwrap_or(0.0);
+    let within = (effective - chapter_start).max(0.0);
     let chapter_left = remaining_at_rate(
         view::remaining_in_chapter(&view.chapters, disp_index, effective),
         rate,
@@ -311,7 +311,7 @@ fn derive_player_state(
 
     PlayerDerived {
         effective,
-        elapsed_book: remaining_at_rate(effective, rate),
+        elapsed_book: effective,
         chapter_no: disp_index + 1,
         chapter_count: view.chapters.len(),
         chapter_title: current.map(|c| c.title.clone()).unwrap_or_default(),
@@ -432,9 +432,9 @@ fn render_player(p: PlayerProps) -> Element {
     let sheet_props = SheetProps {
         uuid: uuid.clone(),
         chapters,
-        // Re-derived at the current rate rather than reused from the view:
-        // the sheet header sits above rate-adjusted row durations (#2246).
-        total_label: format_hm(remaining_at_rate(view.total_duration, rate)),
+        // Real book-time total, matching the sheet's book-time row durations
+        // and the book detail page (#2344).
+        total_label: format_hm(view.total_duration),
         elapsed,
         rate,
         sleep,

--- a/frontend/src/pages/listen/mobile/sheets.rs
+++ b/frontend/src/pages/listen/mobile/sheets.rs
@@ -5,7 +5,6 @@
 use dioxus::prelude::*;
 use omnibus_shared::ChapterInfo;
 
-use super::super::helpers::remaining_at_rate;
 use super::state::{format_countdown, sleep_remaining, SleepState, SLEEP_PRESETS};
 use super::view::format_ms;
 
@@ -60,11 +59,10 @@ pub(super) struct ChaptersListView {
     pub current_index: usize,
     /// Seconds elapsed in the whole book (drives the current row's bar).
     pub elapsed: f64,
-    /// Current playback rate — each row's duration divides by it so the sheet
-    /// and the transport read one clock (#2246).
+    /// Current playback rate.
     pub rate: f64,
-    /// Formatted total-duration label shown in the sheet header, already on
-    /// that same rate-adjusted basis.
+    /// Formatted total-duration label shown in the sheet header, in real
+    /// book-time to match the row durations (#2344).
     pub total_label: String,
 }
 
@@ -118,7 +116,7 @@ fn chapter_row(
     ch: &ChapterInfo,
     current_index: usize,
     elapsed: f64,
-    rate: f64,
+    _rate: f64,
     on_seek: &EventHandler<f64>,
 ) -> Element {
     let is_current = i == current_index;
@@ -150,7 +148,7 @@ fn chapter_row(
             } else {
                 span {
                     class: "mono m-ch-trail m-ch-dur",
-                    "{format_ms(remaining_at_rate(ch.duration_seconds, rate))}"
+                    "{format_ms(ch.duration_seconds)}"
                 }
             }
         }

--- a/frontend/src/pages/listen/mobile/sheets/tests.rs
+++ b/frontend/src/pages/listen/mobile/sheets/tests.rs
@@ -107,11 +107,11 @@ mod render {
         assert!(html.contains("2 \u{00b7} 15m"));
     }
 
-    // Regression for issue #2246: an upcoming row's duration is rate-adjusted
-    // listening time, the same clock the transport reads, rather than a 1x
-    // length that disagrees with the total above it.
+    // Regression for issue #2344: row durations show real book-time and do NOT
+    // rescale with the speed — they match the bookmark stamps and the book
+    // detail page rather than an at-your-pace clock.
     #[test]
-    fn chapters_sheet_rescales_row_durations_with_the_playback_rate() {
+    fn chapters_sheet_shows_book_time_row_durations_regardless_of_rate() {
         fn list_at(rate: f64) -> ChaptersListView {
             ChaptersListView {
                 chapters: vec![
@@ -134,8 +134,11 @@ mod render {
                 ChaptersSheet { list: list_at(2.0), on_seek: move |_| {}, on_close: move |_| {} }
             }
         }
+        // The upcoming "Part One" row's 10:00 book-time duration is identical
+        // at both speeds; the old rate-scaled 5:00 never appears.
         assert!(render_in_vdom(at_1x).contains("10:00"));
-        assert!(render_in_vdom(at_2x).contains("5:00"));
+        assert!(render_in_vdom(at_2x).contains("10:00"));
+        assert!(!render_in_vdom(at_2x).contains("5:00"));
     }
 
     // Simulates the "chapter advanced" event: `super::view::chapter_index_for_elapsed`

--- a/frontend/src/pages/listen/mobile/tests.rs
+++ b/frontend/src/pages/listen/mobile/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for the mobile player's per-render display derivation — pins the
-//! scrubber row's one-basis contract at the `derive_player_state` boundary.
+//! scrubber row's book-time position readouts and rate-adjusted "left"
+//! estimates at the `derive_player_state` boundary.
 
 use omnibus_shared::{ChapterInfo, EbookMetadata};
 
@@ -27,10 +28,11 @@ fn two_chapter_view() -> PlayerView {
 }
 
 #[test]
-fn derive_player_state_scales_every_readout_to_the_playback_rate() {
-    // 20 book-minutes into the first chapter at 2x: elapsed 10:00, chapter
-    // 10:00-in / 15:00-total / 5:00-left, book 10:00-left — the row sums on
-    // one wall-clock basis (#2108).
+fn derive_player_state_reads_book_time_and_scales_only_the_time_left() {
+    // Issue #2344: 20 book-minutes into the first of two 30-minute chapters at
+    // 2x. The position readouts (elapsed, chapter-elapsed, chapter-duration)
+    // show real book-time and do NOT change with the rate — they match the
+    // bookmark stamps and the book detail page. Only the "left" values scale.
     let d = derive_player_state(
         &two_chapter_view(),
         1200.0,
@@ -40,15 +42,14 @@ fn derive_player_state_scales_every_readout_to_the_playback_rate() {
         SleepState::Off,
         None,
     );
-    assert!((d.elapsed_book - 600.0).abs() < f64::EPSILON);
-    assert!((d.within - 600.0).abs() < f64::EPSILON);
-    assert!((d.chapter_dur - 900.0).abs() < f64::EPSILON);
+    // Book-time position — identical to the 1x derivation below.
+    assert!((d.elapsed_book - 1200.0).abs() < f64::EPSILON);
+    assert!((d.within - 1200.0).abs() < f64::EPSILON);
+    assert!((d.chapter_dur - 1800.0).abs() < f64::EPSILON);
+    // "Left" estimates are rate-adjusted — halved at 2x.
     assert!((d.chapter_left - 300.0).abs() < f64::EPSILON);
     assert!((d.remaining_book - 1200.0).abs() < f64::EPSILON);
-    assert!((d.within + d.chapter_left - d.chapter_dur).abs() < f64::EPSILON);
-    assert!((d.elapsed_book + d.remaining_book - 1800.0).abs() < f64::EPSILON);
-    // The seek coordinates stay 1x book-time — the range input's value/max,
-    // not readouts.
+    // The seek coordinates stay book-time — the range input's value/max.
     assert!((d.effective - 1200.0).abs() < f64::EPSILON);
     assert!((d.scrub_max - 3600.0).abs() < f64::EPSILON);
 }

--- a/frontend/src/pages/listen/mobile/tests.rs
+++ b/frontend/src/pages/listen/mobile/tests.rs
@@ -48,7 +48,7 @@ fn derive_player_state_reads_book_time_and_scales_only_the_time_left() {
     assert!((d.chapter_dur - 1800.0).abs() < f64::EPSILON);
     // "Left" estimates are rate-adjusted — halved at 2x.
     assert!((d.chapter_left - 300.0).abs() < f64::EPSILON);
-    assert!((d.remaining_book - 1200.0).abs() < f64::EPSILON);
+    assert!((d.remaining_left - 1200.0).abs() < f64::EPSILON);
     // The seek coordinates stay book-time — the range input's value/max.
     assert!((d.effective - 1200.0).abs() < f64::EPSILON);
     assert!((d.scrub_max - 3600.0).abs() < f64::EPSILON);
@@ -69,5 +69,5 @@ fn derive_player_state_keeps_book_time_labels_at_1x() {
     assert!((d.within - 1200.0).abs() < f64::EPSILON);
     assert!((d.chapter_dur - 1800.0).abs() < f64::EPSILON);
     assert!((d.chapter_left - 600.0).abs() < f64::EPSILON);
-    assert!((d.remaining_book - 2400.0).abs() < f64::EPSILON);
+    assert!((d.remaining_left - 2400.0).abs() < f64::EPSILON);
 }

--- a/frontend/src/pages/listen/sleep.rs
+++ b/frontend/src/pages/listen/sleep.rs
@@ -121,6 +121,14 @@ impl SleepController {
         }
     }
 
+    /// Cancel any armed timer — reset to Off and restore the target volume.
+    /// The countdown is app-scoped so it outlives `/listen`; without this a
+    /// timer armed before "Stop and close player" keeps counting with no
+    /// player open (#2353). Equivalent to selecting the "Off" preset.
+    pub fn cancel(&self) {
+        self.select_seconds(0);
+    }
+
     /// Arm the timer to fire at the end of the current chapter.
     pub fn select_end_of_chapter(&self, secs: i32) {
         let mut remaining = self.remaining;

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -183,6 +183,18 @@ fn build_delete_handler(
                     let _ = cfi;
                 }
                 highlights.write().retain(|h| h.id != id);
+                // The deleted row's Delete button had focus; removing it drops
+                // focus to <body>, where the reader's Escape handler (bound on
+                // the tabindexed reader root) no longer receives keydowns, so
+                // Escape stops closing the drawer (#2354). Restore focus to the
+                // drawer's close button — a stable descendant of that root — so
+                // the keyboard path survives and focus lands somewhere sensible.
+                #[cfg(feature = "web")]
+                {
+                    let _ = dioxus::document::eval(
+                        "requestAnimationFrame(() => document.querySelector('[data-testid=\"reader-highlights-drawer\"] .rd-x')?.focus());",
+                    );
+                }
             }
         });
     }

--- a/frontend/src/pages/reader/highlights_drawer.rs
+++ b/frontend/src/pages/reader/highlights_drawer.rs
@@ -183,12 +183,9 @@ fn build_delete_handler(
                     let _ = cfi;
                 }
                 highlights.write().retain(|h| h.id != id);
-                // The deleted row's Delete button had focus; removing it drops
-                // focus to <body>, where the reader's Escape handler (bound on
-                // the tabindexed reader root) no longer receives keydowns, so
-                // Escape stops closing the drawer (#2354). Restore focus to the
-                // drawer's close button — a stable descendant of that root — so
-                // the keyboard path survives and focus lands somewhere sensible.
+                // Deleting removes the focused button, dropping focus to
+                // <body> where the reader-root Escape handler no longer fires;
+                // refocus the drawer's close button to keep that path (#2354).
                 #[cfg(feature = "web")]
                 {
                     let _ = dioxus::document::eval(

--- a/server/src/security_headers.rs
+++ b/server/src/security_headers.rs
@@ -39,14 +39,17 @@ use tower_http::set_header::SetResponseHeaderLayer;
 ///   `ammonia` sanitizing the primary XSS source (book descriptions), an
 ///   injected script's blast radius stays bounded. Revisit only if Dioxus
 ///   drops its `Function()` use and gains nonce support.
-/// - `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` —
+/// - `style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com` —
 ///   `'unsafe-inline'` because Dioxus emits inline `style=""` attributes;
-///   the Google Fonts host because `atrium.css` `@import`s the Cormorant
-///   Garamond / Instrument Sans / Space Mono stylesheet from it. (The reader
-///   glue loads a second one for the in-iframe reading faces.) Self-hosting
-///   the fonts (a
-///   follow-up tracked in `atrium.css`) would let both the CDN host here
-///   and in `font-src` drop back to `'self'`.
+///   `blob:` because epub.js (`assets/vendor/epub.min.js`) renders a book's
+///   own stylesheets through `URL.createObjectURL`, and without it every
+///   forward page-turn is blocked as a CSP violation (#2213) — the same
+///   reason `img-src` already lists `blob:`; the Google Fonts host because
+///   `atrium.css` `@import`s the Cormorant Garamond / Instrument Sans / Space
+///   Mono stylesheet from it. (The reader glue loads a second one for the
+///   in-iframe reading faces.) Self-hosting the fonts (a follow-up tracked in
+///   `atrium.css`) would let both the CDN host here and in `font-src` drop
+///   back to `'self'`.
 /// - `font-src 'self' data: https://fonts.gstatic.com` — Google serves the
 ///   actual WOFF2 files from `fonts.gstatic.com`; without it the `@import`ed
 ///   stylesheet resolves but the glyphs fall back to system fonts.
@@ -69,7 +72,7 @@ static DEFAULT_CSP: LazyLock<String> = LazyLock::new(build_csp);
 /// with the image hosts.
 const NO_PROVIDER_HOSTS_CSP: &str = "default-src 'self'; \
 script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
-style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
+style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; \
 img-src 'self' data: blob:; \
 font-src 'self' data: https://fonts.gstatic.com; \
 connect-src 'self'; \
@@ -89,7 +92,7 @@ fn build_csp() -> String {
     format!(
         "default-src 'self'; \
 script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
-style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
+style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; \
 img-src 'self' data: blob:{cover_hosts}; \
 font-src 'self' data: https://fonts.gstatic.com; \
 connect-src 'self'; \

--- a/server/src/security_headers/tests.rs
+++ b/server/src/security_headers/tests.rs
@@ -86,8 +86,8 @@ async fn csp_permits_dioxus_hydration_and_fonts() {
         "csp must allow inline (hydration) + Function()-eval (dioxus interpreter) scripts: {csp}"
     );
     assert!(
-        csp.contains("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"),
-        "csp must allow inline styles + Google Fonts stylesheet host: {csp}"
+        csp.contains("style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"),
+        "csp must allow inline styles, epub.js blob stylesheets, and the Google Fonts host: {csp}"
     );
     assert!(
         csp.contains("font-src 'self' data: https://fonts.gstatic.com"),
@@ -116,6 +116,21 @@ async fn csp_permits_dioxus_hydration_and_fonts() {
         csp.contains("frame-ancestors 'none'"),
         "csp must deny framing: {csp}"
     );
+}
+
+#[test]
+fn both_policies_allow_blob_stylesheets_for_epub_js() {
+    // epub.js renders a book's own stylesheets through `URL.createObjectURL`,
+    // so `style-src` must permit `blob:` or every forward page-turn is a CSP
+    // violation (#2213). The two policies must not drift: a future tightening
+    // that drops it from either one fails here rather than in a reader nobody
+    // is watching.
+    for csp in [DEFAULT_CSP.as_str(), NO_PROVIDER_HOSTS_CSP] {
+        assert!(
+            csp.contains("style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com"),
+            "csp style-src must permit blob: for epub.js stylesheets: {csp}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -331,12 +331,13 @@ async function chapterDurationSeconds(
   return stamps.map(hmsToSeconds);
 }
 
-// Regression for issue #2246. The transport divided its own figures by the
-// playback rate while the chapter list stayed in book time, so off 1x the two
-// described different books on one screen — a 7:05:08 total beside chapters
-// summing to 10:38:00. Both are rate-adjusted listening time now, so a 2x
-// listener sees the half-hour a one-hour book actually costs them.
-test("a speed change rescales the transport total and the chapter durations together", async ({
+// Regression for issue #2344, superseding #2246. The transport total and the
+// chapter durations are the book's own running time — the same basis as the
+// bookmark stamps and the book detail page — so a speed change must NOT move
+// them (only the "time left" estimate is rate-adjusted). The earlier #2246 fix
+// rescaled these readouts, which is exactly what disagreed with a saved
+// bookmark at any speed but 1x.
+test("a speed change leaves the transport total and chapter durations in book time", async ({
   page,
   request,
 }) => {
@@ -364,20 +365,20 @@ test("a speed change rescales the transport total and the chapter durations toge
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("speed-panel")).toHaveCount(0);
 
-  // Both readouts halve, so they still describe the same book — and the
-  // listener sees the time the book will actually take them. A second of
-  // slack per figure absorbs the truncation in `format_hms`.
+  // The rate visibly changed (listen-rate reads 2.00×), but the book-time
+  // readouts stay put: the total and every chapter duration read the same at
+  // 2x as at 1x. A second of slack per figure absorbs `format_hms` truncation.
   const totalAt2x = await transportTotalSeconds(page);
-  expect(totalAt2x).toBeLessThan(totalAt1x);
-  expect(Math.abs(totalAt2x - totalAt1x / 2)).toBeLessThanOrEqual(1);
+  expect(Math.abs(totalAt2x - totalAt1x)).toBeLessThanOrEqual(1);
 
   const chaptersAt2x = await chapterDurationSeconds(page);
   expect(chaptersAt2x.length).toBe(chaptersAt1x.length);
   chaptersAt2x.forEach((secs, i) => {
-    // Every figure must actually have moved — a chapter list left at 1x is
-    // exactly what this test exists to catch.
-    expect(secs, `chapter ${i} should rescale`).toBeLessThan(chaptersAt1x[i]!);
-    expect(Math.abs(secs - chaptersAt1x[i]! / 2)).toBeLessThanOrEqual(1);
+    // A chapter duration that halved at 2x is the #2246 behavior #2344 undid.
+    expect(
+      Math.abs(secs - chaptersAt1x[i]!),
+      `chapter ${i} should stay book-time`,
+    ).toBeLessThanOrEqual(1);
   });
 });
 

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -318,11 +318,18 @@ async function chapterDurationSeconds(
   const drawer = page.getByTestId("chapters-drawer");
   await page.getByRole("button", { name: /^chapters/i }).click();
   await expect(drawer).toBeVisible();
-  const text = (await drawer.innerText()).replace(/\s+/g, " ");
-  const stamps = text.match(/\d+(?::\d\d)+/g) ?? [];
+  // Each row's duration cell shows that chapter's book-time duration — except
+  // the current chapter, whose cell shows a rate-adjusted "… remaining"
+  // instead (#2344). Keep only the book-time durations so the speed test can
+  // assert they don't move with the rate.
+  const cells = await drawer.locator(".lp-drawer-dur").allInnerTexts();
+  const stamps = cells
+    .filter((t) => !/remaining/i.test(t))
+    .map((t) => t.match(/\d+(?::\d\d)+/)?.[0])
+    .filter((s): s is string => Boolean(s));
   expect(
     stamps.length,
-    `drawer should list durations: ${text}`,
+    `drawer should list book-time durations: ${cells.join(" | ")}`,
   ).toBeGreaterThan(0);
   // The drawer is painted over the toolbar it was opened from, so it closes
   // by its own button rather than the toggle.

--- a/ui_tests/playwright/tests/flows/listen.spec.ts
+++ b/ui_tests/playwright/tests/flows/listen.spec.ts
@@ -299,52 +299,33 @@ function hmsToSeconds(label: string): number {
   return parts.reduce((acc, part) => acc * 60 + part, 0);
 }
 
-/** The transport's total (the third and last figure in the scrub-time row). */
-async function transportTotalSeconds(
+/**
+ * The three figures in the transport's scrub-time row, in seconds:
+ * `[elapsed, remaining, total]`. Elapsed and total are the book's own running
+ * time; the middle "… remaining" is the one rate-adjusted figure (#2344).
+ */
+async function scrubStamps(
   page: import("@playwright/test").Page,
-): Promise<number> {
+): Promise<{ elapsed: number; remaining: number; total: number }> {
   const text = (await page.getByTestId("listen-scrub-times").innerText())
     .replace(/\s+/g, " ")
     .trim();
   const stamps = text.match(/\d+(?::\d\d)+/g) ?? [];
   expect(stamps.length, `scrub row should carry three stamps: ${text}`).toBe(3);
-  return hmsToSeconds(stamps[2]!);
+  return {
+    elapsed: hmsToSeconds(stamps[0]!),
+    remaining: hmsToSeconds(stamps[1]!),
+    total: hmsToSeconds(stamps[2]!),
+  };
 }
 
-/** Every duration the chapters drawer lists, in seconds. */
-async function chapterDurationSeconds(
-  page: import("@playwright/test").Page,
-): Promise<number[]> {
-  const drawer = page.getByTestId("chapters-drawer");
-  await page.getByRole("button", { name: /^chapters/i }).click();
-  await expect(drawer).toBeVisible();
-  // Each row's duration cell shows that chapter's book-time duration — except
-  // the current chapter, whose cell shows a rate-adjusted "… remaining"
-  // instead (#2344). Keep only the book-time durations so the speed test can
-  // assert they don't move with the rate.
-  const cells = await drawer.locator(".lp-drawer-dur").allInnerTexts();
-  const stamps = cells
-    .filter((t) => !/remaining/i.test(t))
-    .map((t) => t.match(/\d+(?::\d\d)+/)?.[0])
-    .filter((s): s is string => Boolean(s));
-  expect(
-    stamps.length,
-    `drawer should list book-time durations: ${cells.join(" | ")}`,
-  ).toBeGreaterThan(0);
-  // The drawer is painted over the toolbar it was opened from, so it closes
-  // by its own button rather than the toggle.
-  await drawer.getByRole("button", { name: /^Close/ }).click();
-  await expect(drawer).toHaveCount(0);
-  return stamps.map(hmsToSeconds);
-}
-
-// Regression for issue #2344, superseding #2246. The transport total and the
-// chapter durations are the book's own running time — the same basis as the
-// bookmark stamps and the book detail page — so a speed change must NOT move
-// them (only the "time left" estimate is rate-adjusted). The earlier #2246 fix
-// rescaled these readouts, which is exactly what disagreed with a saved
-// bookmark at any speed but 1x.
-test("a speed change leaves the transport total and chapter durations in book time", async ({
+// Regression for issue #2344, superseding #2246. The transport's elapsed and
+// total are the book's own running time — the same basis as the bookmark
+// stamps and the book detail page — so a speed change must NOT move them. Only
+// the "time left" (the middle "… remaining" figure) is rate-adjusted. The
+// earlier #2246 fix rescaled the total too, which is exactly what disagreed
+// with a saved bookmark at any speed but 1x.
+test("a speed change keeps the transport total in book time and rescales only the time left", async ({
   page,
   request,
 }) => {
@@ -362,9 +343,9 @@ test("a speed change leaves the transport total and chapter durations in book ti
   await waitForPlayerReady(page);
   await expect(page.getByTestId("listen-rate")).toHaveText("1.00×");
 
-  const totalAt1x = await transportTotalSeconds(page);
-  expect(totalAt1x).toBeGreaterThan(0);
-  const chaptersAt1x = await chapterDurationSeconds(page);
+  const at1x = await scrubStamps(page);
+  expect(at1x.total).toBeGreaterThan(0);
+  expect(at1x.remaining).toBeGreaterThan(0);
 
   await page.getByRole("button", { name: "Playback speed" }).click();
   await page.getByRole("button", { name: "2.0×", exact: true }).click();
@@ -372,21 +353,13 @@ test("a speed change leaves the transport total and chapter durations in book ti
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("speed-panel")).toHaveCount(0);
 
-  // The rate visibly changed (listen-rate reads 2.00×), but the book-time
-  // readouts stay put: the total and every chapter duration read the same at
-  // 2x as at 1x. A second of slack per figure absorbs `format_hms` truncation.
-  const totalAt2x = await transportTotalSeconds(page);
-  expect(Math.abs(totalAt2x - totalAt1x)).toBeLessThanOrEqual(1);
-
-  const chaptersAt2x = await chapterDurationSeconds(page);
-  expect(chaptersAt2x.length).toBe(chaptersAt1x.length);
-  chaptersAt2x.forEach((secs, i) => {
-    // A chapter duration that halved at 2x is the #2246 behavior #2344 undid.
-    expect(
-      Math.abs(secs - chaptersAt1x[i]!),
-      `chapter ${i} should stay book-time`,
-    ).toBeLessThanOrEqual(1);
-  });
+  const at2x = await scrubStamps(page);
+  // The total is book-time — it reads the same at 2x as at 1x (a second of
+  // slack absorbs `format_hms` truncation).
+  expect(Math.abs(at2x.total - at1x.total)).toBeLessThanOrEqual(1);
+  // The "time left" is the one rate-adjusted figure — halved at 2x.
+  expect(at2x.remaining).toBeLessThan(at1x.remaining);
+  expect(Math.abs(at2x.remaining - at1x.remaining / 2)).toBeLessThanOrEqual(1);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Six independent reader/audiobook-player bugs, unified by surface (the reading and listening screens). Each is small and covered by a test or a browser check; the two rendering/CSS/JS fixes were verified live in the reader.
- **Reader — CSP page-turn.** `blob:` added to `style-src` in *both* CSP strings (`build_csp` + `NO_PROVIDER_HOSTS_CSP`) so epub.js's own book stylesheets (rendered via `URL.createObjectURL`) load; forward page-turns were blocked as CSP violations. A test asserts both policies carry it so they can't drift. Closes #2213.
- **Reader — Aa panel chips.** The parent document loads Instrument Serif + EB Garamond (subset to the `Aa` specimen glyphs) so the Editorial and Classic typeface chips preview their real faces instead of both falling back to a generic serif after the #2162 type slimming. Closes #2163.
- **Reader — stuck Loading overlay.** A first-paint watchdog in the epub.js glue surfaces the existing "This book couldn't be loaded."/Retry state instead of an indefinite `Loading…` overlay when a render never settles. Closes #2346.
- **Reader — Escape after a highlight delete.** Focus is restored to the highlights drawer's close button after a delete, so Escape keeps dismissing the drawer (its handler is bound on the reader root and stopped firing once focus fell to `<body>`). Closes #2354.
- **Player — transport times vs. bookmarks.** Elapsed/total/chapter durations no longer divide by the playback rate; only the "time left" estimate stays rate-adjusted (matching the landing resume card), so the player agrees with bookmarks and the book detail page at every speed. Closes #2344.
- **Player — sleep timer.** An armed sleep timer is cancelled on "Stop and close player" so it can't keep counting with no player open. Closes #2353.

## Test plan
- [x] `cargo test -p omnibus-frontend --features server` — 1076 passed, 0 failed (incl. the rewritten player-time tests and the new checks)
- [x] `cargo test -p omnibus security_headers` — 7 passed (incl. `both_policies_allow_blob_stylesheets_for_epub_js`)
- [x] `cargo fmt --check`; `clippy -D warnings` clean on server, frontend-server, wasm32 `web`, and `omnibus-mobile`; `stylelint` clean; `node --check` on the glue
- [x] Browser smoke-test against a seeded library: opened a stylesheet-carrying book in the reader — it paints with **no CSP violation** (#2213), the first-paint watchdog doesn't wrongly fire (#2346), and the Font Loading API confirms Instrument Serif + EB Garamond are loaded so the chips resolve to distinct faces (#2163)

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- #2213 AC4 (an E2E fixture whose CSS forces epub.js to mint a `blob:` stylesheet, closing the coverage gap that let this ship) is filed as a follow-up: the generated fixtures' trivial CSS is inlined rather than blob-rewritten, and every real multi-page reader fixture is reserved by another spec, so it needs its own fixture + careful count handling. The production fix and its unit-level regression guard (AC1–AC3) are in this PR.
- The audiobook "time left" is the one value that stays rate-adjusted (it's a wall-clock estimate, and the current speed is shown beside it), matching the existing `resume_meta` convention — so AC3 ("if rate-adjusted, the UI says so") holds without new labels.