### PR TITLE
fix: render the stale sync line in the warning colour

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -11092,7 +11092,9 @@ html {
   font-size: 10.5px; color: var(--ink-3); margin-top: 12px;
   display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
 }
-.bdmq-syncline-warn { color: var(--warn); }
+/* Scoped past `.atrium .mono`, which this line carries for its face and
+   which would otherwise win the colour on specificity alone. */
+.bdmq-syncline.bdmq-syncline-warn { color: var(--warn); }
 .bdmq-synclink {
   border: 0; background: transparent; padding: 0; cursor: pointer;
   font-family: var(--mono); font-size: 10.5px; letter-spacing: .02em;


### PR DESCRIPTION
## Summary
- `.bdmq-syncline-warn { color: var(--warn) }` was dead CSS. The base utility is declared `.mono, .atrium .mono { … color: var(--ink-1) }`, and the `.atrium .mono` half is (0,2,0) against the warn rule's (0,1,0) — so the book-detail sync line's stale state has always rendered in ordinary ink rather than amber. Scoping it to `.bdmq-syncline.bdmq-syncline-warn` restores the colour the rule was written to apply; the comment mirrors the same fix already made at `.st-log .st-log-when`.
- The `.atrium` prefix on `.mono` is load-bearing, so the tempting root fix is unsafe: `.atrium a { color: inherit }` is (0,1,1), so dropping `.mono` to (0,1,0) via `:where(.atrium)` would silently break every mono anchor. Any future sweep has to deal with that first.

## Test plan
- [x] `just lint-css` clean. Pure CSS change — no Rust touched, so no cargo lane applies.
- [x] Verified live against a dev server with the class applied to the real line: `getComputedStyle(line).color` now returns `lab(74.4048 16.5655 55.5067)` (= `--warn`), where before the change it returned `lab(79.1367 …)` (= `--ink-1`).
- [ ] No automated guard. The stale flag needs the audio files to change after linking, which a Playwright spec can't readily force, so there is no regression test on this line.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes

>[!WARNING]
> `--warn` and `--accent` are `oklch(0.78 0.13 75)` and `oklch(0.78 0.13 65)` — identical lightness, identical chroma, 10° of hue apart — and the `light` theme inherits both from `:root`. At the line's real 10.5px they are indistinguishable. The fix still does its job, because the distinction that matters is against the *normal* line's `--ink-3` grey, and nothing on the stale line is accent-coloured at rest; but on hover the affordance goes `--accent` and matches the warn text, which weakens the hover affordance. If the stale state should be unmistakable, the house pattern is a non-colour signal — `.worker-status-warn` pairs warn with a left border and an 8% tint, `.tkx-pill-idle` with a tinted pill border.

This is one instance of a systemic trap, not a straggler. An audit of the markup found **98 classes across 126 sites** carrying `mono`/`label` alongside a single-class colour rule that loses to `.atrium .mono` / `.atrium .label` the same way. Most are cosmetic (a hint rendering one step brighter than its intended `--ink-3`), but a few are semantic:

| Class | Declares | Sites |
|---|---|---|
| `.bd-journal-error` | `var(--bad)` | 3 — journal error messages do not render red |
| `.m-sort-pill-badge` | `var(--accent-ink)` | 1 — near-black ink meant for an accent-filled badge |
| `.me-label-edited`, `.m-sheet-meta-num`, `.mg-kicker`, `.m-player-eyebrow` | `var(--accent)` | 6 |
| `.del-badge`, `.m-strip-badge` | `var(--ink-0)` | 2 |

`.bd-journal-error` is the one worth fixing next.

>[!NOTE]
> This one-line diff sits directly adjacent to the `.bdmq-synclink` block changed in #2379, which is still open — expect a trivial conflict depending on merge order.