### PR TITLE
feat: one continuous book detail flow unless scroll stops are on

### DIFF
--- a/omnibus-ios/omnibus/Features/Account/AccountView.swift
+++ b/omnibus-ios/omnibus/Features/Account/AccountView.swift
@@ -10,11 +10,6 @@
 import SwiftUI
 
 struct AccountView: View {
-    /// Whether the book-detail scroll-stops switch is inert. `true` until
-    /// the book detail page actually branches on the stored preference — see
-    /// `bookDetailSection`. The web card carries the same constant.
-    static let scrollStopsParked = true
-
     /// Owned by `MainTabView` — see `isImmersiveDetail` there.
     @Binding var path: [Destination]
 
@@ -349,29 +344,18 @@ struct AccountView: View {
         }
     }
 
-    /// Whether this reader's book detail page uses the snap-stop marquee.
-    /// Account configuration: saved directly, never queued (rule 08).
-    ///
-    /// Parked behind `AccountView.scrollStopsParked` — nothing reads the
-    /// preference yet, so the switch renders disabled under a "Coming soon"
-    /// marker rather than letting a reader set a value that changes nothing.
-    /// Dropping that constant is what lights it up.
+    /// Whether this reader's book detail page uses the snap-stop marquee —
+    /// off, it renders as one continuous flow. Account configuration: saved
+    /// directly, never queued (rule 08).
     private var bookDetailSection: some View {
         group("Book details") {
             VStack(alignment: .leading, spacing: Spacing.md) {
                 Plate {
                     PlateRow(label: "Use scroll stops", isFirst: true) {
-                        if Self.scrollStopsParked {
-                            Text("Coming soon")
-                                .font(.monoUI(9.5, weight: .medium))
-                                .tracking(0.8)
-                                .textCase(.uppercase)
-                                .foregroundStyle(palette.ink3Color)
-                        }
                         Toggle("", isOn: $scrollStops)
                             .labelsHidden()
                             .tint(palette.accentColor)
-                            .disabled(Self.scrollStopsParked || !connectivity.isOnline)
+                            .disabled(!connectivity.isOnline)
                     }
                 }
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailFlow.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailFlow.swift
@@ -1,0 +1,121 @@
+//  BookDetailFlow.swift
+//  The shell pieces of the book detail's Option B — the marquee unrolled:
+//  one snap stop (the cover, whole) and past it a single continuous list of
+//  every section. The scroller and its content live in `BookDetailView`;
+//  this file holds the standalone parts — the hero-region snap behavior,
+//  the lift cue, the section rules, and the nav strip that replaces the
+//  dot rail's chrome once the cover has gone.
+
+import SwiftUI
+
+/// The flow's snapping: only the hero region snaps — the whole cover, or
+/// the body under the nav strip — and past a small overshoot the list
+/// scrolls free. The design's `scroll-snap-type: proximity`, by hand.
+struct FlowSnapBehavior: ScrollTargetBehavior {
+    var restTop: CGFloat
+    var navPeek: CGFloat = BookDetailView.flowNavPeek
+
+    func updateTarget(_ target: inout ScrollTarget, context: TargetContext) {
+        let lifted = max(1, restTop - navPeek)
+        let y = target.rect.origin.y
+
+        if y < lifted / 2 {
+            target.rect.origin.y = 0
+        } else if y < lifted + 60 {
+            target.rect.origin.y = lifted
+        }
+    }
+}
+
+/// The flow's lift cue: the grab bar and its one-line invitation, shown
+/// while the cover rests whole and gone once the list is up. Its space is
+/// kept either way, so the body's first section doesn't jump.
+struct FlowCue: View {
+    let visible: Bool
+    var onLift: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Button {
+            Haptics.tap()
+            onLift()
+        } label: {
+            HStack(spacing: 9) {
+                Capsule()
+                    .fill(palette.ink2Color.opacity(0.55))
+                    .frame(width: 36, height: 4)
+                Text("SWIPE UP FOR EVERYTHING")
+                    .font(.monoUI(8.5))
+                    .tracking(1.4)
+                    .foregroundStyle(palette.ink3Color)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 7)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.bottom, 9)
+        .opacity(visible ? 1 : 0)
+        .allowsHitTesting(visible)
+        .animation(Motion.snap, value: visible)
+        .accessibilityLabel("Show everything")
+        .accessibilityIdentifier("flow-lift-cue")
+    }
+}
+
+/// The rule that introduces each section of the flow — its number, its
+/// name, and a hairline running out to the edge.
+struct FlowSectionLabel: View {
+    let stop: DetailStop
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(String(format: "%02d", stop.rawValue + 1))
+                .foregroundStyle(palette.ink3Color)
+            Text(stop.name.uppercased())
+                .foregroundStyle(palette.ink1Color)
+            LinearGradient(
+                colors: [palette.line2.color, .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 1)
+        }
+        .font(.monoUI(9.5))
+        .tracking(1.6)
+        .padding(.bottom, 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+}
+
+/// The blurred strip that fades in under the chrome discs once the cover
+/// has gone — the flow has no full panel behind them, so this is what keeps
+/// the status bar and discs legible over the running list.
+struct FlowNavStrip: View {
+    let shown: Bool
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Color.clear
+            .frame(maxWidth: .infinity)
+            // The strip ends level with the chrome discs; its background
+            // runs on up under the status bar.
+            .frame(height: 46)
+            .background {
+                ZStack {
+                    Rectangle().fill(.ultraThinMaterial)
+                    palette.bg0Color.opacity(0.78)
+                }
+                .ignoresSafeArea(edges: .top)
+            }
+            .overlay(alignment: .bottom) { Hairline() }
+            .opacity(shown ? 1 : 0)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailFlow.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailFlow.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// scrolls free. The design's `scroll-snap-type: proximity`, by hand.
 struct FlowSnapBehavior: ScrollTargetBehavior {
     var restTop: CGFloat
-    var navPeek: CGFloat = BookDetailView.flowNavPeek
+    var navPeek: CGFloat = DetailRead.flowNavPeek
 
     func updateTarget(_ target: inout ScrollTarget, context: TargetContext) {
         let lifted = max(1, restTop - navPeek)

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -102,6 +102,23 @@ enum DetailRead {
         )
     }
 
+    /// The Option B flow's scroll → shell state. `lift` is the rest→lifted
+    /// progress across the run to the body's snap position (it drives the
+    /// art's whole→windowed morph and the rest fade); `page` feeds the art's
+    /// pan and wash as the list runs on; `past` is when the cover has gone
+    /// and the nav strip takes over under the discs.
+    static func flowMap(
+        offset: CGFloat, restTop: CGFloat, navPeek: CGFloat = 96
+    ) -> (lift: CGFloat, page: CGFloat, past: Bool) {
+        let run = max(1, restTop - navPeek)
+        let ratio = offset / max(1, restTop)
+        return (
+            lift: min(1, max(0, offset / run)),
+            page: max(0, (ratio - 0.35) * 2.4),
+            past: ratio > 0.55
+        )
+    }
+
     /// What the Home sync row states per link state, and the action word its
     /// trailing affordance promises. Every action opens the alignment sheet —
     /// link, re-confirm, and unlink all live there.
@@ -1234,6 +1251,9 @@ struct StopStats: View {
 struct StopHighlights: View {
     let book: Book
     let model: BookDetailModel
+    /// The flow (Option B) has no fixed screenful to fit, so it lists every
+    /// kept line inline instead of capping at `stopCount` behind a sheet.
+    var uncapped = false
     var onAll: () -> Void
 
     /// Passages shown on the stop before the sheet takes over.
@@ -1267,16 +1287,22 @@ struct StopHighlights: View {
                 DetailKicker(text: "Kept lines · \(all.count)")
 
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Self.preview(of: all)) { highlight in
+                    ForEach(
+                        uncapped
+                            ? all.sorted { $0.createdAt > $1.createdAt }
+                            : Self.preview(of: all)
+                    ) { highlight in
                         HighlightRow(highlight: highlight)
                     }
                 }
                 .padding(.top, 6)
 
-                MoreRowButton(
-                    label: "All \(all.count) highlights",
-                    identifier: "highlights-show-more"
-                ) { onAll() }
+                if !uncapped {
+                    MoreRowButton(
+                        label: "All \(all.count) highlights",
+                        identifier: "highlights-show-more"
+                    ) { onAll() }
+                }
             }
         }
     }
@@ -1327,6 +1353,9 @@ struct HighlightRow: View {
 struct StopJournals: View {
     let book: Book
     let model: BookDetailModel
+    /// The flow (Option B) has no fixed screenful to fit, so it lists every
+    /// entry inline instead of capping at `stopCount` behind a sheet.
+    var uncapped = false
     var onWrite: () -> Void
     var onOpen: (JournalEntry) -> Void
     var onAll: () -> Void
@@ -1360,13 +1389,15 @@ struct StopJournals: View {
                     .padding(.top, 22)
             } else {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(entries.prefix(Self.stopCount)) { entry in
+                    ForEach(
+                        uncapped ? entries : Array(entries.prefix(Self.stopCount))
+                    ) { entry in
                         JournalRow(entry: entry) { onOpen(entry) }
                     }
                 }
                 .padding(.top, 8)
 
-                if entries.count > Self.stopCount {
+                if !uncapped, entries.count > Self.stopCount {
                     MoreRowButton(label: "All \(entries.count) entries") { onAll() }
                 } else {
                     MonoNote(text: "everyone reading this book writes here")

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -102,13 +102,18 @@ enum DetailRead {
         )
     }
 
+    /// How much art keeps peeking behind the nav strip at the flow body's
+    /// snap position, measured from the screen's top — the one source for
+    /// the snap behavior, the scroll map, and the scroller's marker.
+    static let flowNavPeek: CGFloat = 96
+
     /// The Option B flow's scroll → shell state. `lift` is the rest→lifted
     /// progress across the run to the body's snap position (it drives the
     /// art's whole→windowed morph and the rest fade); `page` feeds the art's
     /// pan and wash as the list runs on; `past` is when the cover has gone
     /// and the nav strip takes over under the discs.
     static func flowMap(
-        offset: CGFloat, restTop: CGFloat, navPeek: CGFloat = 96
+        offset: CGFloat, restTop: CGFloat, navPeek: CGFloat = DetailRead.flowNavPeek
     ) -> (lift: CGFloat, page: CGFloat, past: Bool) {
         let run = max(1, restTop - navPeek)
         let ratio = offset / max(1, restTop)
@@ -1286,18 +1291,23 @@ struct StopHighlights: View {
             } else {
                 DetailKicker(text: "Kept lines · \(all.count)")
 
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(
-                        uncapped
-                            ? all.sorted { $0.createdAt > $1.createdAt }
-                            : Self.preview(of: all)
-                    ) { highlight in
-                        HighlightRow(highlight: highlight)
+                if uncapped {
+                    // Lazy: the flow's list is unbounded, and the model
+                    // already stores highlights newest-first.
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(all) { highlight in
+                            HighlightRow(highlight: highlight)
+                        }
                     }
-                }
-                .padding(.top, 6)
+                    .padding(.top, 6)
+                } else {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Self.preview(of: all)) { highlight in
+                            HighlightRow(highlight: highlight)
+                        }
+                    }
+                    .padding(.top, 6)
 
-                if !uncapped {
                     MoreRowButton(
                         label: "All \(all.count) highlights",
                         identifier: "highlights-show-more"
@@ -1388,14 +1398,22 @@ struct StopJournals: View {
                 StopRuledVoid()
                     .padding(.top, 22)
             } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(
-                        uncapped ? entries : Array(entries.prefix(Self.stopCount))
-                    ) { entry in
-                        JournalRow(entry: entry) { onOpen(entry) }
+                if uncapped {
+                    // Lazy, and no copied slice: the flow's list is unbounded.
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(entries) { entry in
+                            JournalRow(entry: entry) { onOpen(entry) }
+                        }
                     }
+                    .padding(.top, 8)
+                } else {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(entries.prefix(Self.stopCount)) { entry in
+                            JournalRow(entry: entry) { onOpen(entry) }
+                        }
+                    }
+                    .padding(.top, 8)
                 }
-                .padding(.top, 8)
 
                 if !uncapped, entries.count > Self.stopCount {
                     MoreRowButton(label: "All \(entries.count) entries") { onAll() }

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -115,7 +115,10 @@ final class BookDetailModel {
             }
             group.addTask { @MainActor in
                 for await items in UserDataService.highlights(uuid: uuid).values() {
-                    self.highlights = items
+                    // Sorted once at ingestion: the stops re-render on every
+                    // scroll tick, so a per-render sort is a real cost the
+                    // flow's uncapped list would pay constantly.
+                    self.highlights = items.sorted { $0.createdAt > $1.createdAt }
                 }
             }
             group.addTask { @MainActor in
@@ -262,11 +265,8 @@ struct BookDetailView: View {
     /// Scroll id of the rest run above the Home stop — the pre-Home snap
     /// target the two-position panel rests at.
     static let restMarkerID = -1
-    /// How much art keeps peeking behind the nav strip at the flow body's
-    /// snap position — the strip's region, measured from the screen's top.
-    static let flowNavPeek: CGFloat = 96
-    /// Scroll id of the flow body's snap position, `flowNavPeek` short of
-    /// the cover's end — where the lift cue's tap sends the list.
+    /// Scroll id of the flow body's snap position, `DetailRead.flowNavPeek`
+    /// short of the cover's end — where the lift cue's tap sends the list.
     static let flowLiftedMarkerID = -2
 
     /// What the journal composer was opened for. `Identifiable` so the
@@ -644,12 +644,12 @@ struct BookDetailView: View {
         ScrollView(.vertical) {
             VStack(spacing: 0) {
                 Color.clear
-                    .frame(height: max(0, restTop - Self.flowNavPeek))
+                    .frame(height: max(0, restTop - DetailRead.flowNavPeek))
                     .id(Self.restMarkerID)
                 // The body's snap position: this marker's top edge, a
                 // nav strip's worth of art short of the cover's end.
                 Color.clear
-                    .frame(height: Self.flowNavPeek)
+                    .frame(height: DetailRead.flowNavPeek)
                     .id(Self.flowLiftedMarkerID)
                 flowBody(book)
             }
@@ -668,7 +668,7 @@ struct BookDetailView: View {
             let map = DetailRead.flowMap(
                 offset: state.offset,
                 restTop: restTop,
-                navPeek: Self.flowNavPeek
+                navPeek: DetailRead.flowNavPeek
             )
             lift = map.lift
             page = map.page

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -1,13 +1,14 @@
 //  BookDetailView.swift
-//  The book detail marquee: full-bleed cover art running off the top edge,
-//  a translucent panel riding over its lower edge, and the page organised as
-//  seven snap stops on a vertical pager — Home · Shelf · Stats · Highlights ·
-//  Journals · The files · Recommendations. Home has two positions: the page
-//  opens on the artwork whole — the cover, or the generated plate at the
-//  same size — with the panel resting under it, and the first swipe lifts
-//  the panel to full height before the next one moves on to stop 02. Chrome
-//  is immersive: glass discs over the art, a tappable dot rail, and a
-//  persistent bottom action bar so Resume never scrolls away.
+//  The book detail: full-bleed cover art running off the top edge and the
+//  page opening on it whole — the cover, or the generated plate at the same
+//  size — with the panel resting under it. Past that, the layout follows the
+//  reader's scroll-stops preference. Off (the default), the flow: every
+//  section — Home · Shelf · Stats · Highlights · Journals · The files ·
+//  Recommendations — runs on in one continuous list, nothing capped. On,
+//  the marquee: the same sections as seven snap stops on a vertical pager,
+//  one screenful each. Chrome is immersive either way: glass discs over the
+//  art, a persistent bottom action bar so Resume never scrolls away, and
+//  the marquee's tappable dot rail or the flow's nav strip behind the discs.
 
 import SwiftUI
 
@@ -261,6 +262,12 @@ struct BookDetailView: View {
     /// Scroll id of the rest run above the Home stop — the pre-Home snap
     /// target the two-position panel rests at.
     static let restMarkerID = -1
+    /// How much art keeps peeking behind the nav strip at the flow body's
+    /// snap position — the strip's region, measured from the screen's top.
+    static let flowNavPeek: CGFloat = 96
+    /// Scroll id of the flow body's snap position, `flowNavPeek` short of
+    /// the cover's end — where the lift cue's tap sends the list.
+    static let flowLiftedMarkerID = -2
 
     /// What the journal composer was opened for. `Identifiable` so the
     /// composer can be an item-driven sheet, which is what keeps a chosen
@@ -322,6 +329,9 @@ struct BookDetailView: View {
     @State private var lifted = false
     /// The stop the scroller has settled nearest to.
     @State private var at: Int = 0
+    /// Flow only: whether the cover has scrolled away — the discs go flat
+    /// and the nav strip fades in under them.
+    @State private var flowPast = false
     /// Scroll-position binding for the dot rail's jumps. Written on a tap;
     /// the scroller keeps it updated as pages snap.
     @State private var scrollTarget: Int?
@@ -476,6 +486,13 @@ struct BookDetailView: View {
 
     // MARK: - Shell
 
+    /// Whether this reader opted into the snap-stop marquee. Off — the
+    /// default — renders the page as the flow: one snap stop (the cover,
+    /// whole), then every section in a single continuous list.
+    private var usesScrollStops: Bool {
+        app.user?.bookDetailScrollStops ?? false
+    }
+
     private func content(_ book: Book) -> some View {
         GeometryReader { geometry in
             // The scroller and art ignore the safe areas, so the rest
@@ -493,16 +510,28 @@ struct BookDetailView: View {
                 ScreenBackground()
                 DetailArtLayer(book: book, page: page, lift: lift)
                     .ignoresSafeArea()
-                snapScroller(book, restTop: restTop)
-                    .ignoresSafeArea()
+                if usesScrollStops {
+                    snapScroller(book, restTop: restTop)
+                        .ignoresSafeArea()
+                } else {
+                    flowScroller(book, restTop: restTop)
+                        .ignoresSafeArea()
+                }
+            }
+            .overlay(alignment: .top) {
+                if !usesScrollStops { FlowNavStrip(shown: flowPast) }
             }
             .overlay(alignment: .top) { chromeDiscs(book) }
             .overlay(alignment: .trailing) {
-                DetailDotRail(at: at) { stop in
-                    withAnimation(Motion.settle) { scrollTarget = stop.rawValue }
+                if usesScrollStops {
+                    DetailDotRail(at: at) { stop in
+                        withAnimation(Motion.settle) { scrollTarget = stop.rawValue }
+                    }
                 }
             }
-            .overlay(alignment: .bottomTrailing) { nextHint }
+            .overlay(alignment: .bottomTrailing) {
+                if usesScrollStops { nextHint }
+            }
             .overlay(alignment: .bottom) { restFade }
             .overlay(alignment: .bottom) { actionBar(book) }
         }
@@ -606,6 +635,86 @@ struct BookDetailView: View {
         }
     }
 
+    // MARK: - Flow (Option B)
+
+    /// The marquee unrolled: the rest run is the one snap stop, and past it
+    /// every section runs on in a single continuous list. Only the hero
+    /// region snaps (`FlowSnapBehavior`); the list itself scrolls free.
+    private func flowScroller(_ book: Book, restTop: CGFloat) -> some View {
+        ScrollView(.vertical) {
+            VStack(spacing: 0) {
+                Color.clear
+                    .frame(height: max(0, restTop - Self.flowNavPeek))
+                    .id(Self.restMarkerID)
+                // The body's snap position: this marker's top edge, a
+                // nav strip's worth of art short of the cover's end.
+                Color.clear
+                    .frame(height: Self.flowNavPeek)
+                    .id(Self.flowLiftedMarkerID)
+                flowBody(book)
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(FlowSnapBehavior(restTop: restTop))
+        .scrollPosition(id: $scrollTarget)
+        .scrollIndicators(.hidden)
+        .onScrollGeometryChange(for: DetailScrollState.self) { geometry in
+            DetailScrollState(
+                offset: geometry.contentOffset.y + geometry.contentInsets.top,
+                viewport: geometry.containerSize.height
+            )
+        } action: { _, state in
+            guard state.viewport > 0 else { return }
+            let map = DetailRead.flowMap(
+                offset: state.offset,
+                restTop: restTop,
+                navPeek: Self.flowNavPeek
+            )
+            lift = map.lift
+            page = map.page
+            if map.past != flowPast {
+                withAnimation(Motion.snap) { flowPast = map.past }
+            }
+            let settled = map.lift > 0.6
+            if settled != lifted {
+                withAnimation(Motion.snap) { lifted = settled }
+            }
+        }
+    }
+
+    /// The list itself: the lift cue, then every section in stop order,
+    /// each introduced by its number and a hairline — and nothing capped,
+    /// so every kept line and journal entry is in the list.
+    private func flowBody(_ book: Book) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            FlowCue(visible: !lifted) {
+                withAnimation(Motion.settle) { scrollTarget = Self.flowLiftedMarkerID }
+            }
+            ForEach(DetailStop.allCases) { stop in
+                VStack(alignment: .leading, spacing: 0) {
+                    if stop != .home {
+                        Hairline()
+                            .padding(.top, 34)
+                        FlowSectionLabel(stop: stop)
+                            .padding(.top, 30)
+                    }
+                    stopContent(stop, book, uncapped: true)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(EdgeInsets(top: 13, leading: 22, bottom: 132, trailing: 30))
+        .background {
+            // Slightly lighter than a full stop's 0.82: the art ghosts
+            // through near the top and the ground is behind the rest.
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                palette.bg0Color.opacity(0.74)
+            }
+        }
+        .overlay(alignment: .top) { Hairline() }
+    }
+
     /// At rest the panel's lower content runs on under the action bar; this
     /// fades it into the ground the way the design masks it out, and lifts
     /// away with the panel.
@@ -626,7 +735,9 @@ struct BookDetailView: View {
     }
 
     @ViewBuilder
-    private func stopContent(_ stop: DetailStop, _ book: Book) -> some View {
+    private func stopContent(
+        _ stop: DetailStop, _ book: Book, uncapped: Bool = false
+    ) -> some View {
         switch stop {
         case .home:
             StopHome(
@@ -642,11 +753,14 @@ struct BookDetailView: View {
         case .stats:
             StopStats(book: book, model: model)
         case .highlights:
-            StopHighlights(book: book, model: model) { showAllHighlights = true }
+            StopHighlights(book: book, model: model, uncapped: uncapped) {
+                showAllHighlights = true
+            }
         case .journals:
             StopJournals(
                 book: book,
                 model: model,
+                uncapped: uncapped,
                 onWrite: {
                     composing = .new
                 },
@@ -668,6 +782,12 @@ struct BookDetailView: View {
 
     // MARK: - Chrome
 
+    /// Whether the chrome discs still float over artwork: the marquee's
+    /// first stop, or the flow while the cover has not yet scrolled away.
+    private var discsOverArt: Bool {
+        usesScrollStops ? at == 0 : !flowPast
+    }
+
     /// Back and ⋯, as glass discs over the art — flat controls once the
     /// panel has taken the screen and there is no artwork left to blur.
     private func chromeDiscs(_ book: Book) -> some View {
@@ -679,7 +799,7 @@ struct BookDetailView: View {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 16, weight: .semibold))
             }
-            .buttonStyle(DiscButtonStyle(overArt: at == 0))
+            .buttonStyle(DiscButtonStyle(overArt: discsOverArt))
             .accessibilityLabel("Back")
 
             Spacer()
@@ -711,12 +831,12 @@ struct BookDetailView: View {
                 Image(systemName: "ellipsis")
                     .font(.system(size: 15, weight: .semibold))
             }
-            .buttonStyle(DiscButtonStyle(overArt: at == 0))
+            .buttonStyle(DiscButtonStyle(overArt: discsOverArt))
             .accessibilityLabel("More")
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
-        .animation(Motion.snap, value: at == 0)
+        .animation(Motion.snap, value: discsOverArt)
     }
 
     /// A quiet pointer at what the next swipe reaches. Home speaks for

--- a/omnibus-ios/omnibusTests/BookDetailScrollStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailScrollStopsTests.swift
@@ -1,7 +1,7 @@
 //  BookDetailScrollStopsTests.swift
 //  The book-detail scroll-stops account preference: its wire decode (a
 //  pre-0092 payload has no key and must land on the off default) and the
-//  parked state the Account switch currently renders.
+//  flow map the off-default Option B layout scrolls by.
 
 import Foundation
 import Testing
@@ -29,10 +29,32 @@ struct BookDetailScrollStopsTests {
         #expect(me.bookDetailScrollStops)
     }
 
-    /// The switch ships inert. Pinning it keeps the flag from being lit up
-    /// without the book detail page being taught to read the preference —
-    /// which would give the reader a control that changes nothing.
-    @Test func scrollStopsSwitchIsParkedUntilTheDetailPageReadsIt() {
-        #expect(AccountView.scrollStopsParked)
+    // MARK: - Flow geometry
+
+    @Test func flowMapRestsWithTheCoverWholeAtTheTop() {
+        let map = DetailRead.flowMap(offset: 0, restTop: 603)
+        #expect(map.lift == 0)
+        #expect(map.page == 0)
+        #expect(!map.past)
+    }
+
+    @Test func flowMapLiftsAcrossTheRunToTheBodySnapPosition() {
+        // The body snaps navPeek short of the cover's end — fully lifted,
+        // and already "past": the strip is what covers the peeking art.
+        let map = DetailRead.flowMap(offset: 603 - 96, restTop: 603)
+        #expect(map.lift == 1)
+        #expect(map.past)
+    }
+
+    @Test func flowMapStaysUnpastWhileTheCoverMostlyShows() {
+        let map = DetailRead.flowMap(offset: 200, restTop: 603)
+        #expect(map.lift > 0)
+        #expect(!map.past)
+    }
+
+    @Test func flowMapWashesTheArtAsTheListRunsOn() {
+        let map = DetailRead.flowMap(offset: 603 * 2, restTop: 603)
+        #expect(map.past)
+        #expect(map.page > 1)
     }
 }

--- a/omnibus-ios/omnibusTests/BookDetailScrollStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailScrollStopsTests.swift
@@ -41,7 +41,7 @@ struct BookDetailScrollStopsTests {
     @Test func flowMapLiftsAcrossTheRunToTheBodySnapPosition() {
         // The body snaps navPeek short of the cover's end — fully lifted,
         // and already "past": the strip is what covers the peeking art.
-        let map = DetailRead.flowMap(offset: 603 - 96, restTop: 603)
+        let map = DetailRead.flowMap(offset: 603 - DetailRead.flowNavPeek, restTop: 603)
         #expect(map.lift == 1)
         #expect(map.past)
     }


### PR DESCRIPTION
## Summary
- Implements the design's Option B on iOS: the book detail opens on the artwork whole with the panel resting under it, and past that one stop every section runs on in a single free-scrolling list — numbered hairline rules between sections, nothing capped (every kept line and journal entry inline), no dot rail, a blurred nav strip fading in under the discs once the cover is gone, and the action bar staying put.
- Gated by the #2395 account setting: `book_detail_scroll_stops` off (the default) renders the flow, on renders the shipped snap-stop marquee unchanged; the parked iOS Account toggle is lit up now that the page reads the preference (the web card stays parked until the web page learns it).
- Snapping is a custom `ScrollTargetBehavior` that settles only the hero region — the design's `proximity` semantics — with the lift cue jumping to the body's snap position, `flowNavPeek` short of the cover's end.
- New `BookDetailFlow.swift` carries the standalone pieces (snap behavior, cue, section rule, nav strip); the pure geometry lives in `DetailRead.flowMap`.

## Test plan
- [x] `just ios-build` + `just ios-test` — unit suite green, 4 new `flowMap` tests (the parked-switch pin retired with the constant)
- [x] Simulator against the dev server: flow by default (rest → cue → continuous list through Files/Recommendations, nav strip fade); Account toggle on → marquee with dot rail, off → flow; toggle write confirmed in the users table and restored to default

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.