### PR TITLE
[OMNI-2381] Restore Edge-Swipe Back and Clear the Chrome Discs

### DIFF
--- a/omnibus-ios/omnibus/Design/Components/EdgeSwipeBack.swift
+++ b/omnibus-ios/omnibus/Design/Components/EdgeSwipeBack.swift
@@ -1,0 +1,95 @@
+//  EdgeSwipeBack.swift
+//  Keeps the edge-swipe back gesture alive on screens that hide the system
+//  navigation bar.
+//
+//  `UINavigationController` gates its interactive pop on an internal delegate
+//  that refuses the gesture while the bar is hidden — so a screen drawing its
+//  own chrome (the book detail marquee) silently loses the most ingrained
+//  back gesture on the platform. Re-pointing the recognizer at a delegate of
+//  our own restores it.
+
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Re-enables the enclosing navigation controller's edge-swipe back
+    /// gesture. Attach to any screen that hides the navigation bar.
+    func keepsEdgeSwipeBack() -> some View {
+        background(EdgeSwipeBackEnabler())
+    }
+}
+
+/// The recognizer's replacement delegate: allow the pop whenever the stack
+/// has somewhere to pop to and no transition is mid-flight — the same answer
+/// the system gives with the bar visible.
+///
+/// Stateless and shared, deliberately: `UIGestureRecognizer.delegate` is
+/// weak, so a per-view delegate that deallocates on pop would leave the
+/// recognizer with no gate at all — and an ungated pop on a root screen
+/// wedges the stack. The navigation controller is resolved per-call from the
+/// recognizer's own view, so one instance serves every tab's stack.
+final class EdgeSwipeBackDelegate: NSObject, UIGestureRecognizerDelegate {
+    static let shared = EdgeSwipeBackDelegate()
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let navigationController = Self.navigationController(of: gestureRecognizer)
+        else { return false }
+        return navigationController.viewControllers.count > 1
+            && navigationController.transitionCoordinator == nil
+    }
+
+    /// The navigation controller owning this recognizer, via the responder
+    /// chain from the recognizer's view.
+    static func navigationController(of recognizer: UIGestureRecognizer)
+        -> UINavigationController?
+    {
+        var responder: UIResponder? = recognizer.view
+        while let current = responder {
+            if let navigationController = current as? UINavigationController {
+                return navigationController
+            }
+            responder = current.next
+        }
+        return nil
+    }
+}
+
+/// Invisible representable that walks up to the enclosing navigation
+/// controller once it lands in the hierarchy and installs the delegate.
+private struct EdgeSwipeBackEnabler: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> Proxy { Proxy() }
+    func updateUIViewController(_ proxy: Proxy, context: Context) {}
+
+    final class Proxy: UIViewController {
+        override func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            install()
+        }
+
+        // `didMove` can fire before the navigation controller is reachable;
+        // by first appearance it always is.
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            install()
+        }
+
+        private func install() {
+            guard let recognizer = enclosingNavigationController?
+                .interactivePopGestureRecognizer
+            else { return }
+            recognizer.delegate = EdgeSwipeBackDelegate.shared
+            recognizer.isEnabled = true
+        }
+
+        private var enclosingNavigationController: UINavigationController? {
+            var responder: UIResponder? = self
+            while let current = responder {
+                if let navigationController = current as? UINavigationController {
+                    return navigationController
+                }
+                responder = current.next
+            }
+            return nil
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -315,6 +315,8 @@ struct BookDetailView: View {
         .toolbar(.hidden, for: .navigationBar)
         .toolbar(.hidden, for: .tabBar)
         .navigationBarBackButtonHidden(true)
+        // Hiding the bar kills the system's edge-swipe pop; bring it back.
+        .keepsEdgeSwipeBack()
         .bookZoomDestination(uuid, in: bookZoom)
         .task { await model.load(uuid: uuid) }
         .refreshTask { await model.load(uuid: uuid) }
@@ -482,7 +484,9 @@ struct BookDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(EdgeInsets(
-            top: isHome ? 14 : 104,
+            // A full stop's label must clear the chrome discs, which end
+            // ~105pt below the top edge on current devices.
+            top: isHome ? 14 : 128,
             leading: 22,
             bottom: Self.barClearance,
             trailing: 30

--- a/omnibus-ios/omnibusTests/EdgeSwipeBackTests.swift
+++ b/omnibus-ios/omnibusTests/EdgeSwipeBackTests.swift
@@ -1,0 +1,37 @@
+//  EdgeSwipeBackTests.swift
+//  The restored edge-swipe back gesture's gate: pop only when the stack has
+//  somewhere to pop to — an ungated pop on a root screen wedges the stack.
+
+import Testing
+import UIKit
+
+@testable import omnibus
+
+@Test @MainActor func edgeSwipeBeginsOnlyWithSomewhereToPop() throws {
+    let navigationController = UINavigationController(rootViewController: UIViewController())
+    navigationController.loadViewIfNeeded()
+    let recognizer = try #require(navigationController.interactivePopGestureRecognizer)
+
+    // At the root there is nowhere to pop to.
+    #expect(!EdgeSwipeBackDelegate.shared.gestureRecognizerShouldBegin(recognizer))
+
+    navigationController.pushViewController(UIViewController(), animated: false)
+    #expect(EdgeSwipeBackDelegate.shared.gestureRecognizerShouldBegin(recognizer))
+}
+
+@Test @MainActor func edgeSwipeResolvesItsOwnNavigationController() throws {
+    // Two stacks, one shared delegate: each recognizer answers for its own
+    // stack, so one tab's depth can't leak into another's.
+    let deep = UINavigationController(rootViewController: UIViewController())
+    deep.loadViewIfNeeded()
+    deep.pushViewController(UIViewController(), animated: false)
+    let shallow = UINavigationController(rootViewController: UIViewController())
+    shallow.loadViewIfNeeded()
+
+    let deepRecognizer = try #require(deep.interactivePopGestureRecognizer)
+    let shallowRecognizer = try #require(shallow.interactivePopGestureRecognizer)
+
+    #expect(EdgeSwipeBackDelegate.navigationController(of: deepRecognizer) === deep)
+    #expect(EdgeSwipeBackDelegate.shared.gestureRecognizerShouldBegin(deepRecognizer))
+    #expect(!EdgeSwipeBackDelegate.shared.gestureRecognizerShouldBegin(shallowRecognizer))
+}


### PR DESCRIPTION
## Summary
- Adds `EdgeSwipeBack.swift`: hiding the navigation bar makes UIKit's internal delegate refuse the interactive pop, so the detail screen re-points `interactivePopGestureRecognizer` at a shared stateless delegate that allows the pop when the stack has somewhere to pop to and no transition is running — stateless because the delegate property is weak, and a deallocating per-view delegate would leave the gesture ungated (the frozen-root-stack bug).
- Raises the full-panel stops' top padding 104 → 128 so the stop label clears the 38pt chrome discs.

Fixes #2381

## Test plan
- [x] `just ios-test` — 631 passed / 0 failed, including 2 new `EdgeSwipeBackTests` (pop gated on stack depth; per-stack resolution across two navigation controllers)
- [x] Simulator: edge swipe pops the detail from a mid-stack stop (tab bar restores), the same swipe at the Library root is inert, and navigation stays healthy after both; stop label sits clear of the back disc

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.