### PR TITLE
feat: set iOS journal entries as real markdown blocks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -351,10 +351,17 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       the web composer's own highlighter already does), and a
                       masked span is a bar carrying a `omnibus-spoiler://<id>`
                       link that `JournalBody` swallows via `OpenURLAction` —
-                      `Text` has no per-run gesture. Not revealable inside
-                      `AllJournalsSheet`, where the card is a button; the row
-                      excerpt censors every span as `███`, as the web ladder's
-                      `journal_excerpt` does. Stats carries the annual
+                      `Text` has no per-run gesture. Reveal is a **toggle**, so
+                      an open span keeps its link and has to restate the
+                      block's ink or it would draw in the tint colour. Not
+                      revealable inside `AllJournalsSheet`, where the card is a
+                      button; the row excerpt censors every span as `███`, as
+                      the web ladder's `journal_excerpt` does. The composer is
+                      an item-driven sheet keyed on `ComposerTarget`
+                      (`.new` / `.editing`) rather than a Bool beside a payload
+                      `@State`: `.sheet(isPresented:)` captured its content
+                      before the payload landed, so Edit opened a blank "New
+                      entry". Stats carries the annual
                       reading-goal card above the range picker — progress, or an
                       invitation when no goal is set, never a zero-of-zero bar —
                       on the same never-queued contract: `setReadingGoal` writes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,7 +340,21 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       `WishlistSection` is the native twin of the web page's
                       rail tracking card (tracked-since line, store search,
                       remove): same never-queued contract, plus a confirmation
