### PR TITLE
feat: refetch the book detail when returning to it

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -302,8 +302,14 @@ struct BookDetailView: View {
     /// Scroll-position binding for the dot rail's jumps. Written on a tap;
     /// the scroller keeps it updated as pages snap.
     @State private var scrollTarget: Int?
+    /// Whether the screen has appeared before. The first `onAppear` belongs
+    /// to `.task`'s load; every later one means a pushed screen — the
+    /// metadata editor, a nested detail — was popped off, and whatever it
+    /// wrote should show immediately.
+    @State private var hasAppeared = false
 
     private var downloads = DownloadManager.shared
+    private var presentation = Presentation.shared
 
     var body: some View {
         Group {
@@ -329,6 +335,26 @@ struct BookDetailView: View {
         .bookZoomDestination(uuid, in: bookZoom)
         .task { await model.load(uuid: uuid) }
         .refreshTask { await model.load(uuid: uuid) }
+        // Refetch on the way back from a pushed screen (edited metadata, a
+        // nested detail). Sheets reload through their own callbacks; the
+        // reader and player are full-screen covers over the tab view, so
+        // closing one never re-appears this view — that path is the
+        // `progressToken` observation below.
+        .onAppear {
+            guard hasAppeared else {
+                hasAppeared = true
+                return
+            }
+            Task { await model.load(uuid: uuid) }
+        }
+        // Refetch once a reading or listening session has *persisted* its
+        // final position — the position, status, highlights, and stats it
+        // wrote should show the moment the reader or player closes. Keyed on
+        // the token rather than the dismissal so the read never lands before
+        // the write it is meant to pick up.
+        .onChange(of: presentation.progressToken) { _, _ in
+            Task { await model.load(uuid: uuid) }
+        }
         .sheet(isPresented: $showAlignment) {
             if let book = model.book {
                 AlignmentSheet(book: book) {


### PR DESCRIPTION
## Summary
- The book detail reloads its model the moment you return to it, so progress, read status, highlights, journals, and stats written elsewhere show immediately.
- Closing the reader or player never re-appears the view (they are full-screen covers), so that path observes `Presentation.progressToken` — the existing bumped-after-persist signal LibraryView already uses, which also means the refetch can never race the session's final position write.
- Returning from a pushed screen (metadata edit, a nested detail) reloads through a first-appearance-guarded `onAppear`; journal sheets keep their existing reload callbacks.

## Test plan
- [x] `just ios-build` + `just ios-test` — unit suite green
- [x] Simulator round trip against the dev server: jumped a comic from 91% back to page 74, closed the reader, detail read "Resume — 32%" immediately with no manual refresh

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.