### PR TITLE
feat: give the iOS empty states a composition, and stop them painting a band

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,7 +315,16 @@ Design/             — Theme (Atrium tokens + the type scale), Fonts/ (static
                       metadata editor's chip and series fields, the native twin
                       of the web's `components/suggestion_dropdown/` —
                       UserAvatar — a user's picture or monogram, the native twin
-                      of the web's `components/user_avatar.rs`)
+                      of the web's `components/user_avatar.rs`, GhostPlate — the
+                      dashed 2:3 "book with nothing on it" motif every empty
+                      state leads with, optionally fanned for a surface that
+                      holds a collection). `EmptyStateView`/`ErrorStateView` in
+                      Primitives claim `maxHeight: .infinity` deliberately:
+                      their callers wrap them in a `Group` carrying
+                      `.background(ScreenBackground())`, and a `Group` is only
+                      as tall as its content, so a state view sized to its own
+                      text painted the page ground as a *band* across an
+                      otherwise system-black screen.
 Features/           — one directory per surface: Account, AddBooks, Auth,
                       BookDetail, CheckIn, Discovery, Library, Player, Search,
                       Settings, Shelves, Stats. Account's identity card opens

--- a/omnibus-ios/omnibus/Design/Components/Primitives.swift
+++ b/omnibus-ios/omnibus/Design/Components/Primitives.swift
@@ -212,8 +212,17 @@ struct GhostPlate: View {
     /// How far a fanned sibling is pushed out, and how far it leans.
     private static let fanOffset: CGFloat = 0.5
     private static let fanAngle: Double = 11
-    /// Total width a fan occupies, in multiples of one plate — see `body`.
-    private static let fanSpan: CGFloat = 2.6
+
+    /// Half the width a fan occupies, in multiples of one plate.
+    ///
+    /// Derived rather than written down: a sibling sits `fanOffset` out, and
+    /// rotating it about its bottom throws its outer top corner a further
+    /// `fanOffset·cos + 1.5·sin`. A hand-computed constant would silently go
+    /// stale the first time the angle or the offset moved.
+    private static var fanReach: CGFloat {
+        let radians = fanAngle * .pi / 180
+        return fanOffset + fanOffset * cos(radians) + 1.5 * sin(radians)
+    }
 
     var body: some View {
         ZStack {
@@ -225,11 +234,10 @@ struct GhostPlate: View {
         }
         // Bound the fan explicitly: a ZStack sizes to its largest child, so
         // without this the offset, rotated siblings would run under whatever
-        // sits beside the motif. A sibling sits `0.5w` out and rotating it
-        // `fanAngle` about its bottom throws its outer top corner a further
-        // `0.5w·cos + 1.5w·sin` ≈ `0.78w`, so the half-width to reserve is
-        // ~`1.28w` — hence `2.6w`, not the `2.2w` that left 13pt outside.
-        .frame(width: fanned ? width * Self.fanSpan : width, height: height + 16)
+        // sits beside the motif. The hardcoded 2.2 this replaced reserved
+        // 1.1w a side against the ~1.28w a sibling actually reaches, and left
+        // ~13pt of it outside.
+        .frame(width: fanned ? width * Self.fanReach * 2 : width, height: height + 16)
         .accessibilityHidden(true)
     }
 

--- a/omnibus-ios/omnibus/Design/Components/Primitives.swift
+++ b/omnibus-ios/omnibus/Design/Components/Primitives.swift
@@ -190,38 +190,168 @@ struct LoadingView: View {
     }
 }
 
+/// A book-shaped plate with nothing on it — the motif every "nothing here
+/// yet" surface leads with.
+///
+/// This app's world is 2:3 covers, so an empty surface says so with an empty
+/// cover: the same dashed plate the new-shelf tile draws, at rest. A bare SF
+/// Symbol floating on the ground was the one stock-iOS element left on these
+/// screens, and it read as a missing image rather than as a considered state.
+struct GhostPlate: View {
+    let glyph: String
+    var width: CGFloat = 74
+    /// Two dimmer plates fanned behind the lead one. For surfaces that hold a
+    /// *collection* — a shelf, a library, a download list — where one plate
+    /// under-describes what is missing.
+    var fanned = false
+
+    @Environment(\.palette) private var palette
+
+    private var height: CGFloat { width * 1.5 }
+
+    var body: some View {
+        ZStack {
+            if fanned {
+                sibling(angle: -11, x: -width * 0.5)
+                sibling(angle: 11, x: width * 0.5)
+            }
+            lead
+        }
+        // Bound the fan explicitly: the rotated siblings overflow the lead
+        // plate, and an unbounded ZStack would let them run under whatever
+        // sits beside it.
+        .frame(width: fanned ? width * 2.2 : width, height: height + 16)
+        .accessibilityHidden(true)
+    }
+
+    /// The plate in front. Its ground is opaque — a translucent one let the
+    /// fan behind it show straight through, so three plates read as one
+    /// tangle of lines rather than as a stack.
+    private var lead: some View {
+        RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+            .fill(palette.bg0Color)
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                    .fill(palette.bg1Color.opacity(0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                    .strokeBorder(
+                        palette.line.color,
+                        style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+                    )
+            )
+            .overlay {
+                Image(systemName: glyph)
+                    .font(.system(size: width * 0.3, weight: .light))
+                    .foregroundStyle(palette.ink3Color)
+            }
+            .frame(width: width, height: height)
+    }
+
+    /// One of the plates fanned behind: outline only, and dropped a little so
+    /// the lead plate reads as the nearest of a stack rather than as the
+    /// middle of a row.
+    private func sibling(angle: Double, x: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+            .fill(palette.bg0Color)
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                    .strokeBorder(palette.line2.color, lineWidth: 1)
+            )
+            .frame(width: width, height: height)
+            .rotationEffect(.degrees(angle), anchor: .bottom)
+            .offset(x: x, y: 6)
+    }
+}
+
+/// The gentle call to action an empty state offers — the accent-tinted capsule
+/// the book detail's WRITE pill established, rather than a grey slab that reads
+/// as a form control.
+struct EmptyStateActionStyle: ButtonStyle {
+    @Environment(\.palette) private var palette
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.ui(14, weight: .medium))
+            .foregroundStyle(palette.accentColor)
+            .padding(.horizontal, 18)
+            .frame(height: 38)
+            .background(Capsule().fill(palette.accentColor.opacity(0.14)))
+            .overlay(Capsule().strokeBorder(palette.accentColor.opacity(0.45), lineWidth: 0.5))
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(Motion.lift, value: configuration.isPressed)
+    }
+}
+
+/// A surface with nothing on it yet.
+///
+/// Set as a page rather than a notice: the ghost plate, an accent rule, an
+/// optional mono kicker, the headline in the display cut, and the explanation
+/// under it. It claims the whole container — that is not cosmetic. Callers
+/// wrap it in a `Group` carrying `.background(ScreenBackground())`, and a
+/// `Group` is only as tall as its content, so a state view that sized to its
+/// text painted the page ground as a *band* across an otherwise system-black
+/// screen.
 struct EmptyStateView: View {
     let icon: String
     let title: String
     var message: String?
+    /// Mono small-caps lead-in above the headline, in the voice the rest of
+    /// the app uses for section kickers.
+    var kicker: String?
+    /// Fans two dimmer plates behind the motif — for surfaces that hold a
+    /// collection rather than a single thing.
+    var fanned = false
     var actionTitle: String?
     var action: (() -> Void)?
 
     @Environment(\.palette) private var palette
 
     var body: some View {
-        VStack(spacing: Spacing.md) {
-            Image(systemName: icon)
-                .font(.system(size: 40, weight: .light))
-                .foregroundStyle(palette.ink3Color)
+        VStack(spacing: 0) {
+            GhostPlate(glyph: icon, fanned: fanned)
+
+            Rectangle()
+                .fill(palette.accentColor)
+                .frame(width: 26, height: 1.5)
+                .padding(.top, 26)
+
+            if let kicker {
+                Text(kicker.uppercased())
+                    .font(.monoUI(9.5))
+                    .tracking(1.6)
+                    .foregroundStyle(palette.ink3Color)
+                    .padding(.top, 14)
+            }
+
             Text(title)
-                .font(.display(24))
+                .font(.display(29))
                 .foregroundStyle(palette.ink0Color)
+                .multilineTextAlignment(.center)
+                .padding(.top, kicker == nil ? 14 : 6)
+
             if let message {
                 Text(message)
-                    .font(.ui(14))
+                    .font(.ui(13.5))
                     .foregroundStyle(palette.ink2Color)
                     .multilineTextAlignment(.center)
+                    .lineSpacing(3)
                     .frame(maxWidth: 300)
+                    .padding(.top, 8)
             }
+
             if let actionTitle, let action {
-                Button(actionTitle, action: action)
-                    .buttonStyle(QuietButtonStyle())
-                    .padding(.top, Spacing.xs)
+                Button(actionTitle) {
+                    Haptics.tap()
+                    action()
+                }
+                .buttonStyle(EmptyStateActionStyle())
+                .padding(.top, 22)
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 56)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 44)
         .padding(.horizontal, Spacing.screen)
     }
 }
@@ -233,22 +363,42 @@ struct ErrorStateView: View {
     @Environment(\.palette) private var palette
 
     var body: some View {
-        VStack(spacing: Spacing.md) {
+        VStack(spacing: 0) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 34, weight: .light))
+                .font(.system(size: 30, weight: .light))
                 .foregroundStyle(palette.badColor)
+
+            Rectangle()
+                .fill(palette.badColor)
+                .frame(width: 26, height: 1.5)
+                .padding(.top, 20)
+
+            Text("Couldn't load this")
+                .font(.display(27))
+                .foregroundStyle(palette.ink0Color)
+                .padding(.top, 14)
+
             Text(message)
-                .font(.ui(14))
-                .foregroundStyle(palette.ink1Color)
+                .font(.ui(13.5))
+                .foregroundStyle(palette.ink2Color)
                 .multilineTextAlignment(.center)
+                .lineSpacing(3)
                 .frame(maxWidth: 320)
+                .padding(.top, 8)
+
             if let retry {
-                Button("Try again", action: retry)
-                    .buttonStyle(QuietButtonStyle())
+                Button("Try again") {
+                    Haptics.tap()
+                    retry()
+                }
+                .buttonStyle(EmptyStateActionStyle())
+                .padding(.top, 22)
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 48)
+        // Same reason as `EmptyStateView`: the container's ground must paint
+        // the page, not a band across it.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 44)
         .padding(.horizontal, Spacing.screen)
     }
 }