-                      the web button doesn't ask for. Stats carries the annual
+                      the web button doesn't ask for. `JournalMarkdown` is the
+                      journal body's renderer — the web reads the server's
+                      `body_html`, but the native app only ever has `body_md`,
+                      so it carries its own line-based splitter (paragraphs,
+                      headings, bullet/ordered lists, quotes, fenced code,
+                      rules) plus a `||spoiler||` pass. Two contracts differ
+                      from `db::journals::markdown` deliberately: spoilers pair
+                      **per line** (the fix #2366 asks of the server, and what
+                      the web composer's own highlighter already does), and a
+                      masked span is a bar carrying a `omnibus-spoiler://<id>`
+                      link that `JournalBody` swallows via `OpenURLAction` —
+                      `Text` has no per-run gesture. Not revealable inside
+                      `AllJournalsSheet`, where the card is a button; the row
+                      excerpt censors every span as `███`, as the web ladder's
+                      `journal_excerpt` does. Stats carries the annual
                       reading-goal card above the range picker — progress, or an
                       invitation when no goal is set, never a zero-of-zero bar —
                       on the same never-queued contract: `setReadingGoal` writes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -341,9 +341,11 @@ Features/           — one directory per surface: Account, AddBooks, Auth,
                       rail tracking card (tracked-since line, store search,
                       remove): same never-queued contract, plus a confirmation
                       the web button doesn't ask for. `JournalMarkdown` is the
-                      journal body's renderer — the web reads the server's
-                      `body_html`, but the native app only ever has `body_md`,
-                      so it carries its own line-based splitter (paragraphs,
+                      journal body's renderer — the web sets the server's
+                      `body_html` with `dangerous_inner_html`, which SwiftUI
+                      has no equivalent of, so the native app renders from the
+                      `body_md` riding alongside it and carries its own
+                      line-based splitter (paragraphs,
                       headings, bullet/ordered lists, quotes, fenced code,
                       rules) plus a `||spoiler||` pass. Two contracts differ
                       from `db::journals::markdown` deliberately: spoilers pair

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -1408,18 +1408,19 @@ struct JournalRow: View {
     /// The opening line as plain text. Parsed as markdown rather than
     /// regex-stripped, so prose that happens to contain `#` or `_` (C#,
     /// snake_case) keeps its characters while real syntax is dropped.
+    ///
+    /// The row is always visible, so a `||spoiler||` is censored before
+    /// anything else runs — the same guard the web ladder row applies.
     static func preview(_ md: String) -> String {
         guard let first = md.split(separator: "\n").first else { return "" }
-        let line = String(first)
-            // A leading list or heading marker is block syntax the inline
-            // parser would pass through verbatim.
+        let line = JournalMarkdown.masked(String(first))
+            // A leading list, heading or quote marker is block syntax the
+            // inline parser would pass through verbatim.
             .replacingOccurrences(
-                of: #"^\s*([-*+]\s+|#{1,6}\s+)"#, with: "", options: .regularExpression)
-        let parsed = (try? AttributedString(
-            markdown: line,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )).map { String($0.characters) }
-        return (parsed ?? line).trimmingCharacters(in: .whitespaces)
+                of: #"^\s*([-*+]\s+|\d{1,9}[.)]\s+|#{1,6}\s+|>\s?)"#,
+                with: "", options: .regularExpression)
+        let parsed = String(JournalMarkdown.inline(line).characters)
+        return parsed.trimmingCharacters(in: .whitespaces)
     }
 
     var body: some View {
@@ -1925,7 +1926,10 @@ struct AllJournalsSheet: View {
                         } label: {
                             VStack(alignment: .leading, spacing: 9) {
                                 JournalByline(entry: entry, avatarSize: 26)
-                                JournalBody(md: entry.bodyMd)
+                                // Not revealable here: the card is a button, so
+                                // a tap belongs to the row — it opens the entry
+                                // in the drawer, where a spoiler does open.
+                                JournalBody(md: entry.bodyMd, revealable: false)
                             }
                             .contentShape(Rectangle())
                         }
@@ -2043,30 +2047,6 @@ struct JournalByline: View {
         parts.append(Format.date(unix: entry.createdAt))
         if entry.status == .draft { parts.append("draft") }
         return parts.joined(separator: " · ")
-    }
-}
-
-/// A journal body in the reading face. Bodies are markdown; inline-only
-/// rendering keeps the author's line breaks instead of collapsing the entry
-/// into one paragraph.
-struct JournalBody: View {
-    let md: String
-
-    @Environment(\.palette) private var palette
-
-    private var rendered: AttributedString {
-        (try? AttributedString(
-            markdown: md,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(md)
-    }
-
-    var body: some View {
-        Text(rendered)
-            .font(.display(18))
-            .foregroundStyle(palette.ink1Color)
-            .lineSpacing(6)
-            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -262,6 +262,27 @@ struct BookDetailView: View {
     /// target the two-position panel rests at.
     static let restMarkerID = -1
 
+    /// What the journal composer was opened for. `Identifiable` so the
+    /// composer can be an item-driven sheet, which is what keeps a chosen
+    /// entry attached to the presentation that carries it.
+    enum ComposerTarget: Identifiable {
+        case new
+        case editing(JournalEntry)
+
+        var id: String {
+            switch self {
+            case .new: "new"
+            case .editing(let entry): entry.pathID
+            }
+        }
+
+        /// The entry being edited, or `nil` when writing a new one.
+        var entry: JournalEntry? {
+            if case .editing(let entry) = self { return entry }
+            return nil
+        }
+    }
+
     @Environment(\.palette) private var palette
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
@@ -269,7 +290,6 @@ struct BookDetailView: View {
     @Environment(AudioPlayer.self) private var player
     @Environment(\.bookZoomNamespace) private var bookZoom
     @State private var model = BookDetailModel()
-    @State private var showJournalComposer = false
     @State private var showShelfPicker = false
     @State private var showAlignment = false
     @State private var showBookmarks = false
@@ -287,8 +307,11 @@ struct BookDetailView: View {
     /// presenting the full-screen player while the sheet is still up would
     /// be refused.
     @State private var pickedAudioFile: BookFileInfo?
-    /// Non-nil when the composer is open on an existing entry.
-    @State private var editingJournal: JournalEntry?
+    /// What the journal composer is open on, when it is. The entry rides
+    /// with the presentation rather than in a payload `@State` beside a Bool:
+    /// `.sheet(isPresented:)` captured its content before that payload landed,
+    /// so Edit opened a blank "New entry".
+    @State private var composing: ComposerTarget?
     /// Continuous page position, 0...6 — drives the art pan and fade.
     @State private var page: CGFloat = 0
     /// The Home panel's rest→lifted progress, 0...1 — drives the art's
@@ -362,9 +385,9 @@ struct BookDetailView: View {
                 }
             }
         }
-        .sheet(isPresented: $showJournalComposer) {
+        .sheet(item: $composing) { target in
             if let book = model.book {
-                JournalComposer(book: book, editing: editingJournal) {
+                JournalComposer(book: book, editing: target.entry) {
                     Task { await model.load(uuid: uuid) }
                 }
             }
@@ -421,8 +444,7 @@ struct BookDetailView: View {
                 isMine: entry.authorId == app.user?.id
             ) {
                 openJournal = nil
-                editingJournal = entry
-                showJournalComposer = true
+                composing = .editing(entry)
             } onDelete: {
                 openJournal = nil
                 Task {
@@ -626,8 +648,7 @@ struct BookDetailView: View {
                 book: book,
                 model: model,
                 onWrite: {
-                    editingJournal = nil
-                    showJournalComposer = true
+                    composing = .new
                 },
                 onOpen: { openJournal = $0 },
                 onAll: { showAllJournals = true }

--- a/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
@@ -21,7 +21,9 @@ enum JournalBlock: Equatable {
     case heading(level: Int, spans: [JournalSpan])
     case paragraph([JournalSpan])
     case bullets([[JournalSpan]])
-    case numbered([[JournalSpan]])
+    /// `start` is the first item's authored number — `5.` opens at five, as
+    /// `<ol start="5">` does. Later markers are ignored, per CommonMark.
+    case numbered([[JournalSpan]], start: Int)
     case quote([JournalSpan])
     /// Fenced source, kept verbatim — no inline parse, no spoilers.
     case code(String)
@@ -161,7 +163,7 @@ extension JournalMarkdown {
             case none
             case paragraph([String])
             case bullets([[String]])
-            case numbered([[String]])
+            case numbered([[String]], Int)
             case quote([String])
         }
 
@@ -224,12 +226,12 @@ extension JournalMarkdown {
                 return
             }
             if let item = Self.numberedItem(trimmed) {
-                if case .numbered(var items) = pending {
-                    items.append([item])
-                    pending = .numbered(items)
+                if case .numbered(var items, let start) = pending {
+                    items.append([item.text])
+                    pending = .numbered(items, start)
                 } else {
                     flush()
-                    pending = .numbered([[item]])
+                    pending = .numbered([[item.text]], item.number)
                 }
                 return
             }
@@ -249,9 +251,9 @@ extension JournalMarkdown {
             case .bullets(var items):
                 items[items.count - 1].append(trimmed)
                 pending = .bullets(items)
-            case .numbered(var items):
+            case .numbered(var items, let start):
                 items[items.count - 1].append(trimmed)
-                pending = .numbered(items)
+                pending = .numbered(items, start)
             case .quote(var lines):
                 lines.append(trimmed)
                 pending = .quote(lines)
@@ -284,8 +286,9 @@ extension JournalMarkdown {
                 block = .paragraph(inline(lines.joined(separator: "\n")))
             case .bullets(let items):
                 block = .bullets(items.map { inline($0.joined(separator: "\n")) })
-            case .numbered(let items):
-                block = .numbered(items.map { inline($0.joined(separator: "\n")) })
+            case .numbered(let items, let start):
+                block = .numbered(
+                    items.map { inline($0.joined(separator: "\n")) }, start: start)
             case .quote(let lines):
                 block = .quote(inline(lines.joined(separator: "\n")))
             }
@@ -360,17 +363,18 @@ extension JournalMarkdown {
             return String(rest.drop { $0 == " " })
         }
 
-        /// `1. item` / `1) item`, up to the nine digits CommonMark allows.
-        static func numberedItem(_ line: String) -> String? {
+        /// `1. item` / `1) item`, up to the nine digits CommonMark allows —
+        /// with the number, which the first item of a list opens it at.
+        static func numberedItem(_ line: String) -> (number: Int, text: String)? {
             let digits = line.prefix(while: \.isNumber)
-            guard (1...9).contains(digits.count) else { return nil }
+            guard (1...9).contains(digits.count), let number = Int(digits) else { return nil }
             let rest = line.dropFirst(digits.count)
             guard let delimiter = rest.first, delimiter == "." || delimiter == ")" else {
                 return nil
             }
             let body = rest.dropFirst()
             guard body.first == " " else { return nil }
-            return String(body.drop { $0 == " " })
+            return (number, String(body.drop { $0 == " " }))
         }
 
         /// `> quoted`, with the one optional space after the marker.
@@ -437,8 +441,8 @@ struct JournalBody: View {
             prose(spans)
         case .bullets(let items):
             list(items) { _ in "\u{2022}" }
-        case .numbered(let items):
-            list(items) { "\($0 + 1)." }
+        case .numbered(let items, let start):
+            list(items) { "\(start + $0)." }
         case .quote(let spans):
             prose(spans)
                 .padding(.leading, 13)

--- a/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
@@ -1,0 +1,459 @@
+//  JournalMarkdown.swift
+//  Journal bodies are authored as light markdown. This splits one into the
+//  blocks and inline runs the reading face sets — the server's own vocabulary
+//  minus what a phone has no room for — and renders them.
+
+import SwiftUI
+
+// MARK: - The pieces
+
+/// One inline run of a journal line: prose the markdown parser handles, or a
+/// `||spoiler||` region the reading face hides until it is tapped.
+enum JournalSpan: Equatable {
+    case prose(String)
+    /// `id` is assigned in reading order across the whole entry, so a reveal
+    /// survives the re-render it triggers.
+    case spoiler(String, id: Int)
+}
+
+/// One block of a journal body, in the order the author wrote them.
+enum JournalBlock: Equatable {
+    case heading(level: Int, spans: [JournalSpan])
+    case paragraph([JournalSpan])
+    case bullets([[JournalSpan]])
+    case numbered([[JournalSpan]])
+    case quote([JournalSpan])
+    /// Fenced source, kept verbatim — no inline parse, no spoilers.
+    case code(String)
+    case rule
+}
+
+// MARK: - The splitter
+
+/// Markdown for journal bodies. Line-based rather than a real CommonMark
+/// parser: the server owns the canonical render, and this only has to agree
+/// with it on the constructs a phone actually shows. Images, tables and task
+/// lists are not among them — their source falls through as prose.
+enum JournalMarkdown {
+    /// URL scheme the spoiler reveal rides on. `Text` has no per-run gesture,
+    /// but it does route link taps through `OpenURLAction` — so a masked span
+    /// is a link the body intercepts rather than opens.
+    static let revealScheme = "omnibus-spoiler"
+
+    /// Split a body into blocks, numbering every spoiler in reading order.
+    static func blocks(_ md: String) -> [JournalBlock] {
+        var splitter = Splitter()
+        // Normalized first: splitting on a newline *set* would read CRLF as two
+        // breaks, and the blank line between them ends the block.
+        let normalized = md
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        for line in normalized.components(separatedBy: "\n") {
+            splitter.take(line)
+        }
+        return splitter.finish()
+    }
+
+    /// Split one run of inline markdown on its `||spoiler||` pairs.
+    ///
+    /// Pairing is **line-local**: a marker never pairs across a newline, so an
+    /// unbalanced one cannot invert every line after it (#2366 — the server's
+    /// own renderer is being brought to the same rule). An unterminated marker
+    /// is left literal, as it is there.
+    static func spans(_ text: String, from next: inout Int) -> [JournalSpan] {
+        var out: [JournalSpan] = []
+
+        func prose(_ chunk: String) {
+            guard !chunk.isEmpty else { return }
+            if case .prose(let head) = out.last {
+                out[out.count - 1] = .prose(head + chunk)
+            } else {
+                out.append(.prose(chunk))
+            }
+        }
+
+        for (index, line) in text.components(separatedBy: "\n").enumerated() {
+            if index > 0 { prose("\n") }
+            var rest = Substring(line)
+            while let open = rest.range(of: "||") {
+                let after = rest[open.upperBound...]
+                guard let close = after.range(of: "||") else { break }
+                prose(String(rest[..<open.lowerBound]))
+                out.append(.spoiler(String(after[..<close.lowerBound]), id: next))
+                next += 1
+                rest = after[close.upperBound...]
+            }
+            prose(String(rest))
+        }
+        return out
+    }
+
+    /// One line with every spoiler region replaced by censor bars. For the
+    /// always-visible surfaces — a row excerpt can never leak one.
+    static func masked(_ line: String) -> String {
+        var ignored = 0
+        return spans(line, from: &ignored).map { span in
+            switch span {
+            case .prose(let text): text
+            case .spoiler: "\u{2588}\u{2588}\u{2588}"
+            }
+        }.joined()
+    }
+
+    /// One run of inline markdown — bold, italic, strikethrough, code, links.
+    /// `inlineOnlyPreservingWhitespace` keeps the line breaks the splitter has
+    /// already reduced to breaks *within* a block.
+    static func inline(_ source: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: source,
+            options: .init(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace,
+                failurePolicy: .returnPartiallyParsedIfPossible
+            )
+        )) ?? AttributedString(source)
+    }
+
+    /// The link a masked spoiler carries, and the id back out of one.
+    static func revealURL(_ id: Int) -> URL? { URL(string: "\(revealScheme)://\(id)") }
+
+    static func revealID(_ url: URL) -> Int? {
+        guard url.scheme == revealScheme else { return nil }
+        return url.host.flatMap(Int.init)
+    }
+}
+
+// MARK: - Line classification
+
+extension JournalMarkdown {
+    /// Accumulates lines into blocks. A struct rather than a pile of free
+    /// functions so the pending-block state and the spoiler counter — which
+    /// must advance in reading order — stay in one place.
+    private struct Splitter {
+        /// The block still taking lines. Items hold their own lines so a
+        /// wrapped list item keeps its breaks: the server promotes a soft break
+        /// to a hard one, so a newline the author can see stays visible.
+        private enum Pending {
+            case none
+            case paragraph([String])
+            case bullets([[String]])
+            case numbered([[String]])
+            case quote([String])
+        }
+
+        private var out: [JournalBlock] = []
+        private var pending = Pending.none
+        private var nextSpoiler = 0
+        /// The open fence's marker run, when inside a fenced code block.
+        private var fence: String?
+        private var code: [String] = []
+
+        mutating func take(_ line: String) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if let open = fence {
+                if trimmed.hasPrefix(open), trimmed.allSatisfy({ $0 == open.first }) {
+                    out.append(.code(code.joined(separator: "\n")))
+                    fence = nil
+                    code = []
+                } else {
+                    code.append(line)
+                }
+                return
+            }
+            if let opened = Self.fenceMarker(trimmed) {
+                flush()
+                fence = opened
+                return
+            }
+            if trimmed.isEmpty {
+                flush()
+                return
+            }
+            // Setext before the thematic break: `---` under a paragraph
+            // underlines it rather than ruling below it.
+            if case .paragraph(let lines) = pending, let level = Self.setextLevel(trimmed) {
+                pending = .none
+                let spans = inline(lines.joined(separator: "\n"))
+                out.append(.heading(level: level, spans: spans))
+                return
+            }
+            if Self.isRule(trimmed) {
+                flush()
+                out.append(.rule)
+                return
+            }
+            if let heading = Self.atxHeading(trimmed) {
+                flush()
+                let spans = inline(heading.text)
+                out.append(.heading(level: heading.level, spans: spans))
+                return
+            }
+            if let item = Self.bulletItem(trimmed) {
+                if case .bullets(var items) = pending {
+                    items.append([item])
+                    pending = .bullets(items)
+                } else {
+                    flush()
+                    pending = .bullets([[item]])
+                }
+                return
+            }
+            if let item = Self.numberedItem(trimmed) {
+                if case .numbered(var items) = pending {
+                    items.append([item])
+                    pending = .numbered(items)
+                } else {
+                    flush()
+                    pending = .numbered([[item]])
+                }
+                return
+            }
+            if let text = Self.quoteLine(trimmed) {
+                if case .quote(var lines) = pending {
+                    lines.append(text)
+                    pending = .quote(lines)
+                } else {
+                    flush()
+                    pending = .quote([text])
+                }
+                return
+            }
+            // A plain line under an open list or quote is a lazy continuation of
+            // its last item, not a new paragraph.
+            switch pending {
+            case .bullets(var items):
+                items[items.count - 1].append(trimmed)
+                pending = .bullets(items)
+            case .numbered(var items):
+                items[items.count - 1].append(trimmed)
+                pending = .numbered(items)
+            case .quote(var lines):
+                lines.append(trimmed)
+                pending = .quote(lines)
+            case .paragraph(var lines):
+                lines.append(trimmed)
+                pending = .paragraph(lines)
+            case .none:
+                pending = .paragraph([trimmed])
+            }
+        }
+
+        mutating func finish() -> [JournalBlock] {
+            // An unclosed fence still holds real text; keep it rather than drop
+            // the tail of the entry.
+            if fence != nil {
+                if !code.isEmpty { out.append(.code(code.joined(separator: "\n"))) }
+                fence = nil
+                code = []
+            }
+            flush()
+            return out
+        }
+
+        private mutating func flush() {
+            let block: JournalBlock?
+            switch pending {
+            case .none:
+                block = nil
+            case .paragraph(let lines):
+                block = .paragraph(inline(lines.joined(separator: "\n")))
+            case .bullets(let items):
+                block = .bullets(items.map { inline($0.joined(separator: "\n")) })
+            case .numbered(let items):
+                block = .numbered(items.map { inline($0.joined(separator: "\n")) })
+            case .quote(let lines):
+                block = .quote(inline(lines.joined(separator: "\n")))
+            }
+            pending = .none
+            if let block { out.append(block) }
+        }
+
+        private mutating func inline(_ text: String) -> [JournalSpan] {
+            JournalMarkdown.spans(text, from: &nextSpoiler)
+        }
+
+        // MARK: Line shapes
+
+        /// The backtick or tilde run opening a fence, if this line is one.
+        static func fenceMarker(_ line: String) -> String? {
+            ["```", "~~~"].first(where: line.hasPrefix)
+        }
+
+        /// `---`, `***`, `___` — three or more of one marker and nothing else.
+        static func isRule(_ line: String) -> Bool {
+            guard let first = line.first, "-*_".contains(first) else { return false }
+            let body = line.filter { !$0.isWhitespace }
+            return body.count >= 3 && body.allSatisfy { $0 == first }
+        }
+
+        /// A setext underline: an unbroken run of `=` (h1) or `-` (h2). `- - -`
+        /// is a thematic break, so internal whitespace disqualifies it.
+        static func setextLevel(_ line: String) -> Int? {
+            guard let first = line.first, first == "=" || first == "-" else { return nil }
+            guard line.allSatisfy({ $0 == first }) else { return nil }
+            return first == "=" ? 1 : 2
+        }
+
+        /// `# Heading` through `###### Heading`, closing `#`s dropped.
+        static func atxHeading(_ line: String) -> (level: Int, text: String)? {
+            let hashes = line.prefix { $0 == "#" }
+            guard (1...6).contains(hashes.count) else { return nil }
+            let rest = line.dropFirst(hashes.count)
+            guard rest.isEmpty || rest.first == " " else { return nil }
+            let text = rest.trimmingCharacters(in: .whitespaces)
+            // A trailing `#` run only *closes* the heading when a space runs up
+            // to it, so `# C#` keeps its sharp rather than losing it.
+            let closing = text.reversed().prefix { $0 == "#" }.count
+            guard closing > 0 else { return (hashes.count, text) }
+            let head = String(text.dropLast(closing))
+            guard head.isEmpty || head.last == " " else { return (hashes.count, text) }
+            return (hashes.count, head.trimmingCharacters(in: .whitespaces))
+        }
+
+        /// `- item`, `* item`, `+ item`. The space is required, so `---` stays a
+        /// rule and `*emphasis*` stays prose.
+        static func bulletItem(_ line: String) -> String? {
+            guard let first = line.first, "-*+".contains(first) else { return nil }
+            let rest = line.dropFirst()
+            guard rest.first == " " else { return nil }
+            return String(rest.drop { $0 == " " })
+        }
+
+        /// `1. item` / `1) item`, up to the nine digits CommonMark allows.
+        static func numberedItem(_ line: String) -> String? {
+            let digits = line.prefix(while: \.isNumber)
+            guard (1...9).contains(digits.count) else { return nil }
+            let rest = line.dropFirst(digits.count)
+            guard let delimiter = rest.first, delimiter == "." || delimiter == ")" else {
+                return nil
+            }
+            let body = rest.dropFirst()
+            guard body.first == " " else { return nil }
+            return String(body.drop { $0 == " " })
+        }
+
+        /// `> quoted`, with the one optional space after the marker.
+        static func quoteLine(_ line: String) -> String? {
+            guard line.first == ">" else { return nil }
+            let rest = line.dropFirst()
+            return String(rest.first == " " ? rest.dropFirst() : rest)
+        }
+    }
+}
+
+// MARK: - The reading face
+
+/// A journal body set as real blocks — paragraphs, lists, headings, quotes —
+/// rather than one run-on run. `||spoilers||` render as bars; where they are
+/// revealable, tapping one opens it.
+struct JournalBody: View {
+    let md: String
+    /// Whether a spoiler here can be tapped open. False inside the all-entries
+    /// sheet, where the whole card is a button and the row's own tap — which
+    /// opens the entry in the drawer — has to win.
+    var revealable: Bool = true
+
+    @Environment(\.palette) private var palette
+    @State private var revealed: Set<Int> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            ForEach(Array(JournalMarkdown.blocks(md).enumerated()), id: \.offset) { _, block in
+                view(for: block)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .environment(\.openURL, OpenURLAction { url in
+            // Links the author wrote still open; only the reveal scheme is ours
+            // to swallow.
+            guard let id = JournalMarkdown.revealID(url) else { return .systemAction }
+            withAnimation(Motion.snap) { _ = revealed.insert(id) }
+            return .handled
+        })
+    }
+
+    @ViewBuilder
+    private func view(for block: JournalBlock) -> some View {
+        switch block {
+        case .heading(let level, let spans):
+            text(spans)
+                .font(.display(level <= 1 ? 25 : level == 2 ? 21 : 18, weight: .semibold))
+                .foregroundStyle(palette.ink0Color)
+                .lineSpacing(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .paragraph(let spans):
+            prose(spans)
+        case .bullets(let items):
+            list(items) { _ in "\u{2022}" }
+        case .numbered(let items):
+            list(items) { "\($0 + 1)." }
+        case .quote(let spans):
+            prose(spans)
+                .padding(.leading, 13)
+                .overlay(alignment: .leading) {
+                    Capsule().fill(palette.accentColor.opacity(0.5)).frame(width: 2)
+                }
+        case .code(let source):
+            Text(source)
+                .font(.monoUI(12.5))
+                .foregroundStyle(palette.ink1Color)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(11)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                        .fill(palette.bg2Color)
+                )
+        case .rule:
+            Hairline().padding(.vertical, 3)
+        }
+    }
+
+    private func prose(_ spans: [JournalSpan]) -> some View {
+        text(spans)
+            .font(.display(18))
+            .foregroundStyle(palette.ink1Color)
+            .lineSpacing(6)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// A list hung on its markers, so a wrapped line lines up under the text
+    /// rather than under the bullet.
+    private func list(_ items: [[JournalSpan]], marker: (Int) -> String) -> some View {
+        // Resolved up front: `ForEach`'s content escapes, and the caller's
+        // marker closure does not.
+        let markers = items.indices.map(marker)
+        return VStack(alignment: .leading, spacing: 6) {
+            ForEach(items.indices, id: \.self) { index in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(markers[index])
+                        .font(.monoUI(11))
+                        .foregroundStyle(palette.ink3Color)
+                        .frame(minWidth: 12, alignment: .trailing)
+                    prose(items[index])
+                }
+            }
+        }
+    }
+
+    /// The inline runs of one block, spoilers masked or open.
+    private func text(_ spans: [JournalSpan]) -> Text {
+        spans.reduce(Text(verbatim: "")) { line, span in line + piece(span) }
+    }
+
+    private func piece(_ span: JournalSpan) -> Text {
+        switch span {
+        case .prose(let source):
+            return Text(JournalMarkdown.inline(source))
+        case .spoiler(let source, let id):
+            var run = JournalMarkdown.inline(source)
+            guard !revealed.contains(id) else { return Text(run) }
+            // Ink the colour of its own bar: the region keeps the width it will
+            // have once open, so revealing it never reflows the paragraph.
+            run.foregroundColor = palette.bg3Color
+            run.backgroundColor = palette.bg3Color
+            if revealable { run.link = JournalMarkdown.revealURL(id) }
+            return Text(run)
+        }
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
@@ -345,7 +345,7 @@ extension JournalMarkdown {
 
 /// A journal body set as real blocks — paragraphs, lists, headings, quotes —
 /// rather than one run-on run. `||spoilers||` render as bars; where they are
-/// revealable, tapping one opens it.
+/// revealable, tapping one opens it and tapping it again puts it back.
 struct JournalBody: View {
     let md: String
     /// Whether a spoiler here can be tapped open. False inside the all-entries
@@ -355,6 +355,14 @@ struct JournalBody: View {
 
     @Environment(\.palette) private var palette
     @State private var revealed: Set<Int> = []
+
+    /// Reveal is a toggle, not a latch: having read a span, you can hide it
+    /// again before handing the phone over.
+    static func toggling(_ id: Int, in revealed: Set<Int>) -> Set<Int> {
+        var next = revealed
+        if next.remove(id) == nil { next.insert(id) }
+        return next
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 13) {
@@ -367,7 +375,7 @@ struct JournalBody: View {
             // Links the author wrote still open; only the reveal scheme is ours
             // to swallow.
             guard let id = JournalMarkdown.revealID(url) else { return .systemAction }
-            withAnimation(Motion.snap) { _ = revealed.insert(id) }
+            withAnimation(Motion.snap) { revealed = Self.toggling(id, in: revealed) }
             return .handled
         })
     }
@@ -376,7 +384,7 @@ struct JournalBody: View {
     private func view(for block: JournalBlock) -> some View {
         switch block {
         case .heading(let level, let spans):
-            text(spans)
+            text(spans, ink: palette.ink0Color)
                 .font(.display(level <= 1 ? 25 : level == 2 ? 21 : 18, weight: .semibold))
                 .foregroundStyle(palette.ink0Color)
                 .lineSpacing(2)
@@ -404,12 +412,17 @@ struct JournalBody: View {
                         .fill(palette.bg2Color)
                 )
         case .rule:
-            Hairline().padding(.vertical, 3)
+            // Not `Hairline`: that is a row separator at line-2/0.5pt, which an
+            // authored break disappears into. A `---` is a deliberate mark.
+            Rectangle()
+                .fill(palette.lineColor)
+                .frame(height: 1)
+                .padding(.vertical, 5)
         }
     }
 
     private func prose(_ spans: [JournalSpan]) -> some View {
-        text(spans)
+        text(spans, ink: palette.ink1Color)
             .font(.display(18))
             .foregroundStyle(palette.ink1Color)
             .lineSpacing(6)
@@ -436,22 +449,28 @@ struct JournalBody: View {
         }
     }
 
-    /// The inline runs of one block, spoilers masked or open.
-    private func text(_ spans: [JournalSpan]) -> Text {
-        spans.reduce(Text(verbatim: "")) { line, span in line + piece(span) }
+    /// The inline runs of one block, spoilers masked or open. `ink` is the
+    /// block's own text colour, which an open spoiler has to restate: it keeps
+    /// its reveal link so a second tap re-hides it, and a link left to itself
+    /// would draw in the tint colour rather than as prose.
+    private func text(_ spans: [JournalSpan], ink: Color) -> Text {
+        spans.reduce(Text(verbatim: "")) { line, span in line + piece(span, ink: ink) }
     }
 
-    private func piece(_ span: JournalSpan) -> Text {
+    private func piece(_ span: JournalSpan, ink: Color) -> Text {
         switch span {
         case .prose(let source):
             return Text(JournalMarkdown.inline(source))
         case .spoiler(let source, let id):
             var run = JournalMarkdown.inline(source)
-            guard !revealed.contains(id) else { return Text(run) }
-            // Ink the colour of its own bar: the region keeps the width it will
-            // have once open, so revealing it never reflows the paragraph.
-            run.foregroundColor = palette.bg3Color
-            run.backgroundColor = palette.bg3Color
+            if revealed.contains(id) {
+                run.foregroundColor = ink
+            } else {
+                // Ink the colour of its own bar: the region keeps the width it
+                // will have open, so a reveal never reflows the paragraph.
+                run.foregroundColor = palette.bg3Color
+                run.backgroundColor = palette.bg3Color
+            }
             if revealable { run.link = JournalMarkdown.revealURL(id) }
             return Text(run)
         }

--- a/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/JournalMarkdown.swift
@@ -113,6 +113,31 @@ enum JournalMarkdown {
         )) ?? AttributedString(source)
     }
 
+    /// The block as assistive tech should hear it: markup resolved, and every
+    /// still-hidden span named rather than read out. Masking a run by colour
+    /// hides it from exactly one audience and not from the other — VoiceOver
+    /// speaks the text under the bar — so the label has to censor it too.
+    static func spoken(_ spans: [JournalSpan], revealed: Set<Int>) -> String {
+        spans.map { span in
+            switch span {
+            case .prose(let text):
+                String(inline(text).characters)
+            case .spoiler(let text, let id):
+                revealed.contains(id) ? String(inline(text).characters) : "spoiler, hidden"
+            }
+        }.joined()
+    }
+
+    /// The spans in one block that are still hidden — what a reveal-all
+    /// accessibility action opens, and whether to offer one at all.
+    static func hiddenIDs(_ spans: [JournalSpan], revealed: Set<Int>) -> Set<Int> {
+        var out: Set<Int> = []
+        for case .spoiler(_, let id) in spans where !revealed.contains(id) {
+            out.insert(id)
+        }
+        return out
+    }
+
     /// The link a masked spoiler carries, and the id back out of one.
     static func revealURL(_ id: Int) -> URL? { URL(string: "\(revealScheme)://\(id)") }
 
@@ -151,7 +176,7 @@ extension JournalMarkdown {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
             if let open = fence {
-                if trimmed.hasPrefix(open), trimmed.allSatisfy({ $0 == open.first }) {
+                if Self.closesFence(trimmed, open: open) {
                     out.append(.code(code.joined(separator: "\n")))
                     fence = nil
                     code = []
@@ -274,9 +299,25 @@ extension JournalMarkdown {
 
         // MARK: Line shapes
 
-        /// The backtick or tilde run opening a fence, if this line is one.
+        /// The backtick or tilde run opening a fence, if this line is one —
+        /// the whole run, not just its first three. CommonMark lets a longer
+        /// fence carry ``` inside it, and only a run at least as long closes
+        /// one, so the length has to survive to the closing check.
         static func fenceMarker(_ line: String) -> String? {
-            ["```", "~~~"].first(where: line.hasPrefix)
+            for marker: Character in ["`", "~"] {
+                let run = line.prefix { $0 == marker }
+                if run.count >= 3 { return String(run) }
+            }
+            return nil
+        }
+
+        /// Whether this line closes the open fence: a bare run of the same
+        /// marker, at least as long as the one that opened it. A shorter run,
+        /// or one with an info string after it, is content.
+        static func closesFence(_ line: String, open: String) -> Bool {
+            guard let marker = open.first else { return false }
+            let run = line.prefix { $0 == marker }
+            return run.count >= open.count && run.count == line.count
         }
 
         /// `---`, `***`, `___` — three or more of one marker and nothing else.
@@ -384,11 +425,14 @@ struct JournalBody: View {
     private func view(for block: JournalBlock) -> some View {
         switch block {
         case .heading(let level, let spans):
-            text(spans, ink: palette.ink0Color)
-                .font(.display(level <= 1 ? 25 : level == 2 ? 21 : 18, weight: .semibold))
-                .foregroundStyle(palette.ink0Color)
-                .lineSpacing(2)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            spoilerSafe(
+                text(spans, ink: palette.ink0Color)
+                    .font(.display(level <= 1 ? 25 : level == 2 ? 21 : 18, weight: .semibold))
+                    .foregroundStyle(palette.ink0Color)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, alignment: .leading),
+                spans
+            )
         case .paragraph(let spans):
             prose(spans)
         case .bullets(let items):
@@ -422,12 +466,35 @@ struct JournalBody: View {
     }
 
     private func prose(_ spans: [JournalSpan]) -> some View {
-        text(spans, ink: palette.ink1Color)
-            .font(.display(18))
-            .foregroundStyle(palette.ink1Color)
-            .lineSpacing(6)
-            .multilineTextAlignment(.leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        spoilerSafe(
+            text(spans, ink: palette.ink1Color)
+                .font(.display(18))
+                .foregroundStyle(palette.ink1Color)
+                .lineSpacing(6)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading),
+            spans
+        )
+    }
+
+    /// A block holding a masked span speaks a censored label — the colour
+    /// mask means nothing to VoiceOver — and, where its spans can be opened,
+    /// offers one rotor action to open them, since the per-span reveal links
+    /// the label replaces are no longer reachable.
+    @ViewBuilder
+    private func spoilerSafe(_ view: some View, _ spans: [JournalSpan]) -> some View {
+        let hidden = JournalMarkdown.hiddenIDs(spans, revealed: revealed)
+        if hidden.isEmpty {
+            view
+        } else if revealable {
+            view
+                .accessibilityLabel(JournalMarkdown.spoken(spans, revealed: revealed))
+                .accessibilityAction(named: "Reveal spoilers") {
+                    withAnimation(Motion.snap) { revealed.formUnion(hidden) }
+                }
+        } else {
+            view.accessibilityLabel(JournalMarkdown.spoken(spans, revealed: revealed))
+        }
     }
 
     /// A list hung on its markers, so a wrapped line lines up under the text

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -254,6 +254,40 @@ private func sitting(
     #expect(preview == "Cannot believe \u{2588}\u{2588}\u{2588} honestly")
 }
 
+// MARK: - Journal composer target
+
+private func entry(id: Int64, clientID: String? = nil) -> JournalEntry {
+    JournalEntry(
+        id: id, bookUUID: "b", authorId: 1, authorName: "admin",
+        bodyMd: "body", bodyHtml: "<p>body</p>", progress: nil,
+        clientID: clientID, createdAt: 0, updatedAt: 0
+    )
+}
+
+@Test func composerTargetCarriesTheEntryItWasOpenedOn() {
+    // The regression this type exists for: Edit lost its entry when the
+    // composer was a Bool with the entry in a separate `@State` beside it.
+    let target = BookDetailView.ComposerTarget.editing(entry(id: 7))
+    #expect(target.entry?.id == 7)
+    #expect(BookDetailView.ComposerTarget.new.entry == nil)
+}
+
+@Test func composerTargetIdentitySeparatesNewFromEachEditedEntry() {
+    // The id is what `.sheet(item:)` re-presents on, so two entries must not
+    // share one — and neither may collide with a new entry.
+    let first = BookDetailView.ComposerTarget.editing(entry(id: 7))
+    let second = BookDetailView.ComposerTarget.editing(entry(id: 8))
+    #expect(first.id != second.id)
+    #expect(first.id != BookDetailView.ComposerTarget.new.id)
+}
+
+@Test func composerTargetIdentityFollowsAnOfflineEntrysClientID() {
+    // An entry created offline has no server id yet; its client-minted handle
+    // is what distinguishes it (migration 0051's whole point).
+    let pending = BookDetailView.ComposerTarget.editing(entry(id: 0, clientID: "abc"))
+    #expect(pending.id == "abc")
+}
+
 
 // MARK: - Two-position Home geometry
 

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -240,6 +240,20 @@ private func sitting(
     #expect(preview == "The Cinder scene lands differently in audio")
 }
 
+@Test func journalRowPreviewUnwrapsANumberedOrQuotedOpeningLine() {
+    #expect(JournalRow.preview("1. Started it again") == "Started it again")
+    #expect(JournalRow.preview("> The Beauty of the House") == "The Beauty of the House")
+    // Prose that merely opens with a year keeps its digits — the marker needs
+    // its `.` or `)`.
+    #expect(JournalRow.preview("1984 reads differently now") == "1984 reads differently now")
+}
+
+@Test func journalRowPreviewCensorsASpoilerSoTheRowCannotLeakIt() {
+    // The row is always visible, so the span never reaches it in the clear.
+    let preview = JournalRow.preview("Cannot believe ||Fitchner was **ARES**|| honestly")
+    #expect(preview == "Cannot believe \u{2588}\u{2588}\u{2588} honestly")
+}
+
 
 // MARK: - Two-position Home geometry
 

--- a/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
+++ b/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
@@ -155,6 +155,35 @@ private func plain(_ spans: [JournalSpan]) -> String {
     #expect(blocks == [.code("still mine")])
 }
 
+@Test func blocksLetALongFenceCarryAShorterOne() {
+    // A four-backtick fence exists so its body can contain ```; a three-run
+    // must not close it. Server ground truth: ````\ninner ``` fence\n````
+    // renders as one <pre> holding the inner run.
+    let blocks = JournalMarkdown.blocks("````\ninner ``` fence\n````")
+    #expect(blocks == [.code("inner ``` fence")])
+}
+
+@Test func blocksCloseAFenceOnAtLeastItsOwnLength() {
+    // Longer closes shorter; an info string on the closing line does not.
+    #expect(JournalMarkdown.blocks("```\nbody\n`````") == [.code("body")])
+    #expect(JournalMarkdown.blocks("```\nbody\n``` js\nmore\n```") == [.code("body\n``` js\nmore")])
+}
+
+@Test func blocksReadATildeFence() {
+    #expect(JournalMarkdown.blocks("~~~\nbody\n~~~") == [.code("body")])
+}
+
+@Test func blocksKeepAMultiLineSetextHeadingWhole() {
+    // Not a bug: CommonMark's setext content may span lines, and the server
+    // agrees — `Foo\nbar\n---` renders as `<h2>Foo<br>bar</h2>`. iOS matching
+    // it is the point; diverging would make one entry read two ways.
+    let blocks = JournalMarkdown.blocks("Foo\nbar\n---\nafter")
+    #expect(blocks == [
+        .heading(level: 2, spans: [.prose("Foo\nbar")]),
+        .paragraph([.prose("after")]),
+    ])
+}
+
 @Test func blocksSurviveCarriageReturns() {
     // Splitting on a newline *set* would read CRLF as two breaks, and the blank
     // line between them would end the paragraph.
@@ -229,6 +258,40 @@ private func plain(_ spans: [JournalSpan]) -> String {
 
 @Test func maskedLeavesProseAlone() {
     #expect(JournalMarkdown.masked("Wrote a C# parser") == "Wrote a C# parser")
+}
+
+// MARK: - What assistive tech hears
+
+@Test func spokenNamesAHiddenSpanRatherThanReadingIt() {
+    // The colour mask means nothing to VoiceOver, so the label has to censor
+    // the span itself — otherwise a spoiler leaks to the one audience that
+    // cannot see it is meant to be hidden.
+    var next = 0
+    let spans = JournalMarkdown.spans("Cannot believe ||**Fitchner** was ARES||", from: &next)
+    #expect(JournalMarkdown.spoken(spans, revealed: []) == "Cannot believe spoiler, hidden")
+}
+
+@Test func spokenReadsASpanOnceItIsRevealed() {
+    var next = 0
+    let spans = JournalMarkdown.spans("He was ||**Ares**||", from: &next)
+    // Inline markup is resolved too — "star star Ares star star" is not a
+    // sentence.
+    #expect(JournalMarkdown.spoken(spans, revealed: [0]) == "He was Ares")
+}
+
+@Test func hiddenIDsNamesOnlyTheSpansStillClosed() {
+    let blocks = JournalMarkdown.blocks("||one|| and ||two|| and ||three||")
+    guard case .paragraph(let spans) = blocks[0] else {
+        Issue.record("expected one paragraph")
+        return
+    }
+    #expect(JournalMarkdown.hiddenIDs(spans, revealed: []) == [0, 1, 2])
+    #expect(JournalMarkdown.hiddenIDs(spans, revealed: [1]) == [0, 2])
+    #expect(JournalMarkdown.hiddenIDs(spans, revealed: [0, 1, 2]) == [])
+}
+
+@Test func hiddenIDsIsEmptyForABlockWithNoSpoilers() {
+    #expect(JournalMarkdown.hiddenIDs([.prose("plain")], revealed: []) == [])
 }
 
 // MARK: - Inline rendering

--- a/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
+++ b/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
@@ -254,6 +254,17 @@ private func plain(_ spans: [JournalSpan]) -> String {
     #expect(JournalMarkdown.revealID(URL(string: "https://example.com/3")!) == nil)
 }
 
+@Test func revealIsAToggleSoASpanCanBeHiddenAgain() {
+    let opened = JournalBody.toggling(2, in: [])
+    #expect(opened == [2])
+    #expect(JournalBody.toggling(2, in: opened) == [])
+}
+
+@Test func togglingOneSpanLeavesTheOthersAlone() {
+    #expect(JournalBody.toggling(1, in: [0, 1, 2]) == [0, 2])
+    #expect(JournalBody.toggling(3, in: [0, 2]) == [0, 2, 3])
+}
+
 // MARK: - The whole entry
 
 @Test func blocksReadARealReviewEntryEndToEnd() {

--- a/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
+++ b/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
@@ -1,0 +1,290 @@
+//  JournalMarkdownTests.swift
+//  The block splitter and spoiler pass behind a journal body: what becomes a
+//  paragraph, a list, a heading or a rule, and where a `||spoiler||` starts
+//  and stops.
+
+import Foundation
+import Testing
+
+@testable import omnibus
+
+/// Most blocks carry one plain run; asserting on that reads better than on the
+/// span array.
+private func plain(_ spans: [JournalSpan]) -> String {
+    spans.map { span in
+        switch span {
+        case .prose(let text): text
+        case .spoiler(let text, _): text
+        }
+    }.joined()
+}
+
+// MARK: - Blocks
+
+@Test func blocksSplitParagraphsOnBlankLines() {
+    let blocks = JournalMarkdown.blocks("First thought.\n\nSecond thought.")
+    #expect(blocks == [
+        .paragraph([.prose("First thought.")]),
+        .paragraph([.prose("Second thought.")]),
+    ])
+}
+
+@Test func blocksKeepAuthoredLineBreaksInsideOneParagraph() {
+    // The server promotes a soft break to a hard one, so a newline the author
+    // can see has to stay visible rather than collapse to a space.
+    let blocks = JournalMarkdown.blocks("One line\nand its wrap")
+    #expect(blocks == [.paragraph([.prose("One line\nand its wrap")])])
+}
+
+@Test func blocksGatherDashedLinesIntoOneBulletList() {
+    let blocks = JournalMarkdown.blocks("- first\n- second\n- third")
+    #expect(blocks == [.bullets([
+        [.prose("first")], [.prose("second")], [.prose("third")],
+    ])])
+}
+
+@Test func blocksAcceptEveryBulletMarker() {
+    let blocks = JournalMarkdown.blocks("- dash\n* star\n+ plus")
+    #expect(blocks == [.bullets([[.prose("dash")], [.prose("star")], [.prose("plus")]])])
+}
+
+@Test func blocksNumberAnOrderedList() {
+    let blocks = JournalMarkdown.blocks("1. first\n2) second")
+    #expect(blocks == [.numbered([[.prose("first")], [.prose("second")]])])
+}
+
+@Test func blocksContinueAListItemAcrossALazyWrap() {
+    // A plain line under an open list belongs to its last item, not to a new
+    // paragraph that would break the list in two.
+    let blocks = JournalMarkdown.blocks("- a long thought\nthat wrapped\n- the next one")
+    #expect(blocks == [.bullets([
+        [.prose("a long thought\nthat wrapped")], [.prose("the next one")],
+    ])])
+}
+
+@Test func blocksEndAListAtABlankLine() {
+    let blocks = JournalMarkdown.blocks("- item\n\nBack to prose.")
+    #expect(blocks == [
+        .bullets([[.prose("item")]]),
+        .paragraph([.prose("Back to prose.")]),
+    ])
+}
+
+@Test func blocksReadAnATXHeadingAndItsLevel() {
+    let blocks = JournalMarkdown.blocks("## The Highlights\nA thought.")
+    #expect(blocks == [
+        .heading(level: 2, spans: [.prose("The Highlights")]),
+        .paragraph([.prose("A thought.")]),
+    ])
+}
+
+@Test func blocksDropAHeadingsClosingHashes() {
+    let blocks = JournalMarkdown.blocks("# Title #")
+    #expect(blocks == [.heading(level: 1, spans: [.prose("Title")])])
+}
+
+@Test func blocksKeepASharpThatBelongsToTheHeadingsLastWord() {
+    // A closing run only closes when a space runs up to it, so the language
+    // keeps its name.
+    let blocks = JournalMarkdown.blocks("# Notes on C#")
+    #expect(blocks == [.heading(level: 1, spans: [.prose("Notes on C#")])])
+}
+
+@Test func blocksLeaveASevenHashLineAsProse() {
+    // CommonMark stops at six; a longer run is a paragraph that starts with
+    // hashes, not a heading.
+    let blocks = JournalMarkdown.blocks("####### not a heading")
+    #expect(blocks == [.paragraph([.prose("####### not a heading")])])
+}
+
+@Test func blocksReadAThematicBreakAfterAHeading() {
+    // The shape the composer's own template uses: a heading, a rule under it,
+    // then the list. The rule must not be read as the heading's underline.
+    let blocks = JournalMarkdown.blocks("## The Highlights\n---\n- first")
+    #expect(blocks == [
+        .heading(level: 2, spans: [.prose("The Highlights")]),
+        .rule,
+        .bullets([[.prose("first")]]),
+    ])
+}
+
+@Test func blocksReadDashesUnderAParagraphAsASetextHeading() {
+    let blocks = JournalMarkdown.blocks("First Thoughts\n---\nA thought.")
+    #expect(blocks == [
+        .heading(level: 2, spans: [.prose("First Thoughts")]),
+        .paragraph([.prose("A thought.")]),
+    ])
+}
+
+@Test func blocksReadEqualsUnderAParagraphAsATopLevelHeading() {
+    let blocks = JournalMarkdown.blocks("First Thoughts\n===")
+    #expect(blocks == [.heading(level: 1, spans: [.prose("First Thoughts")])])
+}
+
+@Test func blocksTreatSpacedDashesAsARuleNotAnUnderline() {
+    // `- - -` is a thematic break in CommonMark even under a paragraph, so the
+    // paragraph survives it.
+    let blocks = JournalMarkdown.blocks("A thought.\n- - -")
+    #expect(blocks == [.paragraph([.prose("A thought.")]), .rule])
+}
+
+@Test func blocksReadEveryThematicBreakMarker() {
+    let blocks = JournalMarkdown.blocks("---\n\n***\n\n___")
+    #expect(blocks == [.rule, .rule, .rule])
+}
+
+@Test func blocksKeepEmphasisMarkersOffTheRulePath() {
+    // `***bold***` opens with three stars but is not alone on the line.
+    let blocks = JournalMarkdown.blocks("***bold***")
+    #expect(blocks == [.paragraph([.prose("***bold***")])])
+}
+
+@Test func blocksGatherAQuote() {
+    let blocks = JournalMarkdown.blocks("> a line\n> and another")
+    #expect(blocks == [.quote([.prose("a line\nand another")])])
+}
+
+@Test func blocksKeepFencedCodeVerbatim() {
+    let blocks = JournalMarkdown.blocks("```\nlet x = ||1||\n```")
+    // No inline parse and no spoiler pass inside a fence.
+    #expect(blocks == [.code("let x = ||1||")])
+}
+
+@Test func blocksKeepAnUnclosedFencesText() {
+    let blocks = JournalMarkdown.blocks("```\nstill mine")
+    #expect(blocks == [.code("still mine")])
+}
+
+@Test func blocksSurviveCarriageReturns() {
+    // Splitting on a newline *set* would read CRLF as two breaks, and the blank
+    // line between them would end the paragraph.
+    let blocks = JournalMarkdown.blocks("One line\r\nand its wrap")
+    #expect(blocks == [.paragraph([.prose("One line\nand its wrap")])])
+}
+
+@Test func blocksAreEmptyForAnEmptyBody() {
+    #expect(JournalMarkdown.blocks("") == [])
+    #expect(JournalMarkdown.blocks("\n  \n") == [])
+}
+
+// MARK: - Inline spoilers
+
+@Test func spansSplitASpoilerOutOfItsLine() {
+    var next = 0
+    let spans = JournalMarkdown.spans("He was ||Ares|| all along", from: &next)
+    #expect(spans == [.prose("He was "), .spoiler("Ares", id: 0), .prose(" all along")])
+    #expect(next == 1)
+}
+
+@Test func spansNumberSpoilersInReadingOrderAcrossTheWholeEntry() {
+    let blocks = JournalMarkdown.blocks("||one||\n\n- ||two||\n- ||three||")
+    #expect(blocks == [
+        .paragraph([.spoiler("one", id: 0)]),
+        .bullets([[.spoiler("two", id: 1)], [.spoiler("three", id: 2)]]),
+    ])
+}
+
+@Test func spansLeaveAnUnterminatedMarkerLiteral() {
+    var next = 0
+    let spans = JournalMarkdown.spans("Darrow hid ||that he trained with Lorn", from: &next)
+    #expect(spans == [.prose("Darrow hid ||that he trained with Lorn")])
+    #expect(next == 0)
+}
+
+@Test func spansNeverPairAMarkerAcrossALineBoundary() {
+    // #2366: one stray marker must not invert every line after it. The line
+    // that is short a marker keeps it literal; the next line still pairs.
+    let blocks = JournalMarkdown.blocks("- hid ||in the gap|\n- killing ||Leto|| was smart")
+    #expect(blocks == [.bullets([
+        [.prose("hid ||in the gap|")],
+        [.prose("killing "), .spoiler("Leto", id: 0), .prose(" was smart")],
+    ])])
+}
+
+@Test func spansPairSeveralSpoilersOnOneLine() {
+    var next = 0
+    let spans = JournalMarkdown.spans(
+        "During the ||Iron Rain||, the ||EMP blast|| landed", from: &next)
+    #expect(spans == [
+        .prose("During the "),
+        .spoiler("Iron Rain", id: 0),
+        .prose(", the "),
+        .spoiler("EMP blast", id: 1),
+        .prose(" landed"),
+    ])
+}
+
+@Test func spansKeepInlineMarkupInsideASpoilerForTheInlineParser() {
+    var next = 0
+    let spans = JournalMarkdown.spans("Cannot believe ||**Fitchner** was ARES||", from: &next)
+    #expect(spans == [.prose("Cannot believe "), .spoiler("**Fitchner** was ARES", id: 0)])
+}
+
+// MARK: - Masking
+
+@Test func maskedCensorsEverySpoilerRegion() {
+    let line = JournalMarkdown.masked("He was ||Ares|| and ||her uncle||")
+    #expect(line == "He was \u{2588}\u{2588}\u{2588} and \u{2588}\u{2588}\u{2588}")
+}
+
+@Test func maskedLeavesProseAlone() {
+    #expect(JournalMarkdown.masked("Wrote a C# parser") == "Wrote a C# parser")
+}
+
+// MARK: - Inline rendering
+
+@Test func inlineStillResolvesBoldAndItalic() {
+    let rendered = JournalMarkdown.inline("**Kvothe** is an *unreliable* narrator")
+    #expect(String(rendered.characters) == "Kvothe is an unreliable narrator")
+}
+
+@Test func inlineKeepsTheLineBreaksTheSplitterLeftInABlock() {
+    let rendered = JournalMarkdown.inline("one\ntwo")
+    #expect(String(rendered.characters) == "one\ntwo")
+}
+
+// MARK: - Reveal links
+
+@Test func revealURLRoundTripsItsSpoilerID() {
+    let url = JournalMarkdown.revealURL(12)
+    #expect(url.flatMap(JournalMarkdown.revealID) == 12)
+}
+
+@Test func revealIDIgnoresAnAuthorsOwnLinks() {
+    #expect(JournalMarkdown.revealID(URL(string: "https://example.com/3")!) == nil)
+}
+
+// MARK: - The whole entry
+
+@Test func blocksReadARealReviewEntryEndToEnd() {
+    let entry = """
+        ## First Thoughts
+        There was never a dull moment in this book.
+
+        I still can't figure out how ||The Jackal knew.||
+
+        ## The Highlights
+        ---
+        - Bellona boys ||deserve everything they got.||
+        - Cannot believe that ||Fitchner was **ARES**||...
+        """
+    let blocks = JournalMarkdown.blocks(entry)
+
+    #expect(blocks.count == 6)
+    #expect(blocks[0] == .heading(level: 2, spans: [.prose("First Thoughts")]))
+    #expect(blocks[1] == .paragraph([.prose("There was never a dull moment in this book.")]))
+    if case .paragraph(let spans) = blocks[2] {
+        #expect(spans.contains(.spoiler("The Jackal knew.", id: 0)))
+    } else {
+        Issue.record("expected the spoiler line to be a paragraph")
+    }
+    #expect(blocks[3] == .heading(level: 2, spans: [.prose("The Highlights")]))
+    #expect(blocks[4] == .rule)
+    guard case .bullets(let items) = blocks[5] else {
+        Issue.record("expected the dashed lines to gather into one list")
+        return
+    }
+    #expect(items.count == 2)
+    #expect(plain(items[0]) == "Bellona boys deserve everything they got.")
+    #expect(plain(items[1]) == "Cannot believe that Fitchner was **ARES**...")
+}

--- a/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
+++ b/omnibus-ios/omnibusTests/JournalMarkdownTests.swift
@@ -50,7 +50,23 @@ private func plain(_ spans: [JournalSpan]) -> String {
 
 @Test func blocksNumberAnOrderedList() {
     let blocks = JournalMarkdown.blocks("1. first\n2) second")
-    #expect(blocks == [.numbered([[.prose("first")], [.prose("second")]])])
+    #expect(blocks == [.numbered([[.prose("first")], [.prose("second")]], start: 1)])
+}
+
+@Test func blocksOpenAnOrderedListAtItsAuthoredNumber() {
+    // Server ground truth: `5. fifth` opens `<ol start="5">`, so the list must
+    // read 5, 6, 7 — not restart at 1.
+    let blocks = JournalMarkdown.blocks("5. fifth\n6. sixth\n7. seventh")
+    #expect(blocks == [.numbered(
+        [[.prose("fifth")], [.prose("sixth")], [.prose("seventh")]], start: 5)])
+}
+
+@Test func blocksIgnoreEveryMarkerAfterTheFirst() {
+    // `<ol>` carries one start; the rest of the authored numbers are dropped,
+    // so an all-`1.` list still counts up.
+    let blocks = JournalMarkdown.blocks("1. one\n1. also one\n1. still one")
+    #expect(blocks == [.numbered(
+        [[.prose("one")], [.prose("also one")], [.prose("still one")]], start: 1)])
 }
 
 @Test func blocksContinueAListItemAcrossALazyWrap() {


### PR DESCRIPTION
## Summary
- Journal bodies were parsed with `inlineOnlyPreservingWhitespace`, so only bold and italic survived — headings, paragraph breaks and dashed lists collapsed into one run-on run, and `||spoiler||` markers rendered in the clear, pipes and all.
- New `JournalMarkdown` splits a body into blocks (paragraphs, ATX + setext headings, bullet and ordered lists with lazy continuation, quotes, fenced code, rules) and each line into prose and spoiler runs, set in the reading face the design's `IBMd` calls for. Applied in the drawer, the all-entries sheet, and the row preview.
- Spoilers pair **per line**, which is the fix #2366 asks of the server and what the web composer's own highlighter already does — the sample entry in that issue is what this was built against.
- A masked span is a bar carrying an `omnibus-spoiler://<id>` link the body swallows via `OpenURLAction`, since `Text` has no per-run gesture. Reveal is a toggle. Not revealable inside `AllJournalsSheet`, where the card is a button and the row's tap opens the drawer instead; the always-visible row excerpt censors every span as `███`, matching the web ladder's `journal_excerpt`.
- Also fixes a pre-existing bug the drawer surfaced: **Edit opened a blank "New entry"**. The composer was a Bool paired with the entry in a separate `@State`, and `.sheet(isPresented:)` captured its content before that payload landed. It is now an item-driven sheet keyed on `ComposerTarget`, so the entry rides with the presentation.

Images, tables and task lists are deliberately out of scope — their source falls through as prose rather than rendering half-formed.

Closes #2373

## Test plan
- [x] `just ios-test` — 734 cases, 0 failures (43 new: block splitter, spoiler pairing, masking, reveal toggle, composer target).
- [x] `just ios-release-guard` clean.
- [x] Drove the real app against a dev server with the #2366 sample entry: headings, paragraph breaks, the dashed list, the `---` rule, ordered lists and blockquotes all set as blocks; per-span tap-to-reveal and tap-to-re-hide; row excerpt censored; all-entries sheet non-revealable and opening the drawer instead; Edit loading the entry's source with its progress.

## Version
- [x] **Patch** — the default.

## Notes
- `---` renders as a 1pt `line` rule, not `Hairline`: that is the line-2/0.5pt row separator, which an authored break disappears into.