### PR TITLE
fix: bring the iOS tab bar back with the pop, not after it

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -302,7 +302,9 @@ surface as `mobile/`, never the `/api/rpc/*` server functions.
 omnibusApp.swift    — @main OmnibusApp: audio session + appearance bootstrap
 App/                — AppState (server URL, auth, theme), RootView phase router
                       (launching → connect → login → tabs), MainTabView shell +
-                      destination routing + global reader/player presentation
+                      destination routing + the four tabs' navigation paths
+                      (which is what decides whether the bottom bar is up) +
+                      global reader/player presentation
 Design/             — Theme (Atrium tokens + the type scale), Fonts/ (static
                       cuts of Cormorant Garamond / Instrument Sans / Space Mono,
                       the three families the web pulls from Google Fonts, each

--- a/omnibus-ios/omnibus/App/MainTabView.swift
+++ b/omnibus-ios/omnibus/App/MainTabView.swift
@@ -22,6 +22,24 @@ enum Destination: Hashable {
     case authorsIndex
     case searchResults(query: String)
     case metadataEdit(uuid: String)
+
+    /// Whether this screen draws its own bottom-edge chrome, so the tab bar
+    /// and mini player must step aside for it.
+    var hidesTabBar: Bool {
+        if case .book = self { return true }
+        return false
+    }
+}
+
+extension [Destination] {
+    /// Whether anything in this stack is holding the bottom edge.
+    ///
+    /// The whole stack, not just its top: a book detail with the metadata
+    /// editor pushed over it still owns that edge, and the bar stays away
+    /// until the detail itself pops.
+    var hidesTabBar: Bool {
+        contains { $0.hidesTabBar }
+    }
 }
 
 struct MainTabView: View {
@@ -32,20 +50,50 @@ struct MainTabView: View {
     @State private var selection: AppTab = .library
     @State private var addSheetPresented = false
     @State private var reselect = TabReselect()
+    // One navigation path per tab, owned here rather than by each tab root:
+    // whether the bottom bar is up is a question about the *selected* stack,
+    // and this is the only view that knows which stack that is.
+    @State private var libraryPath: [Destination] = []
+    @State private var searchPath: [Destination] = []
+    @State private var statsPath: [Destination] = []
+    @State private var accountPath: [Destination] = []
+
+    /// The stack the reader is actually looking at. A tab switch changes the
+    /// answer below without anything having been pushed or popped.
+    private var activePath: [Destination] {
+        switch selection {
+        case .library: libraryPath
+        case .search: searchPath
+        case .stats: statsPath
+        case .you: accountPath
+        }
+    }
+
+    /// Whether an immersive detail screen is up.
+    ///
+    /// Derived from the navigation path rather than that screen's own
+    /// `onAppear` / `onDisappear`, because a `NavigationStack` fires the
+    /// latter only once the pop has *finished*: the bar used to sit out the
+    /// whole transition and only then spring back, which read as a lag on
+    /// every exit. A bound path moves the instant the pop is committed, so
+    /// the bar now returns alongside the screen sliding away.
+    private var isImmersiveDetail: Bool {
+        activePath.hidesTabBar
+    }
 
     var body: some View {
         TabView(selection: $selection) {
             Tab(value: AppTab.library) {
-                LibraryView(addSheetPresented: $addSheetPresented)
+                LibraryView(addSheetPresented: $addSheetPresented, path: $libraryPath)
             }
             Tab(value: AppTab.search) {
-                SearchTab()
+                SearchTab(path: $searchPath)
             }
             Tab(value: AppTab.stats) {
-                StatsView()
+                StatsView(path: $statsPath)
             }
             Tab(value: AppTab.you) {
-                AccountView()
+                AccountView(path: $accountPath)
             }
         }
         // `TabView` keeps tab state and lazy loading; only its chrome is
@@ -57,7 +105,7 @@ struct MainTabView: View {
             // bar sits where the tabs do — so the whole block steps aside
             // while one is up. Audio keeps playing; the mini player returns
             // with the bar on pop.
-            if !Presentation.shared.isImmersiveDetail {
+            if !isImmersiveDetail {
                 VStack(spacing: 0) {
                     if player.isActive {
                         MiniPlayerBar()
@@ -71,7 +119,7 @@ struct MainTabView: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        .animation(Motion.glide, value: Presentation.shared.isImmersiveDetail)
+        .animation(Motion.glide, value: isImmersiveDetail)
         // The keyboard belongs over the tab bar, not under it. Has to sit on
         // the modified view — on the inset's content it is a no-op (#2102).
         .ignoresSafeArea(.keyboard, edges: .bottom)
@@ -165,22 +213,6 @@ final class Presentation {
 
     var reader: ReaderSession?
     var player: ReaderSession?
-
-    /// How many immersive detail screens are on screen — pushed book details
-    /// hide the tab bar and mini player. A count, not a flag: a series-strip
-    /// tap pushes a second detail over the first, and appear/disappear of the
-    /// two interleave during the transition.
-    private(set) var immersiveDetailDepth = 0
-
-    var isImmersiveDetail: Bool { immersiveDetailDepth > 0 }
-
-    func pushImmersiveDetail() {
-        immersiveDetailDepth += 1
-    }
-
-    func popImmersiveDetail() {
-        immersiveDetailDepth = max(0, immersiveDetailDepth - 1)
-    }
 
     /// Bumped once a reading or listening session has *persisted* its final
     /// position. Surfaces that show resume state observe this instead of

--- a/omnibus-ios/omnibus/App/MainTabView.swift
+++ b/omnibus-ios/omnibus/App/MainTabView.swift
@@ -1,7 +1,8 @@
 //  MainTabView.swift
-//  The signed-in shell: five native tabs, one NavigationStack each (so every
-//  push gets interactive swipe-back for free), and the audiobook mini player
-//  docked in the tab bar's accessory slot.
+//  The signed-in shell: four native tabs, one NavigationStack each (so every
+//  push gets interactive swipe-back for free). The system tab bar is hidden and
+//  replaced by `OmnibusTabBar` in a bottom safe-area inset, with the audiobook
+//  mini player stacked directly above it.
 
 import SwiftUI
 
@@ -42,6 +43,29 @@ extension [Destination] {
     }
 }
 
+/// The four tabs' navigation stacks, held together so the tab → stack mapping
+/// is one nameable thing rather than a `switch` buried in a view.
+///
+/// Worth a type of its own because a transposed case in the subscript type
+/// checks perfectly and would simply answer for the wrong tab — the bar would
+/// go missing on one and linger on another. `tabPathsSubscriptReadsEachTabsOwnStack`
+/// is what actually pins it.
+struct TabPaths: Equatable {
+    var library: [Destination] = []
+    var search: [Destination] = []
+    var stats: [Destination] = []
+    var you: [Destination] = []
+
+    subscript(tab: AppTab) -> [Destination] {
+        switch tab {
+        case .library: library
+        case .search: search
+        case .stats: stats
+        case .you: you
+        }
+    }
+}
+
 struct MainTabView: View {
     @Environment(AppState.self) private var app
     @Environment(AudioPlayer.self) private var player
@@ -53,21 +77,7 @@ struct MainTabView: View {
     // One navigation path per tab, owned here rather than by each tab root:
     // whether the bottom bar is up is a question about the *selected* stack,
     // and this is the only view that knows which stack that is.
-    @State private var libraryPath: [Destination] = []
-    @State private var searchPath: [Destination] = []
-    @State private var statsPath: [Destination] = []
-    @State private var accountPath: [Destination] = []
-
-    /// The stack the reader is actually looking at. A tab switch changes the
-    /// answer below without anything having been pushed or popped.
-    private var activePath: [Destination] {
-        switch selection {
-        case .library: libraryPath
-        case .search: searchPath
-        case .stats: statsPath
-        case .you: accountPath
-        }
-    }
+    @State private var paths = TabPaths()
 
     /// Whether an immersive detail screen is up.
     ///
@@ -78,22 +88,22 @@ struct MainTabView: View {
     /// every exit. A bound path moves the instant the pop is committed, so
     /// the bar now returns alongside the screen sliding away.
     private var isImmersiveDetail: Bool {
-        activePath.hidesTabBar
+        paths[selection].hidesTabBar
     }
 
     var body: some View {
         TabView(selection: $selection) {
             Tab(value: AppTab.library) {
-                LibraryView(addSheetPresented: $addSheetPresented, path: $libraryPath)
+                LibraryView(addSheetPresented: $addSheetPresented, path: $paths.library)
             }
             Tab(value: AppTab.search) {
-                SearchTab(path: $searchPath)
+                SearchTab(path: $paths.search)
             }
             Tab(value: AppTab.stats) {
-                StatsView(path: $statsPath)
+                StatsView(path: $paths.stats)
             }
             Tab(value: AppTab.you) {
-                AccountView(path: $accountPath)
+                AccountView(path: $paths.you)
             }
         }
         // `TabView` keeps tab state and lazy loading; only its chrome is

--- a/omnibus-ios/omnibus/Features/Account/AccountView.swift
+++ b/omnibus-ios/omnibus/Features/Account/AccountView.swift
@@ -10,6 +10,13 @@
 import SwiftUI
 
 struct AccountView: View {
+    /// Owned by `MainTabView` — see `isImmersiveDetail` there.
+    @Binding var path: [Destination]
+
+    init(path: Binding<[Destination]>) {
+        _path = path
+    }
+
     @Environment(AppState.self) private var app
     @Environment(\.palette) private var palette
 
@@ -33,7 +40,7 @@ struct AccountView: View {
     var body: some View {
         @Bindable var app = app
 
-        NavigationStack {
+        NavigationStack(path: $path) {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 30) {
                     Masthead(title: "You")

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -320,11 +320,6 @@ struct BookDetailView: View {
         .bookZoomDestination(uuid, in: bookZoom)
         .task { await model.load(uuid: uuid) }
         .refreshTask { await model.load(uuid: uuid) }
-        // The tab bar and mini player yield the bottom edge to the action
-        // bar while this screen is up. Counted, not toggled: a series-strip
-        // tap pushes a second detail over this one.
-        .onAppear { Presentation.shared.pushImmersiveDetail() }
-        .onDisappear { Presentation.shared.popImmersiveDetail() }
         .sheet(isPresented: $showAlignment) {
             if let book = model.book {
                 AlignmentSheet(book: book) {

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -227,15 +227,17 @@ final class LibraryModel {
 
 struct LibraryView: View {
     @Binding var addSheetPresented: Bool
+    /// Owned by `MainTabView` — see `isImmersiveDetail` there.
+    @Binding var path: [Destination]
 
-    init(addSheetPresented: Binding<Bool>) {
+    init(addSheetPresented: Binding<Bool>, path: Binding<[Destination]>) {
         _addSheetPresented = addSheetPresented
+        _path = path
     }
 
     @Environment(\.palette) private var palette
     @Environment(AppState.self) private var app
     @State private var model = LibraryModel()
-    @State private var path = NavigationPath()
     @Namespace private var bookZoom
     private var presentation = Presentation.shared
 

--- a/omnibus-ios/omnibus/Features/Search/SearchTab.swift
+++ b/omnibus-ios/omnibus/Features/Search/SearchTab.swift
@@ -10,9 +10,15 @@
 import SwiftUI
 
 struct SearchTab: View {
+    /// Owned by `MainTabView` — see `isImmersiveDetail` there.
+    @Binding var path: [Destination]
+
+    init(path: Binding<[Destination]>) {
+        _path = path
+    }
+
     @Environment(\.palette) private var palette
     @Environment(TabReselect.self) private var reselect
-    @State private var path = NavigationPath()
 
     var body: some View {
         NavigationStack(path: $path) {

--- a/omnibus-ios/omnibus/Features/Search/SearchTab.swift
+++ b/omnibus-ios/omnibus/Features/Search/SearchTab.swift
@@ -29,7 +29,7 @@ struct SearchTab: View {
         // page — unwinding any pushed authors/series/tags screens.
         .onChange(of: reselect.token) { _, _ in
             guard reselect.tab == .search, !path.isEmpty else { return }
-            withAnimation(Motion.glide) { path.removeLast(path.count) }
+            withAnimation(Motion.glide) { path.removeAll() }
         }
     }
 }

--- a/omnibus-ios/omnibus/Features/Stats/StatsView.swift
+++ b/omnibus-ios/omnibus/Features/Stats/StatsView.swift
@@ -13,6 +13,16 @@
 import SwiftUI
 
 struct StatsView: View {
+    /// Owned by `MainTabView` (see `isImmersiveDetail` there) and read here so
+    /// the tab can tell a pop apart from a tab switch: the goals are edited on
+    /// a screen pushed onto this stack, and returning from it has to re-read a
+    /// summary the write has already invalidated.
+    @Binding var path: [Destination]
+
+    init(path: Binding<[Destination]>) {
+        _path = path
+    }
+
     @Environment(\.palette) private var palette
 
     @State private var range: StatsRange = .month
@@ -39,10 +49,6 @@ struct StatsView: View {
     @State private var standingSummary: StatsSummary?
     @State private var isLoading = true
     @State private var error: String?
-    /// Owned here so the tab can tell a pop apart from a tab switch: the goals
-    /// are edited on a screen pushed onto this stack, and returning from it has
-    /// to re-read a summary the write has already invalidated.
-    @State private var path = NavigationPath()
     /// Whether the tab has been on screen once. `onAppear` and `task` both
     /// fire on the first appearance, so without this the reload below doubles
     /// the opening fetch on every launch.

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -240,26 +240,3 @@ private func sitting(
     #expect(preview == "The Cinder scene lands differently in audio")
 }
 
-// MARK: - Immersive chrome
-
-@Test func onlyTheBookDetailYieldsTheBottomEdge() {
-    #expect(Destination.book(uuid: "u").hidesTabBar)
-    #expect(!Destination.metadataEdit(uuid: "u").hidesTabBar)
-    #expect(!Destination.author(id: 1).hidesTabBar)
-    #expect(!Destination.shelves.hidesTabBar)
-    #expect(!Destination.settings.hidesTabBar)
-}
-
-@Test func aStackYieldsTheBottomEdgeUntilTheDetailItselfPops() {
-    #expect(![Destination]().hidesTabBar)
-    #expect([Destination.shelves, .shelf(id: 1)].hidesTabBar == false)
-
-    // A detail pushed over a detail, and the metadata editor pushed over
-    // one: both still hold the edge, so the answer is about the whole stack
-    // rather than its top.
-    #expect([Destination.book(uuid: "a"), .book(uuid: "b")].hidesTabBar)
-    #expect([Destination.book(uuid: "a"), .metadataEdit(uuid: "a")].hidesTabBar)
-
-    // And popping the last detail is what brings the bar back.
-    #expect(![Destination.author(id: 1)].hidesTabBar)
-}

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -240,26 +240,26 @@ private func sitting(
     #expect(preview == "The Cinder scene lands differently in audio")
 }
 
-// MARK: - Immersive chrome depth
+// MARK: - Immersive chrome
 
-@Test @MainActor func immersiveDepthSurvivesNestedDetailsAndClampsAtZero() {
-    let presentation = Presentation.shared
-    #expect(!presentation.isImmersiveDetail)
+@Test func onlyTheBookDetailYieldsTheBottomEdge() {
+    #expect(Destination.book(uuid: "u").hidesTabBar)
+    #expect(!Destination.metadataEdit(uuid: "u").hidesTabBar)
+    #expect(!Destination.author(id: 1).hidesTabBar)
+    #expect(!Destination.shelves.hidesTabBar)
+    #expect(!Destination.settings.hidesTabBar)
+}
 
-    // A detail pushed over a detail: the bar stays hidden until both pop.
-    presentation.pushImmersiveDetail()
-    presentation.pushImmersiveDetail()
-    #expect(presentation.isImmersiveDetail)
-    presentation.popImmersiveDetail()
-    #expect(presentation.isImmersiveDetail)
-    presentation.popImmersiveDetail()
-    #expect(!presentation.isImmersiveDetail)
+@Test func aStackYieldsTheBottomEdgeUntilTheDetailItselfPops() {
+    #expect(![Destination]().hidesTabBar)
+    #expect([Destination.shelves, .shelf(id: 1)].hidesTabBar == false)
 
-    // An interleaved extra pop must clamp, not go negative and swallow the
-    // next push.
-    presentation.popImmersiveDetail()
-    presentation.pushImmersiveDetail()
-    #expect(presentation.isImmersiveDetail)
-    presentation.popImmersiveDetail()
-    #expect(!presentation.isImmersiveDetail)
+    // A detail pushed over a detail, and the metadata editor pushed over
+    // one: both still hold the edge, so the answer is about the whole stack
+    // rather than its top.
+    #expect([Destination.book(uuid: "a"), .book(uuid: "b")].hidesTabBar)
+    #expect([Destination.book(uuid: "a"), .metadataEdit(uuid: "a")].hidesTabBar)
+
+    // And popping the last detail is what brings the bar back.
+    #expect(![Destination.author(id: 1)].hidesTabBar)
 }

--- a/omnibus-ios/omnibusTests/MainTabChromeTests.swift
+++ b/omnibus-ios/omnibusTests/MainTabChromeTests.swift
@@ -1,0 +1,70 @@
+//  MainTabChromeTests.swift
+//  What decides whether the bottom bar is up: which destinations hold the
+//  bottom edge, whether a stack is holding it, and that each tab reads the
+//  stack it owns.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+// MARK: - Which screens hold the bottom edge
+
+@Test func onlyTheBookDetailYieldsTheBottomEdge() {
+    #expect(Destination.book(uuid: "u").hidesTabBar)
+    #expect(!Destination.metadataEdit(uuid: "u").hidesTabBar)
+    #expect(!Destination.author(id: 1).hidesTabBar)
+    #expect(!Destination.shelves.hidesTabBar)
+    #expect(!Destination.settings.hidesTabBar)
+}
+
+@Test func aStackYieldsTheBottomEdgeUntilTheDetailItselfPops() {
+    #expect(![Destination]().hidesTabBar)
+    #expect(![Destination.shelves, .shelf(id: 1)].hidesTabBar)
+
+    // A detail pushed over a detail, and the metadata editor pushed over
+    // one: both still hold the edge, so the answer is about the whole stack
+    // rather than its top.
+    #expect([Destination.book(uuid: "a"), .book(uuid: "b")].hidesTabBar)
+    #expect([Destination.book(uuid: "a"), .metadataEdit(uuid: "a")].hidesTabBar)
+
+    // And popping the last detail is what brings the bar back.
+    #expect(![Destination.author(id: 1)].hidesTabBar)
+}
+
+// MARK: - Each tab reads its own stack
+
+@Test func tabPathsSubscriptReadsEachTabsOwnStack() {
+    var paths = TabPaths()
+    paths.library = [.book(uuid: "library")]
+    paths.search = [.author(id: 1)]
+    paths.stats = [.readingGoals]
+    paths.you = [.settings]
+
+    // A transposed case in the subscript type checks perfectly and would
+    // simply answer for the wrong tab, so each pairing is pinned by hand.
+    #expect(paths[.library] == [.book(uuid: "library")])
+    #expect(paths[.search] == [.author(id: 1)])
+    #expect(paths[.stats] == [.readingGoals])
+    #expect(paths[.you] == [.settings])
+}
+
+@Test func onlyTheSelectedTabsStackDecidesTheBar() {
+    var paths = TabPaths()
+    paths.library = [.book(uuid: "a")]
+
+    // Parking one tab on a detail must not take the bar away from the others
+    // — that is the whole reason the answer is scoped to the selection.
+    #expect(paths[.library].hidesTabBar)
+    #expect(!paths[.search].hidesTabBar)
+    #expect(!paths[.stats].hidesTabBar)
+    #expect(!paths[.you].hidesTabBar)
+}
+
+@Test func aFreshTabPathsHoldsNothing() {
+    let paths = TabPaths()
+    for tab in AppTab.allCases {
+        #expect(paths[tab].isEmpty)
+        #expect(!paths[tab].hidesTabBar)
+    }
+}


### PR DESCRIPTION
## Summary
- Exiting a book detail left the bottom edge bare for the best part of a second before the tab bar and mini player came back.
- The bar's visibility was a counter on `Presentation`, pushed and popped from `BookDetailView`'s `onAppear` / `onDisappear`. A `NavigationStack` fires `onAppear` at the *start* of a push but `onDisappear` only once the pop has *finished*, so the hide was correctly timed and the show was not: the bar sat out the entire transition, then ran its own `.move(edge: .bottom)` spring on top of that.
- Measured off a simulator screen recording, timed from the frame the pop begins: the bar did not start moving until ~800ms, and settled at ~1.2s.
- `isImmersiveDetail` is now derived from navigation state instead of view lifecycle. Each tab's path becomes a typed `[Destination]` owned by `MainTabView` — the only view that knows which stack is selected — and the predicate is "this stack holds a `.book`".
- A bound path mutates the instant the pop is committed, by back button or edge swipe, so the bar comes back alongside the screen sliding away: moving by ~150ms, settled by ~400ms.
- Semantics are deliberately unchanged. The predicate asks whether a `.book` is anywhere in the stack rather than only on top, which is exactly what the mounted-view counter measured — a book detail with the metadata editor pushed over it still holds the bottom edge. Keying it on `path.last` instead would have started showing the bar over the metadata editor and over author/series screens pushed from a detail, which is a behaviour change this PR is not making.
- The counter's clamping and its nested-detail special case both drop out, since a path is unambiguous where two interleaved `onAppear` / `onDisappear` callbacks were not.
- `AccountView` gains the path binding it previously did without; the other three tab roots swap `NavigationPath` for the typed array. Each takes an explicit `init` because a struct with `private` stored properties gets a `private` memberwise one.

## Test plan
- [x] `just ios-test` — 711 passed, 0 failed. Two new tests over the new derivation replace the deleted counter test: one pinning that only `.book` yields the bottom edge, one pinning that a stack keeps yielding it until the detail itself pops.
- [x] `just ios-test-ui` — 3 passed.
- [x] Verified against a simulator screen recording of the same gesture on both builds, read frame by frame: back-button exit went from bar-starts-moving at +800ms / settled +1.2s, to +150ms / +400ms.
- [x] Edge-swipe exit recorded separately. The path holds until the gesture *commits* rather than while the finger is down, then the bar returns within ~150ms — which is the correct behaviour, since an in-progress swipe can still be cancelled.
- [x] Confirmed every push site in `omnibus-ios/` already goes through `NavigationLink(value: Destination…)` or `path.append(Destination…)`, so no call site can push a value the typed path would reject.

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- `docs/architecture.md`'s `App/` entry now records that `MainTabView` owns the four tabs' navigation paths, since that is what decides whether the bottom bar is up.
- No rule or skill under `.claude/` referenced the removed counter, so nothing there needed updating.