--- a/omnibus-ios/omnibus/Design/Components/Primitives.swift
+++ b/omnibus-ios/omnibus/Design/Components/Primitives.swift
@@ -209,18 +209,27 @@ struct GhostPlate: View {
 
     private var height: CGFloat { width * 1.5 }
 
+    /// How far a fanned sibling is pushed out, and how far it leans.
+    private static let fanOffset: CGFloat = 0.5
+    private static let fanAngle: Double = 11
+    /// Total width a fan occupies, in multiples of one plate — see `body`.
+    private static let fanSpan: CGFloat = 2.6
+
     var body: some View {
         ZStack {
             if fanned {
-                sibling(angle: -11, x: -width * 0.5)
-                sibling(angle: 11, x: width * 0.5)
+                sibling(angle: -Self.fanAngle, x: -width * Self.fanOffset)
+                sibling(angle: Self.fanAngle, x: width * Self.fanOffset)
             }
             lead
         }
-        // Bound the fan explicitly: the rotated siblings overflow the lead
-        // plate, and an unbounded ZStack would let them run under whatever
-        // sits beside it.
-        .frame(width: fanned ? width * 2.2 : width, height: height + 16)
+        // Bound the fan explicitly: a ZStack sizes to its largest child, so
+        // without this the offset, rotated siblings would run under whatever
+        // sits beside the motif. A sibling sits `0.5w` out and rotating it
+        // `fanAngle` about its bottom throws its outer top corner a further
+        // `0.5w·cos + 1.5w·sin` ≈ `0.78w`, so the half-width to reserve is
+        // ~`1.28w` — hence `2.6w`, not the `2.2w` that left 13pt outside.
+        .frame(width: fanned ? width * Self.fanSpan : width, height: height + 16)
         .accessibilityHidden(true)
     }
 
@@ -229,11 +238,10 @@ struct GhostPlate: View {
     /// tangle of lines rather than as a stack.
     private var lead: some View {
         RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
-            .fill(palette.bg0Color)
-            .overlay(
-                RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
-                    .fill(palette.bg1Color.opacity(0.55))
-            )
+            // One opaque fill, not a translucent one over the page ground:
+            // `bg1` at 55% over `bg0` is a colour, and stacking two shapes to
+            // arrive at it costs a layer and hides the intent.
+            .fill(palette.bg0Color.mix(with: palette.bg1Color, by: 0.55))
             .overlay(
                 RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
                     .strokeBorder(

--- a/omnibus-ios/omnibus/Features/Account/AccountView.swift
+++ b/omnibus-ios/omnibus/Features/Account/AccountView.swift
@@ -634,7 +634,9 @@ struct DownloadsView: View {
                 EmptyStateView(
                     icon: "arrow.down.circle",
                     title: "Nothing downloaded",
-                    message: "Download a book from its detail screen to read or listen offline."
+                    message: "Download a book from its detail screen and it reads and plays with no server in reach.",
+                    kicker: "On this device",
+                    fanned: true
                 )
             } else {
                 // Record rows on the page ground rather than a `List`: a

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -210,6 +210,9 @@ struct StopRuledVoid: View {
 
     @Environment(\.palette) private var palette
 
+    private static let barHeight: CGFloat = 5
+    private static let barGap: CGFloat = 8
+
     var body: some View {
         VStack(spacing: 0) {
             ForEach(0 ..< rows, id: \.self) { row in
@@ -220,10 +223,7 @@ struct StopRuledVoid: View {
                                 .fill(palette.line.color)
                                 .frame(width: 3, height: 30)
                         }
-                        VStack(alignment: .leading, spacing: 8) {
-                            blank(0.82)
-                            blank(0.54)
-                        }
+                        bars
                         Spacer(minLength: 0)
                     }
                     .padding(.vertical, 12)
@@ -231,20 +231,37 @@ struct StopRuledVoid: View {
                     Hairline()
                 }
                 // Fades out down the page, so the rules read as the page
-                // continuing rather than as three specific missing rows.
-                .opacity(1 - Double(row) * 0.3)
+                // continuing rather than as N specific missing rows. Derived
+                // from `rows` rather than a fixed step, so the last row lands
+                // at the same faintness whatever the arity — a fixed 0.3 step
+                // went *negative* past four rows and left the result to
+                // whatever `.opacity` happens to clamp to.
+                .opacity(1 - (Double(row) / Double(max(rows, 1))) * 0.75)
             }
         }
         .accessibilityHidden(true)
     }
 
-    private func blank(_ fraction: CGFloat) -> some View {
+    /// The two blank rules of one row.
+    ///
+    /// One `GeometryReader` for the pair rather than one each: it is the only
+    /// way to take a *fraction* of the row's width, but it has no intrinsic
+    /// height, so every use has to be given one back — and stating that once
+    /// per row beats stating it once per bar.
+    private var bars: some View {
         GeometryReader { geometry in
-            Capsule()
-                .fill(palette.line2.color)
-                .frame(width: geometry.size.width * fraction, height: 5)
+            VStack(alignment: .leading, spacing: Self.barGap) {
+                bar(geometry.size.width * 0.82)
+                bar(geometry.size.width * 0.54)
+            }
         }
-        .frame(height: 5)
+        .frame(height: Self.barHeight * 2 + Self.barGap)
+    }
+
+    private func bar(_ width: CGFloat) -> some View {
+        Capsule()
+            .fill(palette.line2.color)
+            .frame(width: width, height: Self.barHeight)
     }
 }
 
@@ -785,6 +802,15 @@ struct StopShelf: View {
             .map(\.name)
     }
 
+    /// Whether "this book is on none of your shelves" is a thing we can yet
+    /// say. `allShelves` and `shelvesContaining` are separate live reads, so
+    /// on a cold cache the stop renders before either lands — and asserting
+    /// "· none" then told the reader something the app did not know, and took
+    /// it back a moment later when the chips appeared. Derived from the data
+    /// rather than a load flag: naming the shelves a book is on requires the
+    /// shelf catalog, so having it *is* the precondition.
+    private var knowsMembership: Bool { !model.allShelves.isEmpty }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if series.count > 1, let name = book.series {
@@ -823,14 +849,16 @@ struct StopShelf: View {
                     .padding(.top, 14)
                 }
             } else {
-                DetailKicker(text: shelfNames.isEmpty
+                DetailKicker(text: knowsMembership && shelfNames.isEmpty
                     ? "On your shelves · none"
-                    : "On your shelves · \(shelfNames.count)")
+                    : shelfNames.isEmpty
+                        ? "On your shelves"
+                        : "On your shelves · \(shelfNames.count)")
             }
 
             // A lone "+ Shelf" chip under a bare kicker said nothing about
             // what a shelf is or why this book has none.
-            if series.count <= 1, shelfNames.isEmpty {
+            if series.count <= 1, knowsMembership, shelfNames.isEmpty {
                 Text("This book isn't on a shelf yet.")
                     .font(.displayItalic(21))
                     .foregroundStyle(palette.ink2Color)
@@ -853,7 +881,7 @@ struct StopShelf: View {
             }
             .padding(.top, series.count > 1 ? 18 : 12)
 
-            if series.count <= 1, model.authorBooks.isEmpty, shelfNames.isEmpty {
+            if series.count <= 1, knowsMembership, model.authorBooks.isEmpty, shelfNames.isEmpty {
                 MonoNote(text: "a shelf gathers books by hand, or fills itself from a rule")
                     .padding(.top, 20)
                 StopRuledVoid(rows: 2)

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -231,12 +231,12 @@ struct StopRuledVoid: View {
                     Hairline()
                 }
                 // Fades out down the page, so the rules read as the page
-                // continuing rather than as N specific missing rows. Derived
-                // from `rows` rather than a fixed step, so the last row lands
-                // at the same faintness whatever the arity — a fixed 0.3 step
-                // went *negative* past four rows and left the result to
-                // whatever `.opacity` happens to clamp to.
-                .opacity(1 - (Double(row) / Double(max(rows, 1))) * 0.75)
+                // continuing rather than as N specific missing rows. Spread
+                // across `rows - 1` so the *last* row lands at 0.25 whatever
+                // the arity — dividing by `rows` would make a two-row void
+                // end brighter than a three-row one. The fixed 0.3 step this
+                // replaced went negative past four rows.
+                .opacity(1 - (Double(row) / Double(max(rows - 1, 1))) * 0.75)
             }
         }
         .accessibilityHidden(true)

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -194,6 +194,60 @@ struct MonoNote: View {
     }
 }
 
+/// The shape of what a stop will hold, drawn as blank rules.
+///
+/// Every stop gets a whole screen, so one with nothing in it was one line of
+/// italic text above eight hundred points of black. Rather than pad that out,
+/// the stop shows the *form* its rows take — the same tick and hairline the
+/// real ones draw — fading down the page. It reads as a ruled page waiting to
+/// be written on rather than as a load that failed, and it costs nothing when
+/// the stop does have content, because it isn't drawn then.
+struct StopRuledVoid: View {
+    var rows = 3
+    /// Highlights carry a colour tick down their leading edge; journal rows
+    /// don't. Matching it is what keeps this reading as *this* stop's shape.
+    var ticked = false
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0 ..< rows, id: \.self) { row in
+                VStack(spacing: 0) {
+                    HStack(alignment: .top, spacing: 11) {
+                        if ticked {
+                            Capsule()
+                                .fill(palette.line.color)
+                                .frame(width: 3, height: 30)
+                        }
+                        VStack(alignment: .leading, spacing: 8) {
+                            blank(0.82)
+                            blank(0.54)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 12)
+
+                    Hairline()
+                }
+                // Fades out down the page, so the rules read as the page
+                // continuing rather than as three specific missing rows.
+                .opacity(1 - Double(row) * 0.3)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func blank(_ fraction: CGFloat) -> some View {
+        GeometryReader { geometry in
+            Capsule()
+                .fill(palette.line2.color)
+                .frame(width: geometry.size.width * fraction, height: 5)
+        }
+        .frame(height: 5)
+    }
+}
+
 /// A single-line horizontal chip shelf that scrolls past the panel edge
 /// instead of wrapping — vertical space at a stop is fixed.
 struct ChipStrip<Content: View>: View {
@@ -769,7 +823,19 @@ struct StopShelf: View {
                     .padding(.top, 14)
                 }
             } else {
-                DetailKicker(text: "On your shelves")
+                DetailKicker(text: shelfNames.isEmpty
+                    ? "On your shelves · none"
+                    : "On your shelves · \(shelfNames.count)")
+            }
+
+            // A lone "+ Shelf" chip under a bare kicker said nothing about
+            // what a shelf is or why this book has none.
+            if series.count <= 1, shelfNames.isEmpty {
+                Text("This book isn't on a shelf yet.")
+                    .font(.displayItalic(21))
+                    .foregroundStyle(palette.ink2Color)
+                    .lineSpacing(4)
+                    .padding(.top, 12)
             }
 
             ChipStrip {
@@ -786,6 +852,13 @@ struct StopShelf: View {
                 .buttonStyle(PressableStyle())
             }
             .padding(.top, series.count > 1 ? 18 : 12)
+
+            if series.count <= 1, model.authorBooks.isEmpty, shelfNames.isEmpty {
+                MonoNote(text: "a shelf gathers books by hand, or fills itself from a rule")
+                    .padding(.top, 20)
+                StopRuledVoid(rows: 2)
+                    .padding(.top, 18)
+            }
 
             if series.count <= 1, !model.authorBooks.isEmpty {
                 MonoNote(text: "more by \(book.authorDisplay)")
@@ -827,15 +900,23 @@ struct StopStats: View {
                 SparkBars(minutes: DetailStats.sparkMinutes(from: model.sessions))
                     .padding(.top, 18)
             } else {
+                DetailKicker(text: "This read · not begun")
+
                 Text("No stats yet.")
                     .font(.display(34))
                     .foregroundStyle(palette.ink0Color)
+                    .padding(.top, 10)
 
                 Text(emptyExplainer)
                     .font(.ui(13.5))
                     .foregroundStyle(palette.ink2Color)
                     .lineSpacing(4)
                     .padding(.top, 12)
+
+                // The four tiles this stop fills in, drawn empty — so the
+                // shape of what a read records is legible before there is one.
+                emptyStatGrid
+                    .padding(.top, 20)
             }
 
             ratingBlock
@@ -852,6 +933,22 @@ struct StopStats: View {
         model.isWishlistOnly
             ? "Stats begin when the book does — check in a copy to start the record."
             : "Open the book to start tracking your reading here."
+    }
+
+    /// The stat grid with its keys shown and its values withheld — the same
+    /// four tiles, so the layout doesn't jump the first time a sitting lands.
+    private var emptyStatGrid: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 14) {
+                DetailStatTile(key: "Started", value: "—", sub: nil)
+                DetailStatTile(key: "Time in book", value: "—", sub: nil)
+            }
+            HStack(spacing: 14) {
+                DetailStatTile(key: "Pickups", value: "—", sub: nil)
+                DetailStatTile(key: "Longest sit", value: "—", sub: nil)
+            }
+        }
+        .opacity(0.45)
     }
 
     private func statGrid(_ record: DetailReadRecord) -> some View {
@@ -959,6 +1056,8 @@ struct StopHighlights: View {
                     MonoNote(text: "find a copy first — check in when it arrives")
                         .padding(.top, 16)
                 }
+                StopRuledVoid(ticked: true)
+                    .padding(.top, 22)
             } else {
                 DetailKicker(text: "Kept lines · \(all.count)")
 
@@ -1052,6 +1151,8 @@ struct StopJournals: View {
                     .padding(.top, 12)
                 MonoNote(text: "a shared log — anyone reading this book can write here")
                     .padding(.top, 16)
+                StopRuledVoid()
+                    .padding(.top, 22)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(entries.prefix(Self.stopCount)) { entry in
@@ -1462,8 +1563,10 @@ struct StopRecommendations: View {
             .padding(.top, 18)
 
             if model.suggestions.isEmpty {
-                MonoNote(text: "no suggestions yet")
+                MonoNote(text: "nothing suggested for this book yet")
                     .padding(.top, 10)
+                StopRuledVoid(rows: 2)
+                    .padding(.top, 14)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(model.suggestions.prefix(4)) { suggestion in

--- a/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
+++ b/omnibus-ios/omnibus/Features/Discovery/DiscoveryViews.swift
@@ -62,7 +62,12 @@ struct AuthorsView: View {
             } else if let error, authors.isEmpty {
                 ErrorStateView(message: error) { Task { await load() } }
             } else if authors.isEmpty {
-                EmptyStateView(icon: "person.2", title: "No authors yet")
+                EmptyStateView(
+                    icon: "person.2",
+                    title: "No authors yet",
+                    message: "Authors appear as the library is indexed — every name a book credits gets a page here.",
+                    kicker: "By author"
+                )
             } else if filtered.isEmpty {
                 EmptyStateView(
                     icon: "questionmark.circle",
@@ -309,9 +314,18 @@ struct SeriesIndexView: View {
             if isLoading {
                 LoadingView()
             } else if series.isEmpty {
-                EmptyStateView(icon: "square.grid.2x2", title: "No series yet")
+                EmptyStateView(
+                    icon: "square.grid.2x2",
+                    title: "No series yet",
+                    message: "A book that names the series it belongs to files itself here, in reading order.",
+                    kicker: "By series"
+                )
             } else if filtered.isEmpty {
-                EmptyStateView(icon: "questionmark.circle", title: "No series match")
+                EmptyStateView(
+                    icon: "questionmark.circle",
+                    title: "No series match",
+                    message: "Nothing in the library is filed under \u{201C}\(query)\u{201D}."
+                )
             } else {
                 ScrollView {
                     VStack(spacing: 0) {
@@ -501,7 +515,12 @@ struct TagCloudView: View {
             if isLoading {
                 LoadingView()
             } else if tags.isEmpty {
-                EmptyStateView(icon: "tag", title: "No tags yet")
+                EmptyStateView(
+                    icon: "tag",
+                    title: "No tags yet",
+                    message: "Tags come from a book\u{2019}s own subjects, and from any you add on its detail page.",
+                    kicker: "By tag"
+                )
             } else {
                 ScrollView {
                     FlowLayout(spacing: 8, lineSpacing: 10) {

--- a/omnibus-ios/omnibus/Features/Library/LibraryView.swift
+++ b/omnibus-ios/omnibus/Features/Library/LibraryView.swift
@@ -268,7 +268,9 @@ struct LibraryView: View {
                     EmptyStateView(
                         icon: "books.vertical",
                         title: "No books yet",
-                        message: "Point the server at a library folder, or add a book from the You tab."
+                        message: "Point the server at a library folder, or add a book from the You tab.",
+                        kicker: "Your library",
+                        fanned: true
                     )
                 } else {
                     content

--- a/omnibus-ios/omnibus/Features/Search/SearchView.swift
+++ b/omnibus-ios/omnibus/Features/Search/SearchView.swift
@@ -289,7 +289,11 @@ struct SearchResultsView: View {
             if isLoading {
                 LoadingView()
             } else if books.isEmpty {
-                EmptyStateView(icon: "questionmark.circle", title: "No matches")
+                EmptyStateView(
+                    icon: "questionmark.circle",
+                    title: "No matches",
+                    message: "Nothing here matches \u{201C}\(query)\u{201D}."
+                )
             } else {
                 ScrollView {
                     LazyVGrid(columns: columns, spacing: 20) {

--- a/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
@@ -22,7 +22,9 @@ struct ShelvesView: View {
                 EmptyStateView(
                     icon: "square.stack",
                     title: "No shelves yet",
-                    message: "Shelves group books by a rule you set, or by hand.",
+                    message: "A shelf gathers books by hand, or fills itself from a rule you set.",
+                    kicker: "Your shelves",
+                    fanned: true,
                     actionTitle: "Create a shelf",
                     action: { showCreate = true }
                 )
@@ -100,6 +102,16 @@ struct ShelfDetailView: View {
 
     @Environment(\.palette) private var palette
     @State private var shelf: Shelf?
+    /// The shelf's identity as the cached index knows it, for when the detail
+    /// read hasn't landed.
+    ///
+    /// `UserDataService.shelf(id:)` is the only read carrying rules and a
+    /// description, and on a cold cache it is network-only — so offline this
+    /// page lost its name, its mosaic and its *kind* at once, and with the kind
+    /// gone it told a manual shelf that nothing matched its conditions. The
+    /// shelves index is already in the replica and carries every field the
+    /// header needs.
+    @State private var indexed: ShelfSummary?
     @State private var books: [Book] = []
     @State private var isLoading = true
     @State private var showAddBooks = false
@@ -109,9 +121,12 @@ struct ShelfDetailView: View {
     // in the same row wrap to different line counts — see LibraryView.swift.
     private let columns = [GridItem(.adaptive(minimum: 112, maximum: 168), spacing: 16, alignment: .top)]
 
+    /// Whatever is known about this shelf, detail read first.
+    private var identity: ShelfSummary? { shelf.map(Self.summary) ?? indexed }
+
     /// Only a manual shelf can be filled by hand — a smart shelf's membership
-    /// is whatever its rules match.
-    private var canAddBooks: Bool { shelf?.kind == .manual }
+    /// is whatever its rules match, and the wishlist's is what you check in.
+    private var canAddBooks: Bool { identity?.kind == .manual }
 
     var body: some View {
         Group {
@@ -123,7 +138,17 @@ struct ShelfDetailView: View {
                         header
 
                         if books.isEmpty {
-                            emptyState
+                            // The index knows the count; only the member page
+                            // carries the books. Offline with the page uncached
+                            // we know there are some and can't show them, which
+                            // is not the same as the shelf being empty — and
+                            // saying "nothing on this shelf" under a header
+                            // reading "1 book" contradicts itself.
+                            if let identity, identity.bookCount > 0 {
+                                unreachableState(count: identity.bookCount)
+                            } else {
+                                emptyState
+                            }
                         } else {
                             LazyVGrid(columns: columns, spacing: 26) {
                                 ForEach(Array(books.enumerated()), id: \.element.id) { index, book in
@@ -163,7 +188,7 @@ struct ShelfDetailView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            FadingBarTitle(title: shelf?.name ?? "", scrollY: scrollY, appearsAfter: 76)
+            FadingBarTitle(title: identity?.name ?? "", scrollY: scrollY, appearsAfter: 76)
         }
         .toolbar {
             if canAddBooks {
@@ -179,10 +204,10 @@ struct ShelfDetailView: View {
             }
         }
         .sheet(isPresented: $showAddBooks) {
-            if let shelf {
+            if let identity {
                 AddBooksToShelfSheet(
-                    shelfId: shelf.id,
-                    shelfName: shelf.name,
+                    shelfId: identity.id,
+                    shelfName: identity.name,
                     existing: Set(books.map(\.uuid))
                 ) {
                     Task { await load(force: true) }
@@ -195,51 +220,44 @@ struct ShelfDetailView: View {
 
     /// A shelf you can fill asks to be filled; one driven by rules explains
     /// itself instead of offering an action that wouldn't apply.
-    @ViewBuilder
     private var emptyState: some View {
-        if canAddBooks {
-            Button {
-                Haptics.tap()
-                showAddBooks = true
-            } label: {
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Add the first book")
-                        .font(.display(20))
-                        .foregroundStyle(palette.ink1Color)
-                    Text("Search your library and pick as many as you like.")
-                        .font(.ui(13))
-                        .foregroundStyle(palette.ink3Color)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(Spacing.lg)
-                .background(
-                    RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-                        .strokeBorder(
-                            palette.line2.color,
-                            style: StrokeStyle(lineWidth: 1, dash: [5, 4])
-                        )
-                )
-            }
-            .buttonStyle(.plain)
-            .screenPadding()
-        } else {
-            EmptyStateView(
-                icon: "square.stack",
-                title: "Nothing here yet",
-                message: "No books match this shelf's conditions."
-            )
-        }
+        let copy = ShelfEmptyCopy.forKind(identity?.kind)
+
+        return EmptyStateView(
+            icon: (identity?.kind ?? .manual).glyph,
+            title: copy.title,
+            message: copy.message,
+            kicker: copy.kicker,
+            fanned: true,
+            actionTitle: copy.actionTitle,
+            action: copy.actionTitle == nil ? nil : { showAddBooks = true }
+        )
+        // Inside the page's scroll view this sizes to its content, so give it
+        // enough of the pane to sit in rather than letting it hug the header.
+        .frame(minHeight: 380)
+    }
+
+    /// The shelf has books the device hasn't got a copy of.
+    private func unreachableState(count: Int64) -> some View {
+        EmptyStateView(
+            icon: "arrow.trianglehead.2.clockwise.rotate.90",
+            title: "Not here yet",
+            message: ShelfEmptyCopy.unreachable(count: count),
+            kicker: "Off the network",
+            fanned: true
+        )
+        .frame(minHeight: 380)
     }
 
     /// Mosaic beside the shelf's identity, so a smart shelf's conditions are
     /// visible without opening an editor.
     @ViewBuilder
     private var header: some View {
-        if let shelf {
+        if let identity {
             VStack(alignment: .leading, spacing: Spacing.lg) {
                 HStack(alignment: .top, spacing: Spacing.lg) {
                     ShelfMosaic(
-                        preview: ShelfPreview(shelf: summary(shelf), covers: Array(books.prefix(4)))
+                        preview: ShelfPreview(shelf: identity, covers: Array(books.prefix(4)))
                     )
                     .frame(width: 104)
                     .coverShadow(1.2)
@@ -250,18 +268,18 @@ struct ShelfDetailView: View {
                             .fill(palette.accentColor)
                             .frame(width: 24, height: 1.5)
 
-                        Text(shelf.name)
+                        Text(identity.name)
                             .font(.display(30))
                             .foregroundStyle(palette.ink0Color)
                             .fixedSize(horizontal: false, vertical: true)
 
-                        Text(metaLine(shelf))
+                        Text(Self.metaLine(identity))
                             .font(.monoUI(10, weight: .medium))
                             .tracking(0.7)
                             .textCase(.uppercase)
                             .foregroundStyle(palette.ink3Color)
 
-                        if let description = shelf.description?.nilIfBlank {
+                        if let description = shelf?.description?.nilIfBlank {
                             Text(description)
                                 .font(.display(18))
                                 .foregroundStyle(palette.ink2Color)
@@ -272,7 +290,7 @@ struct ShelfDetailView: View {
                     Spacer(minLength: 0)
                 }
 
-                if shelf.kind == .smart, !shelf.rules.isEmpty {
+                if let shelf, shelf.kind == .smart, !shelf.rules.isEmpty {
                     ruleSummary(shelf)
                 }
             }
@@ -297,16 +315,23 @@ struct ShelfDetailView: View {
         }
     }
 
-    private func metaLine(_ shelf: Shelf) -> String {
+    /// Every kind names itself. It used to print "Manual" for anything that
+    /// wasn't smart, so the wishlist — which nobody fills by hand — described
+    /// itself as the one kind you do.
+    static func metaLine(_ shelf: ShelfSummary) -> String {
         var parts = ["\(shelf.bookCount) book\(shelf.bookCount == 1 ? "" : "s")"]
-        parts.append(shelf.kind == .smart ? "Smart" : "Manual")
+        switch shelf.kind {
+        case .smart: parts.append("Smart")
+        case .manual: parts.append("Manual")
+        case .wishlist: parts.append("Wishlist")
+        }
         if shelf.visibility == .public { parts.append("Public") }
         return parts.joined(separator: " · ")
     }
 
     /// The mosaic takes a summary; detail carries the same fields under a
     /// different type.
-    private func summary(_ shelf: Shelf) -> ShelfSummary {
+    static func summary(_ shelf: Shelf) -> ShelfSummary {
         ShelfSummary(
             id: shelf.id,
             ownerUserId: shelf.ownerUserId,
@@ -326,6 +351,12 @@ struct ShelfDetailView: View {
         }
         await withTaskGroup(of: Void.self) { group in
             group.addTask { @MainActor in
+                // Cheap, local, and only ever a fallback — the detail read
+                // wins the moment it lands.
+                let previews: [ShelfPreview]? = await Cache.cachedOnly(CacheKey.shelfPreviews)
+                self.indexed = previews?.first { $0.shelf.id == self.id }?.shelf
+            }
+            group.addTask { @MainActor in
                 for await value in UserDataService.shelf(id: id).values() {
                     self.shelf = value
                     self.isLoading = false
@@ -339,6 +370,68 @@ struct ShelfDetailView: View {
             }
         }
         isLoading = false
+    }
+}
+
+/// What a shelf with nothing on it should say.
+///
+/// A table rather than a branch in the view: the three kinds are filled by
+/// three different mechanisms — by hand, by a rule, by checking a book in —
+/// so only one of them has an action to offer, and telling the other two that
+/// "no books match this shelf's conditions" describes machinery they don't
+/// have. `nil` is the honest fourth case: offline before the detail read has
+/// landed, the kind isn't known, and the page must not guess at one.
+enum ShelfEmptyCopy {
+    struct Copy: Equatable {
+        let kicker: String
+        let title: String
+        let message: String
+        /// Non-nil only where the reader can actually fill this shelf here.
+        let actionTitle: String?
+    }
+
+    static func forKind(_ kind: ShelfKind?) -> Copy {
+        switch kind {
+        case .manual:
+            Copy(
+                kicker: "Empty shelf",
+                title: "Nothing on this shelf",
+                message: "Pick books out of your library and they gather here, in the order you add them.",
+                actionTitle: "Add books"
+            )
+        case .smart:
+            Copy(
+                kicker: "No matches",
+                title: "Nothing matches yet",
+                message: "This shelf fills itself from its rules. Nothing in the library meets them right now.",
+                actionTitle: nil
+            )
+        case .wishlist:
+            Copy(
+                kicker: "Wishlist",
+                title: "Nothing on the wishlist",
+                message: "Check in a book you don't own yet and it waits here until a copy arrives.",
+                actionTitle: nil
+            )
+        case nil:
+            Copy(
+                kicker: "Empty shelf",
+                title: "Nothing on this shelf",
+                message: "No books are on it yet.",
+                actionTitle: nil
+            )
+        }
+    }
+
+    /// What to say when the shelf is known to hold books the device hasn't
+    /// fetched — offline, with the member page never cached. States the count
+    /// so the line agrees with the header rather than contradicting it.
+    static func unreachable(count: Int64) -> String {
+        count == 1
+            ? "This shelf holds one book, but it hasn't reached this device. "
+                + "It'll appear the next time you're online."
+            : "This shelf holds \(count) books, but they haven't reached this device. "
+                + "They'll appear the next time you're online."
     }
 }
 

--- a/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
@@ -367,7 +367,10 @@ struct ShelfDetailView: View {
             await OfflineStore.shared.cacheDelete(CacheKey.shelf(id))
             await OfflineStore.shared.cacheDelete(CacheKey.shelfPage(id))
         }
-        booksSettled = false
+        // Deliberately not reset on a refresh. `books` keeps its previous
+        // value across one, so un-settling only opens a window where a shelf
+        // showing the unreachable state falls back to "Nothing on this shelf"
+        // — the same false claim this flag was added to stop.
         await withTaskGroup(of: Void.self) { group in
             group.addTask { @MainActor in
                 // Cheap, local, and only ever a fallback — the detail read

--- a/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
+++ b/omnibus-ios/omnibus/Features/Shelves/ShelvesViews.swift
@@ -111,8 +111,14 @@ struct ShelfDetailView: View {
     /// gone it told a manual shelf that nothing matched its conditions. The
     /// shelves index is already in the replica and carries every field the
     /// header needs.
-    @State private var indexed: ShelfSummary?
+    @State private var indexed: ShelfPreview?
     @State private var books: [Book] = []
+    /// Whether the member read has finished, as opposed to not having answered
+    /// yet. `isLoading` clears on *either* stream's first value, so a cold
+    /// online load where the detail read wins the race left `books` empty with
+    /// the page already showing — and the unreachable state then told a reader
+    /// who was online that the books would arrive when they next were.
+    @State private var booksSettled = false
     @State private var isLoading = true
     @State private var showAddBooks = false
     @State private var scrollY: CGFloat = 0
@@ -122,7 +128,15 @@ struct ShelfDetailView: View {
     private let columns = [GridItem(.adaptive(minimum: 112, maximum: 168), spacing: 16, alignment: .top)]
 
     /// Whatever is known about this shelf, detail read first.
-    private var identity: ShelfSummary? { shelf.map(Self.summary) ?? indexed }
+    private var identity: ShelfSummary? { shelf.map(Self.summary) ?? indexed?.shelf }
+
+    /// Covers for the header mosaic: this shelf's own members once they land,
+    /// and the ones the cached index already holds until then. Without the
+    /// fallback the offline header drew the flat empty plate while the shelves
+    /// screen one back was showing that shelf's art from the same replica.
+    private var mosaicCovers: [Book] {
+        books.isEmpty ? (indexed?.covers ?? []) : Array(books.prefix(4))
+    }
 
     /// Only a manual shelf can be filled by hand — a smart shelf's membership
     /// is whatever its rules match, and the wishlist's is what you check in.
@@ -144,7 +158,7 @@ struct ShelfDetailView: View {
                             // is not the same as the shelf being empty — and
                             // saying "nothing on this shelf" under a header
                             // reading "1 book" contradicts itself.
-                            if let identity, identity.bookCount > 0 {
+                            if booksSettled, let identity, identity.bookCount > 0 {
                                 unreachableState(count: identity.bookCount)
                             } else {
                                 emptyState
@@ -237,10 +251,14 @@ struct ShelfDetailView: View {
         .frame(minHeight: 380)
     }
 
+    /// Named so a test can prove it resolves — `Image(systemName:)` neither
+    /// warns nor fails on a name that doesn't, it just draws nothing.
+    static let unreachableGlyph = "arrow.trianglehead.2.clockwise.rotate.90"
+
     /// The shelf has books the device hasn't got a copy of.
     private func unreachableState(count: Int64) -> some View {
         EmptyStateView(
-            icon: "arrow.trianglehead.2.clockwise.rotate.90",
+            icon: Self.unreachableGlyph,
             title: "Not here yet",
             message: ShelfEmptyCopy.unreachable(count: count),
             kicker: "Off the network",
@@ -257,7 +275,7 @@ struct ShelfDetailView: View {
             VStack(alignment: .leading, spacing: Spacing.lg) {
                 HStack(alignment: .top, spacing: Spacing.lg) {
                     ShelfMosaic(
-                        preview: ShelfPreview(shelf: identity, covers: Array(books.prefix(4)))
+                        preview: ShelfPreview(shelf: identity, covers: mosaicCovers)
                     )
                     .frame(width: 104)
                     .coverShadow(1.2)
@@ -349,12 +367,13 @@ struct ShelfDetailView: View {
             await OfflineStore.shared.cacheDelete(CacheKey.shelf(id))
             await OfflineStore.shared.cacheDelete(CacheKey.shelfPage(id))
         }
+        booksSettled = false
         await withTaskGroup(of: Void.self) { group in
             group.addTask { @MainActor in
                 // Cheap, local, and only ever a fallback — the detail read
                 // wins the moment it lands.
                 let previews: [ShelfPreview]? = await Cache.cachedOnly(CacheKey.shelfPreviews)
-                self.indexed = previews?.first { $0.shelf.id == self.id }?.shelf
+                self.indexed = previews?.first { $0.shelf.id == self.id }
             }
             group.addTask { @MainActor in
                 for await value in UserDataService.shelf(id: id).values() {
@@ -367,6 +386,10 @@ struct ShelfDetailView: View {
                     self.books = page.books
                     self.isLoading = false
                 }
+                // The stream is done — offline with nothing cached it finishes
+                // without ever yielding, which is exactly the case the
+                // unreachable state describes.
+                self.booksSettled = true
             }
         }
         isLoading = false

--- a/omnibus-ios/omnibus/Reader/ReaderContentsSheet.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderContentsSheet.swift
@@ -133,7 +133,11 @@ struct ReaderContentsSheet: View {
     @ViewBuilder
     private var contentsList: some View {
         if controller.toc.isEmpty {
-            EmptyStateView(icon: "list.bullet", title: "No table of contents")
+            EmptyStateView(
+                icon: "list.bullet",
+                title: "No table of contents",
+                message: "This edition ships without one — the scrubber still moves you through it."
+            )
         } else {
             ScrollViewReader { proxy in
                 ScrollView {

--- a/omnibus-ios/omnibusTests/ShelfEmptyCopyTests.swift
+++ b/omnibus-ios/omnibusTests/ShelfEmptyCopyTests.swift
@@ -1,0 +1,97 @@
+//  ShelfEmptyCopyTests.swift
+//  What an empty shelf says about itself, per kind.
+//
+//  The three kinds fill by three different mechanisms — by hand, by a rule, by
+//  checking a copy in — and only the first has an action to offer here. The
+//  page used to give every one of them the smart shelf's line, so a wishlist
+//  with nothing on it reported that no books matched conditions it does not
+//  have. `nil` is the fourth case and the one that regressed in the field:
+//  offline, before the detail read lands, the kind is unknown, and the page
+//  must describe the shelf without inventing machinery for it.
+
+import Testing
+
+@testable import omnibus
+
+@Suite("Empty shelf copy")
+struct ShelfEmptyCopyTests {
+    @Test("offers to fill a manual shelf, which is the only kind you fill here")
+    func manualShelfOffersAnAction() {
+        let copy = ShelfEmptyCopy.forKind(.manual)
+        #expect(copy.actionTitle == "Add books")
+        #expect(copy.title == "Nothing on this shelf")
+    }
+
+    @Test("explains a smart shelf's rules instead of offering an action it can't take")
+    func smartShelfExplainsItsRules() {
+        let copy = ShelfEmptyCopy.forKind(.smart)
+        #expect(copy.actionTitle == nil)
+        #expect(copy.message.contains("rules"))
+    }
+
+    @Test("tells the wishlist to check a copy in, not that nothing matched conditions")
+    func wishlistSpeaksOfCheckingIn() {
+        let copy = ShelfEmptyCopy.forKind(.wishlist)
+        #expect(copy.actionTitle == nil)
+        #expect(copy.message.contains("Check in"))
+        #expect(!copy.message.contains("rules"))
+    }
+
+    @Test("claims no mechanism when the kind is still unknown")
+    func unknownKindStaysNeutral() {
+        let copy = ShelfEmptyCopy.forKind(nil)
+        #expect(copy.actionTitle == nil)
+        #expect(!copy.message.contains("rules"))
+        #expect(!copy.message.contains("Check in"))
+    }
+
+    @Test("agrees with itself on number when the members haven't reached the device")
+    func unreachableCopyAgreesOnNumber() {
+        let one = ShelfEmptyCopy.unreachable(count: 1)
+        #expect(one.contains("one book"))
+        #expect(one.contains("it hasn't"))
+        #expect(!one.contains("they haven't"))
+
+        let many = ShelfEmptyCopy.unreachable(count: 4)
+        #expect(many.contains("4 books"))
+        #expect(many.contains("they haven't"))
+    }
+
+    @Test("every kind says something, and never repeats the smart shelf's line")
+    func noKindBorrowsAnother() {
+        let kinds: [ShelfKind?] = [.manual, .smart, .wishlist, nil]
+        let messages = kinds.map { ShelfEmptyCopy.forKind($0).message }
+        #expect(messages.allSatisfy { !$0.isEmpty })
+        #expect(Set(messages).count == messages.count)
+    }
+}
+
+@Suite("Shelf meta line")
+struct ShelfMetaLineTests {
+    private func shelf(kind: ShelfKind, count: Int64 = 0,
+                       visibility: ShelfVisibility = .private) -> ShelfSummary
+    {
+        ShelfSummary(
+            id: 1, ownerUserId: 1, ownerUsername: "reader", kind: kind,
+            name: "A shelf", visibility: visibility, accent: nil, bookCount: count
+        )
+    }
+
+    @Test("names the wishlist as a wishlist rather than as a manual shelf")
+    func wishlistNamesItself() {
+        #expect(ShelfDetailView.metaLine(shelf(kind: .wishlist)) == "0 books · Wishlist")
+    }
+
+    @Test("names a manual shelf")
+    func manualNamesItself() {
+        #expect(ShelfDetailView.metaLine(shelf(kind: .manual, count: 1)) == "1 book · Manual")
+    }
+
+    @Test("names a smart shelf, and marks a public one")
+    func smartNamesItselfAndItsVisibility() {
+        #expect(
+            ShelfDetailView.metaLine(shelf(kind: .smart, count: 3, visibility: .public))
+                == "3 books · Smart · Public"
+        )
+    }
+}

--- a/omnibus-ios/omnibusTests/SymbolNameTests.swift
+++ b/omnibus-ios/omnibusTests/SymbolNameTests.swift
@@ -24,4 +24,11 @@ struct SymbolNameTests {
         #expect(UIImage(systemName: BookMenuGlyph.detail) != nil)
         #expect(UIImage(systemName: BookMenuGlyph.edit) != nil)
     }
+
+    @Test("the shelf's off-the-network glyph resolves")
+    func shelfUnreachableGlyphResolves() {
+        // A long `arrow.trianglehead.…` name, and the only mark that state
+        // carries — a typo would leave a bare dashed plate with nothing in it.
+        #expect(UIImage(systemName: ShelfDetailView.unreachableGlyph) != nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Every "nothing here yet" surface on iOS led with a 40pt grey SF Symbol over a centred serif line — the one stock-iOS element left in an app whose whole visual language is editorial (serif display type, mono small-caps kickers, accent hairlines, cover mosaics).
- Three faults sat underneath that, all visible on the shelves screens: the state views painted a lit band rather than a page, shelf detail lost its entire identity offline, and the meta line called the wishlist a manual shelf.
- `EmptyStateView` / `ErrorStateView` sized to their own text, but every caller wraps them in a `Group` carrying `.background(ScreenBackground())` — and a `Group` is only as tall as its content, so Atrium's warm near-black ground painted a visible rectangle across an otherwise system-black screen (Downloads, Shelves, Authors, Series, Tags, Library). Both now claim `maxHeight: .infinity`.
- `ShelfDetailView` took its name, mosaic and kind from `UserDataService.shelf(id:)` alone, which is network-only on a cold cache — so offline the page was a bare glyph on black, and with the kind gone it told a *manual* shelf that "no books match this shelf's conditions". It now falls back to the shelves index already in the replica.
- `metaLine` printed "Manual" for anything that wasn't smart, so the wishlist — which nobody fills by hand — described itself as the one kind you do.
- The redesign introduces `GhostPlate`: the dashed 2:3 plate the new-shelf tile already draws, optionally fanned into a stack of three for a surface that holds a collection. Above an accent rule, an optional mono kicker, the headline in the display cut, and the action as the accent capsule the book detail's WRITE pill established.
- Book detail's stops get `StopRuledVoid` — the shape of the rows that would be there, fading down the page — so an empty stop reads as a ruled page waiting to be written on rather than one italic line above eight hundred points of black.
- The stats stop now shows its four tile keys with the values withheld, so the layout doesn't jump the first time a sitting lands, and the shelf stop says why a book is on no shelf instead of floating a lone "+ Shelf" chip under a bare kicker.
- `ShelfEmptyCopy` is a table rather than a branch in the view: the three shelf kinds fill by three different mechanisms and only one of them has an action to offer here, and `nil` is the honest fourth case for "the detail read hasn't landed, so the kind isn't known".
- A shelf whose members haven't reached the device now says so with its count, instead of claiming to be empty under a header reading "1 book" — the contradiction the offline fix above would otherwise have introduced.
- Thin call sites gained real copy: "No authors yet", "No series yet", "No tags yet", the search grid's "No matches" and the reader's "No table of contents" were title-only.

## Test plan

- [x] `just ios-test` — full `omnibusTests` suite green (850 test nodes), including the two new suites `ShelfEmptyCopyTests` and `ShelfMetaLineTests`.
- [x] `just ios-build` equivalent (`xcodebuild build`, Debug, iOS Simulator) — clean, no new warnings.
- [x] Drove the simulator against a live dev server: shelves index, an empty wishlist shelf, an empty manual shelf (accent "Add books" action), Downloads (band gone), search with no matches, and the book detail Highlights / Journals / Stats / Shelf stops.
- [x] Drove the same screens with the dev server stopped, to confirm the shelf-detail header survives with no network and that a shelf with uncached members reports its count rather than reading as empty.

## Version

- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; a polish pass over existing surfaces, no schema or wire change.
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes

- No server, DB, or wire changes — the diff is `omnibus-ios/**` plus one paragraph in `docs/architecture.md` recording the `GhostPlate` motif and the reason both state views claim their container.
- The `maxHeight: .infinity` on `EmptyStateView` / `ErrorStateView` is load-bearing, not cosmetic, and the doc note says so — a future state view that sizes to its text brings the band back.
- Playwright is correctly out of scope here: `e2e.yml`'s paths filter covers `frontend/`, `shared/`, `server/`, `db/` and `ui_tests/`, none of which this touches, so a skipped E2E check is a genuine skip rather than a missing `run_ui_tests` label.
