### PR TITLE
feat: fold the book detail to six sections with a trailing More

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -1,7 +1,8 @@
 //  BookDetailStops.swift
-//  The seven snap-stop panels of the book detail marquee, the small pieces
-//  they share (kicker, ruler, stat tiles, cover strips, inset lists), and the
-//  pure derivations behind them (`DetailRead`, `DetailStats`).
+//  The section panels of the book detail — six in either layout, with the
+//  trailing More holding the shelf block and the recommendations — the small
+//  pieces they share (kicker, ruler, stat tiles, cover strips, inset lists),
+//  and the pure derivations behind them (`DetailRead`, `DetailStats`).
 
 import SwiftUI
 
@@ -978,11 +979,15 @@ struct StopHome: View {
     }
 }
 
-// MARK: - 02 · Shelf
+// MARK: - 06 · More — the shelf block
 
 struct StopShelf: View {
     let book: Book
     let model: BookDetailModel
+    /// Whether to append the "more by <author>" strip. Off inside the More
+    /// section, whose recommendations half already carries the author
+    /// cluster — two copies of the same strip would sit a screen apart.
+    var authorStrip = true
     var onShelfPicker: () -> Void
 
     @Environment(\.palette) private var palette
@@ -1083,11 +1088,16 @@ struct StopShelf: View {
             if series.count <= 1, knowsMembership, model.authorBooks.isEmpty, shelfNames.isEmpty {
                 MonoNote(text: "a shelf gathers books by hand, or fills itself from a rule")
                     .padding(.top, 20)
-                StopRuledVoid(rows: 2)
-                    .padding(.top, 18)
+                // The ruled void filled the old standalone stop's screen; in
+                // the More section the page continues below, so it would read
+                // as a gap rather than a waiting page.
+                if authorStrip {
+                    StopRuledVoid(rows: 2)
+                        .padding(.top, 18)
+                }
             }
 
-            if series.count <= 1, !model.authorBooks.isEmpty {
+            if authorStrip, series.count <= 1, !model.authorBooks.isEmpty {
                 MonoNote(text: "more by \(book.authorDisplay)")
                     .padding(.top, 20)
                 ScrollView(.horizontal) {
@@ -1108,7 +1118,7 @@ struct StopShelf: View {
     }
 }
 
-// MARK: - 03 · Stats
+// MARK: - 02 · Stats
 
 struct StopStats: View {
     let book: Book
@@ -1251,7 +1261,7 @@ struct StopStats: View {
     }
 }
 
-// MARK: - 04 · Highlights
+// MARK: - 03 · Highlights
 
 struct StopHighlights: View {
     let book: Book
@@ -1358,7 +1368,7 @@ struct HighlightRow: View {
     }
 }
 
-// MARK: - 05 · Journals
+// MARK: - 04 · Journals
 
 struct StopJournals: View {
     let book: Book
@@ -1519,7 +1529,7 @@ struct JournalRow: View {
     }
 }
 
-// MARK: - 06 · The files
+// MARK: - 05 · The files
 
 struct StopFiles: View {
     let book: Book
@@ -1757,7 +1767,7 @@ struct DownloadBadge: View {
     }
 }
 
-// MARK: - 07 · Recommendations
+// MARK: - 06 · More — the recommendations block
 
 struct StopRecommendations: View {
     let book: Book

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -984,9 +984,10 @@ struct StopHome: View {
 struct StopShelf: View {
     let book: Book
     let model: BookDetailModel
-    /// Whether to append the "more by <author>" strip. Off inside the More
-    /// section, whose recommendations half already carries the author
-    /// cluster — two copies of the same strip would sit a screen apart.
+    /// Whether this block stands alone as a full stop. Off inside the More
+    /// section, which drops the "more by <author>" strip (the
+    /// recommendations half already carries the author cluster) and the
+    /// full-screen ruled void (the section continues right below it).
     var authorStrip = true
     var onShelfPicker: () -> Void
 

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -3,10 +3,10 @@
 //  page opening on it whole — the cover, or the generated plate at the same
 //  size — with the panel resting under it. Past that, the layout follows the
 //  reader's scroll-stops preference. Off (the default), the flow: every
-//  section — Home · Shelf · Stats · Highlights · Journals · The files ·
-//  Recommendations — runs on in one continuous list, nothing capped. On,
-//  the marquee: the same sections as seven snap stops on a vertical pager,
-//  one screenful each. Chrome is immersive either way: glass discs over the
+//  section — Home · Stats · Highlights · Journals · The files · More —
+//  runs on in one continuous list, nothing capped. On, the marquee: the
+//  same sections as six snap stops on a vertical pager, one screenful
+//  each. Chrome is immersive either way: glass discs over the
 //  art, a persistent bottom action bar so Resume never scrolls away, and
 //  the marquee's tappable dot rail or the flow's nav strip behind the discs.
 
@@ -232,21 +232,22 @@ final class BookDetailModel {
     }
 }
 
-/// The seven stops, in scroll order.
+/// The six stops, in scroll order. The trailing More folds what used to be
+/// two stops — the shelf block and the recommendations — into one, matching
+/// the design's six-section list on both clients.
 enum DetailStop: Int, CaseIterable, Identifiable {
-    case home, shelf, stats, highlights, journals, files, recommendations
+    case home, stats, highlights, journals, files, more
 
     var id: Int { rawValue }
 
     var name: String {
         switch self {
         case .home: "Home"
-        case .shelf: "Shelf"
         case .stats: "Stats"
         case .highlights: "Highlights"
         case .journals: "Journals"
         case .files: "The files"
-        case .recommendations: "Recommendations"
+        case .more: "More"
         }
     }
 }
@@ -748,8 +749,6 @@ struct BookDetailView: View {
                 onAlignment: { showAlignment = true },
                 onRemovedWishlist: { model.wishlistEntry = nil }
             )
-        case .shelf:
-            StopShelf(book: book, model: model) { showShelfPicker = true }
         case .stats:
             StopStats(book: book, model: model)
         case .highlights:
@@ -775,8 +774,17 @@ struct BookDetailView: View {
                 onListen: { listen(book) },
                 onAlignment: { showAlignment = true }
             )
-        case .recommendations:
-            StopRecommendations(book: book, model: model)
+        case .more:
+            // The old Shelf and Recommendations stops, concatenated — the
+            // shelf block keeps its chips and strips, minus its author strip,
+            // which the recommendations' author cluster already carries.
+            VStack(alignment: .leading, spacing: 0) {
+                StopShelf(book: book, model: model, authorStrip: false) {
+                    showShelfPicker = true
+                }
+                StopRecommendations(book: book, model: model)
+                    .padding(.top, 26)
+            }
         }
     }
 

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -348,3 +348,12 @@ private func entry(id: Int64, clientID: String? = nil) -> JournalEntry {
     #expect(DetailRead.syncRow(state: .candidate) == linked)
     #expect(DetailRead.syncRow(state: .nothingNewer) == linked)
 }
+
+// MARK: - Section list
+
+/// Both clients agreed on this six-section list (web folded its Shelf stop
+/// the same way) — pinning it keeps the numbering from drifting apart.
+@Test func detailStopsRunHomeToMoreInSixSections() {
+    #expect(DetailStop.allCases.map(\.name)
+        == ["Home", "Stats", "Highlights", "Journals", "The files", "More"])
+}


### PR DESCRIPTION
## Summary
- Collapses `DetailStop` to the six-section list both clients agreed on — Home · Stats · Highlights · Journals · The files · More — matching the design and the web fold (seamus-sloan/omnibus#2400), so the two clients number sections identically.
- More is a concatenation of the old Shelf and Recommendations stops: the shelf block keeps its chips, strips, and empty states, minus its author strip (the recommendations' author cluster already carries it) and its full-screen ruled void (the section continues below it in both layouts).
- Marquee and flow both derive counts, labels, and the dot rail from `allCases`, so the renumbering is automatic; a unit test pins the six-name order against cross-client drift.

## Test plan
- [x] `just ios-build` + `just ios-test` — unit suite green, order-pinning test added
- [x] Simulator against the dev server: flow runs 01 Home → 06 More continuously; marquee shows six dots with "06 / 06 — MORE" rendering the concatenated section; toggled the scroll-stops setting both ways and restored the default

## Version
By default a merge to `main` cuts a patch release. Pick the version update this
PR should trigger; labels override the default:
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled
  (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

If both `minor version` and `patch version` are applied, `minor version` wins.
Unlabeled PRs that only touch docs (`*.md`, `docs/`) or CI (`.github/`) skip the
release automatically.