### PR TITLE
feat: give the iOS book detail a two-position home

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -78,6 +78,50 @@ enum DetailRead {
         guard let audioSeconds, let audioDuration, audioDuration > 0 else { return nil }
         return min(1, max(0, audioSeconds / audioDuration))
     }
+
+    /// Where the Home panel rests below a whole cover: the 2:3 cover height
+    /// at this width, clamped so a short screen keeps a readable panel strip
+    /// and a degenerate one still shows some art.
+    static func restTop(width: CGFloat, height: CGFloat) -> CGFloat {
+        max(220, min((width * 1.5).rounded(), height - 240))
+    }
+
+    /// Continuous scroll offset → the two numbers the shell reacts to:
+    /// `lift` is the Home panel's rest→lifted progress across the rest run,
+    /// `page` the stop position past it — held at 0 while the panel is still
+    /// lifting, so the art pan and fade wait for stop 02. A zero `restTop`
+    /// means no rest run (a plate cover): plain paging, always lifted.
+    static func scrollMap(
+        offset: CGFloat, restTop: CGFloat, viewport: CGFloat
+    ) -> (lift: CGFloat, page: CGFloat) {
+        guard viewport > 0 else { return (1, 0) }
+        guard restTop > 0 else { return (1, max(0, offset / viewport)) }
+        return (
+            lift: min(1, max(0, offset / restTop)),
+            page: max(0, (offset - restTop) / viewport)
+        )
+    }
+
+    /// What the Home sync row states per link state, and the action word its
+    /// trailing affordance promises. Every action opens the alignment sheet —
+    /// link, re-confirm, and unlink all live there.
+    static func syncRow(state: CrossFormatResumeState?) -> DetailSyncCopy {
+        switch state {
+        case .linkStale:
+            DetailSyncCopy(label: "Sync needs re-confirm", action: "Re-confirm", linked: false)
+        case .notLinked, nil:
+            DetailSyncCopy(label: "Positions unlinked", action: "Link", linked: false)
+        default:
+            DetailSyncCopy(label: "Positions linked", action: "Manage", linked: true)
+        }
+    }
+}
+
+/// The Home sync row's copy, plus whether it wears the linked (accent) look.
+struct DetailSyncCopy: Equatable {
+    var label: String
+    var action: String
+    var linked: Bool
 }
 
 /// What the stats stop states about this read, folded from the session log.
@@ -191,6 +235,103 @@ struct MonoNote: View {
             .font(.monoUI(9.5))
             .foregroundStyle(color ?? palette.ink3Color)
             .lineSpacing(3)
+    }
+}
+
+/// The Home panel's grab bar and its one-line invitation. At rest it points
+/// up; lifted, it carries the stop label and points back down. Tapping
+/// toggles the position for anyone who doesn't read "swipe" as an offer.
+struct LiftHandle: View {
+    let lifted: Bool
+    var onToggle: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Button {
+            Haptics.tap()
+            onToggle()
+        } label: {
+            HStack(spacing: 9) {
+                Capsule()
+                    .fill(palette.ink2Color.opacity(0.55))
+                    .frame(width: 36, height: 4)
+                Text(label)
+                    .font(.monoUI(8.5))
+                    .tracking(1.4)
+                    .foregroundStyle(palette.ink3Color)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 7)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.bottom, 7)
+        .accessibilityLabel(lifted ? "Collapse book details" : "Expand book details")
+        .accessibilityIdentifier("home-lift-handle")
+    }
+
+    private var label: String {
+        lifted
+            ? String(
+                format: "%02d / %02d — HOME · SWIPE DOWN",
+                DetailStop.home.rawValue + 1, DetailStop.allCases.count
+            )
+            : "SWIPE UP FOR THE REST"
+    }
+}
+
+/// The cross-format position-sync state, as a full-width bordered row on the
+/// Home stop: the state on the left, the accent action on the right. Tapping
+/// anywhere opens the alignment sheet — link and unlink both live there.
+struct DetailSyncRow: View {
+    let state: CrossFormatResumeState?
+    var onOpen: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        let copy = DetailRead.syncRow(state: state)
+
+        Button {
+            Haptics.tap()
+            onOpen()
+        } label: {
+            HStack(spacing: 8) {
+                Text("\u{21C4}")
+                    .font(.system(size: 12))
+                    .foregroundStyle(copy.linked ? palette.accentColor : palette.ink3Color)
+                Text(copy.label.uppercased())
+                    .font(.monoUI(9.5))
+                    .tracking(1.3)
+                    .foregroundStyle(copy.linked ? palette.ink1Color : palette.ink2Color)
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.sm)
+                Text(copy.action.uppercased())
+                    .font(.monoUI(9.5))
+                    .tracking(1.3)
+                    .foregroundStyle(palette.accentColor)
+            }
+            .padding(.horizontal, 11)
+            .frame(height: 38)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(copy.linked ? palette.accentColor.opacity(0.07) : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(
+                        copy.linked
+                            ? palette.accentColor.opacity(0.4)
+                            : palette.line2.color,
+                        lineWidth: 1
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        }
+        .buttonStyle(PressableStyle())
+        .accessibilityLabel("\(copy.label). \(copy.action)")
+        .accessibilityIdentifier("home-sync-row")
     }
 }
 
