### PR TITLE
[OMNI-2404] Open the quote card from a book detail highlight on iOS

### DIFF
--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailStops.swift
@@ -1270,6 +1270,7 @@ struct StopHighlights: View {
     /// The flow (Option B) has no fixed screenful to fit, so it lists every
     /// kept line inline instead of capping at `stopCount` behind a sheet.
     var uncapped = false
+    var onQuote: (Highlight) -> Void
     var onAll: () -> Void
 
     /// Passages shown on the stop before the sheet takes over.
@@ -1307,14 +1308,14 @@ struct StopHighlights: View {
                     // already stores highlights newest-first.
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(all) { highlight in
-                            HighlightRow(highlight: highlight)
+                            HighlightRow(highlight: highlight) { onQuote(highlight) }
                         }
                     }
                     .padding(.top, 6)
                 } else {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(Self.preview(of: all)) { highlight in
-                            HighlightRow(highlight: highlight)
+                            HighlightRow(highlight: highlight) { onQuote(highlight) }
                         }
                     }
                     .padding(.top, 6)
@@ -1330,14 +1331,39 @@ struct StopHighlights: View {
 }
 
 /// One kept line: the passage in the italic display cut, its color as a
-/// slim tick, and when it was kept.
+/// slim tick, and when it was kept. A tap opens the passage in the quote-card
+/// sheet — the same one the reader's passage menu opens — so a line can be
+/// styled and shared without reopening the book.
 struct HighlightRow: View {
     let highlight: Highlight
     var large = false
+    var onQuote: (() -> Void)? = nil
 
     @Environment(\.palette) private var palette
 
+    /// The passage a card can be made from, or `nil` when the row carries
+    /// none — Kobo-origin rows can arrive without text, and a card of nothing
+    /// is not worth a sheet, so those rows stay inert.
+    static func quotable(_ highlight: Highlight) -> String? {
+        highlight.text?.nilIfBlank
+    }
+
     var body: some View {
+        if let onQuote, Self.quotable(highlight) != nil {
+            Button {
+                Haptics.tap()
+                onQuote()
+            } label: {
+                row.contentShape(Rectangle())
+            }
+            .buttonStyle(PressableStyle())
+            .accessibilityHint("Makes a quote card")
+        } else {
+            row
+        }
+    }
+
+    private var row: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
                 if let text = highlight.text?.nilIfBlank {
@@ -1346,6 +1372,7 @@ struct HighlightRow: View {
                         .foregroundStyle(palette.ink1Color)
                         .lineSpacing(4)
                         .lineLimit(large ? nil : 3)
+                        .multilineTextAlignment(.leading)
                 }
                 if let note = highlight.note?.nilIfBlank {
                     Text(note)
@@ -1920,9 +1947,12 @@ struct DescriptionDrawer: View {
 }
 
 /// Every kept line, newest first — where the Highlights stop overflows to.
+/// Tapping a line hands it back to the page, which opens the quote-card sheet
+/// once this one is down — two sheets can't be up at once.
 struct AllHighlightsSheet: View {
     let book: Book
     let highlights: [Highlight]
+    var onQuote: (Highlight) -> Void
 
     @Environment(\.palette) private var palette
 
@@ -1942,7 +1972,7 @@ struct AllHighlightsSheet: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(highlights.sorted { $0.createdAt > $1.createdAt }) { highlight in
-                        HighlightRow(highlight: highlight, large: true)
+                        HighlightRow(highlight: highlight, large: true) { onQuote(highlight) }
                     }
                 }
                 .padding(.horizontal, 18)

--- a/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
+++ b/omnibus-ios/omnibus/Features/BookDetail/BookDetailView.swift
@@ -311,6 +311,11 @@ struct BookDetailView: View {
     /// An entry picked inside the all-entries sheet; opened in the drawer
     /// once that sheet has dismissed — two sheets can't be up at once.
     @State private var pendingJournal: JournalEntry?
+    /// The passage being turned into a card, driving the quote sheet.
+    @State private var quoteTarget: QuoteRequest?
+    /// A line picked inside the all-highlights sheet; made into a card once
+    /// that sheet has dismissed, for the same reason as `pendingJournal`.
+    @State private var pendingQuote: Highlight?
     /// The file chosen in the picker, opened from the sheet's `onDismiss` —
     /// presenting the full-screen player while the sheet is still up would
     /// be refused.
@@ -432,9 +437,21 @@ struct BookDetailView: View {
                 DescriptionDrawer(book: book)
             }
         }
-        .sheet(isPresented: $showAllHighlights) {
+        .sheet(isPresented: $showAllHighlights, onDismiss: {
+            guard let pending = pendingQuote else { return }
+            pendingQuote = nil
+            quote(pending)
+        }) {
             if let book = model.book {
-                AllHighlightsSheet(book: book, highlights: model.highlights)
+                AllHighlightsSheet(book: book, highlights: model.highlights) { highlight in
+                    pendingQuote = highlight
+                    showAllHighlights = false
+                }
+            }
+        }
+        .sheet(item: $quoteTarget) { request in
+            if let book = model.book {
+                QuoteCardSheet(quote: request.text, book: book)
             }
         }
         .sheet(isPresented: $showAllJournals, onDismiss: {
@@ -476,6 +493,12 @@ struct BookDetailView: View {
     private var bookPalette: Palette {
         guard let book = model.book else { return palette }
         return palette.accented(by: CoverIdentity(book).tone)
+    }
+
+    /// Open the quote-card sheet on a kept line's passage.
+    private func quote(_ highlight: Highlight) {
+        guard let text = HighlightRow.quotable(highlight) else { return }
+        quoteTarget = QuoteRequest(text: text)
     }
 
     /// Open the player on the file the picker chose, once its sheet is gone.
@@ -752,9 +775,13 @@ struct BookDetailView: View {
         case .stats:
             StopStats(book: book, model: model)
         case .highlights:
-            StopHighlights(book: book, model: model, uncapped: uncapped) {
-                showAllHighlights = true
-            }
+            StopHighlights(
+                book: book,
+                model: model,
+                uncapped: uncapped,
+                onQuote: { quote($0) },
+                onAll: { showAllHighlights = true }
+            )
         case .journals:
             StopJournals(
                 book: book,

--- a/omnibus-ios/omnibus/Reader/QuoteCardView.swift
+++ b/omnibus-ios/omnibus/Reader/QuoteCardView.swift
@@ -24,6 +24,13 @@ extension String {
     }
 }
 
+/// A passage on its way to the quote-card sheet. Identity is per request, so
+/// making a card of the same passage twice reopens the sheet.
+struct QuoteRequest: Identifiable {
+    let id = UUID()
+    let text: String
+}
+
 /// A card background: a ground tone plus whether its ink is light or dark.
 struct QuoteStyle: Identifiable {
     var id: String

--- a/omnibus-ios/omnibus/Reader/ReaderView.swift
+++ b/omnibus-ios/omnibus/Reader/ReaderView.swift
@@ -12,13 +12,6 @@ struct ReturnPoint: Equatable {
     let page: Int
 }
 
-/// A passage on its way to the quote-card sheet. Identity is per request, so
-/// making a card of the same passage twice reopens the sheet.
-struct QuoteRequest: Identifiable {
-    let id = UUID()
-    let text: String
-}
-
 struct ReaderView: View {
     let book: Book
 

--- a/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
+++ b/omnibus-ios/omnibusTests/BookDetailStopsTests.swift
@@ -225,6 +225,20 @@ private func sitting(
     #expect(StopHighlights.preview(of: highlights).count == 1)
 }
 
+@Test func highlightRowQuotesOnlyRowsThatCarryAPassage() {
+    func row(text: String?) -> Highlight {
+        Highlight(
+            id: 1, bookUUID: "b", epubCFIRange: nil, color: .amber,
+            note: "a note", text: text, clientID: nil, createdAt: 5
+        )
+    }
+
+    #expect(HighlightRow.quotable(row(text: "A kept line")) == "A kept line")
+    // A Kobo-origin row can list with no passage; a note alone is no card.
+    #expect(HighlightRow.quotable(row(text: nil)) == nil)
+    #expect(HighlightRow.quotable(row(text: "  \n ")) == nil)
+}
+
 @Test func journalRowPreviewStripsMarkdownFromTheOpeningLine() {
     let preview = JournalRow.preview("**Kvothe** is an *unreliable* narrator\n\nSecond para")
     #expect(preview == "Kvothe is an unreliable narrator")


### PR DESCRIPTION
## Summary
- Tapping a kept line on the iOS book detail Highlights stop, or inside its "All highlights" sheet, now opens the existing `QuoteCardSheet` pre-filled with that passage, so it can be styled and shared without reopening the book.
- Rows with no passage text (Kobo-origin highlights) stay inert; the all-highlights sheet dismisses first and opens the card from its dismiss handler, mirroring the journals sheet.
- `QuoteRequest` moves from the reader into `QuoteCardView.swift` so both entry points share it.

Closes #2404

## Test plan
- [x] `scripts/ios-test.sh unit` (the `just ios-test` recipe): 755 passed, 0 failed, including the new `highlightRowQuotesOnlyRowsThatCarryAPassage` case.
- [ ] On a simulator, open a book with highlights, tap a row on the Highlights stop and one inside "All highlights", and confirm the quote card opens with Share and Copy image working.

## Version
- [ ] **Minor** — add the `minor version` label (`vX.Y.Z` → `vX.(Y+1).0`).
- [x] **Patch** — the default; add the `patch version` label or leave unlabeled (`vX.Y.Z` → `vX.Y.(Z+1)`).
- [ ] **No release** — add the `no release` label to skip cutting a release.

## Notes
- iOS-only change (`omnibus-ios/`); no Cargo crate is touched.