### PR TITLE
[OMNI-2375] Key the Detail Accent to the Book's Tone

### DIFF
--- a/omnibus-ios/omnibus/Design/Theme.swift
+++ b/omnibus-ios/omnibus/Design/Theme.swift
@@ -43,8 +43,10 @@ struct Palette: Sendable {
     let ink1: OKLCH
     let ink2: OKLCH
     let ink3: OKLCH
-    let accent: OKLCH
-    let accentSoft: OKLCH
+    /// `var` so `accented(by:)` can re-key a copy; the static themes below
+    /// are still the only places a palette is built from scratch.
+    var accent: OKLCH
+    var accentSoft: OKLCH
     let accentInk: OKLCH
     let coverFallbackBg: OKLCH
     let coverFallbackInk: OKLCH
@@ -154,6 +156,22 @@ struct Palette: Sendable {
         case .light: .light
         case .sepia: .sepia
         }
+    }
+
+    /// This palette with its accent re-keyed to a book's tone — how a screen
+    /// devoted to one book takes that book's color.
+    ///
+    /// Only hue and chroma come from the tone. Lightness stays the theme's
+    /// own: it is what the theme's `accentInk` was chosen against, so any
+    /// cover color — a near-black jacket included — yields a control whose
+    /// label still reads. Chroma is clamped into the band the theme accents
+    /// occupy rather than taken raw, so a neon cover doesn't outshine the
+    /// page and a grey one keeps a trace of identity.
+    func accented(by tone: OKLCH) -> Palette {
+        var copy = self
+        copy.accent = OKLCH(accent.l, min(max(tone.c, 0.05), 0.16), tone.h)
+        copy.accentSoft = OKLCH(accentSoft.l, min(max(tone.c * 0.6, 0.03), accentSoft.c), tone.h)
+        return copy
     }
 }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -399,6 +399,18 @@ struct BookDetailView: View {
                 }
             }
         }
+        // Outermost, so the stops, bars, chrome, and every sheet above all
+        // inherit the book-toned accent.
+        .environment(\.palette, bookPalette)
+        .tint(bookPalette.accentColor)
+    }
+
+    /// The screen's palette: the theme re-keyed to this book's tone, resolved
+    /// the same way the cover plate and art halo resolve it — so a coverless
+    /// book's controls match the plate it is showing.
+    private var bookPalette: Palette {
+        guard let book = model.book else { return palette }
+        return palette.accented(by: CoverIdentity(book).tone)
     }
 
     /// Open the player on the file the picker chose, once its sheet is gone.
@@ -807,8 +819,12 @@ struct DetailArtLayer: View {
                 path: "/api/covers/\(book.uuid)",
                 alternates: ["/api/thumbs/\(book.uuid)/lg"]
             ) {
-                GeneratedCoverPlate(identity: CoverIdentity(book))
+                Color.clear
             }
+            // Permanent backdrop, not a loading placeholder — the same rule
+            // as `BookCover`: a transparent or degenerate cover image loads
+            // "successfully" and would otherwise leave a black band.
+            .background { GeneratedCoverPlate(identity: CoverIdentity(book)) }
             .frame(width: width, height: imageHeight)
             .offset(y: -progress * travel)
             .frame(width: width, height: BookDetailView.artHeight, alignment: .top)

--- a/omnibus-ios/omnibusTests/PaletteAccentTests.swift
+++ b/omnibus-ios/omnibusTests/PaletteAccentTests.swift
@@ -1,0 +1,36 @@
+//  PaletteAccentTests.swift
+//  The book-toned accent derivation behind the detail screen: the tone's hue
+//  carries the identity, the theme's lightness band keeps the ink contract.
+
+import Testing
+
+@testable import omnibus
+
+@Test func accentedPaletteTakesTheTonesHue() {
+    let toned = Palette.atrium.accented(by: OKLCH(0.52, 0.16, 28))
+    #expect(toned.accent.h == 28)
+    #expect(toned.accentSoft.h == 28)
+}
+
+@Test func accentedPaletteKeepsTheThemesLightnessForInkContrast() {
+    let toned = Palette.sepia.accented(by: OKLCH(0.95, 0.02, 200))
+    #expect(toned.accent.l == Palette.sepia.accent.l)
+    #expect(toned.accentSoft.l == Palette.sepia.accentSoft.l)
+    #expect(toned.accentInk.l == Palette.sepia.accentInk.l)
+}
+
+@Test func accentedPaletteClampsChromaIntoTheAccentBand() {
+    // A neon tone is tempered; a grey one keeps a trace of identity.
+    let neon = Palette.atrium.accented(by: OKLCH(0.6, 0.4, 140))
+    #expect(neon.accent.c == 0.16)
+    let grey = Palette.atrium.accented(by: OKLCH(0.3, 0.0, 0))
+    #expect(grey.accent.c == 0.05)
+}
+
+@Test func accentedPaletteLeavesEverythingElseAlone() {
+    let toned = Palette.atrium.accented(by: OKLCH(0.52, 0.16, 28))
+    #expect(toned.bg0.l == Palette.atrium.bg0.l)
+    #expect(toned.ink0.l == Palette.atrium.ink0.l)
+    #expect(toned.ok.h == Palette.atrium.ok.h)
+    #expect(toned.bad.h == Palette.atrium.bad.h)
+}


### PR DESCRIPTION
## Summary
- Adds `Palette.accented(by:)`: re-keys `accent`/`accentSoft` to the book tone's hue and chroma while keeping the theme's accent lightness band, so `accentInk` and every theme's contrast contract hold for any cover color.
- Applies it as one environment override (plus `.tint`) across the whole detail subtree, sourced from `CoverIdentity(book).tone` — CTA, ruler, kicker, chips, dot rail, pills, links, and sheets all take the book's color with no per-view changes.
- Rides along: the detail art layer now keeps the generated plate as a permanent backdrop behind the cover image (same rule as `BookCover`), fixing a black art band on books whose cover image is transparent or degenerate.

Closes #2375

## Test plan
- [x] `just ios-test` — 629 passed / 0 failed, including 4 new `PaletteAccentTests` (hue adoption, lightness-band retention, chroma clamp, non-accent fields untouched)
- [x] Simulator: two books render visibly different screen accents (plum vs gold) across CTA, ruler, kicker, dot rail, Write pill, sync tie, download badges; coverless book's accent matches its plate

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.