@@ -647,7 +788,14 @@ struct MoreRowButton: View {
 struct StopHome: View {
     let book: Book
     let model: BookDetailModel
+    /// Whether the panel rests under a whole cover (a photographic cover
+    /// exists) and whether it is currently lifted. At rest the panel is a
+    /// short strip, so the compact state trims what the fold would cut
+    /// anyway; a plate book has no rest position and is always lifted.
+    var restingCover = false
+    var lifted = true
     var onMore: () -> Void
+    var onAlignment: () -> Void
     var onRemovedWishlist: () -> Void
 
     @Environment(\.palette) private var palette
@@ -662,7 +810,9 @@ struct StopHome: View {
             ))
 
             Text(book.displayTitle)
-                .font(.display(38, weight: .semibold))
+                // The two-position panel trades title size for the room the
+                // whole cover took — both positions share the smaller cut.
+                .font(.display(restingCover ? 31 : 38, weight: .semibold))
                 .foregroundStyle(palette.ink0Color)
                 .lineLimit(3)
                 .minimumScaleFactor(0.6)
@@ -674,9 +824,16 @@ struct StopHome: View {
                 .lineLimit(1)
                 .padding(.top, 7)
 
-            if !book.genres.isEmpty || !book.subjects.isEmpty {
+            if !book.genres.isEmpty {
                 ChipStrip {
                     ForEach(book.genres, id: \.self) { GenreChip(label: $0) }
+                }
+                .padding(.top, 11)
+                .accessibilityIdentifier("book-detail-genres")
+            }
+
+            if !book.subjects.isEmpty, lifted {
+                ChipStrip {
                     ForEach(book.subjects, id: \.self) { subject in
                         NavigationLink(value: Destination.tag(name: subject)) {
                             TagChip(label: subject)
@@ -684,8 +841,8 @@ struct StopHome: View {
                         .buttonStyle(PressableStyle())
                     }
                 }
-                .padding(.top, 11)
-                .accessibilityIdentifier("book-detail-genres")
+                .padding(.top, book.genres.isEmpty ? 11 : 7)
+                .accessibilityIdentifier("book-detail-tags")
             }
 
             if let description = book.description?.nilIfBlank {
@@ -693,21 +850,25 @@ struct StopHome: View {
                     .font(.ui(13))
                     .foregroundStyle(palette.ink1Color)
                     .lineSpacing(4)
-                    .lineLimit(2)
+                    // Lifted there is room for a real excerpt; at rest the
+                    // fold is close, so two lines tease the drawer instead.
+                    .lineLimit(restingCover && lifted ? 6 : 2)
                     .padding(.top, 11)
                     .onTapGesture { onMore() }
 
-                Button {
-                    Haptics.tap()
-                    onMore()
-                } label: {
-                    Text("MORE")
-                        .font(.monoUI(9.5))
-                        .tracking(1.5)
-                        .foregroundStyle(palette.accentColor)
+                if lifted {
+                    Button {
+                        Haptics.tap()
+                        onMore()
+                    } label: {
+                        Text("MORE")
+                            .font(.monoUI(9.5))
+                            .tracking(1.5)
+                            .foregroundStyle(palette.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 6)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 6)
             }
 
             if model.isWishlistOnly {
@@ -728,8 +889,14 @@ struct StopHome: View {
 
                 ruler
                     .padding(.top, 17)
+
+                if book.hasEbook, book.hasAudiobook {
+                    DetailSyncRow(state: model.syncState, onOpen: onAlignment)
+                        .padding(.top, 14)
+                }
             }
         }
+        .animation(Motion.snap, value: lifted)
     }
 
     @ViewBuilder

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -90,7 +90,7 @@ enum DetailRead {
     /// `lift` is the Home panel's rest→lifted progress across the rest run,
     /// `page` the stop position past it — held at 0 while the panel is still
     /// lifting, so the art pan and fade wait for stop 02. A zero `restTop`
-    /// means no rest run (a plate cover): plain paging, always lifted.
+    /// degenerates to plain paging, permanently lifted.
     static func scrollMap(
         offset: CGFloat, restTop: CGFloat, viewport: CGFloat
     ) -> (lift: CGFloat, page: CGFloat) {
@@ -788,11 +788,9 @@ struct MoreRowButton: View {
 struct StopHome: View {
     let book: Book
     let model: BookDetailModel
-    /// Whether the panel rests under a whole cover (a photographic cover
-    /// exists) and whether it is currently lifted. At rest the panel is a
-    /// short strip, so the compact state trims what the fold would cut
-    /// anyway; a plate book has no rest position and is always lifted.
-    var restingCover = false
+    /// Whether the panel is at its lifted position. At rest it is a short
+    /// strip under the artwork, so the compact state trims what the fold
+    /// would cut anyway.
     var lifted = true
     var onMore: () -> Void
     var onAlignment: () -> Void
@@ -811,8 +809,8 @@ struct StopHome: View {
 
             Text(book.displayTitle)
                 // The two-position panel trades title size for the room the
-                // whole cover took — both positions share the smaller cut.
-                .font(.display(restingCover ? 31 : 38, weight: .semibold))
+                // artwork took — both positions share the smaller cut.
+                .font(.display(31, weight: .semibold))
                 .foregroundStyle(palette.ink0Color)
                 .lineLimit(3)
                 .minimumScaleFactor(0.6)
@@ -852,7 +850,7 @@ struct StopHome: View {
                     .lineSpacing(4)
                     // Lifted there is room for a real excerpt; at rest the
                     // fold is close, so two lines tease the drawer instead.
-                    .lineLimit(restingCover && lifted ? 6 : 2)
+                    .lineLimit(lifted ? 6 : 2)
                     .padding(.top, 11)
                     .onTapGesture { onMore() }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -844,15 +844,27 @@ struct StopHome: View {
             }
 
             if let description = book.description?.nilIfBlank {
-                Text(description.strippingHTML)
-                    .font(.ui(13))
-                    .foregroundStyle(palette.ink1Color)
-                    .lineSpacing(4)
-                    // Lifted there is room for a real excerpt; at rest the
-                    // fold is close, so two lines tease the drawer instead.
-                    .lineLimit(lifted ? 6 : 2)
-                    .padding(.top, 11)
-                    .onTapGesture { onMore() }
+                // A real button, not a bare tap gesture: at rest the "MORE"
+                // affordance is folded away, so the preview itself must
+                // advertise the action for VoiceOver.
+                Button {
+                    Haptics.tap()
+                    onMore()
+                } label: {
+                    Text(description.strippingHTML)
+                        .font(.ui(13))
+                        .foregroundStyle(palette.ink1Color)
+                        .lineSpacing(4)
+                        // Lifted there is room for a real excerpt; at rest
+                        // the fold is close, so two lines tease the drawer.
+                        .lineLimit(lifted ? 6 : 2)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 11)
+                .accessibilityHint("Opens the full description")
 
                 if lifted {
                     Button {

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -763,6 +763,16 @@ struct BookDetailView: View {
                     }
                     .buttonStyle(BarGlassStyle())
                     .accessibilityLabel(toPlayer ? "Read" : "Listen")
+
+                    Button {
+                        Haptics.tap()
+                        immersiveRead(book)
+                    } label: {
+                        ImmersiveReadMark()
+                    }
+                    .buttonStyle(BarGlassStyle())
+                    .accessibilityLabel("Immersive read")
+                    .accessibilityIdentifier("bar-immersive-read")
                 }
             }
         }
@@ -780,6 +790,15 @@ struct BookDetailView: View {
     }
 
     private func read(_ book: Book) {
+        Presentation.shared.openReader(book)
+    }
+
+    /// The immersive read: the reader with the audiobook running under it —
+    /// the docked mini bar keeps playback controllable while reading. Audio
+    /// loads in the background (it resolves the saved-position file itself,
+    /// and re-opening the playing book is a no-op) while the reader opens.
+    private func immersiveRead(_ book: Book) {
+        Task { await player.load(book: book) }
         Presentation.shared.openReader(book)
     }
 
@@ -996,6 +1015,35 @@ struct BarCTAStyle: ButtonStyle {
             )
             .scaleEffect(configuration.isPressed ? 0.97 : 1)
             .animation(Motion.lift, value: configuration.isPressed)
+    }
+}
+
+/// The immersive-read glyph: a page beside sound bars, drawn to match the
+/// design's mark — no SF Symbol says "read along".
+struct ImmersiveReadMark: View {
+    var size: CGFloat = 17
+
+    var body: some View {
+        // Laid out on the mark's 24pt grid, scaled to `size`.
+        let unit = size / 24
+        let stroke = 1.9 * unit
+
+        HStack(alignment: .center, spacing: 3.5 * unit) {
+            RoundedRectangle(cornerRadius: 2 * unit, style: .continuous)
+                .strokeBorder(lineWidth: stroke)
+                .frame(width: 8 * unit, height: 14 * unit)
+            HStack(alignment: .center, spacing: 1.1 * unit) {
+                bar(8, unit: unit, stroke: stroke)
+                bar(12, unit: unit, stroke: stroke)
+                bar(5, unit: unit, stroke: stroke)
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private func bar(_ height: CGFloat, unit: CGFloat, stroke: CGFloat) -> some View {
+        Capsule()
+            .frame(width: stroke, height: height * unit)
     }
 }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -2,9 +2,12 @@
 //  The book detail marquee: full-bleed cover art running off the top edge,
 //  a translucent panel riding over its lower edge, and the page organised as
 //  seven snap stops on a vertical pager — Home · Shelf · Stats · Highlights ·
-//  Journals · The files · Recommendations. Chrome is immersive: glass discs
-//  over the art, a tappable dot rail, and a persistent bottom action bar so
-//  Resume never scrolls away.
+//  Journals · The files · Recommendations. Home has two positions when the
+//  book has a photographic cover: the page opens on the cover whole with the
+//  panel resting under it, and the first swipe lifts the panel to full
+//  height before the next one moves on to stop 02. Chrome is immersive:
+//  glass discs over the art, a tappable dot rail, and a persistent bottom
+//  action bar so Resume never scrolls away.
 
 import SwiftUI
 
@@ -251,13 +254,18 @@ struct BookDetailView: View {
         self.uuid = uuid
     }
 
-    /// Where the panel's top edge sits at the Home stop — how much cover art
-    /// stays in view before the page becomes the panel.
+    /// Where the panel's top edge sits at the Home stop for a plate cover —
+    /// how much art stays in view before the page becomes the panel. A
+    /// photographic cover derives its rest position from the cover height
+    /// instead (`DetailRead.restTop`).
     static let artTop: CGFloat = 300
-    /// Window the artwork pans inside.
+    /// Window the artwork pans inside once the Home panel has lifted.
     static let artHeight: CGFloat = 470
     /// Clearance the panel keeps for the action bar.
     static let barClearance: CGFloat = 108
+    /// Scroll id of the rest run above the Home stop — the pre-Home snap
+    /// target the two-position panel rests at.
+    static let restMarkerID = -1
 
     @Environment(\.palette) private var palette
     @Environment(\.dismiss) private var dismiss
@@ -288,6 +296,13 @@ struct BookDetailView: View {
     @State private var editingJournal: JournalEntry?
     /// Continuous page position, 0...6 — drives the art pan and fade.
     @State private var page: CGFloat = 0
+    /// The Home panel's rest→lifted progress, 0...1 — drives the art's
+    /// whole→windowed transition and the panel's padding and tint. Pinned
+    /// to 1 for books whose panel has no rest position.
+    @State private var lift: CGFloat = 0
+    /// Whether the Home panel has settled lifted — the discrete switch the
+    /// handle label, tag row, and description clamp key on.
+    @State private var lifted = false
     /// The stop the scroller has settled nearest to.
     @State private var at: Int = 0
     /// Scroll-position binding for the dot rail's jumps. Written on a tap;
@@ -419,31 +434,69 @@ struct BookDetailView: View {
 
     // MARK: - Shell
 
-    private func content(_ book: Book) -> some View {
-        ZStack {
-            ScreenBackground()
-            DetailArtLayer(book: book, page: page)
-                .ignoresSafeArea()
-            snapScroller(book)
-                .ignoresSafeArea()
-        }
-        .overlay(alignment: .top) { chromeDiscs(book) }
-        .overlay(alignment: .trailing) { dotRail }
-        .overlay(alignment: .bottomTrailing) { nextHint }
-        .overlay(alignment: .bottom) { actionBar(book) }
+    /// Whether the Home panel gets its two positions: it needs a
+    /// photographic cover to rest against — a typographic plate is shown
+    /// whole anyway, so those books keep the one-position panel.
+    private func hasRestingCover(_ book: Book) -> Bool {
+        book.coverURL != nil
     }
 
-    private func snapScroller(_ book: Book) -> some View {
+    private func content(_ book: Book) -> some View {
+        GeometryReader { geometry in
+            // The scroller and art ignore the safe areas, so the rest
+            // geometry has to be derived from the full screen, not the
+            // inset-trimmed proxy size.
+            let size = CGSize(
+                width: geometry.size.width
+                    + geometry.safeAreaInsets.leading + geometry.safeAreaInsets.trailing,
+                height: geometry.size.height
+                    + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
+            )
+            let twoPosition = hasRestingCover(book)
+            let restTop = DetailRead.restTop(width: size.width, height: size.height)
+
+            ZStack {
+                ScreenBackground()
+                DetailArtLayer(book: book, page: page, lift: twoPosition ? lift : 1)
+                    .ignoresSafeArea()
+                snapScroller(book, twoPosition: twoPosition, restTop: restTop)
+                    .ignoresSafeArea()
+            }
+            .overlay(alignment: .top) { chromeDiscs(book) }
+            .overlay(alignment: .trailing) {
+                DetailDotRail(at: at) { stop in
+                    withAnimation(Motion.settle) { scrollTarget = stop.rawValue }
+                }
+            }
+            .overlay(alignment: .bottomTrailing) { nextHint }
+            .overlay(alignment: .bottom) { restFade(twoPosition) }
+            .overlay(alignment: .bottom) { actionBar(book) }
+        }
+    }
+
+    private func snapScroller(
+        _ book: Book, twoPosition: Bool, restTop: CGFloat
+    ) -> some View {
         ScrollView(.vertical) {
             VStack(spacing: 0) {
+                // The rest run: scrolling it away is what lifts the panel,
+                // and its top edge is the snap target the panel rests at.
+                if twoPosition {
+                    Color.clear
+                        .frame(height: restTop)
+                        .id(Self.restMarkerID)
+                }
                 ForEach(DetailStop.allCases) { stop in
-                    stopSection(stop, book)
+                    stopSection(stop, book, twoPosition: twoPosition)
                         .id(stop.rawValue)
                 }
             }
             .scrollTargetLayout()
         }
-        .scrollTargetBehavior(.paging)
+        // View-aligned rather than paged: the rest run makes the first snap
+        // length differ from a page, and `.always` keeps the one-stop-per-
+        // swipe contract — the same gesture gate the design prescribes.
+        .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
         .scrollPosition(id: $scrollTarget)
         .scrollIndicators(.hidden)
         .onScrollGeometryChange(for: DetailScrollState.self) { geometry in
@@ -453,35 +506,57 @@ struct BookDetailView: View {
             )
         } action: { _, state in
             guard state.viewport > 0 else { return }
-            let raw = state.offset / state.viewport
-            page = min(CGFloat(DetailStop.allCases.count - 1), max(0, raw))
+            let map = DetailRead.scrollMap(
+                offset: state.offset,
+                restTop: twoPosition ? restTop : 0,
+                viewport: state.viewport
+            )
+            lift = map.lift
+            page = min(CGFloat(DetailStop.allCases.count - 1), map.page)
             at = Int(page.rounded())
+            let settled = !twoPosition || map.lift > 0.6
+            if settled != lifted {
+                withAnimation(Motion.snap) { lifted = settled }
+            }
         }
     }
 
-    private func stopSection(_ stop: DetailStop, _ book: Book) -> some View {
+    private func stopSection(
+        _ stop: DetailStop, _ book: Book, twoPosition: Bool
+    ) -> some View {
         VStack(spacing: 0) {
-            if stop == .home {
+            // A plate cover keeps the fixed art window above the panel; a
+            // resting cover's clearance is the rest run before this section.
+            if stop == .home, !twoPosition {
                 Color.clear.frame(height: Self.artTop)
             }
-            stopPanel(stop, book)
+            stopPanel(stop, book, twoPosition: twoPosition)
         }
         .containerRelativeFrame(.vertical)
     }
 
-    private func stopPanel(_ stop: DetailStop, _ book: Book) -> some View {
+    private func stopPanel(
+        _ stop: DetailStop, _ book: Book, twoPosition: Bool
+    ) -> some View {
         let isHome = stop == .home
+        let resting = isHome && twoPosition
 
         return VStack(alignment: .leading, spacing: 0) {
-            StopLabel(stop: stop)
+            if resting {
+                LiftHandle(lifted: lifted) { toggleLift() }
+            } else {
+                StopLabel(stop: stop)
+            }
             stopContent(stop, book)
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(EdgeInsets(
             // A full stop's label must clear the chrome discs, which end
-            // ~105pt below the top edge on current devices.
-            top: isHome ? 14 : 128,
+            // ~105pt below the top edge on current devices. The two-position
+            // Home earns that clearance as it lifts — at rest its top edge
+            // is far below the discs.
+            top: isHome ? (twoPosition ? 14 + 114 * lift : 14) : 128,
             leading: 22,
             bottom: Self.barClearance,
             trailing: 30
@@ -492,16 +567,48 @@ struct BookDetailView: View {
             // blurs, so the tint stays light at Home — heavier and the art it
             // rides over reads as a hard cut instead of a ghost. Past Home the
             // art has faded, so the panel goes nearly opaque and simply is
-            // the screen.
+            // the screen. The two-position Home moves between those poles:
+            // resting below the cover it owns its strip, lifted it ghosts
+            // the whole cover behind it.
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
-                palette.bg0Color.opacity(isHome ? 0.30 : 0.82)
+                palette.bg0Color.opacity(
+                    isHome ? (twoPosition ? 0.60 + 0.22 * lift : 0.30) : 0.82)
             }
         }
         .overlay(alignment: .top) {
-            if isHome { Hairline() }
+            if isHome { Hairline().opacity(twoPosition ? 1 - lift : 1) }
         }
         .clipped()
+    }
+
+    /// The handle's tap: jump the scroller to the other Home position.
+    private func toggleLift() {
+        withAnimation(Motion.settle) {
+            scrollTarget = lifted ? Self.restMarkerID : DetailStop.home.rawValue
+        }
+    }
+
+    /// At rest the panel's lower content runs on under the action bar; this
+    /// fades it into the ground the way the design masks it out, and lifts
+    /// away with the panel.
+    @ViewBuilder
+    private func restFade(_ twoPosition: Bool) -> some View {
+        if twoPosition {
+            LinearGradient(
+                stops: [
+                    .init(color: palette.bg0Color.opacity(0), location: 0),
+                    .init(color: palette.bg0Color, location: 0.62),
+                    .init(color: palette.bg0Color, location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 170)
+            .opacity(1 - lift)
+            .allowsHitTesting(false)
+            .ignoresSafeArea(edges: .bottom)
+        }
     }
 
     @ViewBuilder
@@ -511,7 +618,12 @@ struct BookDetailView: View {
             StopHome(
                 book: book,
                 model: model,
+                restingCover: hasRestingCover(book),
+                // A plate book's panel has no rest position — it is always
+                // the full stop, whatever the scroller last reported.
+                lifted: !hasRestingCover(book) || lifted,
                 onMore: { showDescription = true },
+                onAlignment: { showAlignment = true },
                 onRemovedWishlist: { model.wishlistEntry = nil }
             )
         case .shelf:
@@ -595,39 +707,6 @@ struct BookDetailView: View {
         .padding(.horizontal, 16)
         .padding(.top, 8)
         .animation(Motion.snap, value: at == 0)
-    }
-
-    /// The desktop dot rail, moved to the panel's right edge.
-    private var dotRail: some View {
-        VStack(spacing: 0) {
-            ForEach(DetailStop.allCases) { stop in
-                Button {
-                    Haptics.select()
-                    withAnimation(Motion.settle) { scrollTarget = stop.rawValue }
-                } label: {
-                    Circle()
-                        .fill(at == stop.rawValue ? palette.accentColor : palette.bg3Color)
-                        .frame(width: 7, height: 7)
-                        .scaleEffect(at == stop.rawValue ? 1.35 : 1)
-                        // The dot is the indicator, not the target — the row
-                        // is sized for a finger, near the 44pt guideline.
-                        .frame(width: 44, height: 26)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(stop.name)
-            }
-        }
-        .padding(.vertical, 5)
-        // The visible pill stays slim while the touch strip stays wide — the
-        // capsule is drawn narrower than the rail it backs.
-        .background {
-            Capsule().fill(palette.bg0Color.opacity(0.45))
-                .overlay(Capsule().strokeBorder(palette.line2.color, lineWidth: 0.5))
-                .frame(width: 19)
-        }
-        .offset(y: 90)
-        .animation(Motion.snap, value: at)
     }
 
     /// A quiet pointer at what the next swipe reaches. Home speaks for
@@ -775,15 +854,62 @@ private struct DetailScrollState: Equatable {
     var viewport: CGFloat
 }
 
+/// The desktop dot rail, moved to the panel's right edge. A view of its own
+/// so it reads the palette from the environment — the screen re-keys that to
+/// the book's tone, and the active dot must carry the book accent, not the
+/// app's.
+struct DetailDotRail: View {
+    let at: Int
+    var onJump: (DetailStop) -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(DetailStop.allCases) { stop in
+                Button {
+                    Haptics.select()
+                    onJump(stop)
+                } label: {
+                    Circle()
+                        .fill(at == stop.rawValue ? palette.accentColor : palette.bg3Color)
+                        .frame(width: 7, height: 7)
+                        .scaleEffect(at == stop.rawValue ? 1.35 : 1)
+                        // The dot is the indicator, not the target — the row
+                        // is sized for a finger, near the 44pt guideline.
+                        .frame(width: 44, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(stop.name)
+            }
+        }
+        .padding(.vertical, 5)
+        // The visible pill stays slim while the touch strip stays wide — the
+        // capsule is drawn narrower than the rail it backs.
+        .background {
+            Capsule().fill(palette.bg0Color.opacity(0.45))
+                .overlay(Capsule().strokeBorder(palette.line2.color, lineWidth: 0.5))
+                .frame(width: 19)
+        }
+        .offset(y: 90)
+        .animation(Motion.snap, value: at)
+    }
+}
+
 // MARK: - Art layer
 
-/// The cover, full-bleed off the top edge. Photographic art is taller than
-/// its window and pans as the page moves through the stops; a generated
-/// plate is shown whole instead — cropping one would eat its own layout.
-/// Both dissolve to a wash as the panel takes the screen.
+/// The cover, full-bleed off the top edge. While the Home panel rests, a
+/// photographic cover shows whole — unmasked, nothing cropped; as the panel
+/// lifts, the art closes down to the window it pans inside across the
+/// stops. A generated plate is shown whole always — cropping one would eat
+/// its own layout. Both dissolve to a wash as the panel takes the screen.
 struct DetailArtLayer: View {
     let book: Book
     let page: CGFloat
+    /// The Home panel's rest→lifted progress; 1 for books with no rest
+    /// position, so the window and mask sit at their shipped values.
+    var lift: CGFloat = 1
 
     @Environment(\.palette) private var palette
 
@@ -811,8 +937,14 @@ struct DetailArtLayer: View {
         GeometryReader { geometry in
             let width = geometry.size.width
             let imageHeight = width * 1.5
-            let travel = max(0, imageHeight - BookDetailView.artHeight)
+            // The window opens to the whole image at rest and closes to the
+            // pan height as the panel lifts; the mask's fade-out arrives
+            // with it, so the resting cover keeps its bottom edge.
+            let windowHeight = BookDetailView.artHeight
+                + (imageHeight - BookDetailView.artHeight) * (1 - lift)
+            let travel = max(0, imageHeight - windowHeight)
             let progress = min(1, page / CGFloat(DetailStop.allCases.count - 1))
+            let fadeStart = 0.58 + 0.42 * (1 - lift)
 
             RemoteImage(
                 path: "/api/covers/\(book.uuid)",
@@ -826,7 +958,7 @@ struct DetailArtLayer: View {
             .background { GeneratedCoverPlate(identity: CoverIdentity(book)) }
             .frame(width: width, height: imageHeight)
             .offset(y: -progress * travel)
-            .frame(width: width, height: BookDetailView.artHeight, alignment: .top)
+            .frame(width: width, height: windowHeight, alignment: .top)
             .clipped()
             // Dark scrim off the top edge so the status bar and discs stay
             // legible over bright artwork.
@@ -842,7 +974,7 @@ struct DetailArtLayer: View {
                 LinearGradient(
                     stops: [
                         .init(color: .black, location: 0),
-                        .init(color: .black, location: 0.58),
+                        .init(color: .black, location: fadeStart),
                         .init(color: .clear, location: 1),
                     ],
                     startPoint: .top,
@@ -850,7 +982,6 @@ struct DetailArtLayer: View {
                 )
             }
         }
-        .frame(height: BookDetailView.artHeight)
     }
 
     /// The typographic plate, whole, in a soft accent halo.

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -3,11 +3,11 @@
 //  a translucent panel riding over its lower edge, and the page organised as
 //  seven snap stops on a vertical pager — Home · Shelf · Stats · Highlights ·
 //  Journals · The files · Recommendations. Home has two positions: the page
-//  opens on the artwork — a photographic cover whole, a plate in its halo —
-//  with the panel resting under it, and the first swipe lifts the panel to
-//  full height before the next one moves on to stop 02. Chrome is immersive:
-//  glass discs over the art, a tappable dot rail, and a persistent bottom
-//  action bar so Resume never scrolls away.
+//  opens on the artwork whole — the cover, or the generated plate at the
+//  same size — with the panel resting under it, and the first swipe lifts
+//  the panel to full height before the next one moves on to stop 02. Chrome
+//  is immersive: glass discs over the art, a tappable dot rail, and a
+//  persistent bottom action bar so Resume never scrolls away.
 
 import SwiftUI
 
@@ -254,11 +254,6 @@ struct BookDetailView: View {
         self.uuid = uuid
     }
 
-    /// Where the Home panel rests for a plate cover — how much of the plate
-    /// window stays in view before the page becomes the panel. A
-    /// photographic cover derives its rest position from the cover height
-    /// instead (`DetailRead.restTop`).
-    static let artTop: CGFloat = 300
     /// Window the artwork pans inside once the Home panel has lifted.
     static let artHeight: CGFloat = 470
     /// Clearance the panel keeps for the action bar.
@@ -433,16 +428,6 @@ struct BookDetailView: View {
 
     // MARK: - Shell
 
-    /// Where the Home panel rests for this book: below the whole cover when
-    /// a photographic one exists, at the plate window's edge otherwise — a
-    /// typographic plate is short, so its panel rests higher. Either way the
-    /// first swipe lifts the panel to the top of the page.
-    private func restTop(for book: Book, in size: CGSize) -> CGFloat {
-        book.coverURL != nil
-            ? DetailRead.restTop(width: size.width, height: size.height)
-            : Self.artTop
-    }
-
     private func content(_ book: Book) -> some View {
         GeometryReader { geometry in
             // The scroller and art ignore the safe areas, so the rest
@@ -454,7 +439,7 @@ struct BookDetailView: View {
                 height: geometry.size.height
                     + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
             )
-            let restTop = restTop(for: book, in: size)
+            let restTop = DetailRead.restTop(width: size.width, height: size.height)
 
             ZStack {
                 ScreenBackground()
@@ -877,33 +862,62 @@ struct DetailDotRail: View {
 
 // MARK: - Art layer
 
-/// The cover, full-bleed off the top edge. While the Home panel rests, a
-/// photographic cover shows whole — unmasked, nothing cropped; as the panel
-/// lifts, the art closes down to the window it pans inside across the
-/// stops. A generated plate is shown whole always — cropping one would eat
-/// its own layout. Both dissolve to a wash as the panel takes the screen.
+/// The artwork, full-bleed off the top edge — the cover when the record has
+/// one, the generated plate at the same size otherwise, so every book takes
+/// the identical path. While the Home panel rests the art shows whole —
+/// unmasked, nothing cropped; as the panel lifts, it closes down to the
+/// window it pans inside across the stops, and dissolves to a wash as the
+/// panel takes the screen.
 struct DetailArtLayer: View {
     let book: Book
     let page: CGFloat
-    /// The Home panel's rest→lifted progress. Only photographic art reads
-    /// it — a plate is drawn whole in both positions.
+    /// The Home panel's rest→lifted progress — drives the whole→windowed
+    /// transition.
     var lift: CGFloat = 1
 
-    @Environment(\.palette) private var palette
-
-    /// How much taller the panned image is than its window, at 2:3 on a
-    /// 402pt-wide device — the travel budget the pan spends across the stops.
     private var fade: Double {
         min(1, Double(page) * 1.25)
     }
 
     var body: some View {
-        Group {
-            if book.coverURL != nil {
-                pannedArt
-            } else {
-                plate
-            }
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let imageHeight = width * 1.5
+            // The window opens to the whole image at rest and closes to the
+            // pan height as the panel lifts; the mask's fade-out arrives
+            // with it, so the resting artwork keeps its bottom edge.
+            let windowHeight = BookDetailView.artHeight
+                + (imageHeight - BookDetailView.artHeight) * (1 - lift)
+            let travel = max(0, imageHeight - windowHeight)
+            let progress = min(1, page / CGFloat(DetailStop.allCases.count - 1))
+            let fadeStart = 0.58 + 0.42 * (1 - lift)
+
+            art
+                .frame(width: width, height: imageHeight)
+                .offset(y: -progress * travel)
+                .frame(width: width, height: windowHeight, alignment: .top)
+                .clipped()
+                // Dark scrim off the top edge so the status bar and discs
+                // stay legible over bright artwork.
+                .overlay(alignment: .top) {
+                    LinearGradient(
+                        colors: [.black.opacity(0.5), .clear],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .frame(height: BookDetailView.artHeight * 0.2)
+                }
+                .mask {
+                    LinearGradient(
+                        stops: [
+                            .init(color: .black, location: 0),
+                            .init(color: .black, location: fadeStart),
+                            .init(color: .clear, location: 1),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                }
         }
         .opacity(1 - fade * 0.85)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -911,19 +925,11 @@ struct DetailArtLayer: View {
         .accessibilityHidden(true)
     }
 
-    private var pannedArt: some View {
-        GeometryReader { geometry in
-            let width = geometry.size.width
-            let imageHeight = width * 1.5
-            // The window opens to the whole image at rest and closes to the
-            // pan height as the panel lifts; the mask's fade-out arrives
-            // with it, so the resting cover keeps its bottom edge.
-            let windowHeight = BookDetailView.artHeight
-                + (imageHeight - BookDetailView.artHeight) * (1 - lift)
-            let travel = max(0, imageHeight - windowHeight)
-            let progress = min(1, page / CGFloat(DetailStop.allCases.count - 1))
-            let fadeStart = 0.58 + 0.42 * (1 - lift)
-
+    /// The image itself — same frame either way; a coverless record just
+    /// skips the fetch that could only 404.
+    @ViewBuilder
+    private var art: some View {
+        if book.coverURL != nil {
             RemoteImage(
                 path: "/api/covers/\(book.uuid)",
                 alternates: ["/api/thumbs/\(book.uuid)/lg"]
@@ -934,56 +940,9 @@ struct DetailArtLayer: View {
             // as `BookCover`: a transparent or degenerate cover image loads
             // "successfully" and would otherwise leave a black band.
             .background { GeneratedCoverPlate(identity: CoverIdentity(book)) }
-            .frame(width: width, height: imageHeight)
-            .offset(y: -progress * travel)
-            .frame(width: width, height: windowHeight, alignment: .top)
-            .clipped()
-            // Dark scrim off the top edge so the status bar and discs stay
-            // legible over bright artwork.
-            .overlay(alignment: .top) {
-                LinearGradient(
-                    colors: [.black.opacity(0.5), .clear],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-                .frame(height: BookDetailView.artHeight * 0.2)
-            }
-            .mask {
-                LinearGradient(
-                    stops: [
-                        .init(color: .black, location: 0),
-                        .init(color: .black, location: fadeStart),
-                        .init(color: .clear, location: 1),
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            }
+        } else {
+            GeneratedCoverPlate(identity: CoverIdentity(book))
         }
-    }
-
-    /// The typographic plate, whole, in a soft accent halo.
-    private var plate: some View {
-        let tone = CoverIdentity(book).tone
-
-        return ZStack(alignment: .top) {
-            RadialGradient(
-                colors: [
-                    OKLCH(0.45, tone.c * 0.9, tone.h).color.opacity(0.55),
-                    .clear,
-                ],
-                center: UnitPoint(x: 0.5, y: 0.3),
-                startRadius: 0,
-                endRadius: 280
-            )
-            .frame(height: BookDetailView.artHeight)
-
-            BookCover(identity: CoverIdentity(book), size: .lg, cornerRadius: 7)
-                .frame(width: 190)
-                .coverShadow(1.2)
-                .padding(.top, 58)
-        }
-        .frame(maxWidth: .infinity)
     }
 }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -2,10 +2,10 @@
 //  The book detail marquee: full-bleed cover art running off the top edge,
 //  a translucent panel riding over its lower edge, and the page organised as
 //  seven snap stops on a vertical pager — Home · Shelf · Stats · Highlights ·
-//  Journals · The files · Recommendations. Home has two positions when the
-//  book has a photographic cover: the page opens on the cover whole with the
-//  panel resting under it, and the first swipe lifts the panel to full
-//  height before the next one moves on to stop 02. Chrome is immersive:
+//  Journals · The files · Recommendations. Home has two positions: the page
+//  opens on the artwork — a photographic cover whole, a plate in its halo —
+//  with the panel resting under it, and the first swipe lifts the panel to
+//  full height before the next one moves on to stop 02. Chrome is immersive:
 //  glass discs over the art, a tappable dot rail, and a persistent bottom
 //  action bar so Resume never scrolls away.
 
@@ -254,8 +254,8 @@ struct BookDetailView: View {
         self.uuid = uuid
     }
 
-    /// Where the panel's top edge sits at the Home stop for a plate cover —
-    /// how much art stays in view before the page becomes the panel. A
+    /// Where the Home panel rests for a plate cover — how much of the plate
+    /// window stays in view before the page becomes the panel. A
     /// photographic cover derives its rest position from the cover height
     /// instead (`DetailRead.restTop`).
     static let artTop: CGFloat = 300
@@ -297,8 +297,7 @@ struct BookDetailView: View {
     /// Continuous page position, 0...6 — drives the art pan and fade.
     @State private var page: CGFloat = 0
     /// The Home panel's rest→lifted progress, 0...1 — drives the art's
-    /// whole→windowed transition and the panel's padding and tint. Pinned
-    /// to 1 for books whose panel has no rest position.
+    /// whole→windowed transition and the panel's padding and tint.
     @State private var lift: CGFloat = 0
     /// Whether the Home panel has settled lifted — the discrete switch the
     /// handle label, tag row, and description clamp key on.
@@ -434,11 +433,14 @@ struct BookDetailView: View {
 
     // MARK: - Shell
 
-    /// Whether the Home panel gets its two positions: it needs a
-    /// photographic cover to rest against — a typographic plate is shown
-    /// whole anyway, so those books keep the one-position panel.
-    private func hasRestingCover(_ book: Book) -> Bool {
+    /// Where the Home panel rests for this book: below the whole cover when
+    /// a photographic one exists, at the plate window's edge otherwise — a
+    /// typographic plate is short, so its panel rests higher. Either way the
+    /// first swipe lifts the panel to the top of the page.
+    private func restTop(for book: Book, in size: CGSize) -> CGFloat {
         book.coverURL != nil
+            ? DetailRead.restTop(width: size.width, height: size.height)
+            : Self.artTop
     }
 
     private func content(_ book: Book) -> some View {
@@ -452,14 +454,13 @@ struct BookDetailView: View {
                 height: geometry.size.height
                     + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
             )
-            let twoPosition = hasRestingCover(book)
-            let restTop = DetailRead.restTop(width: size.width, height: size.height)
+            let restTop = restTop(for: book, in: size)
 
             ZStack {
                 ScreenBackground()
-                DetailArtLayer(book: book, page: page, lift: twoPosition ? lift : 1)
+                DetailArtLayer(book: book, page: page, lift: lift)
                     .ignoresSafeArea()
-                snapScroller(book, twoPosition: twoPosition, restTop: restTop)
+                snapScroller(book, restTop: restTop)
                     .ignoresSafeArea()
             }
             .overlay(alignment: .top) { chromeDiscs(book) }
@@ -469,25 +470,21 @@ struct BookDetailView: View {
                 }
             }
             .overlay(alignment: .bottomTrailing) { nextHint }
-            .overlay(alignment: .bottom) { restFade(twoPosition) }
+            .overlay(alignment: .bottom) { restFade }
             .overlay(alignment: .bottom) { actionBar(book) }
         }
     }
 
-    private func snapScroller(
-        _ book: Book, twoPosition: Bool, restTop: CGFloat
-    ) -> some View {
+    private func snapScroller(_ book: Book, restTop: CGFloat) -> some View {
         ScrollView(.vertical) {
             VStack(spacing: 0) {
                 // The rest run: scrolling it away is what lifts the panel,
                 // and its top edge is the snap target the panel rests at.
-                if twoPosition {
-                    Color.clear
-                        .frame(height: restTop)
-                        .id(Self.restMarkerID)
-                }
+                Color.clear
+                    .frame(height: restTop)
+                    .id(Self.restMarkerID)
                 ForEach(DetailStop.allCases) { stop in
-                    stopSection(stop, book, twoPosition: twoPosition)
+                    stopSection(stop, book)
                         .id(stop.rawValue)
                 }
             }
@@ -508,41 +505,29 @@ struct BookDetailView: View {
             guard state.viewport > 0 else { return }
             let map = DetailRead.scrollMap(
                 offset: state.offset,
-                restTop: twoPosition ? restTop : 0,
+                restTop: restTop,
                 viewport: state.viewport
             )
             lift = map.lift
             page = min(CGFloat(DetailStop.allCases.count - 1), map.page)
             at = Int(page.rounded())
-            let settled = !twoPosition || map.lift > 0.6
+            let settled = map.lift > 0.6
             if settled != lifted {
                 withAnimation(Motion.snap) { lifted = settled }
             }
         }
     }
 
-    private func stopSection(
-        _ stop: DetailStop, _ book: Book, twoPosition: Bool
-    ) -> some View {
-        VStack(spacing: 0) {
-            // A plate cover keeps the fixed art window above the panel; a
-            // resting cover's clearance is the rest run before this section.
-            if stop == .home, !twoPosition {
-                Color.clear.frame(height: Self.artTop)
-            }
-            stopPanel(stop, book, twoPosition: twoPosition)
-        }
-        .containerRelativeFrame(.vertical)
+    private func stopSection(_ stop: DetailStop, _ book: Book) -> some View {
+        stopPanel(stop, book)
+            .containerRelativeFrame(.vertical)
     }
 
-    private func stopPanel(
-        _ stop: DetailStop, _ book: Book, twoPosition: Bool
-    ) -> some View {
+    private func stopPanel(_ stop: DetailStop, _ book: Book) -> some View {
         let isHome = stop == .home
-        let resting = isHome && twoPosition
 
         return VStack(alignment: .leading, spacing: 0) {
-            if resting {
+            if isHome {
                 LiftHandle(lifted: lifted) { toggleLift() }
             } else {
                 StopLabel(stop: stop)
@@ -553,10 +538,10 @@ struct BookDetailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(EdgeInsets(
             // A full stop's label must clear the chrome discs, which end
-            // ~105pt below the top edge on current devices. The two-position
-            // Home earns that clearance as it lifts — at rest its top edge
-            // is far below the discs.
-            top: isHome ? (twoPosition ? 14 + 114 * lift : 14) : 128,
+            // ~105pt below the top edge on current devices. Home earns that
+            // clearance as it lifts — at rest its top edge is far below the
+            // discs.
+            top: isHome ? 14 + 114 * lift : 128,
             leading: 22,
             bottom: Self.barClearance,
             trailing: 30
@@ -564,20 +549,19 @@ struct BookDetailView: View {
         .background {
             // The panel rides over the artwork: blur what shows through, then
             // tint with the page ground. The material already darkens what it
-            // blurs, so the tint stays light at Home — heavier and the art it
-            // rides over reads as a hard cut instead of a ghost. Past Home the
-            // art has faded, so the panel goes nearly opaque and simply is
-            // the screen. The two-position Home moves between those poles:
-            // resting below the cover it owns its strip, lifted it ghosts
-            // the whole cover behind it.
+            // blurs, so the tint stays lighter at Home — heavier and the art
+            // it rides over reads as a hard cut instead of a ghost. Past Home
+            // the art has faded, so the panel goes nearly opaque and simply
+            // is the screen. Home moves between those poles as it lifts:
+            // resting below the art it owns its strip, lifted it ghosts the
+            // artwork behind it.
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
-                palette.bg0Color.opacity(
-                    isHome ? (twoPosition ? 0.60 + 0.22 * lift : 0.30) : 0.82)
+                palette.bg0Color.opacity(isHome ? 0.60 + 0.22 * lift : 0.82)
             }
         }
         .overlay(alignment: .top) {
-            if isHome { Hairline().opacity(twoPosition ? 1 - lift : 1) }
+            if isHome { Hairline().opacity(1 - lift) }
         }
         .clipped()
     }
@@ -592,23 +576,20 @@ struct BookDetailView: View {
     /// At rest the panel's lower content runs on under the action bar; this
     /// fades it into the ground the way the design masks it out, and lifts
     /// away with the panel.
-    @ViewBuilder
-    private func restFade(_ twoPosition: Bool) -> some View {
-        if twoPosition {
-            LinearGradient(
-                stops: [
-                    .init(color: palette.bg0Color.opacity(0), location: 0),
-                    .init(color: palette.bg0Color, location: 0.62),
-                    .init(color: palette.bg0Color, location: 1),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .frame(height: 170)
-            .opacity(1 - lift)
-            .allowsHitTesting(false)
-            .ignoresSafeArea(edges: .bottom)
-        }
+    private var restFade: some View {
+        LinearGradient(
+            stops: [
+                .init(color: palette.bg0Color.opacity(0), location: 0),
+                .init(color: palette.bg0Color, location: 0.62),
+                .init(color: palette.bg0Color, location: 1),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 170)
+        .opacity(1 - lift)
+        .allowsHitTesting(false)
+        .ignoresSafeArea(edges: .bottom)
     }
 
     @ViewBuilder
@@ -618,10 +599,7 @@ struct BookDetailView: View {
             StopHome(
                 book: book,
                 model: model,
-                restingCover: hasRestingCover(book),
-                // A plate book's panel has no rest position — it is always
-                // the full stop, whatever the scroller last reported.
-                lifted: !hasRestingCover(book) || lifted,
+                lifted: lifted,
                 onMore: { showDescription = true },
                 onAlignment: { showAlignment = true },
                 onRemovedWishlist: { model.wishlistEntry = nil }
@@ -907,8 +885,8 @@ struct DetailDotRail: View {
 struct DetailArtLayer: View {
     let book: Book
     let page: CGFloat
-    /// The Home panel's rest→lifted progress; 1 for books with no rest
-    /// position, so the window and mask sit at their shipped values.
+    /// The Home panel's rest→lifted progress. Only photographic art reads
+    /// it — a plate is drawn whole in both positions.
     var lift: CGFloat = 1
 
     @Environment(\.palette) private var palette

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -240,3 +240,63 @@ private func sitting(
     #expect(preview == "The Cinder scene lands differently in audio")
 }
 
+
+// MARK: - Two-position Home geometry
+
+@Test func restTopSitsUnderAWholeCoverOnAPhone() {
+    #expect(DetailRead.restTop(width: 402, height: 874) == 603)
+}
+
+@Test func restTopYieldsToAShortScreenSoThePanelKeepsItsStrip() {
+    // A 375pt-wide cover runs 562pt tall; a 700pt screen caps the rest
+    // position so the panel keeps its 240pt strip.
+    #expect(DetailRead.restTop(width: 375, height: 700) == 460)
+}
+
+@Test func restTopKeepsAFloorOfArtOnADegenerateScreen() {
+    #expect(DetailRead.restTop(width: 800, height: 400) == 220)
+}
+
+@Test func scrollMapLiftsAcrossTheRestRunBeforeAnyPageTurns() {
+    let mid = DetailRead.scrollMap(offset: 300, restTop: 600, viewport: 874)
+    #expect(abs(mid.lift - 0.5) < 0.001)
+    #expect(mid.page == 0)
+
+    let lifted = DetailRead.scrollMap(offset: 600, restTop: 600, viewport: 874)
+    #expect(lifted.lift == 1)
+    #expect(lifted.page == 0)
+}
+
+@Test func scrollMapCountsPagesPastTheRestRun() {
+    let map = DetailRead.scrollMap(offset: 600 + 874 * 2, restTop: 600, viewport: 874)
+    #expect(map.lift == 1)
+    #expect(abs(map.page - 2) < 0.001)
+}
+
+@Test func scrollMapDegeneratesToPlainPagingWithoutARestRun() {
+    let map = DetailRead.scrollMap(offset: 874, restTop: 0, viewport: 874)
+    #expect(map.lift == 1)
+    #expect(abs(map.page - 1) < 0.001)
+}
+
+// MARK: - Home sync row
+
+@Test func syncRowInvitesALinkWhileFormatsAreNotLinked() {
+    let copy = DetailSyncCopy(label: "Positions unlinked", action: "Link", linked: false)
+    #expect(DetailRead.syncRow(state: .notLinked) == copy)
+    // No answer yet (offline, or the fetch hasn't landed) reads the same —
+    // the sheet it opens states the truth either way.
+    #expect(DetailRead.syncRow(state: nil) == copy)
+}
+
+@Test func syncRowAsksForAReconfirmWhenTheLinkWentStale() {
+    #expect(DetailRead.syncRow(state: .linkStale)
+        == DetailSyncCopy(label: "Sync needs re-confirm", action: "Re-confirm", linked: false))
+}
+
+@Test func syncRowStatesLinkedForEveryLinkedState() {
+    let linked = DetailSyncCopy(label: "Positions linked", action: "Manage", linked: true)
+    #expect(DetailRead.syncRow(state: .aligned) == linked)
+    #expect(DetailRead.syncRow(state: .candidate) == linked)
+    #expect(DetailRead.syncRow(state: .nothingNewer) == linked)
+}


### PR DESCRIPTION
## Summary
- Home on the iOS book detail gets two positions: the page opens on the artwork whole — a photographic cover full-bleed, a plate in its halo — with a compact panel resting under it, and the first swipe lifts the panel to full height before the next one advances to stop 02.
- The snap scroller moves from `.paging` to `.viewAligned(limitBehavior: .always)` with a rest run above the Home section, so the one-stop-per-swipe gate and the interactive rest→lift transition both fall out of native scroll behavior.
- The lifted panel carries more of the record: a six-line description, the reader-tag chip row, and a position-sync row for dual-format books (linked / unlinked / needs re-confirm, opening the alignment sheet) under the ruler.
- The dot rail read the palette through the view's own environment and so drew the app accent; extracted `DetailDotRail` reads the re-keyed environment, so the active dot now carries the book's accent.

## Test plan
- [x] `just ios-build` + `just ios-test` — unit suite green, 9 new tests (rest geometry, scroll map, sync-row copy)
- [x] Simulator walkthrough against the dev server: rest → lift → stop 02 and back on photographic, plate, and dual-format books; handle tap toggle; dot-rail jumps; sync row opens Position sync

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.