### PR TITLE
fix: always show the book cover's left edge on book detail

### DIFF
--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -10851,8 +10851,8 @@ html {
      always clears the gutter. `100vh - --bdmq-top` is the stage's own height
      (it is fixed to `top: var(--bdmq-top); bottom: 0`), and 1.25 * 2/3 = 5/6. */
   width: min(
-    (100vh - var(--bdmq-top, 61px)) * 5 / 6,
-    100% - var(--bdmq-cover-gutter) * 2
+    calc((100vh - var(--bdmq-top, 61px)) * 5 / 6),
+    calc(100% - var(--bdmq-cover-gutter) * 2)
   );
   height: auto;
 }

--- a/frontend/assets/atrium.css
+++ b/frontend/assets/atrium.css
@@ -10831,18 +10831,30 @@ html {
   position: absolute; left: 0; top: 0; bottom: 0; width: 50%;
   display: flex; align-items: center; justify-content: center;
   z-index: 0;
+  /* Breathing room the cover is sized against, so its left edge and drop
+     shadow never sit flush against the viewport. */
+  --bdmq-cover-gutter: clamp(18px, 2.6vw, 52px);
 }
 .bdmq-coverwrap .cover-wrap {
   filter: drop-shadow(0 40px 60px oklch(0 0 0 / .6))
           drop-shadow(0 4px 0 oklch(0 0 0 / .3));
 }
 .bdmq-coverpx {
-  height: 125%; aspect-ratio: 2/3; flex: 0 0 auto; will-change: transform;
-  /* The design sizes the cover off the stage height (125%, 2:3). On a tall
-     or narrow window that runs wider than the cover column and floods the
-     stage, so cap it to the column: the cover stays centred on the left with
-     its right edge tucked under the translucent panel, as designed. */
-  max-width: 100%;
+  aspect-ratio: 2/3; flex: 0 0 auto; will-change: transform;
+  /* The design sizes the cover off the stage height (125%, 2:3) so it bleeds
+     past the stage under the parallax, and the width follows from that height
+     -- so on a tall or narrow window it runs wider than the 50% cover
+     column. Capping that with `max-width` alone squashed the box off 2:3 (an
+     explicit height outranks the ratio), so `object-fit: cover` then ate the
+     artwork's left edge flush against the viewport. Size off whichever
+     constraint binds instead: the ratio always holds, and the book's left edge
+     always clears the gutter. `100vh - --bdmq-top` is the stage's own height
+     (it is fixed to `top: var(--bdmq-top); bottom: 0`), and 1.25 * 2/3 = 5/6. */
+  width: min(
+    (100vh - var(--bdmq-top, 61px)) * 5 / 6,
+    100% - var(--bdmq-cover-gutter) * 2
+  );
+  height: auto;
 }
 .bdmq-coverpx .cover-wrap { width: 100%; height: 100%; }
 
@@ -11316,6 +11328,9 @@ html {
 /* ── Responsive: below ~940px the cover recedes behind a full-width panel ── */
 @media (max-width: 940px) {
   .bdmq-coverwrap { width: 100%; opacity: .22; }
+  /* Below the split the cover is a full-bleed wash behind the panel rather
+     than the subject, so it wants the stage-height sizing with no gutter. */
+  .bdmq-coverpx { width: auto; height: 125%; max-width: 100%; }
   .bdmq-panel { width: 100%; border-left: 0; padding: 40px 28px; }
   .bdmq-seclab { left: 28px; }
   .bdmq-next { right: 28px; }


### PR DESCRIPTION
## Summary
- The book-detail marquee cover was sized off the stage height (`height: 125%; aspect-ratio: 2/3`), so its width was derived from that height — and on a window that is tall relative to its width, that derived width outgrew the 50% cover column.
- `max-width: 100%` then clamped the width while the explicit height stood. An explicit height outranks `aspect-ratio`, so the clamp squashed the box off 2:3 rather than shrinking it, and `object-fit: cover` cropped the artwork; with the box now flush at `left: 0`, the book's left edge went with it.
- Size the box off whichever constraint binds instead — `width: min(<stage-height-derived>, 100% - 2 * gutter)` with `height: auto` — so the ratio always holds and the cover always clears a gutter.
- Below the 940px split the cover is a 22%-opacity full-bleed wash behind the panel rather than the subject, so that branch keeps the old stage-height sizing and is unchanged.

## Test plan
- [ ] `just lint-css` (stylelint over `frontend/assets/**/*.css`) passes.
- [ ] Live before/after geometry sweep across 10 viewports: after the change the box holds ratio 0.667 with `left >= 24px` and zero horizontal `object-fit` crop at every size; before it was `left: 0` with ratio down to 0.332 and 24.3% side-crop at 941x1200, 8.6% at 1280x1024, 6.2% at 1600x1200, and `left: 0` at 1512x982.
- [ ] Wide/short windows (1366x768, 1920x1080) and both below-split sizes (900x900, 700x1000) measure byte-identical before and after.
- [ ] Parallax still bleeds past the stage and tracks scroll on wide windows, and degrades to a centred, fully-visible cover where the box no longer overflows the stage.
- [ ] Checked against the two supplied real covers' natural dimensions (652x1000 and 1319x2048), since it is the natural ratio that drives the crop.

## Version
- [x] **Patch** — the default; left unlabeled.

## Notes
- No markup, role, or testid changed, so no Playwright specs needed updating; `marquee.js`'s parallax overshoot calc is the only other consumer of the cover box and was verified to still work (and to no-op cleanly when the cover no longer overflows the stage).
- Geometry was verified by injecting the committed rule text into the running dev server's page — that server is the main checkout, so this change has not been through a `dx serve` build of this branch. CI's `bundle` job covers that.