### PR TITLE
fix: catalog and book-detail correctness fixes

### DIFF
--- a/.claude/rules/04-playwright.md
+++ b/.claude/rules/04-playwright.md
@@ -45,6 +45,14 @@ tile (`components/cover_tile.rs`) is a router `Link` that also overrides
 matches nothing and times out. Use `bookTile()` from `utils/shelves.ts`
 (`getByRole("listitem", …)`) or the per-book `ebook-tile-<ident>` testid.
 
+**A landing *table* row is not a `button`.** The row (`landing/table/row.rs`)
+used to be `<tr role="button">` with an "Open details for …" name, but it
+wraps interactive editable cells (invalid ARIA), so that was dropped (#2350).
+The keyboard-reachable navigate affordance is now a `link` on the cover cell:
+`getByRole("link", { name: "Open details for …" })` **inside the row**, or the
+`ebook-cell-cover` testid — not a row-level button, and clicking an editable
+cell (title/author/…) still opens its inline editor rather than navigating.
+
 **The landing's continue surface is a fan, not a carousel.** `landing/stack.rs`
 replaced the hero carousel, so `continue-hero`, `continue-hero-track`,
 `hero-dot-<n>` and `hero-card-<uuid>` no longer exist. The section is

--- a/db/src/cross_format/alignment.rs
+++ b/db/src/cross_format/alignment.rs
@@ -180,6 +180,7 @@ async fn ebook_lane(
         .map(|c| AlignmentEbookChapter {
             title: c.title,
             percent: (100.0 * c.start_chars.max(0) as f64 / total as f64).clamp(0.0, 100.0),
+            spine_index: c.spine_index,
         })
         .collect();
     Ok(Some(AlignmentEbook {

--- a/db/src/normalize.rs
+++ b/db/src/normalize.rs
@@ -35,6 +35,30 @@ pub fn normalize_author(s: &str) -> Option<String> {
     normalize(s)
 }
 
+/// Surname-first sort key for an author *display name*, used as the
+/// `author_sort` fallback when a book carries no OPF `file_as`. Without it the
+/// Author axis mixes two key formats — `"Surname, Given"` for file-as rows and
+/// `"Given Surname"` for the rest — so the same author's books scatter to
+/// opposite ends of the list (#2342).
+///
+/// Mirrors the frontend authors-index `sort_key` so the library table and the
+/// authors index agree on order:
+/// - a name already in `"Surname, Given"` form (it carries a comma) is kept
+///   verbatim — some Calibre dumps store the display name that way;
+/// - a mononym (no whitespace) is kept verbatim;
+/// - otherwise the last whitespace-separated token becomes the surname:
+///   `"Andy Weir"` → `"Weir, Andy"`.
+pub fn author_sort_key(name: &str) -> String {
+    let name = name.trim();
+    if name.contains(',') {
+        return name.to_string();
+    }
+    match name.rsplit_once(' ') {
+        Some((rest, last)) => format!("{last}, {rest}"),
+        None => name.to_string(),
+    }
+}
+
 /// Fold `s` to `[a-z0-9 ]`, expanding `&` and collapsing everything else
 /// to single spaces.
 ///
@@ -148,6 +172,60 @@ pub async fn backfill_norm_columns(pool: &SqlitePool) -> Result<(), NormalizeErr
 /// Rows per chunk for the norm-column backfill UPDATE. Three binds per row
 /// keeps a chunk under SQLite's 999-parameter cap.
 const NORM_UPDATE_CHUNK: usize = 300;
+
+/// Boot backfill: reshape any `books.author_sort` still stored in display
+/// `"Given Surname"` order into the surname-first sort key, so the Author axis
+/// orders every existing row on one key format instead of the mix the old
+/// write path left — `"Surname, Given"` for file-as rows and `"Given Surname"`
+/// for the rest (#2342). New rows are written surname-first by the sync
+/// writers; this heals rows indexed before that change.
+///
+/// Idempotent by construction: it only touches a value that has a space but no
+/// comma (an untransformed display name), and [`author_sort_key`]'s output
+/// always carries a comma — so the second pass skips every row it already
+/// fixed and the pass is a near-no-op once caught up. Runs on every boot from
+/// `init_db` alongside [`backfill_norm_columns`].
+pub async fn backfill_author_sort(pool: &SqlitePool) -> Result<(), NormalizeError> {
+    // Only the rows that actually change: `instr(_, ',') = 0` excludes values
+    // already in "Surname, Given" form, and `instr(_, ' ') > 0` excludes
+    // mononyms (which `author_sort_key` returns verbatim anyway).
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT id, author_sort FROM books
+          WHERE author_sort IS NOT NULL
+            AND author_sort <> ''
+            AND instr(author_sort, ',') = 0
+            AND instr(author_sort, ' ') > 0",
+    )
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let mut tx = pool.begin().await?;
+    for chunk in rows.chunks(AUTHOR_SORT_UPDATE_CHUNK) {
+        let values = std::iter::repeat_n("(?, ?)", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE books
+                SET author_sort = v.column2
+               FROM (VALUES {values}) AS v
+              WHERE books.id = v.column1"
+        );
+        let mut q = sqlx::query(&sql);
+        for (id, sort) in chunk {
+            q = q.bind(id).bind(author_sort_key(sort));
+        }
+        q.execute(&mut *tx).await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Rows per chunk for the author-sort backfill UPDATE. Two binds per row keeps
+/// a chunk well under SQLite's 999-parameter cap.
+const AUTHOR_SORT_UPDATE_CHUNK: usize = 400;
 
 #[cfg(test)]
 mod tests;

--- a/db/src/normalize/tests.rs
+++ b/db/src/normalize/tests.rs
@@ -185,6 +185,83 @@ fn normalize_never_panics_over_varied_unicode() {
     }
 }
 
+#[test]
+fn author_sort_key_reshapes_given_surname_to_surname_first() {
+    assert_eq!(author_sort_key("Andy Weir"), "Weir, Andy");
+    // Last whitespace token becomes the surname — same rule the frontend
+    // authors-index sort_key uses, so multi-word surnames split identically.
+    assert_eq!(author_sort_key("Ursula K. Le Guin"), "Guin, Ursula K. Le");
+}
+
+#[test]
+fn author_sort_key_keeps_comma_and_mononym_forms_verbatim() {
+    assert_eq!(author_sort_key("Weir, Andy"), "Weir, Andy");
+    assert_eq!(author_sort_key("Plato"), "Plato");
+    assert_eq!(author_sort_key("  Madonna  "), "Madonna");
+}
+
+#[test]
+fn author_sort_key_is_idempotent() {
+    for name in ["Andy Weir", "Weir, Andy", "Plato", "Ursula K. Le Guin"] {
+        let once = author_sort_key(name);
+        assert_eq!(author_sort_key(&once), once, "not idempotent for {name:?}");
+    }
+}
+
+#[tokio::test]
+async fn backfill_author_sort_reshapes_given_first_rows_only_and_is_idempotent() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    sqlx::query("INSERT INTO scan_roots (path, display_name) VALUES ('/lib', 'lib')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // Given-first (needs reshaping), already surname-first (comma), mononym.
+    for (uuid, author_sort) in [("u1", "Andy Weir"), ("u2", "Weir, Andy"), ("u3", "Plato")] {
+        sqlx::query(
+            "INSERT INTO books (uuid, library_id, path, title, author_sort) \
+             VALUES (?, 1, '', 't', ?)",
+        )
+        .bind(uuid)
+        .bind(author_sort)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let read = |uuid: &'static str| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query_scalar::<_, String>("SELECT author_sort FROM books WHERE uuid = ?")
+                .bind(uuid)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+        }
+    };
+
+    backfill_author_sort(&pool).await.unwrap();
+    assert_eq!(read("u1").await, "Weir, Andy"); // reshaped
+    assert_eq!(read("u2").await, "Weir, Andy"); // already surname-first, untouched
+    assert_eq!(read("u3").await, "Plato"); // mononym, untouched
+
+    // Idempotent: a second pass skips the now-comma-bearing rows. Prove it by
+    // planting a sentinel the reshape would otherwise clobber.
+    sqlx::query("UPDATE books SET author_sort = 'Weir, Andy sentinel' WHERE uuid = 'u1'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    backfill_author_sort(&pool).await.unwrap();
+    assert_eq!(read("u1").await, "Weir, Andy sentinel");
+}
+
+#[tokio::test]
+async fn backfill_author_sort_propagates_db_error_when_pool_is_closed() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    pool.close().await;
+    let err = backfill_author_sort(&pool).await.unwrap_err();
+    assert!(matches!(err, NormalizeError::Db(_)));
+}
+
 #[tokio::test]
 async fn backfill_norm_columns_propagates_db_error_when_pool_is_closed() {
     let pool = init_db("sqlite::memory:").await.unwrap();

--- a/db/src/physical/fileless.rs
+++ b/db/src/physical/fileless.rs
@@ -7,7 +7,7 @@ use sqlx::{SqlitePool, Transaction};
 use super::{PhysicalError, PHYSICAL_LIBRARY_PATH};
 use crate::covers::write_cover_file;
 use crate::helpers::mint_uuid;
-use crate::normalize::{normalize_author, normalize_title};
+use crate::normalize::{author_sort_key, normalize_author, normalize_title};
 
 /// A cover image for a fileless book: the source `mime` plus raw bytes.
 pub struct FilelessCover {
@@ -42,7 +42,8 @@ pub async fn create_fileless_book(
     let library_id = ensure_physical_library(&mut tx).await?;
     let uuid = mint_uuid();
     let has_cover = i64::from(book.cover.is_some());
-    let author_sort = book.authors.first().cloned();
+    // Surname-first sort key (#2342), matching the scanned write path.
+    let author_sort = book.authors.first().map(|a| author_sort_key(a));
     let author_norm = book.authors.first().and_then(|a| normalize_author(a));
 
     let book_id = sqlx::query_scalar::<_, i64>(

--- a/db/src/pool.rs
+++ b/db/src/pool.rs
@@ -97,6 +97,9 @@ async fn run_boot_backfills(pool: &SqlitePool) -> Result<(), InitDbError> {
     repair_ghosted_audiobook_attachments(pool).await?;
     // Auto-attach match key for rows indexed before migration 0016.
     crate::normalize::backfill_norm_columns(pool).await?;
+    // Surname-first `author_sort` for rows whose write path stored the
+    // given-first display name, so the Author axis keys every row alike (#2342).
+    crate::normalize::backfill_author_sort(pool).await?;
     // Effective (override) match keys for Check-In on rows edited before
     // migration 0048 (and self-heals any drift from the overrides JSON).
     crate::metadata_overrides::backfill_override_norm_columns(pool).await?;

--- a/db/src/sync/audiobooks/shared.rs
+++ b/db/src/sync/audiobooks/shared.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use sqlx::Transaction;
 
 use crate::helpers::{mint_uuid, sanitize_accent_color, stable_uuid};
-use crate::normalize::{normalize_author, normalize_title};
+use crate::normalize::{author_sort_key, normalize_author, normalize_title};
 
 use super::super::attach;
 use super::super::books::SyncError;
@@ -240,7 +240,7 @@ async fn insert_audiobook_row(
     .bind(&book_path)
     .bind(&b.title)
     .bind(&b.title)
-    .bind(&b.creator_name)
+    .bind(b.creator_name.as_deref().map(author_sort_key))
     .bind(has_cover)
     .bind(&b.description)
     .bind(sanitize_accent_color(b.accent.as_deref()))
@@ -480,7 +480,7 @@ async fn update_audiobook_row(
     .bind(&book_path)
     .bind(&b.title)
     .bind(&b.title)
-    .bind(&b.creator_name)
+    .bind(b.creator_name.as_deref().map(author_sort_key))
     .bind(has_cover)
     .bind(&b.description)
     .bind(sanitize_accent_color(b.accent.as_deref()))

--- a/db/src/sync/books/shared.rs
+++ b/db/src/sync/books/shared.rs
@@ -14,7 +14,7 @@ use crate::helpers::{
     cleaned_series_name, mint_uuid, resolved_series_index, sanitize_accent_color, scan_key_for,
     split_filename, stable_uuid,
 };
-use crate::normalize::{normalize_author, normalize_title};
+use crate::normalize::{author_sort_key, normalize_author, normalize_title};
 use crate::sort_keys::series_sort_value;
 use crate::taxonomy::{
     resolve_or_insert_language, resolve_or_insert_publisher, resolve_or_insert_series_with_aliases,
@@ -252,11 +252,14 @@ async fn update_book_row(
     let scan_key = scan_key_for(&m.filename);
     let title = m.display_title();
     let series_index_num = resolved_series_index(m);
+    // With no OPF `file_as`, derive a surname-first key from the display name
+    // rather than storing the given-first name, so the Author axis keys every
+    // book the same way (#2342).
     let author_sort = m
         .creators
         .first()
         .and_then(|c| c.file_as.clone())
-        .or_else(|| m.creators.first().map(|c| c.name.clone()));
+        .or_else(|| m.creators.first().map(|c| author_sort_key(&c.name)));
     let has_cover = i64::from(b.cover.is_some());
 
     sqlx::query(
@@ -316,11 +319,14 @@ pub(super) async fn insert_book_row(
     let (book_path, file_stem, file_ext) = split_filename(&m.filename);
     let title = m.display_title();
     let series_index_num = resolved_series_index(m);
+    // With no OPF `file_as`, derive a surname-first key from the display name
+    // rather than storing the given-first name, so the Author axis keys every
+    // book the same way (#2342).
     let author_sort = m
         .creators
         .first()
         .and_then(|c| c.file_as.clone())
-        .or_else(|| m.creators.first().map(|c| c.name.clone()));
+        .or_else(|| m.creators.first().map(|c| author_sort_key(&c.name)));
     let has_cover = i64::from(b.cover.is_some());
 
     let book_id = sqlx::query_scalar::<_, i64>(

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -94,10 +94,23 @@ async fn insert_book_row_keys_author_sort_surname_first_with_and_without_file_as
     let pool = init_db("sqlite::memory:").await.unwrap();
     let library_id = seed_scan_root(&pool).await;
 
-    let mut with_file_as = indexed("martian.epub", Some("The Martian"), &["Andy Weir"], &[], None, None);
+    let mut with_file_as = indexed(
+        "martian.epub",
+        Some("The Martian"),
+        &["Andy Weir"],
+        &[],
+        None,
+        None,
+    );
     with_file_as.metadata.creators[0].file_as = Some("Weir, Andy".into());
-    let without_file_as =
-        indexed("phm.epub", Some("Project Hail Mary"), &["Andy Weir"], &[], None, None);
+    let without_file_as = indexed(
+        "phm.epub",
+        Some("Project Hail Mary"),
+        &["Andy Weir"],
+        &[],
+        None,
+        None,
+    );
 
     let insert = |b: IndexedBook| {
         let pool = pool.clone();

--- a/db/src/sync/books/tests.rs
+++ b/db/src/sync/books/tests.rs
@@ -82,6 +82,56 @@ async fn seed_book_with_file(pool: &SqlitePool, library_id: i64, filename: &str)
     inserted.book_id
 }
 
+/// #2342: the Author axis must key every book on one format. A book with an
+/// OPF `file_as` ("Weir, Andy") and one without (bare display name "Andy
+/// Weir") by the same author used to store two incompatible sort keys — the
+/// with-file_as book surname-first, the other given-first — and scatter to
+/// opposite ends of the list. The write path now derives the surname-first
+/// key from the display name when `file_as` is absent, so both land under one
+/// key and sort adjacently.
+#[tokio::test]
+async fn insert_book_row_keys_author_sort_surname_first_with_and_without_file_as() {
+    let pool = init_db("sqlite::memory:").await.unwrap();
+    let library_id = seed_scan_root(&pool).await;
+
+    let mut with_file_as = indexed("martian.epub", Some("The Martian"), &["Andy Weir"], &[], None, None);
+    with_file_as.metadata.creators[0].file_as = Some("Weir, Andy".into());
+    let without_file_as =
+        indexed("phm.epub", Some("Project Hail Mary"), &["Andy Weir"], &[], None, None);
+
+    let insert = |b: IndexedBook| {
+        let pool = pool.clone();
+        async move {
+            let mut tx = pool.begin().await.unwrap();
+            let id = insert_book_row(&mut tx, library_id, "/lib", &b)
+                .await
+                .unwrap()
+                .book_id;
+            tx.commit().await.unwrap();
+            id
+        }
+    };
+    let id_with = insert(with_file_as).await;
+    let id_without = insert(without_file_as).await;
+
+    let author_sort = |id: i64| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query_scalar::<_, String>("SELECT author_sort FROM books WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap()
+        }
+    };
+    assert_eq!(author_sort(id_with).await, "Weir, Andy");
+    assert_eq!(
+        author_sort(id_without).await,
+        "Weir, Andy",
+        "a book without file_as must derive the same surname-first key"
+    );
+}
+
 /// COUNT `book_files` rows for one `book_id`.
 async fn book_files_count(pool: &SqlitePool, book_id: i64) -> i64 {
     sqlx::query_scalar("SELECT COUNT(*) FROM book_files WHERE book_id = ?")

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -5556,6 +5556,19 @@ h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
 }
 
 .ebook-col-cover { width: 40px; }
+/* The row's "Open details" affordance (#2350): wraps the cover so a click or
+   keyboard activation navigates, with its own focus ring. `line-height:0`
+   keeps the anchor from adding inline space around the thumb. */
+.ebook-cover-link {
+  display: block;
+  line-height: 0;
+  color: inherit;
+  border-radius: 2px;
+}
+.ebook-cover-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .ebook-thumb {
   width: 26px;
   height: 38px;

--- a/frontend/src/pages/authors_index.rs
+++ b/frontend/src/pages/authors_index.rs
@@ -17,7 +17,12 @@ use crate::{data, index_prefs, use_server_url, Route};
 #[derive(Clone, PartialEq, Eq)]
 struct AuthorIndexCounts {
     total_authors: usize,
-    total_books: usize,
+    /// Σ of each author's `book_count` — author–book *credits*, not distinct
+    /// titles: a two-creator book contributes one credit per creator. Named
+    /// and labelled for what it holds so the header can't misreport it as a
+    /// book count (#2292). A true distinct-book total isn't derivable here —
+    /// the `AuthorSummary` list carries no per-book identity.
+    total_credits: usize,
 }
 
 /// Owned output of the filter/sort/group-by-letter pipeline, memoized as a
@@ -78,10 +83,14 @@ pub fn AuthorsIndexPage() -> Element {
     let any_in_library = !all.is_empty();
     drop(all);
 
-    // Memoized separately from the filter/sort/group-by pipeline below: this
-    // total is unaffected by the filter text or sort key, so tying it to
-    // that memo would recompute it on every keystroke for no reason.
-    let total_books = use_memo(move || authors.read().iter().map(|a| a.book_count).sum::<usize>());
+    // Σ per-author book counts = author–book credits (a multi-creator book
+    // adds one credit per creator), NOT distinct titles — the header labels
+    // it "credits" so the figure isn't a wrong book count (#2292). Memoized
+    // separately from the filter/sort/group-by pipeline below: unaffected by
+    // the filter text or sort key, so tying it to that memo would recompute it
+    // on every keystroke for no reason.
+    let total_credits =
+        use_memo(move || authors.read().iter().map(|a| a.book_count).sum::<usize>());
 
     // Group by first letter of sort key (last name when available, else
     // name); only meaningful when sorting by name. Folded into the same
@@ -98,7 +107,7 @@ pub fn AuthorsIndexPage() -> Element {
 
     let counts = AuthorIndexCounts {
         total_authors,
-        total_books: total_books(),
+        total_credits: total_credits(),
     };
     let filter_state = build_filter_state(filter(), sort(), show_letters, letters, filtered.len());
 
@@ -145,6 +154,16 @@ fn build_filter_state(
         letter_count: letters.len(),
         filtered_count,
     }
+}
+
+/// Header subtitle. The second figure counts author–book *credits* (Σ of each
+/// author's book count), not distinct titles — a multi-creator book adds one
+/// credit per creator — so it is labelled "credits" rather than "books" to
+/// avoid a count that inflates past the real title total (#2292).
+fn index_subtitle(total_authors: usize, total_credits: usize) -> String {
+    format!(
+        "{total_authors} authors \u{b7} {total_credits} author credits \u{b7} the people in your shelves."
+    )
 }
 
 /// Filter → sort → group-by-letter pipeline, folded into one step so the
@@ -271,7 +290,7 @@ fn AuthorsIndexHeader(
 ) -> Element {
     let AuthorIndexCounts {
         total_authors,
-        total_books,
+        total_credits,
     } = counts;
     let AuthorIndexFilter {
         filter,
@@ -292,9 +311,7 @@ fn AuthorsIndexHeader(
                         em { "author" }
                         "."
                     }
-                    p { class: "idx-subtitle",
-                        "{total_authors} authors across {total_books} books \u{b7} the people in your shelves."
-                    }
+                    p { class: "idx-subtitle", "{index_subtitle(total_authors, total_credits)}" }
                 }
             }
             div { class: "idx-toolbar",

--- a/frontend/src/pages/authors_index/tests.rs
+++ b/frontend/src/pages/authors_index/tests.rs
@@ -161,3 +161,14 @@ fn group_by_letter_returns_empty_when_show_letters_is_false() {
     let groups = group_by_letter(&all, false);
     assert!(groups.is_empty());
 }
+
+#[test]
+fn index_subtitle_labels_the_second_figure_as_credits_not_books() {
+    // #2292: the figure is Σ per-author book counts (author–book credits),
+    // which a multi-creator book inflates past the distinct-title total, so
+    // the header must not call it "books".
+    let sub = index_subtitle(23, 27);
+    assert!(sub.contains("23 authors"), "{sub}");
+    assert!(sub.contains("27 author credits"), "{sub}");
+    assert!(!sub.contains("books"), "must not claim a book count: {sub}");
+}

--- a/frontend/src/pages/book_detail/chapter_ref.rs
+++ b/frontend/src/pages/book_detail/chapter_ref.rs
@@ -72,10 +72,7 @@ mod tests {
             Some(1)
         );
         // A CFI past the last chapter's spine stays on the last chapter.
-        assert_eq!(
-            chapter_index_for_cfi(&spines, "epubcfi(/6/20!/4)"),
-            Some(2)
-        );
+        assert_eq!(chapter_index_for_cfi(&spines, "epubcfi(/6/20!/4)"), Some(2));
         // A CFI before the first chapter's spine resolves to nothing (the
         // caller keeps the percent fallback / chapter 1).
         assert_eq!(chapter_index_for_cfi(&spines, "epubcfi(/6/2!/4)"), None);
@@ -86,9 +83,6 @@ mod tests {
         // Two TOC entries inside one spine document (both spine_index 3): a CFI
         // in that spine lands on the later of the two — still the open document.
         let spines = [0, 3, 3, 5];
-        assert_eq!(
-            chapter_index_for_cfi(&spines, "epubcfi(/6/8!/4)"),
-            Some(2)
-        );
+        assert_eq!(chapter_index_for_cfi(&spines, "epubcfi(/6/8!/4)"), Some(2));
     }
 }

--- a/frontend/src/pages/book_detail/chapter_ref.rs
+++ b/frontend/src/pages/book_detail/chapter_ref.rs
@@ -1,0 +1,94 @@
+//! Resolve a reader chapter from an EPUB CFI's spine step. The book-detail
+//! resume readout and the saved-passage locator both name the chapter the
+//! reader opens, so they derive it the same way — from the CFI's spine item
+//! against the chapters' spine indices — rather than the rounded whole-book
+//! percent that lands one chapter ahead when a boundary falls inside the
+//! rounding window (#2345, #2356).
+
+/// 1-based spine index encoded in a CFI's pre-`!` package step.
+///
+/// A CFI opens with the path through the package document — `/6/14[chap3]!…`
+/// — where `/6` selects the `<spine>` and the step after it is the *child*
+/// index of the spine item. Child indices are even (odd steps address text
+/// nodes), so the item's ordinal is that step halved.
+pub(super) fn cfi_spine_ordinal(cfi: &str) -> Option<u32> {
+    let inner = cfi.trim().strip_prefix("epubcfi(")?.strip_suffix(')')?;
+    // Everything up to the first `!` is the package-document path; what follows
+    // steps inside the spine item itself.
+    let package = inner.split('!').next()?;
+    let step = package.rsplit('/').find(|s| !s.is_empty())?;
+    // Drop a trailing `[id]` assertion (`14[chap3]` → `14`).
+    let digits = step.split('[').next()?;
+    let raw: u32 = digits.parse().ok()?;
+    // Odd or zero means this isn't an element step, so the halving would be a
+    // fabrication. Report nothing instead.
+    if raw == 0 || !raw.is_multiple_of(2) {
+        return None;
+    }
+    Some(raw / 2)
+}
+
+/// Index of the chapter a CFI sits in: the last chapter whose 0-based spine
+/// item is at or before the CFI's spine item. `spine_indices` is each
+/// chapter's `spine_index` in TOC order (ascending). `None` when the CFI
+/// carries no readable spine step, letting the caller fall back to the
+/// percent-based estimate.
+///
+/// Matches the reader, which navigates by spine document: one chapter per
+/// spine item resolves exactly, and the percent-rounding off-by-one across a
+/// chapter boundary can no longer occur. Multiple chapters sharing a spine
+/// item resolve to the last of them — still within the reader's open document.
+pub(super) fn chapter_index_for_cfi(spine_indices: &[i64], cfi: &str) -> Option<usize> {
+    let cfi_spine_0 = i64::from(cfi_spine_ordinal(cfi)?) - 1;
+    spine_indices.iter().rposition(|s| *s <= cfi_spine_0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cfi_spine_ordinal_halves_the_even_package_step() {
+        assert_eq!(cfi_spine_ordinal("epubcfi(/6/14[chap3]!/4/2/1:0)"), Some(7));
+        assert_eq!(cfi_spine_ordinal("epubcfi(/6/2!/4)"), Some(1));
+    }
+
+    #[test]
+    fn cfi_spine_ordinal_rejects_non_element_and_malformed_steps() {
+        assert_eq!(cfi_spine_ordinal("epubcfi(/6/13!/4)"), None); // odd step
+        assert_eq!(cfi_spine_ordinal("epubcfi(/6/0!/4)"), None); // zero
+        assert_eq!(cfi_spine_ordinal("not-a-cfi"), None);
+    }
+
+    #[test]
+    fn chapter_index_for_cfi_picks_the_chapter_by_spine_not_percent() {
+        // Three chapters starting in spine items 2, 4 and 6 (0-based). A CFI in
+        // spine item 4 (package step 10 → ordinal 5 → 0-based 4) resolves to the
+        // chapter that *starts* at spine 4 — the middle one — regardless of how
+        // close the whole-book percents of the neighbours round.
+        let spines = [2, 4, 6];
+        assert_eq!(
+            chapter_index_for_cfi(&spines, "epubcfi(/6/10!/4/2:0)"),
+            Some(1)
+        );
+        // A CFI past the last chapter's spine stays on the last chapter.
+        assert_eq!(
+            chapter_index_for_cfi(&spines, "epubcfi(/6/20!/4)"),
+            Some(2)
+        );
+        // A CFI before the first chapter's spine resolves to nothing (the
+        // caller keeps the percent fallback / chapter 1).
+        assert_eq!(chapter_index_for_cfi(&spines, "epubcfi(/6/2!/4)"), None);
+    }
+
+    #[test]
+    fn chapter_index_for_cfi_resolves_to_last_of_chapters_sharing_a_spine() {
+        // Two TOC entries inside one spine document (both spine_index 3): a CFI
+        // in that spine lands on the later of the two — still the open document.
+        let spines = [0, 3, 3, 5];
+        assert_eq!(
+            chapter_index_for_cfi(&spines, "epubcfi(/6/8!/4)"),
+            Some(2)
+        );
+    }
+}

--- a/frontend/src/pages/book_detail/highlights.rs
+++ b/frontend/src/pages/book_detail/highlights.rs
@@ -35,17 +35,36 @@ pub(super) struct BdQuoteMeta {
 pub(super) fn BdHighlightsSection(uuid: String, quote_meta: BdQuoteMeta) -> Element {
     let server_url = use_server_url();
     let mut highlights = use_signal(Vec::<Highlight>::new);
+    // Each chapter's 0-based `spine_index`, in TOC order — used to name a
+    // passage's chapter the way the reader does (#2356). Empty on SSR / first
+    // paint and until the fetch lands, which leaves the locator on its
+    // spine-section fallback.
+    let mut chapter_spines = use_signal(Vec::<i64>::new);
     // The passage targeted for a quote card; `None` on SSR and first paint
     // (rule 07), set by each card's Quote button.
     let quote_target: Signal<Option<Highlight>> = use_signal(|| None);
 
     let load_url = server_url.clone();
     use_effect(use_reactive!(|uuid| {
-        let url = load_url.clone();
-        let uuid = uuid.clone();
+        let hl_url = load_url.clone();
+        let hl_uuid = uuid.clone();
         spawn(async move {
-            if let Ok(list) = data::list_highlights(&url, &uuid).await {
+            if let Ok(list) = data::list_highlights(&hl_url, &hl_uuid).await {
                 highlights.set(list);
+            }
+        });
+        // The alignment view doubles as the chapter table (title + spine index)
+        // for any book with text; take just the spine indices to map each
+        // passage's CFI to the reader's chapter number (#2356).
+        let ch_url = load_url.clone();
+        let ch_uuid = uuid.clone();
+        spawn(async move {
+            if let Ok(align) = data::get_alignment(&ch_url, &ch_uuid).await {
+                let spines = align
+                    .ebook
+                    .map(|e| e.chapters.iter().map(|c| c.spine_index).collect())
+                    .unwrap_or_default();
+                chapter_spines.set(spines);
             }
         });
     }));
@@ -71,6 +90,7 @@ pub(super) fn BdHighlightsSection(uuid: String, quote_meta: BdQuoteMeta) -> Elem
                     highlights,
                     server_url: server_url.clone(),
                     quote_target,
+                    chapter_spines,
                 }
             }
         }
@@ -86,6 +106,7 @@ fn BdHighlightList(
     highlights: Signal<Vec<Highlight>>,
     server_url: String,
     quote_target: Signal<Option<Highlight>>,
+    chapter_spines: ReadSignal<Vec<i64>>,
 ) -> Element {
     // Hoisted once for the whole list rather than once per card — a heavily
     // highlighted book runs to hundreds of rows, and each row resolves its
@@ -104,6 +125,7 @@ fn BdHighlightList(
                     server_url: server_url.clone(),
                     quote_target,
                     dates_ready,
+                    chapter_spines,
                 }
             }
         }
@@ -160,6 +182,7 @@ fn BdHighlightCard(
     server_url: String,
     quote_target: Signal<Option<Highlight>>,
     dates_ready: ReadSignal<bool>,
+    chapter_spines: ReadSignal<Vec<i64>>,
 ) -> Element {
     let offset = local_date_offset(dates_ready(), highlight.created_at);
     let id = highlight.id;
@@ -176,11 +199,13 @@ fn BdHighlightCard(
     let note = highlight.note.clone();
     // A Kobo-origin passage has no CFI: it still lists, but there is no
     // position to derive a locator from and nowhere for "Open in reader" to
-    // jump.
+    // jump. When the chapter table is loaded the locator names the reader's
+    // chapter; until then it falls back to the raw spine section (#2356).
+    let spines = chapter_spines.read();
     let meta_line = match highlight
         .epub_cfi_range
         .as_deref()
-        .and_then(highlight_locator)
+        .and_then(|cfi| highlight_locator(cfi, &spines))
     {
         Some(loc) => format!(
             "{loc} \u{00b7} saved {}",
@@ -188,6 +213,7 @@ fn BdHighlightCard(
         ),
         None => format!("saved {}", fmt_long_date(highlight.created_at, offset)),
     };
+    drop(spines);
     let open_href = highlight
         .epub_cfi_range
         .as_deref()

--- a/frontend/src/pages/book_detail/highlights/locator.rs
+++ b/frontend/src/pages/book_detail/highlights/locator.rs
@@ -1,34 +1,21 @@
 //! Derive a human-readable locator from an EPUB CFI. A highlight stores only
-//! its CFI range, and resolving that to a page needs the paginated book, so
-//! the best the detail page can name without opening the EPUB is which spine
-//! item (section) the passage sits in.
+//! its CFI range; the book-detail page maps that to the reader's chapter
+//! number when the book's chapter structure is loaded, and falls back to the
+//! raw spine "Section N" otherwise.
 
-/// Human locator for a highlight's CFI, e.g. `"Section 7"`. `None` when the
-/// string isn't a CFI we can read a spine step out of — the caller then shows
-/// the saved date alone rather than a made-up position.
-pub(super) fn highlight_locator(cfi: &str) -> Option<String> {
-    spine_position(cfi).map(|n| format!("Section {n}"))
-}
+use crate::pages::book_detail::chapter_ref;
 
-/// 1-based spine index encoded in a CFI's pre-`!` package step.
-///
-/// A CFI opens with the path through the package document — `/6/14[chap3]!…`
-/// — where `/6` selects the `<spine>` and the step after it is the *child*
-/// index of the spine item. Child indices are even (odd steps address text
-/// nodes), so the item's ordinal is that step halved.
-fn spine_position(cfi: &str) -> Option<u32> {
-    let inner = cfi.trim().strip_prefix("epubcfi(")?.strip_suffix(')')?;
-    // Everything up to the first `!` is the package-document path; what
-    // follows steps inside the spine item itself.
-    let package = inner.split('!').next()?;
-    let step = package.rsplit('/').find(|s| !s.is_empty())?;
-    // Drop a trailing `[id]` assertion (`14[chap3]` → `14`).
-    let digits = step.split('[').next()?;
-    let raw: u32 = digits.parse().ok()?;
-    // Odd or zero means this isn't an element step, so the halving would be a
-    // fabrication. Report nothing instead.
-    if raw == 0 || !raw.is_multiple_of(2) {
-        return None;
+/// Human locator for a highlight's CFI. Prefers the reader's chapter number —
+/// the CFI's spine step mapped to the book's TOC chapters, where
+/// `chapter_spines` is each chapter's 0-based `spine_index` in TOC order — so a
+/// saved passage and the reader name the same chapter rather than a raw spine
+/// ordinal that counts front matter (#2356). Falls back to the 1-based spine
+/// "Section N" when no chapter structure is loaded, or when the CFI sits before
+/// the first chapter (front matter). `None` when the string carries no
+/// readable spine step — the caller then shows the saved date alone.
+pub(super) fn highlight_locator(cfi: &str, chapter_spines: &[i64]) -> Option<String> {
+    if let Some(idx) = chapter_ref::chapter_index_for_cfi(chapter_spines, cfi) {
+        return Some(format!("Chapter {}", idx + 1));
     }
-    Some(raw / 2)
+    chapter_ref::cfi_spine_ordinal(cfi).map(|n| format!("Section {n}"))
 }

--- a/frontend/src/pages/book_detail/highlights/tests.rs
+++ b/frontend/src/pages/book_detail/highlights/tests.rs
@@ -5,19 +5,43 @@ use super::locator::highlight_locator;
 use super::*;
 
 #[test]
-fn highlight_locator_names_the_spine_section_for_a_range_cfi() {
-    // epub.js emits ranges as `epubcfi(<common parent>,<start>,<end>)`; the
-    // spine step is the `/14` before the `!`.
+fn highlight_locator_names_the_reader_chapter_when_the_structure_is_loaded() {
+    // #2356: with the chapter table known, a passage names the chapter the
+    // reader shows, not the raw spine ordinal that counts front matter. The
+    // range CFI's spine step is `/14` → ordinal 7 → 0-based spine 6; against
+    // chapters starting at spines 0, 6 and 12 that resolves to chapter 2.
     assert_eq!(
-        highlight_locator("epubcfi(/6/14[chap03]!/4/2,/1:0,/1:120)"),
+        highlight_locator("epubcfi(/6/14[chap03]!/4/2,/1:0,/1:120)", &[0, 6, 12]),
+        Some("Chapter 2".to_string())
+    );
+}
+
+#[test]
+fn highlight_locator_falls_back_to_the_spine_section_without_a_chapter_table() {
+    // Empty chapter table (not yet loaded, or a book with no stored structure):
+    // the raw spine section keeps a passage locatable. The spine step is the
+    // `/14` before the `!`.
+    assert_eq!(
+        highlight_locator("epubcfi(/6/14[chap03]!/4/2,/1:0,/1:120)", &[]),
         Some("Section 7".to_string())
+    );
+}
+
+#[test]
+fn highlight_locator_falls_back_to_the_section_before_the_first_chapter() {
+    // A front-matter CFI (spine before every chapter's start) has no chapter
+    // to name, so it keeps the raw spine section rather than misreporting
+    // chapter 1.
+    assert_eq!(
+        highlight_locator("epubcfi(/6/2!/4)", &[4, 8]),
+        Some("Section 1".to_string())
     );
 }
 
 #[test]
 fn highlight_locator_reads_a_point_cfi_without_an_id_assertion() {
     assert_eq!(
-        highlight_locator("epubcfi(/6/4!/4/2/2/1:15)"),
+        highlight_locator("epubcfi(/6/4!/4/2/2/1:15)", &[]),
         Some("Section 2".to_string())
     );
 }
@@ -25,7 +49,7 @@ fn highlight_locator_reads_a_point_cfi_without_an_id_assertion() {
 #[test]
 fn highlight_locator_tolerates_surrounding_whitespace() {
     assert_eq!(
-        highlight_locator("  epubcfi(/6/8!/4)  "),
+        highlight_locator("  epubcfi(/6/8!/4)  ", &[]),
         Some("Section 4".to_string())
     );
 }
@@ -33,18 +57,18 @@ fn highlight_locator_tolerates_surrounding_whitespace() {
 #[test]
 fn highlight_locator_returns_none_for_unparseable_input() {
     // Not a CFI at all, and a CFI whose wrapper never closes.
-    assert_eq!(highlight_locator(""), None);
-    assert_eq!(highlight_locator("chapter 4, paragraph 2"), None);
-    assert_eq!(highlight_locator("epubcfi(/6/14!/4/2"), None);
+    assert_eq!(highlight_locator("", &[]), None);
+    assert_eq!(highlight_locator("chapter 4, paragraph 2", &[]), None);
+    assert_eq!(highlight_locator("epubcfi(/6/14!/4/2", &[]), None);
 }
 
 #[test]
 fn highlight_locator_returns_none_when_the_spine_step_is_not_an_element() {
     // Odd steps address text nodes and `/0` isn't a step at all — halving
     // either would invent a section number.
-    assert_eq!(highlight_locator("epubcfi(/6/7!/4/2)"), None);
-    assert_eq!(highlight_locator("epubcfi(/6/0!/4/2)"), None);
-    assert_eq!(highlight_locator("epubcfi(/6/x!/4/2)"), None);
+    assert_eq!(highlight_locator("epubcfi(/6/7!/4/2)", &[]), None);
+    assert_eq!(highlight_locator("epubcfi(/6/0!/4/2)", &[]), None);
+    assert_eq!(highlight_locator("epubcfi(/6/x!/4/2)", &[]), None);
 }
 
 #[test]
@@ -175,6 +199,7 @@ mod render_tests {
                 server_url: String::new(),
                 quote_target: use_signal(|| None),
                 dates_ready: use_local_dates_ready(),
+                chapter_spines: use_signal(Vec::<i64>::new),
             }
         }
     }
@@ -221,6 +246,7 @@ mod render_tests {
                 server_url: String::new(),
                 quote_target: use_signal(|| None),
                 dates_ready: use_local_dates_ready(),
+                chapter_spines: use_signal(Vec::<i64>::new),
             }
         }
     }
@@ -264,6 +290,7 @@ mod render_tests {
                 highlights: use_signal(|| seeded_list(8)),
                 server_url: String::new(),
                 quote_target: use_signal(|| None),
+                chapter_spines: use_signal(Vec::<i64>::new),
             }
         }
     }
@@ -294,6 +321,7 @@ mod render_tests {
                 server_url: String::new(),
                 quote_target: use_signal(|| None),
                 dates_ready: use_local_dates_ready(),
+                chapter_spines: use_signal(Vec::<i64>::new),
             }
         }
     }

--- a/frontend/src/pages/book_detail/marquee/home.rs
+++ b/frontend/src/pages/book_detail/marquee/home.rs
@@ -8,7 +8,10 @@ use dioxus::prelude::*;
 use dioxus_router::Link;
 use omnibus_shared::physical::WishlistEntry;
 use omnibus_shared::summary::summary_is_sparse;
-use omnibus_shared::{AlignmentView, BookFileInfo, BookInsights, EbookMetadata, MetadataOverrides};
+use omnibus_shared::{
+    AlignmentEbookChapter, AlignmentView, BookFileInfo, BookInsights, EbookMetadata,
+    MetadataOverrides, ProgressRecord,
+};
 
 use crate::components::alignment_modal::{fmt_hm, listening_frac};
 use crate::components::FetchSummaryButton;
@@ -202,27 +205,45 @@ fn short_chapter_title(title: &str) -> String {
     )
 }
 
+/// The 1-based current chapter + its capped title for the resume readout.
+///
+/// Prefers the reading position's CFI spine step — the reader navigates by
+/// spine document, so this names the chapter it actually opens — and falls
+/// back to the rounded whole-book percent only when no CFI is stored. The old
+/// percent-only path picked the last chapter starting at or below the
+/// *rounded* integer percent, landing one chapter ahead whenever a boundary
+/// fell inside the rounding window (#2345).
+fn chapter_now(
+    chapters: &[AlignmentEbookChapter],
+    reading: Option<&ProgressRecord>,
+) -> Option<(usize, String)> {
+    if chapters.is_empty() {
+        return None;
+    }
+    let reading = reading?;
+    let idx = reading
+        .epub_cfi
+        .as_deref()
+        .and_then(|cfi| {
+            let spines: Vec<i64> = chapters.iter().map(|c| c.spine_index).collect();
+            super::super::chapter_ref::chapter_index_for_cfi(&spines, cfi)
+        })
+        .or_else(|| {
+            // No CFI: chapter starts are whole-book percents (0..=100), the same
+            // scale as the saved position. Only meaningful past the start.
+            let pct = reading.progress_percent.filter(|p| *p > 0)?;
+            chapters.iter().rposition(|c| c.percent <= pct as f64)
+        })?;
+    Some((idx + 1, short_chapter_title(&chapters[idx].title)))
+}
+
 fn derive_readout(alignment: Option<&AlignmentView>, progress: &MarqueeProgress) -> HomeReadout {
     let Some(v) = alignment else {
         return HomeReadout::default();
     };
     let chapters = v.ebook.as_ref().map(|e| &e.chapters);
     let ch_total = chapters.map(|c| c.len()).filter(|n| *n > 1);
-    let ch_now = match (
-        chapters,
-        progress.reading.as_ref().and_then(|r| r.progress_percent),
-    ) {
-        (Some(chapters), Some(pct)) if !chapters.is_empty() && pct > 0 => {
-            // Chapter starts are whole-book percents (0..=100), same scale
-            // as the saved position.
-            let idx = chapters
-                .iter()
-                .rposition(|c| c.percent <= pct as f64)
-                .unwrap_or(0);
-            Some((idx + 1, short_chapter_title(&chapters[idx].title)))
-        }
-        _ => None,
-    };
+    let ch_now = chapters.and_then(|c| chapter_now(c, progress.reading.as_ref()));
     let total_secs: f64 = v.audio_files.iter().map(|f| f.duration_seconds).sum();
     let audio_total = (total_secs > 0.0).then(|| fmt_hm(total_secs));
     let files: Vec<_> = v.audio_files.iter().collect();

--- a/frontend/src/pages/book_detail/marquee/home/tests.rs
+++ b/frontend/src/pages/book_detail/marquee/home/tests.rs
@@ -201,6 +201,43 @@ fn short_chapter_title_keeps_a_terse_title_and_caps_a_verbose_one() {
     );
 }
 
+#[test]
+fn chapter_now_prefers_the_cfi_spine_over_the_rounded_percent() {
+    use omnibus_shared::progress::{ProgressFormat, ProgressRecord};
+    // Two adjacent chapters whose starts round to the same integer percent:
+    // the reader is in the first (spine 4), but a rounded 9% pulls the label
+    // one ahead to the second (spine 6).
+    let chapters = [
+        AlignmentEbookChapter { title: "Front".into(), percent: 0.0, spine_index: 0 },
+        AlignmentEbookChapter { title: "Chapter One".into(), percent: 8.4, spine_index: 4 },
+        AlignmentEbookChapter { title: "Chapter Two".into(), percent: 8.9, spine_index: 6 },
+    ];
+    let rec = |cfi: Option<&str>, pct: Option<i64>| ProgressRecord {
+        book_uuid: "b".into(),
+        format: ProgressFormat::Epub,
+        epub_cfi: cfi.map(Into::into),
+        audio_position_seconds: None,
+        progress_percent: pct,
+        kobo_location: None,
+        book_file_id: None,
+        updated_at: 0,
+        client_updated_at: 0,
+    };
+
+    // CFI in spine item 4 (package step 10 → ordinal 5 → 0-based 4) → Chapter One.
+    let r = rec(Some("epubcfi(/6/10!/4/2:0)"), Some(9));
+    assert_eq!(chapter_now(&chapters, Some(&r)), Some((2, "Chapter One".into())));
+
+    // No CFI: the rounded 9% falls back and lands one chapter ahead — the old
+    // behaviour the CFI path corrects.
+    let r = rec(None, Some(9));
+    assert_eq!(chapter_now(&chapters, Some(&r)), Some((3, "Chapter Two".into())));
+
+    // No position at all → no chapter named.
+    assert_eq!(chapter_now(&chapters, Some(&rec(None, Some(0)))), None);
+    assert_eq!(chapter_now(&chapters, None), None);
+}
+
 /// A series book with the given index, series name, and published date.
 fn series_book(index: Option<&str>, published: Option<&str>) -> EbookMetadata {
     EbookMetadata {

--- a/frontend/src/pages/book_detail/marquee/home/tests.rs
+++ b/frontend/src/pages/book_detail/marquee/home/tests.rs
@@ -208,9 +208,21 @@ fn chapter_now_prefers_the_cfi_spine_over_the_rounded_percent() {
     // the reader is in the first (spine 4), but a rounded 9% pulls the label
     // one ahead to the second (spine 6).
     let chapters = [
-        AlignmentEbookChapter { title: "Front".into(), percent: 0.0, spine_index: 0 },
-        AlignmentEbookChapter { title: "Chapter One".into(), percent: 8.4, spine_index: 4 },
-        AlignmentEbookChapter { title: "Chapter Two".into(), percent: 8.9, spine_index: 6 },
+        AlignmentEbookChapter {
+            title: "Front".into(),
+            percent: 0.0,
+            spine_index: 0,
+        },
+        AlignmentEbookChapter {
+            title: "Chapter One".into(),
+            percent: 8.4,
+            spine_index: 4,
+        },
+        AlignmentEbookChapter {
+            title: "Chapter Two".into(),
+            percent: 8.9,
+            spine_index: 6,
+        },
     ];
     let rec = |cfi: Option<&str>, pct: Option<i64>| ProgressRecord {
         book_uuid: "b".into(),
@@ -226,12 +238,18 @@ fn chapter_now_prefers_the_cfi_spine_over_the_rounded_percent() {
 
     // CFI in spine item 4 (package step 10 → ordinal 5 → 0-based 4) → Chapter One.
     let r = rec(Some("epubcfi(/6/10!/4/2:0)"), Some(9));
-    assert_eq!(chapter_now(&chapters, Some(&r)), Some((2, "Chapter One".into())));
+    assert_eq!(
+        chapter_now(&chapters, Some(&r)),
+        Some((2, "Chapter One".into()))
+    );
 
     // No CFI: the rounded 9% falls back and lands one chapter ahead — the old
     // behaviour the CFI path corrects.
     let r = rec(None, Some(9));
-    assert_eq!(chapter_now(&chapters, Some(&r)), Some((3, "Chapter Two".into())));
+    assert_eq!(
+        chapter_now(&chapters, Some(&r)),
+        Some((3, "Chapter Two".into()))
+    );
 
     // No position at all → no chapter named.
     assert_eq!(chapter_now(&chapters, Some(&rec(None, Some(0)))), None);

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -13,6 +13,7 @@ use omnibus_shared::{EbookMetadata, MergeBooksResult, SuggestionsResponse};
 use crate::components::{PageError, PageLoading, PageNotFound};
 use crate::{data, use_server_url, Route};
 
+mod chapter_ref;
 mod dates;
 mod delete;
 mod discovery;

--- a/frontend/src/pages/book_detail/mod.rs
+++ b/frontend/src/pages/book_detail/mod.rs
@@ -13,6 +13,9 @@ use omnibus_shared::{EbookMetadata, MergeBooksResult, SuggestionsResponse};
 use crate::components::{PageError, PageLoading, PageNotFound};
 use crate::{data, use_server_url, Route};
 
+// Consumed only by the web marquee resume readout and the saved-passage
+// locator, both `not(mobile)` — the mobile layout doesn't render either.
+#[cfg(not(feature = "mobile"))]
 mod chapter_ref;
 mod dates;
 mod delete;

--- a/frontend/src/pages/book_detail/rating.rs
+++ b/frontend/src/pages/book_detail/rating.rs
@@ -202,11 +202,18 @@ fn BdStarHalf(
 ) -> Element {
     let mut hover = state.hover;
     let current = state.current;
+    // The active value's own half is the un-rate control (re-clicking it
+    // clears), so it announces the clear and carries a tooltip — otherwise
+    // clearing is undiscoverable and misannounced as "Rate N stars" (#2352).
+    // `current()` is None on SSR / first hydration and reconciles post-mount
+    // (rule 07), so both sides render the "Rate …" first paint identically.
+    let label = half_star_label(value, current().map(|r| r.stars));
     rsx! {
         button {
             r#type: "button",
             class: "bd-star-half bd-star-half-{side}",
-            aria_label: rate_label(value),
+            aria_label: "{label}",
+            title: "{label}",
             onmouseenter: move |_| hover.set(Some(value)),
             onclick: move |_| {
                 if uuid.is_empty() {
@@ -362,6 +369,18 @@ fn rate_label(value: f32) -> String {
     }
 }
 
+/// Accessible label + tooltip for a half-star click target. When this half
+/// *is* the current rating, re-clicking it clears the rating — so it announces
+/// the clear (and the tooltip makes it discoverable) rather than the
+/// misleading "Rate N stars" it otherwise keeps (#2352).
+fn half_star_label(value: f32, current: Option<f32>) -> String {
+    if current == Some(value) {
+        format!("Clear your {}-star rating", fmt_stars(value))
+    } else {
+        rate_label(value)
+    }
+}
+
 /// Relative "rated N ago" phrase from a unix-seconds timestamp, computed
 /// against the injected `now` (rather than reading the clock internally) so
 /// every call site — the live widget and the other-ratings row alike — shares
@@ -385,7 +404,25 @@ fn rated_ago(now: i64, updated_at: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::rated_ago;
+    use super::{half_star_label, rated_ago};
+
+    #[test]
+    fn half_star_label_announces_clear_on_the_active_value() {
+        // #2352: the half whose value equals the saved rating is the un-rate
+        // control, so it must say it clears.
+        assert_eq!(half_star_label(3.0, Some(3.0)), "Clear your 3-star rating");
+        assert_eq!(
+            half_star_label(0.5, Some(0.5)),
+            "Clear your 0.5-star rating"
+        );
+    }
+
+    #[test]
+    fn half_star_label_rates_when_value_is_not_the_active_one() {
+        assert_eq!(half_star_label(3.0, Some(2.5)), "Rate 3 stars");
+        assert_eq!(half_star_label(4.0, Some(3.0)), "Rate 4 stars");
+        assert_eq!(half_star_label(1.0, None), "Rate 1 star");
+    }
 
     #[test]
     fn rated_ago_shows_just_now_for_sub_minute_gap() {

--- a/frontend/src/pages/landing/table/cells.rs
+++ b/frontend/src/pages/landing/table/cells.rs
@@ -5,12 +5,13 @@
 //! save callbacks.
 
 use dioxus::prelude::*;
+use dioxus_router::Link;
 use omnibus_shared::{Contributor, EbookMetadata, MetadataOverrides};
 
 use super::super::filtering::format_badge_label;
 use super::EditField;
 use crate::components::chip_editor::{ChipEditor, ChipEditorOptions, SuggestionItem};
-use crate::data;
+use crate::{data, Route};
 
 /// Shared edit context for a scalar cell wrapper: admin gating, the row's
 /// current editing signal, and the per-field save callback. Grouped so the
@@ -302,6 +303,7 @@ pub(super) fn RowScalarCell(
 /// fallback otherwise.
 #[component]
 pub(super) fn EbookRowCoverCell(
+    uuid: String,
     thumb_src: String,
     thumb_srcset: String,
     has_cover: bool,
@@ -318,23 +320,33 @@ pub(super) fn EbookRowCoverCell(
     let show_img = has_cover && broken_thumb_src.read().as_deref() != Some(thumb_src.as_str());
     rsx! {
         td { class: "ebook-col-cover", "data-testid": "ebook-cell-cover",
-            if show_img {
-                img {
-                    class: "ebook-thumb",
-                    src: "{thumb_src}",
-                    srcset: "{thumb_srcset}",
-                    sizes: "(max-width: 640px) 160px, (max-width: 1280px) 320px, 640px",
-                    alt: "Cover of {alt_title}",
-                    loading: "lazy",
-                    width: "320",
-                    height: "480",
-                    onerror: {
-                        let thumb_src = thumb_src.clone();
-                        move |_| broken_thumb_src.set(Some(thumb_src.clone()))
-                    },
+            // The row's explicit, keyboard-accessible "open details" affordance.
+            // The <tr> itself is a plain row — its editable cells are separate
+            // interactive controls, so the row must not be a role=button that
+            // wraps them — so this link carries the announced action instead,
+            // and its accessible name matches what activating it does (#2350).
+            Link {
+                to: Route::BookDetail { uuid: uuid.clone() },
+                class: "ebook-cover-link",
+                "aria-label": "Open details for {alt_title}",
+                if show_img {
+                    img {
+                        class: "ebook-thumb",
+                        src: "{thumb_src}",
+                        srcset: "{thumb_srcset}",
+                        sizes: "(max-width: 640px) 160px, (max-width: 1280px) 320px, 640px",
+                        alt: "Cover of {alt_title}",
+                        loading: "lazy",
+                        width: "320",
+                        height: "480",
+                        onerror: {
+                            let thumb_src = thumb_src.clone();
+                            move |_| broken_thumb_src.set(Some(thumb_src.clone()))
+                        },
+                    }
+                } else {
+                    div { class: "ebook-thumb ebook-thumb-fallback", "—" }
                 }
-            } else {
-                div { class: "ebook-thumb ebook-thumb-fallback", "—" }
             }
         }
     }

--- a/frontend/src/pages/landing/table/row.rs
+++ b/frontend/src/pages/landing/table/row.rs
@@ -5,7 +5,6 @@
 //! Per-cell rendering lives in [`super::cells`].
 
 use dioxus::prelude::*;
-use dioxus_router::use_navigator;
 use omnibus_shared::EbookMetadata;
 
 use super::super::sorting::{contributor_names, row_ident};
@@ -15,7 +14,6 @@ use super::cells::{
     RowScalarCellDisplay, RowSeriesCell, RowTitleCell,
 };
 use super::{BookTableContext, EditField};
-use crate::Route;
 
 /// One row in the power-user table for `book`.
 #[component]
@@ -62,7 +60,7 @@ pub(super) fn EbookRow(book: EbookMetadata, ctx: BookTableContext) -> Element {
     };
 
     rsx! {
-        EbookRowMarkup { display, uuid, ctx }
+        EbookRowMarkup { display, ctx }
     }
 }
 
@@ -224,53 +222,30 @@ fn derive_row_display(
 /// so the parent stays a thin state-setup shell. All inputs are already
 /// derived; this component does no signal seeding of its own.
 #[component]
-fn EbookRowMarkup(display: RowDisplay, uuid: String, ctx: RowContext) -> Element {
+fn EbookRowMarkup(display: RowDisplay, ctx: RowContext) -> Element {
     let mut editing = ctx.editing;
-    let nav = use_navigator();
-    let uuid_click = uuid.clone();
-    let uuid_key = uuid;
     let row_testid = display.row_testid.clone();
-    let aria_title = display.title.clone();
 
     rsx! {
         tr {
             class: "ebook-row",
             "data-testid": "{row_testid}",
             id: "{row_testid}",
-            role: "button",
-            tabindex: "0",
-            aria_label: "Open details for {aria_title}",
-            onclick: move |_| {
-                // Row-level click navigates only when no cell-level edit
-                // is in progress. Each editable cell stops propagation on
-                // click already, but a click on a non-editable area
-                // (cover, formats, dates) while a cell is open would
-                // otherwise blur+save the input AND fire the navigation.
-                // Bailing on the editing-is-some path keeps the user on
-                // the page while the blur-save lands.
-                if editing().is_some() {
-                    return;
-                }
-                nav.push(Route::BookDetail { uuid: uuid_click.clone() });
-            },
             onkeydown: move |evt: Event<KeyboardData>| {
-                if editing().is_some() {
-                    // Fallback close: the open cell's own input handles
-                    // Escape (and stops propagation) when it holds focus,
-                    // but focus can end up elsewhere in the row — a chip's
-                    // remove button, or a fresh editor whose autofocus
-                    // didn't land — leaving `editing` stuck with no input
-                    // listening for Escape. Catch it here so the amber
-                    // highlight can always be dismissed.
-                    if evt.key() == Key::Escape {
-                        editing.set(None);
-                    }
-                    return;
-                }
-                let key = evt.key();
-                if key == Key::Enter || key == Key::Character(" ".to_string()) {
-                    evt.prevent_default();
-                    nav.push(Route::BookDetail { uuid: uuid_key.clone() });
+                // Fallback close: the open cell's own input handles Escape
+                // (and stops propagation) when it holds focus, but focus can
+                // end up elsewhere in the row — a chip's remove button, or a
+                // fresh editor whose autofocus didn't land — leaving `editing`
+                // stuck with no input listening for Escape. Catch the bubbled
+                // keydown here so the amber highlight can always be dismissed.
+                //
+                // The row is no longer a `role="button"`: it holds interactive
+                // editable cells, so it must not announce itself as a single
+                // button that "opens details" while a click on those cells
+                // edits instead. The announced, keyboard-reachable navigate
+                // affordance is the cover cell's link (#2350).
+                if editing().is_some() && evt.key() == Key::Escape {
+                    editing.set(None);
                 }
             },
             EbookRowCells { display, ctx }
@@ -335,9 +310,15 @@ fn EbookRowCells(display: RowDisplay, ctx: RowContext) -> Element {
 
     rsx! {
         if is_admin {
-            EbookRowSelectCell { select_uuid, select_aria, is_selected, selected }
+            EbookRowSelectCell { select_uuid: select_uuid.clone(), select_aria, is_selected, selected }
         }
-        EbookRowCoverCell { thumb_src, thumb_srcset, has_cover, alt_title: cover_alt }
+        EbookRowCoverCell {
+            uuid: select_uuid,
+            thumb_src,
+            thumb_srcset,
+            has_cover,
+            alt_title: cover_alt,
+        }
         RowTitleCell { title, error: book.error, ctx: cell_ctx.clone() }
         EbookRowAuthorsCell {
             is_admin,

--- a/shared/src/cross_format.rs
+++ b/shared/src/cross_format.rs
@@ -206,6 +206,13 @@ pub struct AlignmentEbookChapter {
     pub title: String,
     /// Whole-book percent where the chapter starts, 0..=100.
     pub percent: f64,
+    /// 0-based spine item the chapter starts in. Lets a reading position's CFI
+    /// spine step resolve to the same chapter the reader opens, instead of the
+    /// rounded whole-book percent that lands one chapter ahead when a boundary
+    /// falls inside the rounding window (#2345). `#[serde(default)]` so a
+    /// payload from a server predating the field still decodes.
+    #[serde(default)]
+    pub spine_index: i64,
 }
 
 /// One audio file segment for the lane, in current ordinal order.

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -838,9 +838,13 @@ test("lists a saved passage with its locator, note and date, then deletes it", a
   await expect(card.getByTestId("highlight-note")).toHaveText(
     "the line that stuck",
   );
-  // The locator is derived from the CFI's spine step (/14 → section 7); the
+  // The locator names the reader's chapter once the book's chapter structure
+  // is known, and falls back to the CFI's raw spine step (/14 → section 7)
+  // until then (#2356) — either is a valid locator for the same position. The
   // date comes from the server-assigned created_at.
-  await expect(card.getByTestId("highlight-meta")).toContainText("Section 7");
+  await expect(card.getByTestId("highlight-meta")).toContainText(
+    /(?:Chapter|Section) \d+/,
+  );
   await expect(card.getByTestId("highlight-meta")).toContainText("saved ");
 
   // Delete it — the RPC must fire and the card must leave the list.

--- a/ui_tests/playwright/tests/flows/book_detail.spec.ts
+++ b/ui_tests/playwright/tests/flows/book_detail.spec.ts
@@ -250,13 +250,16 @@ test("navigates from a landing row to the detail page and back", async ({
   await gotoReady(page, "/");
   await switchToTableView(page);
 
-  // Click the row's cover cell to follow the SPA navigation. We target the
-  // cover specifically because the seeded admin sees inline-editable cells
-  // (title, author, …) that intercept clicks to open their editor instead of
-  // navigating; the cover cell is non-editable, so its click bubbles to the
-  // row's navigate handler — what a user clicking a non-interactive part of
-  // the row gets.
-  await getRow(page, TARGET.slug).getByTestId("ebook-cell-cover").click();
+  // #2350: the row is a plain <tr> — its editable cells (title, author, …)
+  // are separate interactive controls, so it is no longer a role="button"
+  // that claims to "open details" while a click on those cells edits instead.
+  // The announced, keyboard-reachable navigate affordance is the cover cell's
+  // link; assert its accessible name matches its action, then activate it.
+  const openLink = getRow(page, TARGET.slug).getByRole("link", {
+    name: `Open details for ${TARGET.title}`,
+  });
+  await expect(openLink).toBeVisible();
+  await openLink.click();
   // `/books/:uuid` — UUIDv5 in canonical 8-4-4-4-12 hyphenated form.
   await expect(page).toHaveURL(/\/books\/[0-9a-fA-F-]{36}$/);
 
@@ -612,15 +615,22 @@ test("rates a book a half-star, persists across reload, then un-rates", async ({
   await gotoReady(page, `/books/${uuid}`);
   await expect(page.getByTestId("rating-meta")).toContainText("4.5 of 5");
 
-  // Re-clicking the active half-star clears the rating (un-rate) and cleans up
-  // shared server state for the next run.
+  // #2352: once rated, the active half-star becomes the un-rate control and
+  // announces it — "Clear your 4.5-star rating" — instead of keeping the
+  // misleading "Rate 4.5 stars". Re-clicking it clears the rating (and cleans
+  // up shared server state for the next run).
+  await expect(
+    page
+      .getByTestId("rating-stars")
+      .getByRole("button", { name: "Clear your 4.5-star rating" }),
+  ).toBeVisible();
   await expectMutation(
     page,
     { method: "POST", url: "/api/rpc/ratings/clear", expectedStatus: 200 },
     async () =>
       page
         .getByTestId("rating-stars")
-        .getByRole("button", { name: "Rate 4.5 stars" })
+        .getByRole("button", { name: "Clear your 4.5-star rating" })
         .click(),
   );
   await expect(page.getByTestId("rating-meta")).toHaveText("Not rated yet");


### PR DESCRIPTION
## Summary
Six independent correctness fixes across the library, book-detail, and reader surfaces. The only shared code is the `chapter_ref` CFI→chapter helper that #2345 and #2356 both use.

- Authors index: relabel the header's second figure "author credits" — it is Σ per-author book counts, which a multi-creator book inflates past the distinct-title total (Closes #2292)
- Book-detail rating: the active half-star clears on re-click, so it announces "Clear your N-star rating" (aria-label + tooltip) instead of the misleading "Rate N stars" (Closes #2352)
- Library table row: drop the invalid `role="button"` on a `<tr>` that wraps interactive editable cells; the cover cell is now a keyboard-reachable "Open details for X" link (Closes #2350)
- Library Author sort: derive a surname-first `author_sort` at every write path plus an idempotent boot backfill, so the axis keys every row alike instead of mixing "Weir, Andy" and "Andy Weir" (Closes #2342)
- Book-detail resume chapter: resolve the chapter from the reading position's CFI spine step, not the rounded percent that landed one chapter ahead when a boundary fell in the rounding window (Closes #2345)
- Saved passage: name the reader's TOC chapter (CFI spine → chapter), not the raw spine "Section N" that counts front matter (Closes #2356)
- Known residual (#2342): a book with a *creators override* lacking `file_as` still sorts on its given-first name — closing that means baking a sort key into stored override JSON, deliberately out of scope here.

## Test plan
- [x] `just test` — full matrix green (db + server + frontend server/mobile + shared)
- [x] `just lint` — fmt + clippy (server, frontend-server, mobile, wasm32-web) + stylelint green
- [x] New Rust tests: author-sort key/backfill/write-path (#2342), `chapter_now`/`chapter_index_for_cfi` (#2345), `highlight_locator` chapter mapping (#2356), `half_star_label` (#2352), `index_subtitle` (#2292)
- [ ] Playwright specs updated (row cover-link nav, rating clear, saved-passage locator) — E2E runs in CI via `run_ui_tests`

## Version
- [x] **Patch** — bug fixes only; the new `AlignmentEbookChapter.spine_index` wire field is additive (`#[serde(default)]`), so older mobile clients keep decoding.